### PR TITLE
fix: exclude vscode configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ Win: `ctrl + shift + p`
 
 ### 进阶配置
 
-**⚠️ 切记修改配置前请关闭本插件**
-
 可以在设置面板查找关键字 “Qwerty” 修改设置
 
 ```
@@ -102,8 +100,10 @@ Win: `ctrl + shift + p`
   "description": "是否开启音标"
 },
 "qwerty-learner.chapterLength": {
-  "type": "number",
+  "type": "integer",
   "default": 20,
+  "minimum": 1,
+  "maximum": 100,
   "description": "每个章节包含的单词数量"
 },
 "qwerty-learner.reWrite": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,6 +91,9 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidChangeTextDocument((e) => {
     if (isStart) {
       const { uri } = e.document
+      // 避免破坏配置文件
+      if (uri.scheme.indexOf("vscode") !== -1) { return }
+
       const { range, text, rangeLength } = e.contentChanges[0]
 
       if (text !== '' && text.length === 1) {
@@ -99,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
         const editAction = new vscode.WorkspaceEdit()
         editAction.delete(uri, newRange)
         vscode.workspace.applyEdit(editAction)
-        if (!hasWrong && text.length === 1) {
+        if (!hasWrong) {
           soundPlayer('click')
           inputBar.text += text
           const result = compareWord(wordList[order].name, inputBar.text)


### PR DESCRIPTION
Using the GUI to modify vscode's configuration file also triggers the plugin, causing its json structure to be broken and not applied.