### PR TITLE
feat: add pronounce at linux platform

### DIFF
--- a/src/resource/voice/index.ts
+++ b/src/resource/voice/index.ts
@@ -26,7 +26,13 @@ if (!(NATIVE && NATIVE.playerPlay)) {
     NATIVE = null
   }
 }
-
+if (!(NATIVE && NATIVE.playerPlay)) {
+  try {
+    NATIVE = require(`node-loader!./rodio/linux-x64.node`) as NativeModule
+  } catch (error) {
+    NATIVE = null
+  }
+}
 if (!(NATIVE && NATIVE.playerPlay)) {
   NATIVE = null
 }


### PR DESCRIPTION
This commit add support for words pronounce at linux platform.

The binary file *linux-x64.node* is compiled from code:

```rust
use neon::prelude::*;
use std::io::{BufReader, Cursor};

fn player_play(mut cx: FunctionContext) -> JsResult<JsBoolean> {
    let url = cx.argument::<JsString>(0)?.value(&mut cx);

    let (_stream, handle) = rodio::OutputStream::try_default().unwrap();
    let sink = rodio::Sink::try_new(&handle).unwrap();

    let resp = reqwest::blocking::get(url).unwrap();
    let cursor = Cursor::new(resp.bytes().unwrap());
    let source = rodio::Decoder::new(BufReader::new(cursor)).unwrap();
    sink.append(source);

    sink.sleep_until_end();
    Ok(cx.boolean(true))
}

fn main(mut cx: ModuleContext) -> NeonResult<()> {
    cx.export_function("playerPlay", player_play)?;
    Ok(())
}
```

test passed at Ubuntu 20.04.4 LTS desktop