### PR TITLE
修改了日语词典的格式，使得显示翻译时可以同时显示日文写法和罗马音

### DIFF
--- a/assets/dicts/JapVocabList.N1.json
+++ b/assets/dicts/JapVocabList.N1.json
@@ -2,24312 +2,24312 @@
     {
         "name": "koukyou",
         "trans": [
+            "好況(こうきょう)",
             "prosperous conditions, healthy economy"
-        ],
-        "notation": "好況(こうきょう)"
+        ]
     },
     {
         "name": "masumasu",
         "trans": [
+            "益々(ますます)",
             "increasingly, more and more"
-        ],
-        "notation": "益々(ますます)"
+        ]
     },
     {
         "name": "akirame",
         "trans": [
+            "諦(あきら)め",
             "resignation, acceptance, consolation"
-        ],
-        "notation": "諦(あきら)め"
+        ]
     },
     {
         "name": "yuu",
         "trans": [
+            "優(ゆう)",
             "gentle, affectionate"
-        ],
-        "notation": "優(ゆう)"
+        ]
     },
     {
         "name": "moshimo",
         "trans": [
+            "若(も)しも",
             "if"
-        ],
-        "notation": "若(も)しも"
+        ]
     },
     {
         "name": "saishuu",
         "trans": [
+            "採集(さいしゅう)",
             "collecting, gathering"
-        ],
-        "notation": "採集(さいしゅう)"
+        ]
     },
     {
         "name": "funsou",
         "trans": [
+            "紛争(ふんそう)",
             "dispute, trouble, strife"
-        ],
-        "notation": "紛争(ふんそう)"
+        ]
     },
     {
         "name": "koushou",
         "trans": [
+            "高尚(こうしょう)",
             "high, noble, refined, advanced"
-        ],
-        "notation": "高尚(こうしょう)"
+        ]
     },
     {
         "name": "douyara",
         "trans": [
+            "どうやら",
             "it seems like, somehow or other"
-        ],
-        "notation": "どうやら"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "核(かく)",
             "nucleus, kernel"
-        ],
-        "notation": "核(かく)"
+        ]
     },
     {
         "name": "ayumu",
         "trans": [
+            "歩(あゆ)む",
             "to walk, to go on foot"
-        ],
-        "notation": "歩(あゆ)む"
+        ]
     },
     {
         "name": "kanaeru",
         "trans": [
+            "叶(かな)える",
             "to grant (request wish)"
-        ],
-        "notation": "叶(かな)える"
+        ]
     },
     {
         "name": "muki",
         "trans": [
+            "向(む)き",
             "direction, situation, exposure, aspect, suitability"
-        ],
-        "notation": "向(む)き"
+        ]
     },
     {
         "name": "sokubaku",
         "trans": [
+            "束縛(そくばく)",
             "restraint, shackles, restriction, confinement, binding"
-        ],
-        "notation": "束縛(そくばく)"
+        ]
     },
     {
         "name": "tamashii",
         "trans": [
+            "魂(たましい)",
             "soul, spirit"
-        ],
-        "notation": "魂(たましい)"
+        ]
     },
     {
         "name": "sokumen",
         "trans": [
+            "側面(そくめん)",
             "side, flank, sidelight, lateral"
-        ],
-        "notation": "側面(そくめん)"
+        ]
     },
     {
         "name": "ichibu",
         "trans": [
+            "一部(いちぶ)",
             "1. one copy e.g. of a document, 2. a part, partly, some"
-        ],
-        "notation": "一部(いちぶ)"
+        ]
     },
     {
         "name": "shussha",
         "trans": [
+            "出社(しゅっしゃ)",
             "arrival (in a country at work etc.)"
-        ],
-        "notation": "出社(しゅっしゃ)"
+        ]
     },
     {
         "name": "ichimazu",
         "trans": [
+            "一(いち)まず",
             "for the present, once, in outline"
-        ],
-        "notation": "一(いち)まず"
+        ]
     },
     {
         "name": "katakoto",
         "trans": [
+            "片言(かたこと)",
             "a smattering, talk like a baby, speak haltingly"
-        ],
-        "notation": "片言(かたこと)"
+        ]
     },
     {
         "name": "teate",
         "trans": [
+            "手当(てあ)て",
             "allowance, compensation, treatment, medical care"
-        ],
-        "notation": "手当(てあ)て"
+        ]
     },
     {
         "name": "jodoushi",
         "trans": [
+            "助動詞(じょどうし)",
             "auxiliary verb"
-        ],
-        "notation": "助動詞(じょどうし)"
+        ]
     },
     {
         "name": "koujutsu",
         "trans": [
+            "口述(こうじゅつ)",
             "verbal statement"
-        ],
-        "notation": "口述(こうじゅつ)"
+        ]
     },
     {
         "name": "munashii",
         "trans": [
+            "空(むな)しい",
             "vacant, futile, vain, void, empty, ineffective, lifeless"
-        ],
-        "notation": "空(むな)しい"
+        ]
     },
     {
         "name": "iron",
         "trans": [
+            "異論(いろん)",
             "different opinion, objection"
-        ],
-        "notation": "異論(いろん)"
+        ]
     },
     {
         "name": "akireru",
         "trans": [
+            "呆(あき)れる",
             "to be amazed, to be shocked"
-        ],
-        "notation": "呆(あき)れる"
+        ]
     },
     {
         "name": "tanin",
         "trans": [
+            "他人(たにん)",
             "another person, unrelated person, outsider, stranger"
-        ],
-        "notation": "他人(たにん)"
+        ]
     },
     {
         "name": "yurumi",
         "trans": [
+            "弛(ゆる)み",
             "slack, slackening, dullness, letdown"
-        ],
-        "notation": "弛(ゆる)み"
+        ]
     },
     {
         "name": "yasuppoi",
         "trans": [
+            "安(やす)っぽい",
             "cheap-looking, tawdry, insignificant"
-        ],
-        "notation": "安(やす)っぽい"
+        ]
     },
     {
         "name": "chuusuu",
         "trans": [
+            "中枢(ちゅうすう)",
             "centre, pivot, mainstay, nucleus, backbone, central figure, pillar, key man"
-        ],
-        "notation": "中枢(ちゅうすう)"
+        ]
     },
     {
         "name": "henkan",
         "trans": [
+            "返還(へんかん)",
             "return, restoration"
-        ],
-        "notation": "返還(へんかん)"
+        ]
     },
     {
         "name": "shuzai",
         "trans": [
+            "取材(しゅざい)",
             "choice of subject, collecting data"
-        ],
-        "notation": "取材(しゅざい)"
+        ]
     },
     {
         "name": "konketsu",
         "trans": [
+            "混血(こんけつ)",
             "mixed race, mixed parentage"
-        ],
-        "notation": "混血(こんけつ)"
+        ]
     },
     {
         "name": "hougaku",
         "trans": [
+            "法学(ほうがく)",
             "law, jurisprudence"
-        ],
-        "notation": "法学(ほうがく)"
+        ]
     },
     {
         "name": "shiito",
         "trans": [
+            "シート",
             "seat, sheet"
-        ],
-        "notation": "シート"
+        ]
     },
     {
         "name": "kijitsu",
         "trans": [
+            "期日(きじつ)",
             "fixed date, settlement date"
-        ],
-        "notation": "期日(きじつ)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "留(と)める",
             "to stop, to cease, to put an end to"
-        ],
-        "notation": "留(と)める"
+        ]
     },
     {
         "name": "hantei",
         "trans": [
+            "判定(はんてい)",
             "judgement, decision, award, verdict"
-        ],
-        "notation": "判定(はんてい)"
+        ]
     },
     {
         "name": "kijo",
         "trans": [
+            "貴女(きじょ)",
             "you, lady"
-        ],
-        "notation": "貴女(きじょ)"
+        ]
     },
     {
         "name": "kyouguu",
         "trans": [
+            "境遇(きょうぐう)",
             "environment, circumstances"
-        ],
-        "notation": "境遇(きょうぐう)"
+        ]
     },
     {
         "name": "shiwa",
         "trans": [
+            "皺(しわ)",
             "wrinkles, creases"
-        ],
-        "notation": "皺(しわ)"
+        ]
     },
     {
         "name": "nan",
         "trans": [
+            "難(なん)",
             "difficulty, hardships, defect"
-        ],
-        "notation": "難(なん)"
+        ]
     },
     {
         "name": "kureen",
         "trans": [
+            "クレーン",
             "crane"
-        ],
-        "notation": "クレーン"
+        ]
     },
     {
         "name": "atsuraeru",
         "trans": [
+            "誂(あつら)える",
             "to give an order, to place an order"
-        ],
-        "notation": "誂(あつら)える"
+        ]
     },
     {
         "name": "suiri",
         "trans": [
+            "推理(すいり)",
             "reasoning, inference, mystery or detective genre (movie novel etc.)"
-        ],
-        "notation": "推理(すいり)"
+        ]
     },
     {
         "name": "ninau",
         "trans": [
+            "担(にな)う",
             "to carry on shoulder, to bear (burden), to shoulder (gun)"
-        ],
-        "notation": "担(にな)う"
+        ]
     },
     {
         "name": "jouka",
         "trans": [
+            "上下(じょうか)",
             "high and low, up and down, unloading and loading, praising and blaming"
-        ],
-        "notation": "上下(じょうか)"
+        ]
     },
     {
         "name": "tsujitsuma",
         "trans": [
+            "辻褄(つじつま)",
             "coherence, consistency"
-        ],
-        "notation": "辻褄(つじつま)"
+        ]
     },
     {
         "name": "misupurinto",
         "trans": [
+            "ミスプリント",
             "misprint"
-        ],
-        "notation": "ミスプリント"
+        ]
     },
     {
         "name": "kei",
         "trans": [
+            "刑(けい)",
             "penalty, sentence, punishment"
-        ],
-        "notation": "刑(けい)"
+        ]
     },
     {
         "name": "chisei",
         "trans": [
+            "知性(ちせい)",
             "intelligence"
-        ],
-        "notation": "知性(ちせい)"
+        ]
     },
     {
         "name": "in",
         "trans": [
+            "員(いん)",
             "member"
-        ],
-        "notation": "員(いん)"
+        ]
     },
     {
         "name": "yuragu",
         "trans": [
+            "揺(ゆ)らぐ",
             "to swing, to sway, to shake, to tremble"
-        ],
-        "notation": "揺(ゆ)らぐ"
+        ]
     },
     {
         "name": "jiku",
         "trans": [
+            "軸(じく)",
             "axis, stem, shaft, axle"
-        ],
-        "notation": "軸(じく)"
+        ]
     },
     {
         "name": "kakitoru",
         "trans": [
+            "書(か)き取(と)る",
             "to write down, to take dictation, to take notes"
-        ],
-        "notation": "書(か)き取(と)る"
+        ]
     },
     {
         "name": "mugon",
         "trans": [
+            "無言(むごん)",
             "silence"
-        ],
-        "notation": "無言(むごん)"
+        ]
     },
     {
         "name": "ojamashimasu",
         "trans": [
+            "お邪魔(じゃま)します",
             "Excuse me for disturbing (interrupting) you"
-        ],
-        "notation": "お邪魔(じゃま)します"
+        ]
     },
     {
         "name": "oubo",
         "trans": [
+            "応募(おうぼ)",
             "subscription, application"
-        ],
-        "notation": "応募(おうぼ)"
+        ]
     },
     {
         "name": "marukkiri",
         "trans": [
+            "丸(まる)っきり",
             "completely, perfectly, just as if"
-        ],
-        "notation": "丸(まる)っきり"
+        ]
     },
     {
         "name": "kaihou",
         "trans": [
+            "介抱(かいほう)",
             "nursing, looking after"
-        ],
-        "notation": "介抱(かいほう)"
+        ]
     },
     {
         "name": "tonda",
         "trans": [
+            "とんだ",
             "terrible, awful, serious, preposterous, absolutely not"
-        ],
-        "notation": "とんだ"
+        ]
     },
     {
         "name": "izure",
         "trans": [
+            "何(いず)れ",
             "well, now, let me see, which (of three or more)"
-        ],
-        "notation": "何(いず)れ"
+        ]
     },
     {
         "name": "surakkusu",
         "trans": [
+            "スラックス",
             "slacks"
-        ],
-        "notation": "スラックス"
+        ]
     },
     {
         "name": "kanbu",
         "trans": [
+            "幹部(かんぶ)",
             "management, (executive) staff, leaders"
-        ],
-        "notation": "幹部(かんぶ)"
+        ]
     },
     {
         "name": "sousaku",
         "trans": [
+            "捜索(そうさく)",
             "search (esp. for someone or something missing), investigation"
-        ],
-        "notation": "捜索(そうさく)"
+        ]
     },
     {
         "name": "kyuubou",
         "trans": [
+            "窮乏(きゅうぼう)",
             "poverty"
-        ],
-        "notation": "窮乏(きゅうぼう)"
+        ]
     },
     {
         "name": "seijun",
         "trans": [
+            "清純(せいじゅん)",
             "purity, innocence"
-        ],
-        "notation": "清純(せいじゅん)"
+        ]
     },
     {
         "name": "ojiisan",
         "trans": [
+            "お祖父(じい)さん",
             "grandfather, male senior-citizen"
-        ],
-        "notation": "お祖父(じい)さん"
+        ]
     },
     {
         "name": "kotozute",
         "trans": [
+            "言伝(ことづて)",
             "declaration, hearsay"
-        ],
-        "notation": "言伝(ことづて)"
+        ]
     },
     {
         "name": "funshutsu",
         "trans": [
+            "噴出(ふんしゅつ)",
             "spewing, gushing, spouting, eruption, effusion"
-        ],
-        "notation": "噴出(ふんしゅつ)"
+        ]
     },
     {
         "name": "mashita",
         "trans": [
+            "真下(ました)",
             "right under, directly below"
-        ],
-        "notation": "真下(ました)"
+        ]
     },
     {
         "name": "shibou",
         "trans": [
+            "志望(しぼう)",
             "wish, desire, ambition"
-        ],
-        "notation": "志望(しぼう)"
+        ]
     },
     {
         "name": "keitai",
         "trans": [
+            "形態(けいたい)",
             "form, shape, figure"
-        ],
-        "notation": "形態(けいたい)"
+        ]
     },
     {
         "name": "kanau",
         "trans": [
+            "叶(かな)う",
             "to come true (wish)"
-        ],
-        "notation": "叶(かな)う"
+        ]
     },
     {
         "name": "kurushimeru",
         "trans": [
+            "苦(くる)しめる",
             "to torment, to harass, to inflict pain"
-        ],
-        "notation": "苦(くる)しめる"
+        ]
     },
     {
         "name": "motte",
         "trans": [
+            "以(もっ)て",
             "with, by, by means of, because, in view of"
-        ],
-        "notation": "以(もっ)て"
+        ]
     },
     {
         "name": "janpaa",
         "trans": [
+            "ジャンパー",
             "jacket, jumper"
-        ],
-        "notation": "ジャンパー"
+        ]
     },
     {
         "name": "koubo",
         "trans": [
+            "公募(こうぼ)",
             "public appeal, public contribution"
-        ],
-        "notation": "公募(こうぼ)"
+        ]
     },
     {
         "name": "akka",
         "trans": [
+            "悪化(あっか)",
             "deterioration, growing worse, aggravation, degeneration, corruption"
-        ],
-        "notation": "悪化(あっか)"
+        ]
     },
     {
         "name": "minzoku",
         "trans": [
+            "民俗(みんぞく)",
             "people, race, nation, racial customs, folk customs"
-        ],
-        "notation": "民俗(みんぞく)"
+        ]
     },
     {
         "name": "nayamasu",
         "trans": [
+            "悩(なや)ます",
             "to afflict, to torment, to harass, to molest"
-        ],
-        "notation": "悩(なや)ます"
+        ]
     },
     {
         "name": "seisuru",
         "trans": [
+            "制(せい)する",
             "to control, to command, to get the better of"
-        ],
-        "notation": "制(せい)する"
+        ]
     },
     {
         "name": "isso",
         "trans": [
+            "いっそ",
             "rather, sooner, might as well"
-        ],
-        "notation": "いっそ"
+        ]
     },
     {
         "name": "bokou",
         "trans": [
+            "母校(ぼこう)",
             "alma mater"
-        ],
-        "notation": "母校(ぼこう)"
+        ]
     },
     {
         "name": "tsuiyasu",
         "trans": [
+            "費(つい)やす",
             "to spend, to devote, to waste"
-        ],
-        "notation": "費(つい)やす"
+        ]
     },
     {
         "name": "seitetsu",
         "trans": [
+            "製鉄(せいてつ)",
             "iron manufacture"
-        ],
-        "notation": "製鉄(せいてつ)"
+        ]
     },
     {
         "name": "honne",
         "trans": [
+            "本音(ほんね)",
             "real intention, motive"
-        ],
-        "notation": "本音(ほんね)"
+        ]
     },
     {
         "name": "dokusai",
         "trans": [
+            "独裁(どくさい)",
             "dictatorship, despotism"
-        ],
-        "notation": "独裁(どくさい)"
+        ]
     },
     {
         "name": "chuuritsu",
         "trans": [
+            "中立(ちゅうりつ)",
             "neutrality"
-        ],
-        "notation": "中立(ちゅうりつ)"
+        ]
     },
     {
         "name": "awatadashii",
         "trans": [
+            "慌(あわ)ただしい",
             "busy, hurried, confused, flurried"
-        ],
-        "notation": "慌(あわ)ただしい"
+        ]
     },
     {
         "name": "ori",
         "trans": [
+            "檻(おり)",
             "cage, pen, jail cell"
-        ],
-        "notation": "檻(おり)"
+        ]
     },
     {
         "name": "sokkusu",
         "trans": [
+            "ソックス",
             "socks"
-        ],
-        "notation": "ソックス"
+        ]
     },
     {
         "name": "bajji",
         "trans": [
+            "バッジ",
             "badge"
-        ],
-        "notation": "バッジ"
+        ]
     },
     {
         "name": "bungyou",
         "trans": [
+            "分業(ぶんぎょう)",
             "division of labor, specialization, assembly-line production"
-        ],
-        "notation": "分業(ぶんぎょう)"
+        ]
     },
     {
         "name": "shikumi",
         "trans": [
+            "仕組(しく)み",
             "devising, plan, plot, contrivance, construction, arrangement"
-        ],
-        "notation": "仕組(しく)み"
+        ]
     },
     {
         "name": "chichi",
         "trans": [
+            "乳(ちち)",
             "milk, breast, loop"
-        ],
-        "notation": "乳(ちち)"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "平行(へいこう)",
             "(going) side by side, concurrent, abreast, at the same time, occurring together, parallel, parallelism"
-        ],
-        "notation": "平行(へいこう)"
+        ]
     },
     {
         "name": "taisho",
         "trans": [
+            "対処(たいしょ)",
             "deal with, cope"
-        ],
-        "notation": "対処(たいしょ)"
+        ]
     },
     {
         "name": "dohyou",
         "trans": [
+            "土俵(どひょう)",
             "arena"
-        ],
-        "notation": "土俵(どひょう)"
+        ]
     },
     {
         "name": "yowamaru",
         "trans": [
+            "弱(よわ)まる",
             "to abate, to weaken, to be emaciated, to be dejected, to be perplexed"
-        ],
-        "notation": "弱(よわ)まる"
+        ]
     },
     {
         "name": "jinushi",
         "trans": [
+            "地主(じぬし)",
             "landlord"
-        ],
-        "notation": "地主(じぬし)"
+        ]
     },
     {
         "name": "rakka",
         "trans": [
+            "落下(らっか)",
             "fall, drop, come down"
-        ],
-        "notation": "落下(らっか)"
+        ]
     },
     {
         "name": "henken",
         "trans": [
+            "偏見(へんけん)",
             "prejudice, narrow view"
-        ],
-        "notation": "偏見(へんけん)"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "添(そ)う",
             "to accompany, to become married, to comply with"
-        ],
-        "notation": "添(そ)う"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "期(き)",
             "period, time"
-        ],
-        "notation": "期(き)"
+        ]
     },
     {
         "name": "ikasu",
         "trans": [
+            "生(い)かす",
             "to revive, to resuscitate, to make use of"
-        ],
-        "notation": "生(い)かす"
+        ]
     },
     {
         "name": "honkaku",
         "trans": [
+            "本格(ほんかく)",
             "propriety, fundamental rules"
-        ],
-        "notation": "本格(ほんかく)"
+        ]
     },
     {
         "name": "monozuki",
         "trans": [
+            "物好(ものず)き",
             "curiosity"
-        ],
-        "notation": "物好(ものず)き"
+        ]
     },
     {
         "name": "kyuukon",
         "trans": [
+            "球根(きゅうこん)",
             "(plant) bulb"
-        ],
-        "notation": "球根(きゅうこん)"
+        ]
     },
     {
         "name": "taiguu",
         "trans": [
+            "待遇(たいぐう)",
             "treatment, reception"
-        ],
-        "notation": "待遇(たいぐう)"
+        ]
     },
     {
         "name": "waza",
         "trans": [
+            "技(わざ)",
             "art, technique"
-        ],
-        "notation": "技(わざ)"
+        ]
     },
     {
         "name": "bakeru",
         "trans": [
+            "化(ば)ける",
             "to appear in disguise, to take the form of, to change for the worse"
-        ],
-        "notation": "化(ば)ける"
+        ]
     },
     {
         "name": "bakuha",
         "trans": [
+            "爆破(ばくは)",
             "blast, explosion, blow up"
-        ],
-        "notation": "爆破(ばくは)"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "施行(しこう)",
             "1. execution, enforcing, carrying out"
-        ],
-        "notation": "施行(しこう)"
+        ]
     },
     {
         "name": "tsuide",
         "trans": [
+            "次(つ)いで",
             "next, secondly, subsequently"
-        ],
-        "notation": "次(つ)いで"
+        ]
     },
     {
         "name": "maeuri",
         "trans": [
+            "前売(まえう)り",
             "advance sale, booking"
-        ],
-        "notation": "前売(まえう)り"
+        ]
     },
     {
         "name": "arayuru",
         "trans": [
+            "凡(あら)ゆる",
             "all, every"
-        ],
-        "notation": "凡(あら)ゆる"
+        ]
     },
     {
         "name": "kanryou",
         "trans": [
+            "官僚(かんりょう)",
             "bureaucrat, bureaucracy"
-        ],
-        "notation": "官僚(かんりょう)"
+        ]
     },
     {
         "name": "gawa",
         "trans": [
+            "側(がわ)",
             "side, row, surroundings, part, (watch) case"
-        ],
-        "notation": "側(がわ)"
+        ]
     },
     {
         "name": "maue",
         "trans": [
+            "真上(まうえ)",
             "just above, right overhead"
-        ],
-        "notation": "真上(まうえ)"
+        ]
     },
     {
         "name": "shokuin",
         "trans": [
+            "職員(しょくいん)",
             "staff member, personnel"
-        ],
-        "notation": "職員(しょくいん)"
+        ]
     },
     {
         "name": "kinmotsu",
         "trans": [
+            "禁物(きんもつ)",
             "taboo, forbidden thing"
-        ],
-        "notation": "禁物(きんもつ)"
+        ]
     },
     {
         "name": "shokku",
         "trans": [
+            "ショック",
             "shock"
-        ],
-        "notation": "ショック"
+        ]
     },
     {
         "name": "gidai",
         "trans": [
+            "議題(ぎだい)",
             "topic of discussion, agenda"
-        ],
-        "notation": "議題(ぎだい)"
+        ]
     },
     {
         "name": "doudou",
         "trans": [
+            "堂々(どうどう)",
             "magnificent, grand, impressive"
-        ],
-        "notation": "堂々(どうどう)"
+        ]
     },
     {
         "name": "iesu",
         "trans": [
+            "イエス",
             "Jesus, yes"
-        ],
-        "notation": "イエス"
+        ]
     },
     {
         "name": "tonya",
         "trans": [
+            "問屋(とんや)",
             "wholesale store"
-        ],
-        "notation": "問屋(とんや)"
+        ]
     },
     {
         "name": "shuu",
         "trans": [
+            "衆(しゅう)",
             "masses, great number, the people"
-        ],
-        "notation": "衆(しゅう)"
+        ]
     },
     {
         "name": "tokiori",
         "trans": [
+            "時折(ときおり)",
             "sometimes"
-        ],
-        "notation": "時折(ときおり)"
+        ]
     },
     {
         "name": "teikei",
         "trans": [
+            "提携(ていけい)",
             "cooperation, tie-up, joint business, link-up"
-        ],
-        "notation": "提携(ていけい)"
+        ]
     },
     {
         "name": "fukureru",
         "trans": [
+            "膨(ふく)れる",
             "to get cross, to get sulky, to swell (out), to expand, to be inflated, to distend, to bulge"
-        ],
-        "notation": "膨(ふく)れる"
+        ]
     },
     {
         "name": "kafun",
         "trans": [
+            "花粉(かふん)",
             "pollen"
-        ],
-        "notation": "花粉(かふん)"
+        ]
     },
     {
         "name": "konomashii",
         "trans": [
+            "好(この)ましい",
             "nice, likeable, desirable"
-        ],
-        "notation": "好(この)ましい"
+        ]
     },
     {
         "name": "shuppi",
         "trans": [
+            "出費(しゅっぴ)",
             "expenses, disbursements"
-        ],
-        "notation": "出費(しゅっぴ)"
+        ]
     },
     {
         "name": "tenkin",
         "trans": [
+            "転勤(てんきん)",
             "transfer, transmission"
-        ],
-        "notation": "転勤(てんきん)"
+        ]
     },
     {
         "name": "kodai",
         "trans": [
+            "古代(こだい)",
             "ancient times"
-        ],
-        "notation": "古代(こだい)"
+        ]
     },
     {
         "name": "kouhyou",
         "trans": [
+            "好評(こうひょう)",
             "popularity, favorable reputation"
-        ],
-        "notation": "好評(こうひょう)"
+        ]
     },
     {
         "name": "hajiru",
         "trans": [
+            "恥(は)じる",
             "to feel ashamed"
-        ],
-        "notation": "恥(は)じる"
+        ]
     },
     {
         "name": "kirabiyaka",
         "trans": [
+            "煌(きら)びやか",
             "gorgeous, gaudy, dazzling, gay"
-        ],
-        "notation": "煌(きら)びやか"
+        ]
     },
     {
         "name": "seiken",
         "trans": [
+            "政権(せいけん)",
             "administration, political power"
-        ],
-        "notation": "政権(せいけん)"
+        ]
     },
     {
         "name": "tsuiseki",
         "trans": [
+            "追跡(ついせき)",
             "pursuit"
-        ],
-        "notation": "追跡(ついせき)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "各(かく)",
             "each, every, either, respectively, severally"
-        ],
-        "notation": "各(かく)"
+        ]
     },
     {
         "name": "haifu",
         "trans": [
+            "配布(はいふ)",
             "distribution"
-        ],
-        "notation": "配布(はいふ)"
+        ]
     },
     {
         "name": "izen",
         "trans": [
+            "依然(いぜん)",
             "still, as yet"
-        ],
-        "notation": "依然(いぜん)"
+        ]
     },
     {
         "name": "gappei",
         "trans": [
+            "合併(がっぺい)",
             "combination, union, amalgamation, consolidation, merger, coalition, fusion, annexation, affiliation, incorpor"
-        ],
-        "notation": "合併(がっぺい)"
+        ]
     },
     {
         "name": "kansen",
         "trans": [
+            "幹線(かんせん)",
             "main line, trunk line"
-        ],
-        "notation": "幹線(かんせん)"
+        ]
     },
     {
         "name": "kyoui",
         "trans": [
+            "驚異(きょうい)",
             "wonder, miracle"
-        ],
-        "notation": "驚異(きょうい)"
+        ]
     },
     {
         "name": "heihou",
         "trans": [
+            "平方(へいほう)",
             "square (e.g. metre), square"
-        ],
-        "notation": "平方(へいほう)"
+        ]
     },
     {
         "name": "juujiro",
         "trans": [
+            "十字路(じゅうじろ)",
             "crossroads"
-        ],
-        "notation": "十字路(じゅうじろ)"
+        ]
     },
     {
         "name": "genshu",
         "trans": [
+            "元首(げんしゅ)",
             "ruler, sovereign"
-        ],
-        "notation": "元首(げんしゅ)"
+        ]
     },
     {
         "name": "munou",
         "trans": [
+            "無能(むのう)",
             "inefficiency, incompetence"
-        ],
-        "notation": "無能(むのう)"
+        ]
     },
     {
         "name": "kyouju",
         "trans": [
+            "享受(きょうじゅ)",
             "reception, acceptance, enjoyment, being given"
-        ],
-        "notation": "享受(きょうじゅ)"
+        ]
     },
     {
         "name": "shoushin",
         "trans": [
+            "昇進(しょうしん)",
             "promotion"
-        ],
-        "notation": "昇進(しょうしん)"
+        ]
     },
     {
         "name": "shujinkou",
         "trans": [
+            "主人公(しゅじんこう)",
             "protagonist, main character, hero(ine) (of a story), head of household"
-        ],
-        "notation": "主人公(しゅじんこう)"
+        ]
     },
     {
         "name": "taikin",
         "trans": [
+            "大金(たいきん)",
             "great cost"
-        ],
-        "notation": "大金(たいきん)"
+        ]
     },
     {
         "name": "nozomu",
         "trans": [
+            "臨(のぞ)む",
             "to look out on, to face, to deal with, to attend (function)"
-        ],
-        "notation": "臨(のぞ)む"
+        ]
     },
     {
         "name": "tokuha",
         "trans": [
+            "特派(とくは)",
             "send specially, special envoy"
-        ],
-        "notation": "特派(とくは)"
+        ]
     },
     {
         "name": "fuhai",
         "trans": [
+            "腐敗(ふはい)",
             "decay, depravity"
-        ],
-        "notation": "腐敗(ふはい)"
+        ]
     },
     {
         "name": "seishi",
         "trans": [
+            "静止(せいし)",
             "stillness, repose, standing still"
-        ],
-        "notation": "静止(せいし)"
+        ]
     },
     {
         "name": "keibu",
         "trans": [
+            "警部(けいぶ)",
             "police inspector"
-        ],
-        "notation": "警部(けいぶ)"
+        ]
     },
     {
         "name": "shio",
         "trans": [
+            "潮(しお)",
             "tide"
-        ],
-        "notation": "潮(しお)"
+        ]
     },
     {
         "name": "shokumu",
         "trans": [
+            "職務(しょくむ)",
             "professional duties"
-        ],
-        "notation": "職務(しょくむ)"
+        ]
     },
     {
         "name": "nansensu",
         "trans": [
+            "ナンセンス",
             "nonsense"
-        ],
-        "notation": "ナンセンス"
+        ]
     },
     {
         "name": "arare",
         "trans": [
+            "あられ",
             "kind of cookie, cartoon character"
-        ],
-        "notation": "あられ"
+        ]
     },
     {
         "name": "ikeru",
         "trans": [
+            "活(い)ける",
             "to arrange (flowers)"
-        ],
-        "notation": "活(い)ける"
+        ]
     },
     {
         "name": "memori",
         "trans": [
+            "目盛(めもり)",
             "scale, gradations"
-        ],
-        "notation": "目盛(めもり)"
+        ]
     },
     {
         "name": "hikaeru",
         "trans": [
+            "控(ひか)える",
             "to draw in, to hold back, to make notes, to be temperate in"
-        ],
-        "notation": "控(ひか)える"
+        ]
     },
     {
         "name": "doriru",
         "trans": [
+            "ドリル",
             "drill"
-        ],
-        "notation": "ドリル"
+        ]
     },
     {
         "name": "saizen",
         "trans": [
+            "最善(さいぜん)",
             "the very best"
-        ],
-        "notation": "最善(さいぜん)"
+        ]
     },
     {
         "name": "gikyoku",
         "trans": [
+            "戯曲(ぎきょく)",
             "play, drama"
-        ],
-        "notation": "戯曲(ぎきょく)"
+        ]
     },
     {
         "name": "arumi",
         "trans": [
+            "アルミ",
             "aluminum (Al), aluminium"
-        ],
-        "notation": "アルミ"
+        ]
     },
     {
         "name": "genron",
         "trans": [
+            "言論(げんろん)",
             "discussion"
-        ],
-        "notation": "言論(げんろん)"
+        ]
     },
     {
         "name": "toiawaseru",
         "trans": [
+            "問(と)い合(あ)わせる",
             "to enquire, to seek information"
-        ],
-        "notation": "問(と)い合(あ)わせる"
+        ]
     },
     {
         "name": "hokyuu",
         "trans": [
+            "補給(ほきゅう)",
             "supply, supplying, replenishment"
-        ],
-        "notation": "補給(ほきゅう)"
+        ]
     },
     {
         "name": "keitai",
         "trans": [
+            "携帯(けいたい)",
             "carrying something"
-        ],
-        "notation": "携帯(けいたい)"
+        ]
     },
     {
         "name": "suetsukeru",
         "trans": [
+            "据(す)え付(つ)ける",
             "to install, to equip, to mount"
-        ],
-        "notation": "据(す)え付(つ)ける"
+        ]
     },
     {
         "name": "saikin",
         "trans": [
+            "細菌(さいきん)",
             "bacillus, bacterium, germ"
-        ],
-        "notation": "細菌(さいきん)"
+        ]
     },
     {
         "name": "shibutoi",
         "trans": [
+            "しぶとい",
             "tenacious, stubborn"
-        ],
-        "notation": "しぶとい"
+        ]
     },
     {
         "name": "mashi",
         "trans": [
+            "増(ま)し",
             "extra, additional, less objectionable, better, preferable"
-        ],
-        "notation": "増(ま)し"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "僧(そう)",
             "monk, priest"
-        ],
-        "notation": "僧(そう)"
+        ]
     },
     {
         "name": "besuto",
         "trans": [
+            "ベスト",
             "best, vest"
-        ],
-        "notation": "ベスト"
+        ]
     },
     {
         "name": "shiiku",
         "trans": [
+            "飼育(しいく)",
             "breeding, raising, rearing"
-        ],
-        "notation": "飼育(しいく)"
+        ]
     },
     {
         "name": "memai",
         "trans": [
+            "目眩(めまい)",
             "dizziness, giddiness"
-        ],
-        "notation": "目眩(めまい)"
+        ]
     },
     {
         "name": "tsugu",
         "trans": [
+            "接(つ)ぐ",
             "to join, to piece together, to set (bones), to graft (trees)"
-        ],
-        "notation": "接(つ)ぐ"
+        ]
     },
     {
         "name": "muragaru",
         "trans": [
+            "群(むら)がる",
             "to swarm, to gather"
-        ],
-        "notation": "群(むら)がる"
+        ]
     },
     {
         "name": "numa",
         "trans": [
+            "沼(ぬま)",
             "swamp, bog, pond, lake"
-        ],
-        "notation": "沼(ぬま)"
+        ]
     },
     {
         "name": "kiyo",
         "trans": [
+            "寄与(きよ)",
             "contribution, service"
-        ],
-        "notation": "寄与(きよ)"
+        ]
     },
     {
         "name": "nanite",
         "trans": [
+            "何(なに)て",
             "how...!, what...!"
-        ],
-        "notation": "何(なに)て"
+        ]
     },
     {
         "name": "ikigai",
         "trans": [
+            "域外(いきがい)",
             "outside the area"
-        ],
-        "notation": "域外(いきがい)"
+        ]
     },
     {
         "name": "amai",
         "trans": [
+            "甘(あま)い",
             "delicious"
-        ],
-        "notation": "甘(あま)い"
+        ]
     },
     {
         "name": "magaru",
         "trans": [
+            "曲(ま)がる",
             "to turn, to bend"
-        ],
-        "notation": "曲(ま)がる"
+        ]
     },
     {
         "name": "teokure",
         "trans": [
+            "手遅(ておく)れ",
             "too late, belated treatment"
-        ],
-        "notation": "手遅(ておく)れ"
+        ]
     },
     {
         "name": "jouyaku",
         "trans": [
+            "条約(じょうやく)",
             "treaty, pact"
-        ],
-        "notation": "条約(じょうやく)"
+        ]
     },
     {
         "name": "daun",
         "trans": [
+            "ダウン",
             "down"
-        ],
-        "notation": "ダウン"
+        ]
     },
     {
         "name": "fuchou",
         "trans": [
+            "不調(ふちょう)",
             "bad condition, not to work out (ie a deal), disagreement, break-off, disorder, slump, out of form"
-        ],
-        "notation": "不調(ふちょう)"
+        ]
     },
     {
         "name": "ureyuki",
         "trans": [
+            "売(う)れ行(ゆ)き",
             "sales"
-        ],
-        "notation": "売(う)れ行(ゆ)き"
+        ]
     },
     {
         "name": "magotsuku",
         "trans": [
+            "まごつく",
             "to be confused, to be flustered"
-        ],
-        "notation": "まごつく"
+        ]
     },
     {
         "name": "arappoi",
         "trans": [
+            "荒(あら)っぽい",
             "rough, rude"
-        ],
-        "notation": "荒(あら)っぽい"
+        ]
     },
     {
         "name": "mune",
         "trans": [
+            "棟(むね)",
             "place, section, building"
-        ],
-        "notation": "棟(むね)"
+        ]
     },
     {
         "name": "bachi",
         "trans": [
+            "罰(ばち)",
             "(divine) punishment, curse, retribution"
-        ],
-        "notation": "罰(ばち)"
+        ]
     },
     {
         "name": "imasara",
         "trans": [
+            "今更(いまさら)",
             "now, at this late hour"
-        ],
-        "notation": "今更(いまさら)"
+        ]
     },
     {
         "name": "heikin",
         "trans": [
+            "平均(へいきん)",
             "equilibrium, balance, average, mean"
-        ],
-        "notation": "平均(へいきん)"
+        ]
     },
     {
         "name": "hyotto",
         "trans": [
+            "ひょっと",
             "possibly, accidentally"
-        ],
-        "notation": "ひょっと"
+        ]
     },
     {
         "name": "touron",
         "trans": [
+            "討論(とうろん)",
             "debate, discussion"
-        ],
-        "notation": "討論(とうろん)"
+        ]
     },
     {
         "name": "kokoroe",
         "trans": [
+            "心得(こころえ)",
             "knowledge, information"
-        ],
-        "notation": "心得(こころえ)"
+        ]
     },
     {
         "name": "youbou",
         "trans": [
+            "要望(ようぼう)",
             "demand for, request"
-        ],
-        "notation": "要望(ようぼう)"
+        ]
     },
     {
         "name": "ochiru",
         "trans": [
+            "落(お)ちる",
             "to fail (e.g. exam), to fall down, to drop"
-        ],
-        "notation": "落(お)ちる"
+        ]
     },
     {
         "name": "shitagatte",
         "trans": [
+            "従(したが)って",
             "therefore, consequently, in accordance with"
-        ],
-        "notation": "従(したが)って"
+        ]
     },
     {
         "name": "kizutsuku",
         "trans": [
+            "傷(きず)付(つ)く",
             "to be hurt, to be wounded, to get injured"
-        ],
-        "notation": "傷(きず)付(つ)く"
+        ]
     },
     {
         "name": "shukumei",
         "trans": [
+            "宿命(しゅくめい)",
             "fate, destiny, predestination"
-        ],
-        "notation": "宿命(しゅくめい)"
+        ]
     },
     {
         "name": "dekuwasu",
         "trans": [
+            "出(で)くわす",
             "to happen to meet, to come across"
-        ],
-        "notation": "出(で)くわす"
+        ]
     },
     {
         "name": "hogei",
         "trans": [
+            "捕鯨(ほげい)",
             "whaling, whale fishing"
-        ],
-        "notation": "捕鯨(ほげい)"
+        ]
     },
     {
         "name": "machinozomu",
         "trans": [
+            "待(ま)ち望(のぞ)む",
             "to look anxiously for, to wait eagerly for"
-        ],
-        "notation": "待(ま)ち望(のぞ)む"
+        ]
     },
     {
         "name": "shuuki",
         "trans": [
+            "周期(しゅうき)",
             "cycle, period"
-        ],
-        "notation": "周期(しゅうき)"
+        ]
     },
     {
         "name": "shiba",
         "trans": [
+            "芝(しば)",
             "lawn, sod, turf"
-        ],
-        "notation": "芝(しば)"
+        ]
     },
     {
         "name": "wafuu",
         "trans": [
+            "和風(わふう)",
             "Japanese style"
-        ],
-        "notation": "和風(わふう)"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "老(ふ)ける",
             "to age"
-        ],
-        "notation": "老(ふ)ける"
+        ]
     },
     {
         "name": "juuyaku",
         "trans": [
+            "重役(じゅうやく)",
             "heavy responsibilities, director"
-        ],
-        "notation": "重役(じゅうやく)"
+        ]
     },
     {
         "name": "yogore",
         "trans": [
+            "汚(よご)れ",
             "uncleanness, impurity, disgrace"
-        ],
-        "notation": "汚(よご)れ"
+        ]
     },
     {
         "name": "juku",
         "trans": [
+            "塾(じゅく)",
             "coaching school, lessons"
-        ],
-        "notation": "塾(じゅく)"
+        ]
     },
     {
         "name": "magirawashii",
         "trans": [
+            "紛(まぎ)らわしい",
             "confusing, misleading, equivocal, ambiguous"
-        ],
-        "notation": "紛(まぎ)らわしい"
+        ]
     },
     {
         "name": "kekkan",
         "trans": [
+            "血管(けっかん)",
             "blood vessel"
-        ],
-        "notation": "血管(けっかん)"
+        ]
     },
     {
         "name": "jizen",
         "trans": [
+            "事前(じぜん)",
             "prior, beforehand, in advance"
-        ],
-        "notation": "事前(じぜん)"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "圏(けん)",
             "sphere, circle, range"
-        ],
-        "notation": "圏(けん)"
+        ]
     },
     {
         "name": "naninari",
         "trans": [
+            "何(なに)なり",
             "any, anything, whatever"
-        ],
-        "notation": "何(なに)なり"
+        ]
     },
     {
         "name": "kakimawasu",
         "trans": [
+            "掻(か)き回(まわ)す",
             "to stir up, to churn, to ransack, to disturb"
-        ],
-        "notation": "掻(か)き回(まわ)す"
+        ]
     },
     {
         "name": "mohaya",
         "trans": [
+            "最早(もはや)",
             "already, now"
-        ],
-        "notation": "最早(もはや)"
+        ]
     },
     {
         "name": "ryoukyoku",
         "trans": [
+            "両極(りょうきょく)",
             "both extremities, north and south poles, positive and negative poles"
-        ],
-        "notation": "両極(りょうきょく)"
+        ]
     },
     {
         "name": "kyuugaku",
         "trans": [
+            "休学(きゅうがく)",
             "temporary absence from school, suspension"
-        ],
-        "notation": "休学(きゅうがく)"
+        ]
     },
     {
         "name": "redii",
         "trans": [
+            "レディー",
             "lady"
-        ],
-        "notation": "レディー"
+        ]
     },
     {
         "name": "soshi",
         "trans": [
+            "阻止(そし)",
             "obstruction, check, hindrance, prevention, interdiction"
-        ],
-        "notation": "阻止(そし)"
+        ]
     },
     {
         "name": "uttae",
         "trans": [
+            "訴(うった)え",
             "lawsuit, complaint"
-        ],
-        "notation": "訴(うった)え"
+        ]
     },
     {
         "name": "sagi",
         "trans": [
+            "詐欺(さぎ)",
             "fraud, swindle"
-        ],
-        "notation": "詐欺(さぎ)"
+        ]
     },
     {
         "name": "takibi",
         "trans": [
+            "焚火(たきび)",
             "(open) fire"
-        ],
-        "notation": "焚火(たきび)"
+        ]
     },
     {
         "name": "sakadachi",
         "trans": [
+            "逆立(さかだ)ち",
             "handstand, headstand"
-        ],
-        "notation": "逆立(さかだ)ち"
+        ]
     },
     {
         "name": "hitokoto",
         "trans": [
+            "一言(ひとこと)",
             "single word"
-        ],
-        "notation": "一言(ひとこと)"
+        ]
     },
     {
         "name": "katayoru",
         "trans": [
+            "偏(かたよ)る",
             "to be one-sided, to incline, to be partial, to be prejudiced, to lean, to be biased"
-        ],
-        "notation": "偏(かたよ)る"
+        ]
     },
     {
         "name": "douin",
         "trans": [
+            "動員(どういん)",
             "mobilization"
-        ],
-        "notation": "動員(どういん)"
+        ]
     },
     {
         "name": "ayamachi",
         "trans": [
+            "過(あやま)ち",
             "fault, error, indiscretion"
-        ],
-        "notation": "過(あやま)ち"
+        ]
     },
     {
         "name": "tanso",
         "trans": [
+            "炭素(たんそ)",
             "carbon (C)"
-        ],
-        "notation": "炭素(たんそ)"
+        ]
     },
     {
         "name": "kanyou",
         "trans": [
+            "寛容(かんよう)",
             "forbearance, tolerance, generosity"
-        ],
-        "notation": "寛容(かんよう)"
+        ]
     },
     {
         "name": "kanrei",
         "trans": [
+            "慣例(かんれい)",
             "custom, precedent, of convention"
-        ],
-        "notation": "慣例(かんれい)"
+        ]
     },
     {
         "name": "raisu",
         "trans": [
+            "ライス",
             "rice"
-        ],
-        "notation": "ライス"
+        ]
     },
     {
         "name": "shiireru",
         "trans": [
+            "仕入(しい)れる",
             "to lay in stock, to replenish stock, to procure"
-        ],
-        "notation": "仕入(しい)れる"
+        ]
     },
     {
         "name": "tsukurou",
         "trans": [
+            "繕(つくろ)う",
             "to mend, to repair, to fix, to patch up, to darn, to tidy up, to adjust, to trim"
-        ],
-        "notation": "繕(つくろ)う"
+        ]
     },
     {
         "name": "hokorobiru",
         "trans": [
+            "綻(ほころ)びる",
             "to come apart at the seams, to begin to open, to smile broadly"
-        ],
-        "notation": "綻(ほころ)びる"
+        ]
     },
     {
         "name": "odaijini",
         "trans": [
+            "お大事(だいじ)に",
             "Take care of yourself"
-        ],
-        "notation": "お大事(だいじ)に"
+        ]
     },
     {
         "name": "tenjiru",
         "trans": [
+            "転(てん)じる",
             "to turn, to shift, to alter, to distract"
-        ],
-        "notation": "転(てん)じる"
+        ]
     },
     {
         "name": "tandoku",
         "trans": [
+            "単独(たんどく)",
             "sole, independence, single, solo (flight)"
-        ],
-        "notation": "単独(たんどく)"
+        ]
     },
     {
         "name": "hima",
         "trans": [
+            "暇(ひま)",
             "free time, leisure, leave, spare time, farewell"
-        ],
-        "notation": "暇(ひま)"
+        ]
     },
     {
         "name": "romanchikku",
         "trans": [
+            "ロマンチック",
             "romantic"
-        ],
-        "notation": "ロマンチック"
+        ]
     },
     {
         "name": "kinmu",
         "trans": [
+            "勤務(きんむ)",
             "service, duty, work"
-        ],
-        "notation": "勤務(きんむ)"
+        ]
     },
     {
         "name": "gensho",
         "trans": [
+            "原書(げんしょ)",
             "original document"
-        ],
-        "notation": "原書(げんしょ)"
+        ]
     },
     {
         "name": "gaido",
         "trans": [
+            "ガイド",
             "tour guide"
-        ],
-        "notation": "ガイド"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "賭(か)ける",
             "to wager, to bet, to risk, to stake, to gamble"
-        ],
-        "notation": "賭(か)ける"
+        ]
     },
     {
         "name": "kushami",
         "trans": [
+            "嚏(くしゃみ)",
             "sneeze"
-        ],
-        "notation": "嚏(くしゃみ)"
+        ]
     },
     {
         "name": "itsuka",
         "trans": [
+            "何時(いつ)か",
             "sometime, someday, one day, some time or other, the other day, in due course, in time"
-        ],
-        "notation": "何時(いつ)か"
+        ]
     },
     {
         "name": "majiwaru",
         "trans": [
+            "交(まじ)わる",
             "to cross, to intersect, to associate with, to mingle with, to interest, to join"
-        ],
-        "notation": "交(まじ)わる"
+        ]
     },
     {
         "name": "anzan",
         "trans": [
+            "暗算(あんざん)",
             "mental arithmetic"
-        ],
-        "notation": "暗算(あんざん)"
+        ]
     },
     {
         "name": "shotei",
         "trans": [
+            "所定(しょてい)",
             "fixed, prescribed"
-        ],
-        "notation": "所定(しょてい)"
+        ]
     },
     {
         "name": "jojo",
         "trans": [
+            "徐(じょ)々",
             "gradually, steadily, quietly, slowly, soon"
-        ],
-        "notation": "徐(じょ)々"
+        ]
     },
     {
         "name": "kokudo",
         "trans": [
+            "国土(こくど)",
             "realm"
-        ],
-        "notation": "国土(こくど)"
+        ]
     },
     {
         "name": "interi",
         "trans": [
+            "インテリ",
             "egghead, intelligentsia"
-        ],
-        "notation": "インテリ"
+        ]
     },
     {
         "name": "nogareru",
         "trans": [
+            "逃(のが)れる",
             "to escape"
-        ],
-        "notation": "逃(のが)れる"
+        ]
     },
     {
         "name": "iseki",
         "trans": [
+            "遺跡(いせき)",
             "historic ruins (remains relics)"
-        ],
-        "notation": "遺跡(いせき)"
+        ]
     },
     {
         "name": "tsutomesaki",
         "trans": [
+            "勤(つと)め先(さき)",
             "place of work"
-        ],
-        "notation": "勤(つと)め先(さき)"
+        ]
     },
     {
         "name": "iryoku",
         "trans": [
+            "威力(いりょく)",
             "power, might, authority, influence"
-        ],
-        "notation": "威力(いりょく)"
+        ]
     },
     {
         "name": "tsukasadoru",
         "trans": [
+            "司(つかさど)る",
             "to rule, to govern, to administer"
-        ],
-        "notation": "司(つかさど)る"
+        ]
     },
     {
         "name": "seiretsu",
         "trans": [
+            "整列(せいれつ)",
             "stand in a row, form a line"
-        ],
-        "notation": "整列(せいれつ)"
+        ]
     },
     {
         "name": "ku",
         "trans": [
+            "区(く)",
             "ward, district, section"
-        ],
-        "notation": "区(く)"
+        ]
     },
     {
         "name": "nandakanda",
         "trans": [
+            "なんだかんだ",
             "something or other"
-        ],
-        "notation": "なんだかんだ"
+        ]
     },
     {
         "name": "ochikomu",
         "trans": [
+            "落(お)ち込(こ)む",
             "to fall into, to feel down (sad)"
-        ],
-        "notation": "落(お)ち込(こ)む"
+        ]
     },
     {
         "name": "hourikomu",
         "trans": [
+            "放(ほう)り込(こ)む",
             "to throw into"
-        ],
-        "notation": "放(ほう)り込(こ)む"
+        ]
     },
     {
         "name": "mitei",
         "trans": [
+            "未定(みてい)",
             "not yet fixed, undecided, pending"
-        ],
-        "notation": "未定(みてい)"
+        ]
     },
     {
         "name": "suisou",
         "trans": [
+            "吹奏(すいそう)",
             "playing wind instruments"
-        ],
-        "notation": "吹奏(すいそう)"
+        ]
     },
     {
         "name": "gyousei",
         "trans": [
+            "行政(ぎょうせい)",
             "administration"
-        ],
-        "notation": "行政(ぎょうせい)"
+        ]
     },
     {
         "name": "choudo",
         "trans": [
+            "恰(ちょう)度(ど)",
             "just, right, exactly"
-        ],
-        "notation": "恰(ちょう)度(ど)"
+        ]
     },
     {
         "name": "muyou",
         "trans": [
+            "無用(むよう)",
             "useless, futility, needlessness, unnecessariness"
-        ],
-        "notation": "無用(むよう)"
+        ]
     },
     {
         "name": "kimaru",
         "trans": [
+            "決(き)まる",
             "to be decided, to be settled, to look good in (clothes)"
-        ],
-        "notation": "決(き)まる"
+        ]
     },
     {
         "name": "rentakaa",
         "trans": [
+            "レンタカー",
             "hire car (lit: rent-a-car)"
-        ],
-        "notation": "レンタカー"
+        ]
     },
     {
         "name": "shinzen",
         "trans": [
+            "親善(しんぜん)",
             "friendship"
-        ],
-        "notation": "親善(しんぜん)"
+        ]
     },
     {
         "name": "kurekuremo",
         "trans": [
+            "呉(く)れ呉(く)れも",
             "repeatedly, sincerely, earnestly"
-        ],
-        "notation": "呉(く)れ呉(く)れも"
+        ]
     },
     {
         "name": "tsuukan",
         "trans": [
+            "痛感(つうかん)",
             "feeling keenly, fully realizing"
-        ],
-        "notation": "痛感(つうかん)"
+        ]
     },
     {
         "name": "sonosho",
         "trans": [
+            "其(その)処(しょ)",
             "that place, there"
-        ],
-        "notation": "其(その)処(しょ)"
+        ]
     },
     {
         "name": "sai",
         "trans": [
+            "際(さい)",
             "edge, brink, verge, side"
-        ],
-        "notation": "際(さい)"
+        ]
     },
     {
         "name": "sonoshode",
         "trans": [
+            "其(その)処(しょ)で",
             "so (conj), accordingly, now, then, thereupon"
-        ],
-        "notation": "其(その)処(しょ)で"
+        ]
     },
     {
         "name": "kounetsuhi",
         "trans": [
+            "光熱(こうねつ)費(ひ)",
             "cost of fuel and light"
-        ],
-        "notation": "光熱(こうねつ)費(ひ)"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "補償(ほしょう)",
             "compensation, reparation"
-        ],
-        "notation": "補償(ほしょう)"
+        ]
     },
     {
         "name": "kekkou",
         "trans": [
+            "決行(けっこう)",
             "doing (with resolve), carrying out (i.e. a plan)"
-        ],
-        "notation": "決行(けっこう)"
+        ]
     },
     {
         "name": "kanzei",
         "trans": [
+            "関税(かんぜい)",
             "customs, duty, tariff"
-        ],
-        "notation": "関税(かんぜい)"
+        ]
     },
     {
         "name": "sasageru",
         "trans": [
+            "捧(ささ)げる",
             "to lift up, to give, to offer, to consecrate, to devote, to sacrifice, to dedicate"
-        ],
-        "notation": "捧(ささ)げる"
+        ]
     },
     {
         "name": "odateru",
         "trans": [
+            "煽(おだ)てる",
             "to stir up, to instigate, to flatter"
-        ],
-        "notation": "煽(おだ)てる"
+        ]
     },
     {
         "name": "dangen",
         "trans": [
+            "断言(だんげん)",
             "declaration, affirmation"
-        ],
-        "notation": "断言(だんげん)"
+        ]
     },
     {
         "name": "kousui",
         "trans": [
+            "降水(こうすい)",
             "rainfall, precipitation"
-        ],
-        "notation": "降水(こうすい)"
+        ]
     },
     {
         "name": "danpu",
         "trans": [
+            "ダンプ",
             "dump"
-        ],
-        "notation": "ダンプ"
+        ]
     },
     {
         "name": "gomennasai",
         "trans": [
+            "御免(ごめん)なさい",
             "I beg your pardon, excuse me"
-        ],
-        "notation": "御免(ごめん)なさい"
+        ]
     },
     {
         "name": "gaidobukku",
         "trans": [
+            "ガイドブック",
             "guidebook"
-        ],
-        "notation": "ガイドブック"
+        ]
     },
     {
         "name": "hameru",
         "trans": [
+            "填(は)める",
             "to get in, to insert, to put on, to make love"
-        ],
-        "notation": "填(は)める"
+        ]
     },
     {
         "name": "maemotte",
         "trans": [
+            "前(まえ)もって",
             "in advance, beforehand, previously"
-        ],
-        "notation": "前(まえ)もって"
+        ]
     },
     {
         "name": "pouzu",
         "trans": [
+            "ポーズ",
             "pause"
-        ],
-        "notation": "ポーズ"
+        ]
     },
     {
         "name": "kiddo",
         "trans": [
+            "屹(キッ)度(ど)",
             "1. (uk) surely, undoubtedly, certainly, without fail, 2. sternly, severely"
-        ],
-        "notation": "屹(キッ)度(ど)"
+        ]
     },
     {
         "name": "yoroshiku",
         "trans": [
+            "宜(よろ)しく",
             "well, properly, suitably, best regards, please remember me"
-        ],
-        "notation": "宜(よろ)しく"
+        ]
     },
     {
         "name": "oosuji",
         "trans": [
+            "大筋(おおすじ)",
             "outline, summary"
-        ],
-        "notation": "大筋(おおすじ)"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "資格(しかく)",
             "qualifications, requirements, capabilities"
-        ],
-        "notation": "資格(しかく)"
+        ]
     },
     {
         "name": "nikushimi",
         "trans": [
+            "憎(にく)しみ",
             "hatred"
-        ],
-        "notation": "憎(にく)しみ"
+        ]
     },
     {
         "name": "kanete",
         "trans": [
+            "兼(か)ねて",
             "simultaneously"
-        ],
-        "notation": "兼(か)ねて"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "修士(しゅうし)",
             "Masters degree program"
-        ],
-        "notation": "修士(しゅうし)"
+        ]
     },
     {
         "name": "shuugyou",
         "trans": [
+            "就業(しゅうぎょう)",
             "employment, starting work"
-        ],
-        "notation": "就業(しゅうぎょう)"
+        ]
     },
     {
         "name": "agari",
         "trans": [
+            "上(あ)がり",
             "1. slope, advance income, crop yield, ascent, rise, advance, death, spinning, completion, stop, finish, after"
-        ],
-        "notation": "上(あ)がり"
+        ]
     },
     {
         "name": "senkyou",
         "trans": [
+            "宣教(せんきょう)",
             "religious mission"
-        ],
-        "notation": "宣教(せんきょう)"
+        ]
     },
     {
         "name": "shigarami",
         "trans": [
+            "柵(しがらみ)",
             "fence, paling"
-        ],
-        "notation": "柵(しがらみ)"
+        ]
     },
     {
         "name": "matsufutatsu",
         "trans": [
+            "真(ま)っ二(ふた)つ",
             "in two equal parts"
-        ],
-        "notation": "真(ま)っ二(ふた)つ"
+        ]
     },
     {
         "name": "kurabu",
         "trans": [
+            "クラブ",
             "club, crab"
-        ],
-        "notation": "クラブ"
+        ]
     },
     {
         "name": "enshutsu",
         "trans": [
+            "演出(えんしゅつ)",
             "production (e.g. play), direction"
-        ],
-        "notation": "演出(えんしゅつ)"
+        ]
     },
     {
         "name": "shihatsu",
         "trans": [
+            "始発(しはつ)",
             "first train"
-        ],
-        "notation": "始発(しはつ)"
+        ]
     },
     {
         "name": "shitsu",
         "trans": [
+            "室(しつ)",
             "room"
-        ],
-        "notation": "室(しつ)"
+        ]
     },
     {
         "name": "rouhi",
         "trans": [
+            "浪費(ろうひ)",
             "waste, extravagance"
-        ],
-        "notation": "浪費(ろうひ)"
+        ]
     },
     {
         "name": "tsue",
         "trans": [
+            "杖(つえ)",
             "cane"
-        ],
-        "notation": "杖(つえ)"
+        ]
     },
     {
         "name": "tanshuku",
         "trans": [
+            "短縮(たんしゅく)",
             "shortening, abbreviation, reduction"
-        ],
-        "notation": "短縮(たんしゅく)"
+        ]
     },
     {
         "name": "kanketsu",
         "trans": [
+            "簡潔(かんけつ)",
             "brevity, conciseness, simplicity"
-        ],
-        "notation": "簡潔(かんけつ)"
+        ]
     },
     {
         "name": "shiteki",
         "trans": [
+            "指摘(してき)",
             "pointing out, identification"
-        ],
-        "notation": "指摘(してき)"
+        ]
     },
     {
         "name": "sansei",
         "trans": [
+            "賛成(さんせい)",
             "approval, agreement, support, favour"
-        ],
-        "notation": "賛成(さんせい)"
+        ]
     },
     {
         "name": "nagashi",
         "trans": [
+            "流(なが)し",
             "sink"
-        ],
-        "notation": "流(なが)し"
+        ]
     },
     {
         "name": "-koyuu",
         "trans": [
+            "-固有(こゆう)",
             "characteristic, tradition, peculiar, inherent, eigen"
-        ],
-        "notation": "-固有(こゆう)"
+        ]
     },
     {
         "name": "hagemasu",
         "trans": [
+            "励(はげ)ます",
             "to encourage, to cheer, to raise (the voice)"
-        ],
-        "notation": "励(はげ)ます"
+        ]
     },
     {
         "name": "kakageru",
         "trans": [
+            "掲(かか)げる",
             "to publish, to print, to carry (an article), to put up, to hang out, to hoist, to fly (a sail), to float (a"
-        ],
-        "notation": "掲(かか)げる"
+        ]
     },
     {
         "name": "bosshuu",
         "trans": [
+            "没収(ぼっしゅう)",
             "forfeited"
-        ],
-        "notation": "没収(ぼっしゅう)"
+        ]
     },
     {
         "name": "kenyaku",
         "trans": [
+            "倹約(けんやく)",
             "thrift, economy, frugality"
-        ],
-        "notation": "倹約(けんやく)"
+        ]
     },
     {
         "name": "ikanimo",
         "trans": [
+            "如何(いか)にも",
             "indeed, really, phrase meaning agreement"
-        ],
-        "notation": "如何(いか)にも"
+        ]
     },
     {
         "name": "omo",
         "trans": [
+            "重(おも)",
             "-fold, -ply"
-        ],
-        "notation": "重(おも)"
+        ]
     },
     {
         "name": "hayameru",
         "trans": [
+            "早(はや)める",
             "to hasten, to quicken, to expedite, to precipitate, to accelerate"
-        ],
-        "notation": "早(はや)める"
+        ]
     },
     {
         "name": "hosou",
         "trans": [
+            "舗装(ほそう)",
             "pavement, road surface"
-        ],
-        "notation": "舗装(ほそう)"
+        ]
     },
     {
         "name": "yokozuna",
         "trans": [
+            "横綱(よこづな)",
             "sumo grand champion"
-        ],
-        "notation": "横綱(よこづな)"
+        ]
     },
     {
         "name": "jakkan",
         "trans": [
+            "若干(じゃっかん)",
             "some, few, number of"
-        ],
-        "notation": "若干(じゃっかん)"
+        ]
     },
     {
         "name": "choushinki",
         "trans": [
+            "聴診(ちょうしん)器(き)",
             "stethoscope"
-        ],
-        "notation": "聴診(ちょうしん)器(き)"
+        ]
     },
     {
         "name": "gisei",
         "trans": [
+            "犠牲(ぎせい)",
             "sacrifice"
-        ],
-        "notation": "犠牲(ぎせい)"
+        ]
     },
     {
         "name": "gomenkudasai",
         "trans": [
+            "御免(ごめん)ください",
             "May I come in?"
-        ],
-        "notation": "御免(ごめん)ください"
+        ]
     },
     {
         "name": "gian",
         "trans": [
+            "議案(ぎあん)",
             "legislative bill"
-        ],
-        "notation": "議案(ぎあん)"
+        ]
     },
     {
         "name": "shuugaku",
         "trans": [
+            "修学(しゅうがく)",
             "learning"
-        ],
-        "notation": "修学(しゅうがく)"
+        ]
     },
     {
         "name": "akari",
         "trans": [
+            "灯(あかり)",
             "light"
-        ],
-        "notation": "灯(あかり)"
+        ]
     },
     {
         "name": "enkyoku",
         "trans": [
+            "婉曲(えんきょく)",
             "euphemistic, circumlocution, roundabout, indirect, insinuating"
-        ],
-        "notation": "婉曲(えんきょく)"
+        ]
     },
     {
         "name": "hikisageru",
         "trans": [
+            "引(ひ)き下(さ)げる",
             "to pull down, to lower, to reduce, to withdraw"
-        ],
-        "notation": "引(ひ)き下(さ)げる"
+        ]
     },
     {
         "name": "okage",
         "trans": [
+            "お蔭(かげ)",
             "(your) backing, assistance"
-        ],
-        "notation": "お蔭(かげ)"
+        ]
     },
     {
         "name": "kakuteru",
         "trans": [
+            "カクテル",
             "cocktail"
-        ],
-        "notation": "カクテル"
+        ]
     },
     {
         "name": "tokusan",
         "trans": [
+            "特産(とくさん)",
             "specialty, special product"
-        ],
-        "notation": "特産(とくさん)"
+        ]
     },
     {
         "name": "nigiwau",
         "trans": [
+            "賑(にぎ)わう",
             "to prosper, to flourish, to do thriving business, to be crowded with people"
-        ],
-        "notation": "賑(にぎ)わう"
+        ]
     },
     {
         "name": "takumashii",
         "trans": [
+            "逞(たくま)しい",
             "burly, strong, sturdy"
-        ],
-        "notation": "逞(たくま)しい"
+        ]
     },
     {
         "name": "ankeeto",
         "trans": [
+            "アンケート",
             "(fr:) (n) questionnaire (fr: enquete), survey"
-        ],
-        "notation": "アンケート"
+        ]
     },
     {
         "name": "youhin",
         "trans": [
+            "用品(ようひん)",
             "articles, supplies, parts"
-        ],
-        "notation": "用品(ようひん)"
+        ]
     },
     {
         "name": "ochiba",
         "trans": [
+            "落(お)ち葉(ば)",
             "fallen leaves, leaf litter, defoliation, shedding leaves"
-        ],
-        "notation": "落(お)ち葉(ば)"
+        ]
     },
     {
         "name": "toshigoro",
         "trans": [
+            "年頃(としごろ)",
             "age, marriageable age, age of puberty, adolescence, for some years"
-        ],
-        "notation": "年頃(としごろ)"
+        ]
     },
     {
         "name": "kisuu",
         "trans": [
+            "奇数(きすう)",
             "odd number"
-        ],
-        "notation": "奇数(きすう)"
+        ]
     },
     {
         "name": "choushuu",
         "trans": [
+            "徴収(ちょうしゅう)",
             "collection, levy"
-        ],
-        "notation": "徴収(ちょうしゅう)"
+        ]
     },
     {
         "name": "okasu",
         "trans": [
+            "犯(おか)す",
             "to commit, to perpetrate, to violate, to rape"
-        ],
-        "notation": "犯(おか)す"
+        ]
     },
     {
         "name": "seron",
         "trans": [
+            "世論(せろん)",
             "public opinion"
-        ],
-        "notation": "世論(せろん)"
+        ]
     },
     {
         "name": "musubitsuku",
         "trans": [
+            "結(むす)び付(つ)く",
             "to be connected or related, to join together"
-        ],
-        "notation": "結(むす)び付(つ)く"
+        ]
     },
     {
         "name": "jidoushi",
         "trans": [
+            "自動詞(じどうし)",
             "intransitive verb (no direct obj)"
-        ],
-        "notation": "自動詞(じどうし)"
+        ]
     },
     {
         "name": "fukitsu",
         "trans": [
+            "不吉(ふきつ)",
             "ominous, sinister, bad luck, ill omen, inauspiciousness"
-        ],
-        "notation": "不吉(ふきつ)"
+        ]
     },
     {
         "name": "futsu",
         "trans": [
+            "仏(ふつ)",
             "French"
-        ],
-        "notation": "仏(ふつ)"
+        ]
     },
     {
         "name": "dandan",
         "trans": [
+            "段々(だんだん)",
             "gradually, by degrees"
-        ],
-        "notation": "段々(だんだん)"
+        ]
     },
     {
         "name": "kuukan",
         "trans": [
+            "空間(くうかん)",
             "vacancy, room for rent or lease"
-        ],
-        "notation": "空間(くうかん)"
+        ]
     },
     {
         "name": "supiido",
         "trans": [
+            "スピード",
             "speed"
-        ],
-        "notation": "スピード"
+        ]
     },
     {
         "name": "tojiru",
         "trans": [
+            "綴(と)じる",
             "to bind, to file"
-        ],
-        "notation": "綴(と)じる"
+        ]
     },
     {
         "name": "jikkuri",
         "trans": [
+            "じっくり",
             "deliberately, carefully"
-        ],
-        "notation": "じっくり"
+        ]
     },
     {
         "name": "danzen",
         "trans": [
+            "断然(だんぜん)",
             "firmly, absolutely, definitely"
-        ],
-        "notation": "断然(だんぜん)"
+        ]
     },
     {
         "name": "okonai",
         "trans": [
+            "行(おこな)い",
             "deed, conduct, behavior, action, asceticism"
-        ],
-        "notation": "行(おこな)い"
+        ]
     },
     {
         "name": "u",
         "trans": [
+            "卯(う)",
             "fourth sign of Chinese zodiac (The Hare 5am-7am east February)"
-        ],
-        "notation": "卯(う)"
+        ]
     },
     {
         "name": "tomari",
         "trans": [
+            "泊(とまり)",
             "counter for nights of a stay"
-        ],
-        "notation": "泊(とまり)"
+        ]
     },
     {
         "name": "tsukanoma",
         "trans": [
+            "束(つか)の間(ま)",
             "moment, brief time, brief, transient"
-        ],
-        "notation": "束(つか)の間(ま)"
+        ]
     },
     {
         "name": "hone",
         "trans": [
+            "骨(ほね)",
             "knack, skill"
-        ],
-        "notation": "骨(ほね)"
+        ]
     },
     {
         "name": "haishi",
         "trans": [
+            "廃止(はいし)",
             "abolition, repeal"
-        ],
-        "notation": "廃止(はいし)"
+        ]
     },
     {
         "name": "dokusha",
         "trans": [
+            "読者(どくしゃ)",
             "reader"
-        ],
-        "notation": "読者(どくしゃ)"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "園(えん)",
             "garden, park, plantation"
-        ],
-        "notation": "園(えん)"
+        ]
     },
     {
         "name": "chuudan",
         "trans": [
+            "中断(ちゅうだん)",
             "interruption, suspension, break"
-        ],
-        "notation": "中断(ちゅうだん)"
+        ]
     },
     {
         "name": "shinka",
         "trans": [
+            "進化(しんか)",
             "evolution, progress"
-        ],
-        "notation": "進化(しんか)"
+        ]
     },
     {
         "name": "sao",
         "trans": [
+            "竿(さお)",
             "rod, pole (e.g. for drying laundry)"
-        ],
-        "notation": "竿(さお)"
+        ]
     },
     {
         "name": "shitadori",
         "trans": [
+            "下取(したど)り",
             "trade in, part exchange"
-        ],
-        "notation": "下取(したど)り"
+        ]
     },
     {
         "name": "kanroku",
         "trans": [
+            "貫禄(かんろく)",
             "presence, dignity"
-        ],
-        "notation": "貫禄(かんろく)"
+        ]
     },
     {
         "name": "sanbashi",
         "trans": [
+            "桟橋(さんばし)",
             "wharf, bridge, jetty, pier"
-        ],
-        "notation": "桟橋(さんばし)"
+        ]
     },
     {
         "name": "kousaku",
         "trans": [
+            "耕作(こうさく)",
             "cultivation, farming"
-        ],
-        "notation": "耕作(こうさく)"
+        ]
     },
     {
         "name": "akubi",
         "trans": [
+            "悪日(あくび)",
             "unlucky day"
-        ],
-        "notation": "悪日(あくび)"
+        ]
     },
     {
         "name": "netamu",
         "trans": [
+            "妬(ねた)む",
             "to be jealous, to be envious"
-        ],
-        "notation": "妬(ねた)む"
+        ]
     },
     {
         "name": "kurouto",
         "trans": [
+            "玄人(くろうと)",
             "expert, professional, geisha, prostitute"
-        ],
-        "notation": "玄人(くろうと)"
+        ]
     },
     {
         "name": "inkan",
         "trans": [
+            "印鑑(いんかん)",
             "stamp, seal"
-        ],
-        "notation": "印鑑(いんかん)"
+        ]
     },
     {
         "name": "gunpuku",
         "trans": [
+            "軍服(ぐんぷく)",
             "military or naval uniform"
-        ],
-        "notation": "軍服(ぐんぷく)"
+        ]
     },
     {
         "name": "tachimachi",
         "trans": [
+            "忽(たちま)ち",
             "at once, in a moment, suddenly, all at once"
-        ],
-        "notation": "忽(たちま)ち"
+        ]
     },
     {
         "name": "anjiru",
         "trans": [
+            "案(あん)じる",
             "to be anxious, to ponder"
-        ],
-        "notation": "案(あん)じる"
+        ]
     },
     {
         "name": "kontorouru",
         "trans": [
+            "コントロール",
             "control"
-        ],
-        "notation": "コントロール"
+        ]
     },
     {
         "name": "kusuguguttai",
         "trans": [
+            "擽(くすぐ)ぐったい",
             "ticklish"
-        ],
-        "notation": "擽(くすぐ)ぐったい"
+        ]
     },
     {
         "name": "seiza",
         "trans": [
+            "星座(せいざ)",
             "constellation"
-        ],
-        "notation": "星座(せいざ)"
+        ]
     },
     {
         "name": "jitsugyouka",
         "trans": [
+            "実業(じつぎょう)家(か)",
             "industrialist, businessman"
-        ],
-        "notation": "実業(じつぎょう)家(か)"
+        ]
     },
     {
         "name": "oto",
         "trans": [
+            "音(おと)",
             "sound, note"
-        ],
-        "notation": "音(おと)"
+        ]
     },
     {
         "name": "shiriai",
         "trans": [
+            "知(し)り合(あ)い",
             "acquaintance"
-        ],
-        "notation": "知(し)り合(あ)い"
+        ]
     },
     {
         "name": "yuui",
         "trans": [
+            "優位(ゆうい)",
             "predominance, ascendancy, superiority"
-        ],
-        "notation": "優位(ゆうい)"
+        ]
     },
     {
         "name": "sorekara",
         "trans": [
+            "其(そ)れから",
             "and then, after that"
-        ],
-        "notation": "其(そ)れから"
+        ]
     },
     {
         "name": "chiratto",
         "trans": [
+            "ちらっと",
             "at a glance, by accident"
-        ],
-        "notation": "ちらっと"
+        ]
     },
     {
         "name": "kaikyou",
         "trans": [
+            "海峡(かいきょう)",
             "channel"
-        ],
-        "notation": "海峡(かいきょう)"
+        ]
     },
     {
         "name": "deiriguchi",
         "trans": [
+            "出入(でい)り口(ぐち)",
             "exit and entrance"
-        ],
-        "notation": "出入(でい)り口(ぐち)"
+        ]
     },
     {
         "name": "shitsukeru",
         "trans": [
+            "仕付(しつ)ける",
             "to be used to a job, to begin to do, to baste, to tack, to plant"
-        ],
-        "notation": "仕付(しつ)ける"
+        ]
     },
     {
         "name": "doraibaa",
         "trans": [
+            "ドライバー",
             "driver, screwdriver"
-        ],
-        "notation": "ドライバー"
+        ]
     },
     {
         "name": "asoko",
         "trans": [
+            "彼処(あそこ)",
             "1. (uk) there, over there, that place, 2. (X) (col) genitals"
-        ],
-        "notation": "彼処(あそこ)"
+        ]
     },
     {
         "name": "kouyou",
         "trans": [
+            "公用(こうよう)",
             "government business, public use, public expense"
-        ],
-        "notation": "公用(こうよう)"
+        ]
     },
     {
         "name": "nanigenai",
         "trans": [
+            "何気(なにげ)ない",
             "casual, unconcerned"
-        ],
-        "notation": "何気(なにげ)ない"
+        ]
     },
     {
         "name": "kiyaku",
         "trans": [
+            "規約(きやく)",
             "agreement, rules, code"
-        ],
-        "notation": "規約(きやく)"
+        ]
     },
     {
         "name": "yami",
         "trans": [
+            "闇(やみ)",
             "darkness, the dark, black-marketeering, dark, shady, illegal"
-        ],
-        "notation": "闇(やみ)"
+        ]
     },
     {
         "name": "daburu",
         "trans": [
+            "ダブる",
             "to coincide (fall on the same day), to have two of something, to repeat a school year after failing"
-        ],
-        "notation": "ダブる"
+        ]
     },
     {
         "name": "muchakucha",
         "trans": [
+            "無茶苦茶(むちゃくちゃ)",
             "confused, jumbled, mixed up, unreasonable"
-        ],
-        "notation": "無茶苦茶(むちゃくちゃ)"
+        ]
     },
     {
         "name": "senshuu",
         "trans": [
+            "専修(せんしゅう)",
             "specialization"
-        ],
-        "notation": "専修(せんしゅう)"
+        ]
     },
     {
         "name": "bouseki",
         "trans": [
+            "紡績(ぼうせき)",
             "spinning"
-        ],
-        "notation": "紡績(ぼうせき)"
+        ]
     },
     {
         "name": "kessan",
         "trans": [
+            "決算(けっさん)",
             "balance sheet, settlement of accounts"
-        ],
-        "notation": "決算(けっさん)"
+        ]
     },
     {
         "name": "yuusuru",
         "trans": [
+            "有(ゆう)する",
             "to own, to be endowed with"
-        ],
-        "notation": "有(ゆう)する"
+        ]
     },
     {
         "name": "haibun",
         "trans": [
+            "配分(はいぶん)",
             "distribution, allotment"
-        ],
-        "notation": "配分(はいぶん)"
+        ]
     },
     {
         "name": "tadoritsuku",
         "trans": [
+            "辿(たど)り着(つ)く",
             "to grope along to, to struggle on to, to arrive somewhere after a struggle"
-        ],
-        "notation": "辿(たど)り着(つ)く"
+        ]
     },
     {
         "name": "hooppeta",
         "trans": [
+            "頬(ほお)っぺた",
             "cheek"
-        ],
-        "notation": "頬(ほお)っぺた"
+        ]
     },
     {
         "name": "sai",
         "trans": [
+            "差異(さい)",
             "difference, disparity"
-        ],
-        "notation": "差異(さい)"
+        ]
     },
     {
         "name": "koru",
         "trans": [
+            "凝(こ)る",
             "to congeal, to freeze"
-        ],
-        "notation": "凝(こ)る"
+        ]
     },
     {
         "name": "senpaku",
         "trans": [
+            "船舶(せんぱく)",
             "ship"
-        ],
-        "notation": "船舶(せんぱく)"
+        ]
     },
     {
         "name": "ichiren",
         "trans": [
+            "一連(いちれん)",
             "a series, a chain, a ream (of paper)"
-        ],
-        "notation": "一連(いちれん)"
+        ]
     },
     {
         "name": "mouretsu",
         "trans": [
+            "猛烈(もうれつ)",
             "violent, vehement, rage"
-        ],
-        "notation": "猛烈(もうれつ)"
+        ]
     },
     {
         "name": "shinju",
         "trans": [
+            "真珠(しんじゅ)",
             "pearl"
-        ],
-        "notation": "真珠(しんじゅ)"
+        ]
     },
     {
         "name": "shouko",
         "trans": [
+            "証拠(しょうこ)",
             "evidence, proof"
-        ],
-        "notation": "証拠(しょうこ)"
+        ]
     },
     {
         "name": "gokurousama",
         "trans": [
+            "ご苦労(くろう)様(さま)",
             "Thank you very much for your...."
-        ],
-        "notation": "ご苦労(くろう)様(さま)"
+        ]
     },
     {
         "name": "misshuu",
         "trans": [
+            "密集(みっしゅう)",
             "crowd, close formation, dense"
-        ],
-        "notation": "密集(みっしゅう)"
+        ]
     },
     {
         "name": "moushideru",
         "trans": [
+            "申(もう)し出(で)る",
             "to report to, to tell, to suggest, to submit, to request, to make an offer, to come forward with informati"
-        ],
-        "notation": "申(もう)し出(で)る"
+        ]
     },
     {
         "name": "kairan",
         "trans": [
+            "回覧(かいらん)",
             "circulation"
-        ],
-        "notation": "回覧(かいらん)"
+        ]
     },
     {
         "name": "douchou",
         "trans": [
+            "同調(どうちょう)",
             "sympathy, agree with, alignment, tuning"
-        ],
-        "notation": "同調(どうちょう)"
+        ]
     },
     {
         "name": "chikuseki",
         "trans": [
+            "蓄積(ちくせき)",
             "accumulation, accumulate, store"
-        ],
-        "notation": "蓄積(ちくせき)"
+        ]
     },
     {
         "name": "haaku",
         "trans": [
+            "把握(はあく)",
             "grasp, catch, understanding"
-        ],
-        "notation": "把握(はあく)"
+        ]
     },
     {
         "name": "chouhou",
         "trans": [
+            "重宝(ちょうほう)",
             "priceless treasure, convenience, usefulness"
-        ],
-        "notation": "重宝(ちょうほう)"
+        ]
     },
     {
         "name": "mitsu",
         "trans": [
+            "蜜(みつ)",
             "nectar, honey"
-        ],
-        "notation": "蜜(みつ)"
+        ]
     },
     {
         "name": "boutou",
         "trans": [
+            "冒頭(ぼうとう)",
             "beginning, start, outset"
-        ],
-        "notation": "冒頭(ぼうとう)"
+        ]
     },
     {
         "name": "gochisousama",
         "trans": [
+            "ご馳走(ちそう)さま",
             "feast"
-        ],
-        "notation": "ご馳走(ちそう)さま"
+        ]
     },
     {
         "name": "dakai",
         "trans": [
+            "打開(だかい)",
             "break in the deadlock"
-        ],
-        "notation": "打開(だかい)"
+        ]
     },
     {
         "name": "tehai",
         "trans": [
+            "手配(てはい)",
             "arrangement, search (by police)"
-        ],
-        "notation": "手配(てはい)"
+        ]
     },
     {
         "name": "konokan",
         "trans": [
+            "この間(かん)",
             "the other day, lately, recently"
-        ],
-        "notation": "この間(かん)"
+        ]
     },
     {
         "name": "sawayaka",
         "trans": [
+            "爽(さわ)やか",
             "fresh, refreshing, invigorating, clear, fluent, eloquent"
-        ],
-        "notation": "爽(さわ)やか"
+        ]
     },
     {
         "name": "haishaku",
         "trans": [
+            "拝借(はいしゃく)",
             "borrowing"
-        ],
-        "notation": "拝借(はいしゃく)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "住(じゅう)",
             "dwelling, living"
-        ],
-        "notation": "住(じゅう)"
+        ]
     },
     {
         "name": "tadoushi",
         "trans": [
+            "他動詞(たどうし)",
             "transitive verb (direct obj)"
-        ],
-        "notation": "他動詞(たどうし)"
+        ]
     },
     {
         "name": "saigai",
         "trans": [
+            "災害(さいがい)",
             "calamity, disaster, misfortune"
-        ],
-        "notation": "災害(さいがい)"
+        ]
     },
     {
         "name": "fuzai",
         "trans": [
+            "不在(ふざい)",
             "absence"
-        ],
-        "notation": "不在(ふざい)"
+        ]
     },
     {
         "name": "shushoku",
         "trans": [
+            "主食(しゅしょく)",
             "staple food"
-        ],
-        "notation": "主食(しゅしょく)"
+        ]
     },
     {
         "name": "han",
         "trans": [
+            "反(はん)",
             "roll of cloth (c. 10 yds.), .245 acres, 300 tsubo"
-        ],
-        "notation": "反(はん)"
+        ]
     },
     {
         "name": "mokuromi",
         "trans": [
+            "目論見(もくろみ)",
             "a plan, a scheme, a project, a program, intention, goal"
-        ],
-        "notation": "目論見(もくろみ)"
+        ]
     },
     {
         "name": "unpan",
         "trans": [
+            "運搬(うんぱん)",
             "transport, carriage"
-        ],
-        "notation": "運搬(うんぱん)"
+        ]
     },
     {
         "name": "kadan",
         "trans": [
+            "花壇(かだん)",
             "flower bed"
-        ],
-        "notation": "花壇(かだん)"
+        ]
     },
     {
         "name": "mokei",
         "trans": [
+            "模型(もけい)",
             "model, dummy, maquette"
-        ],
-        "notation": "模型(もけい)"
+        ]
     },
     {
         "name": "hanpa",
         "trans": [
+            "半端(はんぱ)",
             "remnant, fragment, incomplete set, fraction, odd sum, incompleteness"
-        ],
-        "notation": "半端(はんぱ)"
+        ]
     },
     {
         "name": "itatte",
         "trans": [
+            "至(いた)って",
             "very much, exceedingly, extremely"
-        ],
-        "notation": "至(いた)って"
+        ]
     },
     {
         "name": "mine",
         "trans": [
+            "峰(みね)",
             "peak, ridge"
-        ],
-        "notation": "峰(みね)"
+        ]
     },
     {
         "name": "gou",
         "trans": [
+            "業(ごう)",
             "Buddhist karma, actions committed in a former life"
-        ],
-        "notation": "業(ごう)"
+        ]
     },
     {
         "name": "uruou",
         "trans": [
+            "潤(うるお)う",
             "to be moist, to be damp, to get wet, to profit by, to be watered, to receive benefits, to favor, to charm, t"
-        ],
-        "notation": "潤(うるお)う"
+        ]
     },
     {
         "name": "uwaki",
         "trans": [
+            "浮気(うわき)",
             "flighty, fickle, wanton, unfaithful"
-        ],
-        "notation": "浮気(うわき)"
+        ]
     },
     {
         "name": "kikyou",
         "trans": [
+            "帰京(ききょう)",
             "returning to Tokyo"
-        ],
-        "notation": "帰京(ききょう)"
+        ]
     },
     {
         "name": "kengyou",
         "trans": [
+            "兼業(けんぎょう)",
             "side line, second business"
-        ],
-        "notation": "兼業(けんぎょう)"
+        ]
     },
     {
         "name": "dageki",
         "trans": [
+            "打撃(だげき)",
             "1. blow, shock, strike, damage, 2. batting (baseball)"
-        ],
-        "notation": "打撃(だげき)"
+        ]
     },
     {
         "name": "onrain",
         "trans": [
+            "オンライン",
             "on-line"
-        ],
-        "notation": "オンライン"
+        ]
     },
     {
         "name": "tassei",
         "trans": [
+            "達成(たっせい)",
             "achievement"
-        ],
-        "notation": "達成(たっせい)"
+        ]
     },
     {
         "name": "suppai",
         "trans": [
+            "酸(す)っぱい",
             "sour, acid"
-        ],
-        "notation": "酸(す)っぱい"
+        ]
     },
     {
         "name": "motenasu",
         "trans": [
+            "持(も)て成(な)す",
             "to entertain, to make welcome"
-        ],
-        "notation": "持(も)て成(な)す"
+        ]
     },
     {
         "name": "konpasu",
         "trans": [
+            "コンパス",
             "compass"
-        ],
-        "notation": "コンパス"
+        ]
     },
     {
         "name": "dezain",
         "trans": [
+            "デザイン",
             "design"
-        ],
-        "notation": "デザイン"
+        ]
     },
     {
         "name": "tsuyomaru",
         "trans": [
+            "強(つよ)まる",
             "to get strong, to gain strength"
-        ],
-        "notation": "強(つよ)まる"
+        ]
     },
     {
         "name": "tandai",
         "trans": [
+            "短大(たんだい)",
             "junior college"
-        ],
-        "notation": "短大(たんだい)"
+        ]
     },
     {
         "name": "sukuu",
         "trans": [
+            "掬(すく)う",
             "to scoop, to ladle out"
-        ],
-        "notation": "掬(すく)う"
+        ]
     },
     {
         "name": "mittomonai",
         "trans": [
+            "見(み)っともない",
             "shameful, indecent"
-        ],
-        "notation": "見(み)っともない"
+        ]
     },
     {
         "name": "yohodo",
         "trans": [
+            "余程(よほど)",
             "very, greatly, much, to a large extent, quite"
-        ],
-        "notation": "余程(よほど)"
+        ]
     },
     {
         "name": "fufuku",
         "trans": [
+            "不服(ふふく)",
             "dissatisfaction, discontent, disapproval, objection, complaint, protest, disagreement"
-        ],
-        "notation": "不服(ふふく)"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "位地(いち)",
             "place, situation, position, location"
-        ],
-        "notation": "位地(いち)"
+        ]
     },
     {
         "name": "hadashi",
         "trans": [
+            "裸足(はだし)",
             "barefoot"
-        ],
-        "notation": "裸足(はだし)"
+        ]
     },
     {
         "name": "touchi",
         "trans": [
+            "統治(とうち)",
             "rule, reign, government, governing"
-        ],
-        "notation": "統治(とうち)"
+        ]
     },
     {
         "name": "kaitei",
         "trans": [
+            "改定(かいてい)",
             "reform"
-        ],
-        "notation": "改定(かいてい)"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "堪(こた)える",
             "to bear, to stand, to endure, to put up with, to support, to withstand, to resist, to brave, to be fit for, t"
-        ],
-        "notation": "堪(こた)える"
+        ]
     },
     {
         "name": "taimu",
         "trans": [
+            "タイム",
             "time"
-        ],
-        "notation": "タイム"
+        ]
     },
     {
         "name": "dengen",
         "trans": [
+            "電源(でんげん)",
             "source of electricity, power (button on TV etc.)"
-        ],
-        "notation": "電源(でんげん)"
+        ]
     },
     {
         "name": "rireki",
         "trans": [
+            "履歴(りれき)",
             "personal history, background, career, log"
-        ],
-        "notation": "履歴(りれき)"
+        ]
     },
     {
         "name": "shobun",
         "trans": [
+            "処分(しょぶん)",
             "disposal, dealing, punishment"
-        ],
-        "notation": "処分(しょぶん)"
+        ]
     },
     {
         "name": "naguru",
         "trans": [
+            "殴(なぐ)る",
             "to strike, to hit"
-        ],
-        "notation": "殴(なぐ)る"
+        ]
     },
     {
         "name": "kasei",
         "trans": [
+            "火星(かせい)",
             "Mars (planet)"
-        ],
-        "notation": "火星(かせい)"
+        ]
     },
     {
         "name": "kaijuu",
         "trans": [
+            "怪獣(かいじゅう)",
             "monster"
-        ],
-        "notation": "怪獣(かいじゅう)"
+        ]
     },
     {
         "name": "toranjisutaa",
         "trans": [
+            "トランジスター",
             "transistor"
-        ],
-        "notation": "トランジスター"
+        ]
     },
     {
         "name": "kouritsu",
         "trans": [
+            "公立(こうりつ)",
             "public (institution)"
-        ],
-        "notation": "公立(こうりつ)"
+        ]
     },
     {
         "name": "sennyuu",
         "trans": [
+            "潜入(せんにゅう)",
             "infiltration, sneaking in"
-        ],
-        "notation": "潜入(せんにゅう)"
+        ]
     },
     {
         "name": "kizoku",
         "trans": [
+            "貴族(きぞく)",
             "noble, aristocrat"
-        ],
-        "notation": "貴族(きぞく)"
+        ]
     },
     {
         "name": "tassha",
         "trans": [
+            "達者(たっしゃ)",
             "skillful, in good health"
-        ],
-        "notation": "達者(たっしゃ)"
+        ]
     },
     {
         "name": "kojin",
         "trans": [
+            "故人(こじん)",
             "the deceased, old friend"
-        ],
-        "notation": "故人(こじん)"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "回送(かいそう)",
             "forwarding"
-        ],
-        "notation": "回送(かいそう)"
+        ]
     },
     {
         "name": "hibana",
         "trans": [
+            "火花(ひばな)",
             "spark"
-        ],
-        "notation": "火花(ひばな)"
+        ]
     },
     {
         "name": "moushikomi",
         "trans": [
+            "申(もう)し込(こ)み",
             "application, entry, request, subscription, offer, proposal, overture, challenge"
-        ],
-        "notation": "申(もう)し込(こ)み"
+        ]
     },
     {
         "name": "seikei",
         "trans": [
+            "生計(せいけい)",
             "livelihood, living"
-        ],
-        "notation": "生計(せいけい)"
+        ]
     },
     {
         "name": "zatsuboku",
         "trans": [
+            "雑木(ざつぼく)",
             "various kinds of small trees, assorted trees"
-        ],
-        "notation": "雑木(ざつぼく)"
+        ]
     },
     {
         "name": "nengou",
         "trans": [
+            "年号(ねんごう)",
             "name of an era, year number"
-        ],
-        "notation": "年号(ねんごう)"
+        ]
     },
     {
         "name": "kaigara",
         "trans": [
+            "貝殻(かいがら)",
             "shell"
-        ],
-        "notation": "貝殻(かいがら)"
+        ]
     },
     {
         "name": "heijou",
         "trans": [
+            "平常(へいじょう)",
             "normal, usual"
-        ],
-        "notation": "平常(へいじょう)"
+        ]
     },
     {
         "name": "kyousan",
         "trans": [
+            "共産(きょうさん)",
             "communism"
-        ],
-        "notation": "共産(きょうさん)"
+        ]
     },
     {
         "name": "shokuminchi",
         "trans": [
+            "植民(しょくみん)地(ち)",
             "colony"
-        ],
-        "notation": "植民(しょくみん)地(ち)"
+        ]
     },
     {
         "name": "kutsugaesu",
         "trans": [
+            "覆(くつがえ)す",
             "to overturn, to upset, to overthrow, to undermine"
-        ],
-        "notation": "覆(くつがえ)す"
+        ]
     },
     {
         "name": "hikiiru",
         "trans": [
+            "率(ひき)いる",
             "to lead, to spearhead (a group), to command (troops)"
-        ],
-        "notation": "率(ひき)いる"
+        ]
     },
     {
         "name": "gannen",
         "trans": [
+            "元年(がんねん)",
             "first year (of a specific reign)"
-        ],
-        "notation": "元年(がんねん)"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "磁器(じき)",
             "porcelain, china"
-        ],
-        "notation": "磁器(じき)"
+        ]
     },
     {
         "name": "tarento",
         "trans": [
+            "タレント",
             "talent, star, personality"
-        ],
-        "notation": "タレント"
+        ]
     },
     {
         "name": "okoru",
         "trans": [
+            "怒(おこ)る",
             "to get angry, to be angry"
-        ],
-        "notation": "怒(おこ)る"
+        ]
     },
     {
         "name": "waru",
         "trans": [
+            "悪(わる)",
             "evil, wickedness"
-        ],
-        "notation": "悪(わる)"
+        ]
     },
     {
         "name": "ou",
         "trans": [
+            "負(お)う",
             "to bear, to owe"
-        ],
-        "notation": "負(お)う"
+        ]
     },
     {
         "name": "danketsu",
         "trans": [
+            "団結(だんけつ)",
             "unity, union, combination"
-        ],
-        "notation": "団結(だんけつ)"
+        ]
     },
     {
         "name": "yatarani",
         "trans": [
+            "矢(や)鱈(たら)に",
             "randomly, recklessly, blindly"
-        ],
-        "notation": "矢(や)鱈(たら)に"
+        ]
     },
     {
         "name": "gurafu",
         "trans": [
+            "グラフ",
             "graph"
-        ],
-        "notation": "グラフ"
+        ]
     },
     {
         "name": "atsuryoku",
         "trans": [
+            "圧力(あつりょく)",
             "stress, pressure"
-        ],
-        "notation": "圧力(あつりょく)"
+        ]
     },
     {
         "name": "tokorodokoro",
         "trans": [
+            "所々(ところどころ)",
             "here and there, some parts (of something)"
-        ],
-        "notation": "所々(ところどころ)"
+        ]
     },
     {
         "name": "shinnin",
         "trans": [
+            "信任(しんにん)",
             "trust, confidence, credence"
-        ],
-        "notation": "信任(しんにん)"
+        ]
     },
     {
         "name": "shunin",
         "trans": [
+            "主任(しゅにん)",
             "person in charge, responsible official"
-        ],
-        "notation": "主任(しゅにん)"
+        ]
     },
     {
         "name": "shikku",
         "trans": [
+            "シック",
             "chic"
-        ],
-        "notation": "シック"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "灰(はい)",
             "puckery juice"
-        ],
-        "notation": "灰(はい)"
+        ]
     },
     {
         "name": "kisawa",
         "trans": [
+            "気(き)障(さわ)",
             "affectation, conceit, snobbery"
-        ],
-        "notation": "気(き)障(さわ)"
+        ]
     },
     {
         "name": "kuchiru",
         "trans": [
+            "朽(く)ちる",
             "to rot"
-        ],
-        "notation": "朽(く)ちる"
+        ]
     },
     {
         "name": "kyouha",
         "trans": [
+            "今日(きょう)は",
             "hello, good day (daytime greeting id)"
-        ],
-        "notation": "今日(きょう)は"
+        ]
     },
     {
         "name": "chakkou",
         "trans": [
+            "着工(ちゃっこう)",
             "start of (construction) work"
-        ],
-        "notation": "着工(ちゃっこう)"
+        ]
     },
     {
         "name": "araware",
         "trans": [
+            "現(あら)われ",
             "embodiment, materialization"
-        ],
-        "notation": "現(あら)われ"
+        ]
     },
     {
         "name": "mae",
         "trans": [
+            "前(まえ)",
             "before"
-        ],
-        "notation": "前(まえ)"
+        ]
     },
     {
         "name": "kesshou",
         "trans": [
+            "結晶(けっしょう)",
             "crystal, crystallization"
-        ],
-        "notation": "結晶(けっしょう)"
+        ]
     },
     {
         "name": "kamikiru",
         "trans": [
+            "噛(か)み切(き)る",
             "to bite off, to gnaw through"
-        ],
-        "notation": "噛(か)み切(き)る"
+        ]
     },
     {
         "name": "kokorogakeru",
         "trans": [
+            "心掛(こころが)ける",
             "to bear in mind, to aim to do"
-        ],
-        "notation": "心掛(こころが)ける"
+        ]
     },
     {
         "name": "oyasumi",
         "trans": [
+            "お休(やす)み",
             "holiday, absence, rest, Good night"
-        ],
-        "notation": "お休(やす)み"
+        ]
     },
     {
         "name": "janru",
         "trans": [
+            "ジャンル",
             "genre"
-        ],
-        "notation": "ジャンル"
+        ]
     },
     {
         "name": "kake",
         "trans": [
+            "掛(か)け",
             "credit"
-        ],
-        "notation": "掛(か)け"
+        ]
     },
     {
         "name": "hatsuga",
         "trans": [
+            "発芽(はつが)",
             "burgeoning"
-        ],
-        "notation": "発芽(はつが)"
+        ]
     },
     {
         "name": "kou",
         "trans": [
+            "校(こう)",
             "-school, proof"
-        ],
-        "notation": "校(こう)"
+        ]
     },
     {
         "name": "takumi",
         "trans": [
+            "巧(たく)み",
             "skill, cleverness"
-        ],
-        "notation": "巧(たく)み"
+        ]
     },
     {
         "name": "kudaranai",
         "trans": [
+            "下(くだ)らない",
             "good-for-nothing, stupid, trivial, worthless"
-        ],
-        "notation": "下(くだ)らない"
+        ]
     },
     {
         "name": "atehameru",
         "trans": [
+            "当(あ)てはめる",
             "to apply, to adapt"
-        ],
-        "notation": "当(あ)てはめる"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "姓名(せいめい)",
             "full name"
-        ],
-        "notation": "姓名(せいめい)"
+        ]
     },
     {
         "name": "kakushuu",
         "trans": [
+            "隔週(かくしゅう)",
             "every other week"
-        ],
-        "notation": "隔週(かくしゅう)"
+        ]
     },
     {
         "name": "hoshimono",
         "trans": [
+            "干(ほ)し物(もの)",
             "dried washing (clothes)"
-        ],
-        "notation": "干(ほ)し物(もの)"
+        ]
     },
     {
         "name": "buttai",
         "trans": [
+            "物体(ぶったい)",
             "body, object"
-        ],
-        "notation": "物体(ぶったい)"
+        ]
     },
     {
         "name": "daiben",
         "trans": [
+            "大便(だいべん)",
             "feces, excrement, shit"
-        ],
-        "notation": "大便(だいべん)"
+        ]
     },
     {
         "name": "tousen",
         "trans": [
+            "当選(とうせん)",
             "being elected, winning the prize"
-        ],
-        "notation": "当選(とうせん)"
+        ]
     },
     {
         "name": "mikomi",
         "trans": [
+            "見込(みこ)み",
             "hope, prospects, expectation"
-        ],
-        "notation": "見込(みこ)み"
+        ]
     },
     {
         "name": "kukan",
         "trans": [
+            "区間(くかん)",
             "section (of track etc)"
-        ],
-        "notation": "区間(くかん)"
+        ]
     },
     {
         "name": "choutei",
         "trans": [
+            "調停(ちょうてい)",
             "arbitration, conciliation, mediation"
-        ],
-        "notation": "調停(ちょうてい)"
+        ]
     },
     {
         "name": "tsukaeru",
         "trans": [
+            "仕(つか)える",
             "to serve, to work for"
-        ],
-        "notation": "仕(つか)える"
+        ]
     },
     {
         "name": "gun",
         "trans": [
+            "軍(ぐん)",
             "war, battle, campaign, fight"
-        ],
-        "notation": "軍(ぐん)"
+        ]
     },
     {
         "name": "chou",
         "trans": [
+            "兆(ちょう)",
             "signs, omen, symptoms"
-        ],
-        "notation": "兆(ちょう)"
+        ]
     },
     {
         "name": "kokuyuu",
         "trans": [
+            "国有(こくゆう)",
             "national ownership"
-        ],
-        "notation": "国有(こくゆう)"
+        ]
     },
     {
         "name": "mikakeru",
         "trans": [
+            "見掛(みか)ける",
             "to (happen to) see, to notice, to catch sight of"
-        ],
-        "notation": "見掛(みか)ける"
+        ]
     },
     {
         "name": "ryoushitsu",
         "trans": [
+            "良質(りょうしつ)",
             "good quality, superior quality"
-        ],
-        "notation": "良質(りょうしつ)"
+        ]
     },
     {
         "name": "yuusen",
         "trans": [
+            "優先(ゆうせん)",
             "preference, priority"
-        ],
-        "notation": "優先(ゆうせん)"
+        ]
     },
     {
         "name": "hasami",
         "trans": [
+            "鋏(はさみ)",
             "scissors"
-        ],
-        "notation": "鋏(はさみ)"
+        ]
     },
     {
         "name": "megumi",
         "trans": [
+            "恵(めぐ)み",
             "blessing"
-        ],
-        "notation": "恵(めぐ)み"
+        ]
     },
     {
         "name": "eameeru",
         "trans": [
+            "エアメール",
             "air mail"
-        ],
-        "notation": "エアメール"
+        ]
     },
     {
         "name": "osan",
         "trans": [
+            "お産(さん)",
             "(giving) birth"
-        ],
-        "notation": "お産(さん)"
+        ]
     },
     {
         "name": "ika",
         "trans": [
+            "如何(いか)",
             "how, in what way"
-        ],
-        "notation": "如何(いか)"
+        ]
     },
     {
         "name": "toutoi",
         "trans": [
+            "貴(とうと)い",
             "precious, valuable, priceless, noble, exalted, sacred"
-        ],
-        "notation": "貴(とうと)い"
+        ]
     },
     {
         "name": "goku",
         "trans": [
+            "語句(ごく)",
             "words, phrases"
-        ],
-        "notation": "語句(ごく)"
+        ]
     },
     {
         "name": "kikazaru",
         "trans": [
+            "着飾(きかざ)る",
             "to dress up"
-        ],
-        "notation": "着飾(きかざ)る"
+        ]
     },
     {
         "name": "bougai",
         "trans": [
+            "妨害(ぼうがい)",
             "disturbance, obstruction, hindrance, jamming, interference"
-        ],
-        "notation": "妨害(ぼうがい)"
+        ]
     },
     {
         "name": "aseru",
         "trans": [
+            "焦(あせ)る",
             "to be in a hurry, to be impatient"
-        ],
-        "notation": "焦(あせ)る"
+        ]
     },
     {
         "name": "makki",
         "trans": [
+            "末期(まっき)",
             "closing years (period days), last stage"
-        ],
-        "notation": "末期(まっき)"
+        ]
     },
     {
         "name": "kakusa",
         "trans": [
+            "格差(かくさ)",
             "qualitative difference, disparity"
-        ],
-        "notation": "格差(かくさ)"
+        ]
     },
     {
         "name": "busou",
         "trans": [
+            "武装(ぶそう)",
             "arms, armament, armed"
-        ],
-        "notation": "武装(ぶそう)"
+        ]
     },
     {
         "name": "ataisuru",
         "trans": [
+            "値(あたい)する",
             "to be worth, to deserve, to merit"
-        ],
-        "notation": "値(あたい)する"
+        ]
     },
     {
         "name": "atarimae",
         "trans": [
+            "当(あ)たり前(まえ)",
             "usual, common, ordinary, natural, reasonable, obvious"
-        ],
-        "notation": "当(あ)たり前(まえ)"
+        ]
     },
     {
         "name": "tsutsushimu",
         "trans": [
+            "慎(つつし)む",
             "to be careful, to be chaste or discreet, to abstain or refrain"
-        ],
-        "notation": "慎(つつし)む"
+        ]
     },
     {
         "name": "hanpatsu",
         "trans": [
+            "反発(はんぱつ)",
             "repelling, rebound, recover, oppose"
-        ],
-        "notation": "反発(はんぱつ)"
+        ]
     },
     {
         "name": "shiyou",
         "trans": [
+            "私用(しよう)",
             "personal use, private business"
-        ],
-        "notation": "私用(しよう)"
+        ]
     },
     {
         "name": "shukketsu",
         "trans": [
+            "出血(しゅっけつ)",
             "bleeding, haemorrhage"
-        ],
-        "notation": "出血(しゅっけつ)"
+        ]
     },
     {
         "name": "reitan",
         "trans": [
+            "冷淡(れいたん)",
             "coolness, indifference"
-        ],
-        "notation": "冷淡(れいたん)"
+        ]
     },
     {
         "name": "messeeji",
         "trans": [
+            "メッセージ",
             "message"
-        ],
-        "notation": "メッセージ"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "絶(た)つ",
             "to sever, to cut off, to suppress, to abstain (from)"
-        ],
-        "notation": "絶(た)つ"
+        ]
     },
     {
         "name": "yuruyaka",
         "trans": [
+            "緩(ゆる)やか",
             "lenient"
-        ],
-        "notation": "緩(ゆる)やか"
+        ]
     },
     {
         "name": "buumu",
         "trans": [
+            "ブーム",
             "boom"
-        ],
-        "notation": "ブーム"
+        ]
     },
     {
         "name": "tokushuu",
         "trans": [
+            "特集(とくしゅう)",
             "feature (e.g. newspaper), special edition, report"
-        ],
-        "notation": "特集(とくしゅう)"
+        ]
     },
     {
         "name": "inkyo",
         "trans": [
+            "隠居(いんきょ)",
             "retirement, retired person"
-        ],
-        "notation": "隠居(いんきょ)"
+        ]
     },
     {
         "name": "yuderu",
         "trans": [
+            "茹(ゆ)でる",
             "to boil"
-        ],
-        "notation": "茹(ゆ)でる"
+        ]
     },
     {
         "name": "agaru",
         "trans": [
+            "上(あ)がる",
             "to enter, to go up, to rise, to climb up, to advance, to appreciate, to be promoted, to improve, to call on,"
-        ],
-        "notation": "上(あ)がる"
+        ]
     },
     {
         "name": "intaanashonaru",
         "trans": [
+            "インターナショナル",
             "international"
-        ],
-        "notation": "インターナショナル"
+        ]
     },
     {
         "name": "kaitaku",
         "trans": [
+            "開拓(かいたく)",
             "reclamation (of wasteland), cultivation, pioneer"
-        ],
-        "notation": "開拓(かいたく)"
+        ]
     },
     {
         "name": "gunji",
         "trans": [
+            "軍事(ぐんじ)",
             "military affairs"
-        ],
-        "notation": "軍事(ぐんじ)"
+        ]
     },
     {
         "name": "hanayaka",
         "trans": [
+            "華(はな)やか",
             "gay, showy, brilliant, gorgeous, florid"
-        ],
-        "notation": "華(はな)やか"
+        ]
     },
     {
         "name": "honmyou",
         "trans": [
+            "本名(ほんみょう)",
             "real name"
-        ],
-        "notation": "本名(ほんみょう)"
+        ]
     },
     {
         "name": "koukogaku",
         "trans": [
+            "考古学(こうこがく)",
             "archaeology"
-        ],
-        "notation": "考古学(こうこがく)"
+        ]
     },
     {
         "name": "kokkyou",
         "trans": [
+            "国境(こっきょう)",
             "national or state border"
-        ],
-        "notation": "国境(こっきょう)"
+        ]
     },
     {
         "name": "warumono",
         "trans": [
+            "悪者(わるもの)",
             "bad fellow, rascal, ruffian, scoundrel"
-        ],
-        "notation": "悪者(わるもの)"
+        ]
     },
     {
         "name": "kasen",
         "trans": [
+            "河川(かせん)",
             "rivers"
-        ],
-        "notation": "河川(かせん)"
+        ]
     },
     {
         "name": "hageru",
         "trans": [
+            "剥(は)げる",
             "to come off, to be worn off, to fade, to discolor"
-        ],
-        "notation": "剥(は)げる"
+        ]
     },
     {
         "name": "kujibiki",
         "trans": [
+            "籤引(くじびき)",
             "lottery, drawn lot"
-        ],
-        "notation": "籤引(くじびき)"
+        ]
     },
     {
         "name": "hoshu",
         "trans": [
+            "保守(ほしゅ)",
             "conservative, maintaining"
-        ],
-        "notation": "保守(ほしゅ)"
+        ]
     },
     {
         "name": "yuuki",
         "trans": [
+            "有機(ゆうき)",
             "organic"
-        ],
-        "notation": "有機(ゆうき)"
+        ]
     },
     {
         "name": "ishibumi",
         "trans": [
+            "碑(いしぶみ)",
             "stone monument bearing an inscription"
-        ],
-        "notation": "碑(いしぶみ)"
+        ]
     },
     {
         "name": "hanei",
         "trans": [
+            "繁栄(はんえい)",
             "prospering, prosperity, thriving, flourishing"
-        ],
-        "notation": "繁栄(はんえい)"
+        ]
     },
     {
         "name": "sougou",
         "trans": [
+            "総合(そうごう)",
             "synthesis, coordination, putting together, integration, composite"
-        ],
-        "notation": "総合(そうごう)"
+        ]
     },
     {
         "name": "bunretsu",
         "trans": [
+            "分裂(ぶんれつ)",
             "split, division, break up"
-        ],
-        "notation": "分裂(ぶんれつ)"
+        ]
     },
     {
         "name": "osamaru",
         "trans": [
+            "治(おさ)まる",
             "to be at peace, to clamp down, to lessen (storm terror anger)"
-        ],
-        "notation": "治(おさ)まる"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "季刊(きかん)",
             "quarterly (e.g. magazine)"
-        ],
-        "notation": "季刊(きかん)"
+        ]
     },
     {
         "name": "keibatsu",
         "trans": [
+            "刑罰(けいばつ)",
             "judgement, penalty, punishment"
-        ],
-        "notation": "刑罰(けいばつ)"
+        ]
     },
     {
         "name": "sanshou",
         "trans": [
+            "参照(さんしょう)",
             "reference, consultation, consultation"
-        ],
-        "notation": "参照(さんしょう)"
+        ]
     },
     {
         "name": "fui",
         "trans": [
+            "不意(ふい)",
             "sudden, abrupt, unexpected, unforeseen"
-        ],
-        "notation": "不意(ふい)"
+        ]
     },
     {
         "name": "sutajio",
         "trans": [
+            "スタジオ",
             "studio"
-        ],
-        "notation": "スタジオ"
+        ]
     },
     {
         "name": "jishu",
         "trans": [
+            "自首(じしゅ)",
             "surrender, give oneself up"
-        ],
-        "notation": "自首(じしゅ)"
+        ]
     },
     {
         "name": "seishi",
         "trans": [
+            "生死(せいし)",
             "life and death"
-        ],
-        "notation": "生死(せいし)"
+        ]
     },
     {
         "name": "mijuku",
         "trans": [
+            "未(み)熟(じゅく)",
             "inexperience, unripeness, raw, unskilled, immature, inexperienced"
-        ],
-        "notation": "未(み)熟(じゅく)"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "機(き)",
             "loom"
-        ],
-        "notation": "機(き)"
+        ]
     },
     {
         "name": "miburi",
         "trans": [
+            "身振(みぶ)り",
             "gesture"
-        ],
-        "notation": "身振(みぶ)り"
+        ]
     },
     {
         "name": "detarame",
         "trans": [
+            "出鱈目(でたらめ)",
             "irresponsible utterance, nonsense, nonsensical, random, haphazard, unsystematic"
-        ],
-        "notation": "出鱈目(でたらめ)"
+        ]
     },
     {
         "name": "saiyou",
         "trans": [
+            "採用(さいよう)",
             "use, adopt"
-        ],
-        "notation": "採用(さいよう)"
+        ]
     },
     {
         "name": "shugei",
         "trans": [
+            "手芸(しゅげい)",
             "handicrafts"
-        ],
-        "notation": "手芸(しゅげい)"
+        ]
     },
     {
         "name": "kakushin",
         "trans": [
+            "確信(かくしん)",
             "conviction, confidence"
-        ],
-        "notation": "確信(かくしん)"
+        ]
     },
     {
         "name": "kanatakochira",
         "trans": [
+            "彼方(かなた)此方(こちら)",
             "here and there"
-        ],
-        "notation": "彼方(かなた)此方(こちら)"
+        ]
     },
     {
         "name": "sanka",
         "trans": [
+            "酸化(さんか)",
             "oxidation"
-        ],
-        "notation": "酸化(さんか)"
+        ]
     },
     {
         "name": "wazuka",
         "trans": [
+            "僅(わずか)",
             "a little, small quantity"
-        ],
-        "notation": "僅(わずか)"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "難(かた)い",
             "difficult, hard"
-        ],
-        "notation": "難(かた)い"
+        ]
     },
     {
         "name": "kyokutan",
         "trans": [
+            "極端(きょくたん)",
             "extreme, extremity"
-        ],
-        "notation": "極端(きょくたん)"
+        ]
     },
     {
         "name": "ninmu",
         "trans": [
+            "任務(にんむ)",
             "duty, function, office, mission, task"
-        ],
-        "notation": "任務(にんむ)"
+        ]
     },
     {
         "name": "naikaku",
         "trans": [
+            "内閣(ないかく)",
             "cabinet, (government) ministry"
-        ],
-        "notation": "内閣(ないかく)"
+        ]
     },
     {
         "name": "suso",
         "trans": [
+            "裾(すそ)",
             "(trouser) cuff, (skirt) hem, cut edge of a hairdo, foot of mountain"
-        ],
-        "notation": "裾(すそ)"
+        ]
     },
     {
         "name": "amari",
         "trans": [
+            "余(あま)り",
             "not very (this form only used as adverb), not much, remainder, rest, remnant, surplus, balance, excess, rema"
-        ],
-        "notation": "余(あま)り"
+        ]
     },
     {
         "name": "kokorobosoi",
         "trans": [
+            "心細(こころぼそ)い",
             "helpless, forlorn, hopeless, unpromising, lonely, discouraging, disheartening"
-        ],
-        "notation": "心細(こころぼそ)い"
+        ]
     },
     {
         "name": "yaritoosu",
         "trans": [
+            "遣(や)り通(とお)す",
             "to carry through, to achieve, to complete"
-        ],
-        "notation": "遣(や)り通(とお)す"
+        ]
     },
     {
         "name": "shamen",
         "trans": [
+            "斜面(しゃめん)",
             "slope, slanting surface, bevel"
-        ],
-        "notation": "斜面(しゃめん)"
+        ]
     },
     {
         "name": "ijuu",
         "trans": [
+            "移住(いじゅう)",
             "migration, immigration"
-        ],
-        "notation": "移住(いじゅう)"
+        ]
     },
     {
         "name": "toubou",
         "trans": [
+            "逃亡(とうぼう)",
             "escape"
-        ],
-        "notation": "逃亡(とうぼう)"
+        ]
     },
     {
         "name": "rentogen",
         "trans": [
+            "レントゲン",
             "X-ray (lit: Roentgen)"
-        ],
-        "notation": "レントゲン"
+        ]
     },
     {
         "name": "tegakari",
         "trans": [
+            "手掛(てが)かり",
             "contact, trail, scent, on hand, hand hold, clue, key"
-        ],
-        "notation": "手掛(てが)かり"
+        ]
     },
     {
         "name": "shikiru",
         "trans": [
+            "仕切(しき)る",
             "to partition, to divide, to mark off, to settle accounts, to toe the mark"
-        ],
-        "notation": "仕切(しき)る"
+        ]
     },
     {
         "name": "jogai",
         "trans": [
+            "除外(じょがい)",
             "exception, exclusion"
-        ],
-        "notation": "除外(じょがい)"
+        ]
     },
     {
         "name": "kakusan",
         "trans": [
+            "拡散(かくさん)",
             "scattering, diffusion"
-        ],
-        "notation": "拡散(かくさん)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "館(たて)",
             "house, hall, building, hotel, inn, guesthouse"
-        ],
-        "notation": "館(たて)"
+        ]
     },
     {
         "name": "yuuwaku",
         "trans": [
+            "誘惑(ゆうわく)",
             "temptation, allurement, lure"
-        ],
-        "notation": "誘惑(ゆうわく)"
+        ]
     },
     {
         "name": "kifureru",
         "trans": [
+            "気(き)触(ふ)れる",
             "to react to, to be influenced by, to go overboard for"
-        ],
-        "notation": "気(き)触(ふ)れる"
+        ]
     },
     {
         "name": "kokutei",
         "trans": [
+            "国定(こくてい)",
             "state-sponsored, national"
-        ],
-        "notation": "国定(こくてい)"
+        ]
     },
     {
         "name": "deeta",
         "trans": [
+            "データ",
             "data"
-        ],
-        "notation": "データ"
+        ]
     },
     {
         "name": "kingan",
         "trans": [
+            "近眼(きんがん)",
             "nearsightedness, shortsightedness, myopia"
-        ],
-        "notation": "近眼(きんがん)"
+        ]
     },
     {
         "name": "medetai",
         "trans": [
+            "愛(め)でたい",
             "auspicious"
-        ],
-        "notation": "愛(め)でたい"
+        ]
     },
     {
         "name": "binkan",
         "trans": [
+            "敏感(びんかん)",
             "sensibility, susceptibility, sensitive (to), well attuned to"
-        ],
-        "notation": "敏感(びんかん)"
+        ]
     },
     {
         "name": "tsuba",
         "trans": [
+            "唾(つば)",
             "saliva, sputum"
-        ],
-        "notation": "唾(つば)"
+        ]
     },
     {
         "name": "misuborashii",
         "trans": [
+            "見(み)すぼらしい",
             "shabby, seedy"
-        ],
-        "notation": "見(み)すぼらしい"
+        ]
     },
     {
         "name": "hisho",
         "trans": [
+            "秘書(ひしょ)",
             "(private) secretary"
-        ],
-        "notation": "秘書(ひしょ)"
+        ]
     },
     {
         "name": "akuseru",
         "trans": [
+            "アクセル",
             "accelerator"
-        ],
-        "notation": "アクセル"
+        ]
     },
     {
         "name": "okkanai",
         "trans": [
+            "おっかない",
             "frightening, huge"
-        ],
-        "notation": "おっかない"
+        ]
     },
     {
         "name": "shinpan",
         "trans": [
+            "審判(しんぱん)",
             "refereeing, trial, judgement, umpire, referee"
-        ],
-        "notation": "審判(しんぱん)"
+        ]
     },
     {
         "name": "izure",
         "trans": [
+            "何(いず)れ",
             "where, which, who, anyway, anyhow, at any rate"
-        ],
-        "notation": "何(いず)れ"
+        ]
     },
     {
         "name": "shunou",
         "trans": [
+            "首脳(しゅのう)",
             "head, brains"
-        ],
-        "notation": "首脳(しゅのう)"
+        ]
     },
     {
         "name": "tokkyo",
         "trans": [
+            "特許(とっきょ)",
             "special permission, patent"
-        ],
-        "notation": "特許(とっきょ)"
+        ]
     },
     {
         "name": "koukouto",
         "trans": [
+            "煌々(こうこう)と",
             "brilliantly, brightly"
-        ],
-        "notation": "煌々(こうこう)と"
+        ]
     },
     {
         "name": "hinotome",
         "trans": [
+            "丁(ひのと)目(め)",
             "district of a town, city block (of irregular size)"
-        ],
-        "notation": "丁(ひのと)目(め)"
+        ]
     },
     {
         "name": "ichimen",
         "trans": [
+            "一(いち)面(めん)",
             "one side, one phase, front page, the other hand, the whole surface"
-        ],
-        "notation": "一(いち)面(めん)"
+        ]
     },
     {
         "name": "koumyou",
         "trans": [
+            "巧妙(こうみょう)",
             "ingenious, skillful, clever, deft"
-        ],
-        "notation": "巧妙(こうみょう)"
+        ]
     },
     {
         "name": "sobieru",
         "trans": [
+            "聳(そび)える",
             "to rise, to tower, to soar"
-        ],
-        "notation": "聳(そび)える"
+        ]
     },
     {
         "name": "kokoromi",
         "trans": [
+            "試(こころ)み",
             "trial, experiment"
-        ],
-        "notation": "試(こころ)み"
+        ]
     },
     {
         "name": "issun",
         "trans": [
+            "一寸(いっすん)",
             "(ateji) (adv int) (uk) just a minute, a short time, a while, just a little, somewhat, easily, readily, rath"
-        ],
-        "notation": "一寸(いっすん)"
+        ]
     },
     {
         "name": "taiwa",
         "trans": [
+            "対話(たいわ)",
             "interactive, interaction, conversation, dialogue"
-        ],
-        "notation": "対話(たいわ)"
+        ]
     },
     {
         "name": "giri",
         "trans": [
+            "義理(ぎり)",
             "duty, sense of duty, honor, decency, courtesy, debt of gratitude, social obligation"
-        ],
-        "notation": "義理(ぎり)"
+        ]
     },
     {
         "name": "kuchibashi",
         "trans": [
+            "嘴(くちばし)",
             "beak, bill"
-        ],
-        "notation": "嘴(くちばし)"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "戦(せん)",
             "war, battle, campaign, fight"
-        ],
-        "notation": "戦(せん)"
+        ]
     },
     {
         "name": "okotai",
         "trans": [
+            "怠(おこた)い",
             "sluggish, feel heavy, languid, dull"
-        ],
-        "notation": "怠(おこた)い"
+        ]
     },
     {
         "name": "tsukihi",
         "trans": [
+            "月日(つきひ)",
             "(the) date"
-        ],
-        "notation": "月日(つきひ)"
+        ]
     },
     {
         "name": "taigaku",
         "trans": [
+            "退学(たいがく)",
             "dropping out of school"
-        ],
-        "notation": "退学(たいがく)"
+        ]
     },
     {
         "name": "tasuke",
         "trans": [
+            "助(たす)け",
             "assistance"
-        ],
-        "notation": "助(たす)け"
+        ]
     },
     {
         "name": "arakajime",
         "trans": [
+            "予(あらかじ)め",
             "beforehand, in advance, previously"
-        ],
-        "notation": "予(あらかじ)め"
+        ]
     },
     {
         "name": "seidai",
         "trans": [
+            "盛大(せいだい)",
             "grand, prosperous, magnificent"
-        ],
-        "notation": "盛大(せいだい)"
+        ]
     },
     {
         "name": "moteru",
         "trans": [
+            "持(も)てる",
             "to be well liked, to be popular"
-        ],
-        "notation": "持(も)てる"
+        ]
     },
     {
         "name": "shomu",
         "trans": [
+            "庶務(しょむ)",
             "general affairs"
-        ],
-        "notation": "庶務(しょむ)"
+        ]
     },
     {
         "name": "mazui",
         "trans": [
+            "不味(まず)い",
             "unappetising, unpleasant (taste appearance situation), ugly, unskilful, awkward, bungling, unwise, untime"
-        ],
-        "notation": "不味(まず)い"
+        ]
     },
     {
         "name": "ginmi",
         "trans": [
+            "吟味(ぎんみ)",
             "testing, scrutiny, careful investigation"
-        ],
-        "notation": "吟味(ぎんみ)"
+        ]
     },
     {
         "name": "namanurui",
         "trans": [
+            "生温(なまぬる)い",
             "lukewarm, halfhearted"
-        ],
-        "notation": "生温(なまぬる)い"
+        ]
     },
     {
         "name": "kinben",
         "trans": [
+            "勤勉(きんべん)",
             "industry, diligence"
-        ],
-        "notation": "勤勉(きんべん)"
+        ]
     },
     {
         "name": "higoro",
         "trans": [
+            "日頃(ひごろ)",
             "normally, habitually"
-        ],
-        "notation": "日頃(ひごろ)"
+        ]
     },
     {
         "name": "fuushuu",
         "trans": [
+            "風習(ふうしゅう)",
             "custom"
-        ],
-        "notation": "風習(ふうしゅう)"
+        ]
     },
     {
         "name": "chijimaru",
         "trans": [
+            "縮(ちぢ)まる",
             "to be shortened, to be contracted, to shrink"
-        ],
-        "notation": "縮(ちぢ)まる"
+        ]
     },
     {
         "name": "teitaku",
         "trans": [
+            "邸宅(ていたく)",
             "mansion, residence"
-        ],
-        "notation": "邸宅(ていたく)"
+        ]
     },
     {
         "name": "ryoukai",
         "trans": [
+            "領海(りょうかい)",
             "territorial waters"
-        ],
-        "notation": "領海(りょうかい)"
+        ]
     },
     {
         "name": "wa",
         "trans": [
+            "輪(わ)",
             "counter for wheels and flowers"
-        ],
-        "notation": "輪(わ)"
+        ]
     },
     {
         "name": "heru",
         "trans": [
+            "経(へ)る",
             "to pass, to elapse, to experience"
-        ],
-        "notation": "経(へ)る"
+        ]
     },
     {
         "name": "shisutemu",
         "trans": [
+            "システム",
             "system"
-        ],
-        "notation": "システム"
+        ]
     },
     {
         "name": "noujou",
         "trans": [
+            "農場(のうじょう)",
             "farm (agriculture)"
-        ],
-        "notation": "農場(のうじょう)"
+        ]
     },
     {
         "name": "odosu",
         "trans": [
+            "脅(おど)す",
             "to threaten, to menace"
-        ],
-        "notation": "脅(おど)す"
+        ]
     },
     {
         "name": "zaisei",
         "trans": [
+            "財政(ざいせい)",
             "economy, financial affairs"
-        ],
-        "notation": "財政(ざいせい)"
+        ]
     },
     {
         "name": "nantonaku",
         "trans": [
+            "何(なん)となく",
             "somehow or other, for some reason or another"
-        ],
-        "notation": "何(なん)となく"
+        ]
     },
     {
         "name": "eisei",
         "trans": [
+            "衛生(えいせい)",
             "health, hygiene, sanitation, medical"
-        ],
-        "notation": "衛生(えいせい)"
+        ]
     },
     {
         "name": "ajiwai",
         "trans": [
+            "味(あじ)わい",
             "flavour, meaning, significance"
-        ],
-        "notation": "味(あじ)わい"
+        ]
     },
     {
         "name": "soshou",
         "trans": [
+            "訴訟(そしょう)",
             "litigation, lawsuit"
-        ],
-        "notation": "訴訟(そしょう)"
+        ]
     },
     {
         "name": "sashitsukaeru",
         "trans": [
+            "差(さ)し支(つか)える",
             "to interfere, to hinder, to become impeded"
-        ],
-        "notation": "差(さ)し支(つか)える"
+        ]
     },
     {
         "name": "sorede",
         "trans": [
+            "其(それ)で",
             "and (conj), thereupon, because of that"
-        ],
-        "notation": "其(それ)で"
+        ]
     },
     {
         "name": "kisei",
         "trans": [
+            "規制(きせい)",
             "regulation"
-        ],
-        "notation": "規制(きせい)"
+        ]
     },
     {
         "name": "iede",
         "trans": [
+            "家出(いえで)",
             "running away from home, leaving home"
-        ],
-        "notation": "家出(いえで)"
+        ]
     },
     {
         "name": "torikumu",
         "trans": [
+            "取(と)り組(く)む",
             "to tackle, to wrestle with, to engage in a bout, to come to grips with"
-        ],
-        "notation": "取(と)り組(く)む"
+        ]
     },
     {
         "name": "chanoma",
         "trans": [
+            "茶(ちゃ)の間(ま)",
             "living room (Japanese style)"
-        ],
-        "notation": "茶(ちゃ)の間(ま)"
+        ]
     },
     {
         "name": "gyakuten",
         "trans": [
+            "逆転(ぎゃくてん)",
             "(sudden) change, reversal, turn-around, coming from behind (baseball)"
-        ],
-        "notation": "逆転(ぎゃくてん)"
+        ]
     },
     {
         "name": "kanshou",
         "trans": [
+            "干渉(かんしょう)",
             "interference, intervention"
-        ],
-        "notation": "干渉(かんしょう)"
+        ]
     },
     {
         "name": "saboru",
         "trans": [
+            "サボる",
             "to be truant, to be idle, to sabotage by slowness"
-        ],
-        "notation": "サボる"
+        ]
     },
     {
         "name": "dokusen",
         "trans": [
+            "独占(どくせん)",
             "monopoly"
-        ],
-        "notation": "独占(どくせん)"
+        ]
     },
     {
         "name": "hanashiai",
         "trans": [
+            "話(はな)し合(あ)い",
             "discussion, conference"
-        ],
-        "notation": "話(はな)し合(あ)い"
+        ]
     },
     {
         "name": "hitokoro",
         "trans": [
+            "一頃(ひところ)",
             "once, some time ago"
-        ],
-        "notation": "一頃(ひところ)"
+        ]
     },
     {
         "name": "enpou",
         "trans": [
+            "遠方(えんぽう)",
             "long way, distant place"
-        ],
-        "notation": "遠方(えんぽう)"
+        ]
     },
     {
         "name": "tsukuru",
         "trans": [
+            "造(つく)る",
             "to make, to create, to manufacture, to draw up, to write, to compose, to build, to coin, to cultivate, to org"
-        ],
-        "notation": "造(つく)る"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "嗜好(しこう)",
             "taste, liking, preference"
-        ],
-        "notation": "嗜好(しこう)"
+        ]
     },
     {
         "name": "chiimuwaaku",
         "trans": [
+            "チームワーク",
             "teamwork"
-        ],
-        "notation": "チームワーク"
+        ]
     },
     {
         "name": "kaiken",
         "trans": [
+            "会見(かいけん)",
             "interview, audience"
-        ],
-        "notation": "会見(かいけん)"
+        ]
     },
     {
         "name": "shocchuu",
         "trans": [
+            "しょっちゅう",
             "always, constantly"
-        ],
-        "notation": "しょっちゅう"
+        ]
     },
     {
         "name": "darake",
         "trans": [
+            "だらけ",
             "implying (negatively) that something is full of e.g. mistakes"
-        ],
-        "notation": "だらけ"
+        ]
     },
     {
         "name": "soujuu",
         "trans": [
+            "操縦(そうじゅう)",
             "management, handling, control, manipulation"
-        ],
-        "notation": "操縦(そうじゅう)"
+        ]
     },
     {
         "name": "kihin",
         "trans": [
+            "気品(きひん)",
             "aroma"
-        ],
-        "notation": "気品(きひん)"
+        ]
     },
     {
         "name": "nemutai",
         "trans": [
+            "眠(ねむ)たい",
             "sleepy"
-        ],
-        "notation": "眠(ねむ)たい"
+        ]
     },
     {
         "name": "ni",
         "trans": [
+            "荷(に)",
             "load, baggage, cargo"
-        ],
-        "notation": "荷(に)"
+        ]
     },
     {
         "name": "futan",
         "trans": [
+            "負担(ふたん)",
             "burden, charge, responsibility"
-        ],
-        "notation": "負担(ふたん)"
+        ]
     },
     {
         "name": "terikaesu",
         "trans": [
+            "照(て)り返(かえ)す",
             "to reflect, to throw back light"
-        ],
-        "notation": "照(て)り返(かえ)す"
+        ]
     },
     {
         "name": "akakuru",
         "trans": [
+            "明(あか)くる",
             "next, following"
-        ],
-        "notation": "明(あか)くる"
+        ]
     },
     {
         "name": "katazuke",
         "trans": [
+            "片付(かたづ)け",
             "tidying up, finishing"
-        ],
-        "notation": "片付(かたづ)け"
+        ]
     },
     {
         "name": "shinro",
         "trans": [
+            "進路(しんろ)",
             "course, route"
-        ],
-        "notation": "進路(しんろ)"
+        ]
     },
     {
         "name": "shimekiri",
         "trans": [
+            "締(し)め切(き)り",
             "closing, cut-off, end, deadline, Closed, No Entrance"
-        ],
-        "notation": "締(し)め切(き)り"
+        ]
     },
     {
         "name": "nounyuu",
         "trans": [
+            "納入(のうにゅう)",
             "payment, supply"
-        ],
-        "notation": "納入(のうにゅう)"
+        ]
     },
     {
         "name": "gyousha",
         "trans": [
+            "業者(ぎょうしゃ)",
             "trader, merchant"
-        ],
-        "notation": "業者(ぎょうしゃ)"
+        ]
     },
     {
         "name": "intaafon",
         "trans": [
+            "インターフォン",
             "intercom"
-        ],
-        "notation": "インターフォン"
+        ]
     },
     {
         "name": "ikuta",
         "trans": [
+            "幾多(いくた)",
             "many, numerous"
-        ],
-        "notation": "幾多(いくた)"
+        ]
     },
     {
         "name": "zandaka",
         "trans": [
+            "残高(ざんだか)",
             "(bank) balance, remainder"
-        ],
-        "notation": "残高(ざんだか)"
+        ]
     },
     {
         "name": "sarau",
         "trans": [
+            "拐(さら)う",
             "to carry off, to run away with, to kidnap, to abduct"
-        ],
-        "notation": "拐(さら)う"
+        ]
     },
     {
         "name": "soroi",
         "trans": [
+            "揃(そろ)い",
             "set, suit, uniform"
-        ],
-        "notation": "揃(そろ)い"
+        ]
     },
     {
         "name": "sonaetsukeru",
         "trans": [
+            "備(そな)え付(つ)ける",
             "to provide, to furnish, to equip, to install"
-        ],
-        "notation": "備(そな)え付(つ)ける"
+        ]
     },
     {
         "name": "joshi",
         "trans": [
+            "女史(じょし)",
             "Ms."
-        ],
-        "notation": "女史(じょし)"
+        ]
     },
     {
         "name": "wakusei",
         "trans": [
+            "惑星(わくせい)",
             "planet"
-        ],
-        "notation": "惑星(わくせい)"
+        ]
     },
     {
         "name": "kyouri",
         "trans": [
+            "郷里(きょうり)",
             "birth-place, home town"
-        ],
-        "notation": "郷里(きょうり)"
+        ]
     },
     {
         "name": "kousoku",
         "trans": [
+            "拘束(こうそく)",
             "restriction, restraint"
-        ],
-        "notation": "拘束(こうそく)"
+        ]
     },
     {
         "name": "shimei",
         "trans": [
+            "使命(しめい)",
             "mission, errand, message"
-        ],
-        "notation": "使命(しめい)"
+        ]
     },
     {
         "name": "nyuuyoku",
         "trans": [
+            "入浴(にゅうよく)",
             "bathe, bathing"
-        ],
-        "notation": "入浴(にゅうよく)"
+        ]
     },
     {
         "name": "tsuihou",
         "trans": [
+            "追放(ついほう)",
             "exile, banishment"
-        ],
-        "notation": "追放(ついほう)"
+        ]
     },
     {
         "name": "nusumi",
         "trans": [
+            "盗(ぬす)み",
             "stealing"
-        ],
-        "notation": "盗(ぬす)み"
+        ]
     },
     {
         "name": "yoi",
         "trans": [
+            "好(よ)い",
             "good"
-        ],
-        "notation": "好(よ)い"
+        ]
     },
     {
         "name": "tsutomaru",
         "trans": [
+            "勤(つと)まる",
             "to be fit for, to be equal to, to function properly"
-        ],
-        "notation": "勤(つと)まる"
+        ]
     },
     {
         "name": "keisotsu",
         "trans": [
+            "軽率(けいそつ)",
             "rash, thoughtless, careless, hasty"
-        ],
-        "notation": "軽率(けいそつ)"
+        ]
     },
     {
         "name": "ina",
         "trans": [
+            "否(いな)",
             "no, nay, yes, well"
-        ],
-        "notation": "否(いな)"
+        ]
     },
     {
         "name": "kanshuu",
         "trans": [
+            "観衆(かんしゅう)",
             "spectators, onlookers, members of the audience"
-        ],
-        "notation": "観衆(かんしゅう)"
+        ]
     },
     {
         "name": "itadakimasu",
         "trans": [
+            "戴(いただ)きます",
             "expression of gratitude before meals"
-        ],
-        "notation": "戴(いただ)きます"
+        ]
     },
     {
         "name": "hojuu",
         "trans": [
+            "補充(ほじゅう)",
             "supplementation, supplement, replenishment, replenishing"
-        ],
-        "notation": "補充(ほじゅう)"
+        ]
     },
     {
         "name": "kaminari",
         "trans": [
+            "雷(かみなり)",
             "thunder"
-        ],
-        "notation": "雷(かみなり)"
+        ]
     },
     {
         "name": "yuudou",
         "trans": [
+            "誘導(ゆうどう)",
             "guidance, leading, induction, introduction, incitement, inducement"
-        ],
-        "notation": "誘導(ゆうどう)"
+        ]
     },
     {
         "name": "idou",
         "trans": [
+            "異動(いどう)",
             "a change"
-        ],
-        "notation": "異動(いどう)"
+        ]
     },
     {
         "name": "rittai",
         "trans": [
+            "立体(りったい)",
             "solid body"
-        ],
-        "notation": "立体(りったい)"
+        ]
     },
     {
         "name": "shiageru",
         "trans": [
+            "仕上(しあ)げる",
             "to finish up, to complete"
-        ],
-        "notation": "仕上(しあ)げる"
+        ]
     },
     {
         "name": "uketori",
         "trans": [
+            "受(う)け取(と)り",
             "receipt"
-        ],
-        "notation": "受(う)け取(と)り"
+        ]
     },
     {
         "name": "miai",
         "trans": [
+            "見合(みあ)い",
             "formal marriage interview"
-        ],
-        "notation": "見合(みあ)い"
+        ]
     },
     {
         "name": "hakadoru",
         "trans": [
+            "捗(はかど)る",
             "to make progress, to move right ahead (with the work), to advance"
-        ],
-        "notation": "捗(はかど)る"
+        ]
     },
     {
         "name": "tokken",
         "trans": [
+            "特権(とっけん)",
             "privilege, special right"
-        ],
-        "notation": "特権(とっけん)"
+        ]
     },
     {
         "name": "kari",
         "trans": [
+            "仮(かり)",
             "tentative, provisional"
-        ],
-        "notation": "仮(かり)"
+        ]
     },
     {
         "name": "shikakeru",
         "trans": [
+            "仕掛(しか)ける",
             "to commence, to lay (mines), to set (traps), to wage (war), to challenge"
-        ],
-        "notation": "仕掛(しか)ける"
+        ]
     },
     {
         "name": "somuku",
         "trans": [
+            "背(そむ)く",
             "to run counter to, to go against, to disobey, to infringe"
-        ],
-        "notation": "背(そむ)く"
+        ]
     },
     {
         "name": "kakekko",
         "trans": [
+            "駆(か)けっこ",
             "(foot) race"
-        ],
-        "notation": "駆(か)けっこ"
+        ]
     },
     {
         "name": "hotto",
         "trans": [
+            "ほっと",
             "feel relieved"
-        ],
-        "notation": "ほっと"
+        ]
     },
     {
         "name": "jiko",
         "trans": [
+            "自己(じこ)",
             "self, oneself"
-        ],
-        "notation": "自己(じこ)"
+        ]
     },
     {
         "name": "hontai",
         "trans": [
+            "本体(ほんたい)",
             "substance, real form, object of worship"
-        ],
-        "notation": "本体(ほんたい)"
+        ]
     },
     {
         "name": "monitaa",
         "trans": [
+            "モニター",
             "(computer) monitor"
-        ],
-        "notation": "モニター"
+        ]
     },
     {
         "name": "boku",
         "trans": [
+            "僕(ぼく)",
             "manservant, servant (of God)"
-        ],
-        "notation": "僕(ぼく)"
+        ]
     },
     {
         "name": "kaishuu",
         "trans": [
+            "改修(かいしゅう)",
             "repair, improvement"
-        ],
-        "notation": "改修(かいしゅう)"
+        ]
     },
     {
         "name": "chiritori",
         "trans": [
+            "塵(ちり)取(と)り",
             "dustpan"
-        ],
-        "notation": "塵(ちり)取(と)り"
+        ]
     },
     {
         "name": "shizumeru",
         "trans": [
+            "沈(しず)める",
             "to sink, to submerge"
-        ],
-        "notation": "沈(しず)める"
+        ]
     },
     {
         "name": "hentou",
         "trans": [
+            "返答(へんとう)",
             "reply"
-        ],
-        "notation": "返答(へんとう)"
+        ]
     },
     {
         "name": "oohaba",
         "trans": [
+            "大幅(おおはば)",
             "full width, large scale, drastic"
-        ],
-        "notation": "大幅(おおはば)"
+        ]
     },
     {
         "name": "koji",
         "trans": [
+            "孤児(こじ)",
             "orphan"
-        ],
-        "notation": "孤児(こじ)"
+        ]
     },
     {
         "name": "benkai",
         "trans": [
+            "弁解(べんかい)",
             "explanation, justification, defence, excuse"
-        ],
-        "notation": "弁解(べんかい)"
+        ]
     },
     {
         "name": "shitashimu",
         "trans": [
+            "親(した)しむ",
             "to be intimate with, to befriend"
-        ],
-        "notation": "親(した)しむ"
+        ]
     },
     {
         "name": "mikazuki",
         "trans": [
+            "三日月(みかづき)",
             "new moon, crescent moon"
-        ],
-        "notation": "三日月(みかづき)"
+        ]
     },
     {
         "name": "chinmoku",
         "trans": [
+            "沈黙(ちんもく)",
             "silence, reticence"
-        ],
-        "notation": "沈黙(ちんもく)"
+        ]
     },
     {
         "name": "bunkazai",
         "trans": [
+            "文化財(ぶんかざい)",
             "cultural assets, cultural property"
-        ],
-        "notation": "文化財(ぶんかざい)"
+        ]
     },
     {
         "name": "ikichigai",
         "trans": [
+            "行(い)き違(ちが)い",
             "misunderstanding, estrangement, disagreement, crossing without meeting, going astray"
-        ],
-        "notation": "行(い)き違(ちが)い"
+        ]
     },
     {
         "name": "hori",
         "trans": [
+            "捕吏(ほり)",
             "constable"
-        ],
-        "notation": "捕吏(ほり)"
+        ]
     },
     {
         "name": "menkai",
         "trans": [
+            "面会(めんかい)",
             "interview"
-        ],
-        "notation": "面会(めんかい)"
+        ]
     },
     {
         "name": "densetsu",
         "trans": [
+            "伝説(でんせつ)",
             "tradition, legend, folklore"
-        ],
-        "notation": "伝説(でんせつ)"
+        ]
     },
     {
         "name": "kyokugen",
         "trans": [
+            "局限(きょくげん)",
             "limit, localize"
-        ],
-        "notation": "局限(きょくげん)"
+        ]
     },
     {
         "name": "rinshoku",
         "trans": [
+            "吝嗇(りんしょく)",
             "stinginess, miser, miserliness, skinflint, tightwad, niggard, pinching pennies"
-        ],
-        "notation": "吝嗇(りんしょく)"
+        ]
     },
     {
         "name": "fuhen",
         "trans": [
+            "普遍(ふへん)",
             "universality, ubiquity, omnipresence"
-        ],
-        "notation": "普遍(ふへん)"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "分(ぶん)",
             "minute"
-        ],
-        "notation": "分(ぶん)"
+        ]
     },
     {
         "name": "gunbi",
         "trans": [
+            "軍備(ぐんび)",
             "armaments, military preparations"
-        ],
-        "notation": "軍備(ぐんび)"
+        ]
     },
     {
         "name": "gekidan",
         "trans": [
+            "劇団(げきだん)",
             "troupe, theatrical company"
-        ],
-        "notation": "劇団(げきだん)"
+        ]
     },
     {
         "name": "hoyou",
         "trans": [
+            "保養(ほよう)",
             "health preservation, recuperation, recreation"
-        ],
-        "notation": "保養(ほよう)"
+        ]
     },
     {
         "name": "tokorode",
         "trans": [
+            "所(ところ)で",
             "by the way, even if, no matter what"
-        ],
-        "notation": "所(ところ)で"
+        ]
     },
     {
         "name": "yakudatsu",
         "trans": [
+            "役立(やくだ)つ",
             "to be useful, to be helpful, to serve the purpose"
-        ],
-        "notation": "役立(やくだ)つ"
+        ]
     },
     {
         "name": "sakiototoi",
         "trans": [
+            "一昨昨日(さきおととい)",
             "two days before yesterday"
-        ],
-        "notation": "一昨昨日(さきおととい)"
+        ]
     },
     {
         "name": "shinshutsu",
         "trans": [
+            "進出(しんしゅつ)",
             "advance, step forward"
-        ],
-        "notation": "進出(しんしゅつ)"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "声明(せいめい)",
             "declaration, statement, proclamation"
-        ],
-        "notation": "声明(せいめい)"
+        ]
     },
     {
         "name": "hakujou",
         "trans": [
+            "白状(はくじょう)",
             "confession"
-        ],
-        "notation": "白状(はくじょう)"
+        ]
     },
     {
         "name": "kyoushuu",
         "trans": [
+            "郷愁(きょうしゅう)",
             "nostalgia, homesickness"
-        ],
-        "notation": "郷愁(きょうしゅう)"
+        ]
     },
     {
         "name": "mikata",
         "trans": [
+            "見方(みかた)",
             "viewpoint"
-        ],
-        "notation": "見方(みかた)"
+        ]
     },
     {
         "name": "yofuke",
         "trans": [
+            "夜更(よふ)け",
             "late at night"
-        ],
-        "notation": "夜更(よふ)け"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "基(もと)",
             "basis"
-        ],
-        "notation": "基(もと)"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "鉱業(こうぎょう)",
             "mining industry"
-        ],
-        "notation": "鉱業(こうぎょう)"
+        ]
     },
     {
         "name": "atsukai",
         "trans": [
+            "扱(あつか)い",
             "treatment, service"
-        ],
-        "notation": "扱(あつか)い"
+        ]
     },
     {
         "name": "hakai",
         "trans": [
+            "破壊(はかい)",
             "destruction"
-        ],
-        "notation": "破壊(はかい)"
+        ]
     },
     {
         "name": "gomake",
         "trans": [
+            "御(ご)負(ま)け",
             "1. a discount, a prize, 2. something additional, bonus, an extra, 3. an exaggeration"
-        ],
-        "notation": "御(ご)負(ま)け"
+        ]
     },
     {
         "name": "jaku",
         "trans": [
+            "弱(じゃく)",
             "weakness, the weak, little less then"
-        ],
-        "notation": "弱(じゃく)"
+        ]
     },
     {
         "name": "tsugi",
         "trans": [
+            "次(つぎ)",
             "order, sequence, times, next, below"
-        ],
-        "notation": "次(つぎ)"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "古(ふる)",
             "antiquity, ancient times"
-        ],
-        "notation": "古(ふる)"
+        ]
     },
     {
         "name": "sutoraiki",
         "trans": [
+            "ストライキ",
             "strike"
-        ],
-        "notation": "ストライキ"
+        ]
     },
     {
         "name": "uwamawaru",
         "trans": [
+            "上回(うわまわ)る",
             "to exceed"
-        ],
-        "notation": "上回(うわまわ)る"
+        ]
     },
     {
         "name": "kyo",
         "trans": [
+            "巨(きょ)",
             "big, large, great"
-        ],
-        "notation": "巨(きょ)"
+        ]
     },
     {
         "name": "oseji",
         "trans": [
+            "お世辞(せじ)",
             "flattery, compliment"
-        ],
-        "notation": "お世辞(せじ)"
+        ]
     },
     {
         "name": "suuhai",
         "trans": [
+            "崇拝(すうはい)",
             "worship, adoration, admiration, cult"
-        ],
-        "notation": "崇拝(すうはい)"
+        ]
     },
     {
         "name": "kamoshirenai",
         "trans": [
+            "かも知(し)れない",
             "may, might, perhaps, may be, possibly"
-        ],
-        "notation": "かも知(し)れない"
+        ]
     },
     {
         "name": "shutsuen",
         "trans": [
+            "出演(しゅつえん)",
             "performance, stage appearance"
-        ],
-        "notation": "出演(しゅつえん)"
+        ]
     },
     {
         "name": "boyaku",
         "trans": [
+            "ぼやく",
             "to grumble, to complain"
-        ],
-        "notation": "ぼやく"
+        ]
     },
     {
         "name": "tadayou",
         "trans": [
+            "漂(ただよ)う",
             "to drift about, to float, to hang in air"
-        ],
-        "notation": "漂(ただよ)う"
+        ]
     },
     {
         "name": "dorai",
         "trans": [
+            "ドライ",
             "dry"
-        ],
-        "notation": "ドライ"
+        ]
     },
     {
         "name": "tousou",
         "trans": [
+            "逃走(とうそう)",
             "flight, desertion, escape"
-        ],
-        "notation": "逃走(とうそう)"
+        ]
     },
     {
         "name": "haichi",
         "trans": [
+            "配置(はいち)",
             "arrangement (of resources), disposition"
-        ],
-        "notation": "配置(はいち)"
+        ]
     },
     {
         "name": "douki",
         "trans": [
+            "動機(どうき)",
             "motive, incentive"
-        ],
-        "notation": "動機(どうき)"
+        ]
     },
     {
         "name": "dounika",
         "trans": [
+            "どうにか",
             "in some way or other, one way or another"
-        ],
-        "notation": "どうにか"
+        ]
     },
     {
         "name": "goi",
         "trans": [
+            "語彙(ごい)",
             "vocabulary, glossary"
-        ],
-        "notation": "語彙(ごい)"
+        ]
     },
     {
         "name": "chaimu",
         "trans": [
+            "チャイム",
             "chime"
-        ],
-        "notation": "チャイム"
+        ]
     },
     {
         "name": "kiten",
         "trans": [
+            "起点(きてん)",
             "starting point"
-        ],
-        "notation": "起点(きてん)"
+        ]
     },
     {
         "name": "mudazukai",
         "trans": [
+            "無駄遣(むだづか)い",
             "waste money on, squander money on, flog a dead horse"
-        ],
-        "notation": "無駄遣(むだづか)い"
+        ]
     },
     {
         "name": "nama",
         "trans": [
+            "生(なま)",
             "pure, undiluted, raw, crude"
-        ],
-        "notation": "生(なま)"
+        ]
     },
     {
         "name": "tomo",
         "trans": [
+            "共(とも)",
             "both, neither (neg), all, and, as well as, including, with, together with, plural ending"
-        ],
-        "notation": "共(とも)"
+        ]
     },
     {
         "name": "ninshiki",
         "trans": [
+            "認識(にんしき)",
             "recognition, cognizance"
-        ],
-        "notation": "認識(にんしき)"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "堪(こた)える",
             "to bear, to stand, to endure, to put up with, to support, to withstand, to resist, to brave, to be fit for, t"
-        ],
-        "notation": "堪(こた)える"
+        ]
     },
     {
         "name": "uchiwake",
         "trans": [
+            "内訳(うちわけ)",
             "the items, breakdown, classification"
-        ],
-        "notation": "内訳(うちわけ)"
+        ]
     },
     {
         "name": "juunan",
         "trans": [
+            "柔軟(じゅうなん)",
             "flexible, lithe"
-        ],
-        "notation": "柔軟(じゅうなん)"
+        ]
     },
     {
         "name": "hoon",
         "trans": [
+            "保温(ほおん)",
             "retaining warmth, keeping heat in, heat insulation"
-        ],
-        "notation": "保温(ほおん)"
+        ]
     },
     {
         "name": "kataomoi",
         "trans": [
+            "片思(かたおも)い",
             "unrequited love"
-        ],
-        "notation": "片思(かたおも)い"
+        ]
     },
     {
         "name": "tsukekuwaeru",
         "trans": [
+            "付(つ)け加(くわ)える",
             "to add one thing to another"
-        ],
-        "notation": "付(つ)け加(くわ)える"
+        ]
     },
     {
         "name": "kougen",
         "trans": [
+            "高原(こうげん)",
             "tableland, plateau"
-        ],
-        "notation": "高原(こうげん)"
+        ]
     },
     {
         "name": "supuringu",
         "trans": [
+            "スプリング",
             "spring"
-        ],
-        "notation": "スプリング"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "慣(な)らす",
             "to accustom"
-        ],
-        "notation": "慣(な)らす"
+        ]
     },
     {
         "name": "sassuru",
         "trans": [
+            "察(さっ)する",
             "to guess, to sense, to presume, to judge, to sympathize with"
-        ],
-        "notation": "察(さっ)する"
+        ]
     },
     {
         "name": "hamamaru",
         "trans": [
+            "填(はま)まる",
             "to get into, to go into, to fit, to be fit for, to suit, to fall into, to plunge into, to be deceived, to be"
-        ],
-        "notation": "填(はま)まる"
+        ]
     },
     {
         "name": "miharashi",
         "trans": [
+            "見晴(みは)らし",
             "view"
-        ],
-        "notation": "見晴(みは)らし"
+        ]
     },
     {
         "name": "kippari",
         "trans": [
+            "きっぱり",
             "clearly, plainly, distinctly"
-        ],
-        "notation": "きっぱり"
+        ]
     },
     {
         "name": "guree",
         "trans": [
+            "グレー",
             "grey, gray"
-        ],
-        "notation": "グレー"
+        ]
     },
     {
         "name": "tasuuketsu",
         "trans": [
+            "多数決(たすうけつ)",
             "majority rule"
-        ],
-        "notation": "多数決(たすうけつ)"
+        ]
     },
     {
         "name": "rui",
         "trans": [
+            "類(るい)",
             "a kind"
-        ],
-        "notation": "類(るい)"
+        ]
     },
     {
         "name": "hojo",
         "trans": [
+            "補助(ほじょ)",
             "assistance, support, aid, auxiliary"
-        ],
-        "notation": "補助(ほじょ)"
+        ]
     },
     {
         "name": "naganaga",
         "trans": [
+            "長々(ながなが)",
             "long, drawn-out, very long"
-        ],
-        "notation": "長々(ながなが)"
+        ]
     },
     {
         "name": "yokuatsu",
         "trans": [
+            "抑圧(よくあつ)",
             "check, restraint, oppression, suppression"
-        ],
-        "notation": "抑圧(よくあつ)"
+        ]
     },
     {
         "name": "tanchou",
         "trans": [
+            "単調(たんちょう)",
             "monotony, monotone, dullness"
-        ],
-        "notation": "単調(たんちょう)"
+        ]
     },
     {
         "name": "takaraki",
         "trans": [
+            "宝(たから)器(き)",
             "treasured article or vessel, outstanding individual"
-        ],
-        "notation": "宝(たから)器(き)"
+        ]
     },
     {
         "name": "haikyuu",
         "trans": [
+            "配給(はいきゅう)",
             "distribution (eg. films rice)"
-        ],
-        "notation": "配給(はいきゅう)"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "文(ぶん)",
             "letter, writings"
-        ],
-        "notation": "文(ぶん)"
+        ]
     },
     {
         "name": "bijinesu",
         "trans": [
+            "ビジネス",
             "business"
-        ],
-        "notation": "ビジネス"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "終始(しゅうし)",
             "beginning and end, from beginning to end, doing a thing from beginning to end"
-        ],
-        "notation": "終始(しゅうし)"
+        ]
     },
     {
         "name": "seikou",
         "trans": [
+            "精巧(せいこう)",
             "elaborate, delicate, exquisite"
-        ],
-        "notation": "精巧(せいこう)"
+        ]
     },
     {
         "name": "mari",
         "trans": [
+            "鞠(まり)",
             "ball"
-        ],
-        "notation": "鞠(まり)"
+        ]
     },
     {
         "name": "enman",
         "trans": [
+            "円満(えんまん)",
             "perfection, harmony, peace, smoothness, completeness, satisfaction, integrity"
-        ],
-        "notation": "円満(えんまん)"
+        ]
     },
     {
         "name": "kasho",
         "trans": [
+            "箇所(かしょ)",
             "passage, place, point, part"
-        ],
-        "notation": "箇所(かしょ)"
+        ]
     },
     {
         "name": "abekobe",
         "trans": [
+            "あべこべ",
             "contrary, opposite, inverse"
-        ],
-        "notation": "あべこべ"
+        ]
     },
     {
         "name": "kabushiki",
         "trans": [
+            "株式(かぶしき)",
             "stock (company)"
-        ],
-        "notation": "株式(かぶしき)"
+        ]
     },
     {
         "name": "yowaru",
         "trans": [
+            "弱(よわ)る",
             "to weaken, to be troubled, to be downcast, to be emaciated, to be dejected, to be perplexed, to impair"
-        ],
-        "notation": "弱(よわ)る"
+        ]
     },
     {
         "name": "koushinryou",
         "trans": [
+            "香辛料(こうしんりょう)",
             "spices"
-        ],
-        "notation": "香辛料(こうしんりょう)"
+        ]
     },
     {
         "name": "yasei",
         "trans": [
+            "野生(やせい)",
             "wild"
-        ],
-        "notation": "野生(やせい)"
+        ]
     },
     {
         "name": "yokosu",
         "trans": [
+            "寄(よ)こす",
             "to send, to forward"
-        ],
-        "notation": "寄(よ)こす"
+        ]
     },
     {
         "name": "wazato",
         "trans": [
+            "態(わざ)と",
             "on purpose"
-        ],
-        "notation": "態(わざ)と"
+        ]
     },
     {
         "name": "tsuyoite",
         "trans": [
+            "強(つよ)いて",
             "by force"
-        ],
-        "notation": "強(つよ)いて"
+        ]
     },
     {
         "name": "tehazu",
         "trans": [
+            "手筈(てはず)",
             "arrangement, plan, programme"
-        ],
-        "notation": "手筈(てはず)"
+        ]
     },
     {
         "name": "hiryou",
         "trans": [
+            "肥料(ひりょう)",
             "manure, fertilizer"
-        ],
-        "notation": "肥料(ひりょう)"
+        ]
     },
     {
         "name": "nobeiteha",
         "trans": [
+            "延(のべ)いては",
             "not only...but also, in addition to, consequently"
-        ],
-        "notation": "延(のべ)いては"
+        ]
     },
     {
         "name": "koukai",
         "trans": [
+            "航海(こうかい)",
             "sail, voyage"
-        ],
-        "notation": "航海(こうかい)"
+        ]
     },
     {
         "name": "hori",
         "trans": [
+            "濠(ほり)",
             "moat"
-        ],
-        "notation": "濠(ほり)"
+        ]
     },
     {
         "name": "tossa",
         "trans": [
+            "咄嗟(とっさ)",
             "moment, instant"
-        ],
-        "notation": "咄嗟(とっさ)"
+        ]
     },
     {
         "name": "musubi",
         "trans": [
+            "結(むす)び",
             "ending, conclusion, union"
-        ],
-        "notation": "結(むす)び"
+        ]
     },
     {
         "name": "higashi",
         "trans": [
+            "東(ひがし)",
             "east, Eastern Japan"
-        ],
-        "notation": "東(ひがし)"
+        ]
     },
     {
         "name": "kubikazari",
         "trans": [
+            "首飾(くびかざ)り",
             "necklace"
-        ],
-        "notation": "首飾(くびかざ)り"
+        ]
     },
     {
         "name": "horobiru",
         "trans": [
+            "滅(ほろ)びる",
             "to be ruined, to go under, to perish, to be destroyed"
-        ],
-        "notation": "滅(ほろ)びる"
+        ]
     },
     {
         "name": "soukyuu",
         "trans": [
+            "早急(そうきゅう)",
             "urgent"
-        ],
-        "notation": "早急(そうきゅう)"
+        ]
     },
     {
         "name": "bakudan",
         "trans": [
+            "爆弾(ばくだん)",
             "bomb"
-        ],
-        "notation": "爆弾(ばくだん)"
+        ]
     },
     {
         "name": "ketsudan",
         "trans": [
+            "決断(けつだん)",
             "decision, determination"
-        ],
-        "notation": "決断(けつだん)"
+        ]
     },
     {
         "name": "kahei",
         "trans": [
+            "貨幣(かへい)",
             "money, currency, coinage"
-        ],
-        "notation": "貨幣(かへい)"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "縁(えん)",
             "chance, fate, destiny, relation, bonds, connection, karma"
-        ],
-        "notation": "縁(えん)"
+        ]
     },
     {
         "name": "sesshoku",
         "trans": [
+            "接触(せっしょく)",
             "touch, contact"
-        ],
-        "notation": "接触(せっしょく)"
+        ]
     },
     {
         "name": "sensui",
         "trans": [
+            "潜水(せんすい)",
             "diving"
-        ],
-        "notation": "潜水(せんすい)"
+        ]
     },
     {
         "name": "rouru",
         "trans": [
+            "労(ろう)る",
             "to pity, to sympathize with, to console, to care for, to be kind to"
-        ],
-        "notation": "労(ろう)る"
+        ]
     },
     {
         "name": "muyamini",
         "trans": [
+            "無闇(むやみ)に",
             "unreasonably, absurdly, recklessly, indiscreetly, at random"
-        ],
-        "notation": "無闇(むやみ)に"
+        ]
     },
     {
         "name": "shisan",
         "trans": [
+            "資産(しさん)",
             "property, fortune, means, assets"
-        ],
-        "notation": "資産(しさん)"
+        ]
     },
     {
         "name": "saigen",
         "trans": [
+            "再現(さいげん)",
             "reappearance, reproduction, return, revival"
-        ],
-        "notation": "再現(さいげん)"
+        ]
     },
     {
         "name": "kairo",
         "trans": [
+            "海路(かいろ)",
             "sea route"
-        ],
-        "notation": "海路(かいろ)"
+        ]
     },
     {
         "name": "jigoku",
         "trans": [
+            "地獄(じごく)",
             "hell"
-        ],
-        "notation": "地獄(じごく)"
+        ]
     },
     {
         "name": "kikkari",
         "trans": [
+            "きっかり",
             "exactly, precisely"
-        ],
-        "notation": "きっかり"
+        ]
     },
     {
         "name": "busshi",
         "trans": [
+            "物資(ぶっし)",
             "goods, materials"
-        ],
-        "notation": "物資(ぶっし)"
+        ]
     },
     {
         "name": "uchikeshi",
         "trans": [
+            "打(う)ち消(け)し",
             "negation, denial, negative"
-        ],
-        "notation": "打(う)ち消(け)し"
+        ]
     },
     {
         "name": "yousuru",
         "trans": [
+            "要(よう)する",
             "to demand, to require, to take"
-        ],
-        "notation": "要(よう)する"
+        ]
     },
     {
         "name": "mangetsu",
         "trans": [
+            "満月(まんげつ)",
             "full moon"
-        ],
-        "notation": "満月(まんげつ)"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "未(み)",
             "eighth sign of Chinese zodiac (The Ram 1pm-3pm south-southwest June)"
-        ],
-        "notation": "未(み)"
+        ]
     },
     {
         "name": "shikashite",
         "trans": [
+            "然(しか)して",
             "and"
-        ],
-        "notation": "然(しか)して"
+        ]
     },
     {
         "name": "imada",
         "trans": [
+            "未(いま)だ",
             "as yet, hitherto, not yet (neg)"
-        ],
-        "notation": "未(いま)だ"
+        ]
     },
     {
         "name": "hanran",
         "trans": [
+            "氾濫(はんらん)",
             "overflowing, flood"
-        ],
-        "notation": "氾濫(はんらん)"
+        ]
     },
     {
         "name": "bunpai",
         "trans": [
+            "分配(ぶんぱい)",
             "division, sharing"
-        ],
-        "notation": "分配(ぶんぱい)"
+        ]
     },
     {
         "name": "kouin",
         "trans": [
+            "行員(こういん)",
             "bank clerk"
-        ],
-        "notation": "行員(こういん)"
+        ]
     },
     {
         "name": "nishibi",
         "trans": [
+            "西日(にしび)",
             "westering sun"
-        ],
-        "notation": "西日(にしび)"
+        ]
     },
     {
         "name": "shitsuke",
         "trans": [
+            "躾(しつけ)",
             "home discipline, training, upbringing, breeding"
-        ],
-        "notation": "躾(しつけ)"
+        ]
     },
     {
         "name": "hajime",
         "trans": [
+            "始(はじ)め",
             "beginning, start, origin"
-        ],
-        "notation": "始(はじ)め"
+        ]
     },
     {
         "name": "rongi",
         "trans": [
+            "論議(ろんぎ)",
             "discussion"
-        ],
-        "notation": "論議(ろんぎ)"
+        ]
     },
     {
         "name": "kouritsu",
         "trans": [
+            "効率(こうりつ)",
             "efficiency"
-        ],
-        "notation": "効率(こうりつ)"
+        ]
     },
     {
         "name": "nodoka",
         "trans": [
+            "長閑(のどか)",
             "tranquil, calm, quiet"
-        ],
-        "notation": "長閑(のどか)"
+        ]
     },
     {
         "name": "sonoshora",
         "trans": [
+            "其(その)処(しょ)ら",
             "everywhere, somewhere, approximately, that area, around there"
-        ],
-        "notation": "其(その)処(しょ)ら"
+        ]
     },
     {
         "name": "tsupparu",
         "trans": [
+            "突(つ)っ張(ぱ)る",
             "to support, to become stiff, to become taut, to thrust (ones opponent), to stick to (ones opinion), to in"
-        ],
-        "notation": "突(つ)っ張(ぱ)る"
+        ]
     },
     {
         "name": "chochiku",
         "trans": [
+            "貯蓄(ちょちく)",
             "savings"
-        ],
-        "notation": "貯蓄(ちょちく)"
+        ]
     },
     {
         "name": "teki",
         "trans": [
+            "的(てき)",
             "-like, typical"
-        ],
-        "notation": "的(てき)"
+        ]
     },
     {
         "name": "arasoi",
         "trans": [
+            "争(あらそ)い",
             "dispute, strife, quarrel, dissension, conflict, rivalry, contest"
-        ],
-        "notation": "争(あらそ)い"
+        ]
     },
     {
         "name": "genshi",
         "trans": [
+            "原子(げんし)",
             "atom"
-        ],
-        "notation": "原子(げんし)"
+        ]
     },
     {
         "name": "daisui",
         "trans": [
+            "大水(だいすい)",
             "flood"
-        ],
-        "notation": "大水(だいすい)"
+        ]
     },
     {
         "name": "kaerimiru",
         "trans": [
+            "顧(かえり)みる",
             "to look back, to turn around, to review"
-        ],
-        "notation": "顧(かえり)みる"
+        ]
     },
     {
         "name": "masashiku",
         "trans": [
+            "正(まさ)しく",
             "surely, no doubt, evidently"
-        ],
-        "notation": "正(まさ)しく"
+        ]
     },
     {
         "name": "funmatsu",
         "trans": [
+            "粉末(ふんまつ)",
             "fine powder"
-        ],
-        "notation": "粉末(ふんまつ)"
+        ]
     },
     {
         "name": "ryoudo",
         "trans": [
+            "領土(りょうど)",
             "dominion, territory, possession"
-        ],
-        "notation": "領土(りょうど)"
+        ]
     },
     {
         "name": "kozue",
         "trans": [
+            "梢(こずえ)",
             "treetop"
-        ],
-        "notation": "梢(こずえ)"
+        ]
     },
     {
         "name": "kanyuu",
         "trans": [
+            "加入(かにゅう)",
             "becoming a member, joining, entry, admission, subscription, affiliation, adherence, signing"
-        ],
-        "notation": "加入(かにゅう)"
+        ]
     },
     {
         "name": "-kani",
         "trans": [
+            "-簡易(かんい)",
             "simplicity, easiness, quasi"
-        ],
-        "notation": "-簡易(かんい)"
+        ]
     },
     {
         "name": "osou",
         "trans": [
+            "襲(おそ)う",
             "to attack"
-        ],
-        "notation": "襲(おそ)う"
+        ]
     },
     {
         "name": "kyuusai",
         "trans": [
+            "救済(きゅうさい)",
             "relief, aid, rescue, salvation, help"
-        ],
-        "notation": "救済(きゅうさい)"
+        ]
     },
     {
         "name": "shukan",
         "trans": [
+            "主観(しゅかん)",
             "subjectivity, subject, ego"
-        ],
-        "notation": "主観(しゅかん)"
+        ]
     },
     {
         "name": "tsuujou",
         "trans": [
+            "通常(つうじょう)",
             "common, general, usually"
-        ],
-        "notation": "通常(つうじょう)"
+        ]
     },
     {
         "name": "burasageru",
         "trans": [
+            "ぶら下(さ)げる",
             "to hang, to suspend, to dangle, to swing"
-        ],
-        "notation": "ぶら下(さ)げる"
+        ]
     },
     {
         "name": "midasu",
         "trans": [
+            "乱(みだ)す",
             "to throw out of order, to disarrange, to disturb"
-        ],
-        "notation": "乱(みだ)す"
+        ]
     },
     {
         "name": "kuroji",
         "trans": [
+            "黒字(くろじ)",
             "balance (figure) in the black"
-        ],
-        "notation": "黒字(くろじ)"
+        ]
     },
     {
         "name": "zetsubou",
         "trans": [
+            "絶望(ぜつぼう)",
             "despair, hopelessness"
-        ],
-        "notation": "絶望(ぜつぼう)"
+        ]
     },
     {
         "name": "kakushin",
         "trans": [
+            "革新(かくしん)",
             "reform, innovation"
-        ],
-        "notation": "革新(かくしん)"
+        ]
     },
     {
         "name": "yurumu",
         "trans": [
+            "緩(ゆる)む",
             "to become loose, to slacken"
-        ],
-        "notation": "緩(ゆる)む"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "角(かく)",
             "1. angle, 2. bishop (shogi)"
-        ],
-        "notation": "角(かく)"
+        ]
     },
     {
         "name": "kou",
         "trans": [
+            "高(こう)",
             "quantity, amount, volume, number, amount of money"
-        ],
-        "notation": "高(こう)"
+        ]
     },
     {
         "name": "taisei",
         "trans": [
+            "態勢(たいせい)",
             "attitude, conditions, preparations"
-        ],
-        "notation": "態勢(たいせい)"
+        ]
     },
     {
         "name": "shinri",
         "trans": [
+            "真理(しんり)",
             "truth"
-        ],
-        "notation": "真理(しんり)"
+        ]
     },
     {
         "name": "naishi",
         "trans": [
+            "乃至(ないし)",
             "from...to, between...and, or"
-        ],
-        "notation": "乃至(ないし)"
+        ]
     },
     {
         "name": "hatsuiku",
         "trans": [
+            "発育(はついく)",
             "(physical) growth, development"
-        ],
-        "notation": "発育(はついく)"
+        ]
     },
     {
         "name": "niburu",
         "trans": [
+            "鈍(にぶ)る",
             "to become less capable, to grow dull, to become blunt, to weaken"
-        ],
-        "notation": "鈍(にぶ)る"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "膜(まく)",
             "membrane, film"
-        ],
-        "notation": "膜(まく)"
+        ]
     },
     {
         "name": "yutori",
         "trans": [
+            "ゆとり",
             "reserve, affluence, room, time (to spare)"
-        ],
-        "notation": "ゆとり"
+        ]
     },
     {
         "name": "fuudo",
         "trans": [
+            "風土(ふうど)",
             "natural features, topography, climate, spiritual features"
-        ],
-        "notation": "風土(ふうど)"
+        ]
     },
     {
         "name": "marugoto",
         "trans": [
+            "丸(まる)ごと",
             "in its entirety, whole, wholly"
-        ],
-        "notation": "丸(まる)ごと"
+        ]
     },
     {
         "name": "namagusai",
         "trans": [
+            "生臭(なまぐさ)い",
             "smelling of fish or blood, fish or meat"
-        ],
-        "notation": "生臭(なまぐさ)い"
+        ]
     },
     {
         "name": "manmae",
         "trans": [
+            "真(ま)ん前(まえ)",
             "right in front, under the nose"
-        ],
-        "notation": "真(ま)ん前(まえ)"
+        ]
     },
     {
         "name": "damasu",
         "trans": [
+            "騙(だま)す",
             "to trick, to cheat, to deceive"
-        ],
-        "notation": "騙(だま)す"
+        ]
     },
     {
         "name": "kaibatsu",
         "trans": [
+            "海抜(かいばつ)",
             "height above sea level"
-        ],
-        "notation": "海抜(かいばつ)"
+        ]
     },
     {
         "name": "meihaku",
         "trans": [
+            "明白(めいはく)",
             "obvious, overt, plainly, frankly"
-        ],
-        "notation": "明白(めいはく)"
+        ]
     },
     {
         "name": "youin",
         "trans": [
+            "要因(よういん)",
             "primary factor, main cause"
-        ],
-        "notation": "要因(よういん)"
+        ]
     },
     {
         "name": "boikotto",
         "trans": [
+            "ボイコット",
             "boycott"
-        ],
-        "notation": "ボイコット"
+        ]
     },
     {
         "name": "renkyuu",
         "trans": [
+            "連休(れんきゅう)",
             "consecutive holidays"
-        ],
-        "notation": "連休(れんきゅう)"
+        ]
     },
     {
         "name": "douyou",
         "trans": [
+            "動揺(どうよう)",
             "disturbance, unrest, shaking, trembling, pitching, rolling, oscillation, agitation, excitement, commotion"
-        ],
-        "notation": "動揺(どうよう)"
+        ]
     },
     {
         "name": "kizou",
         "trans": [
+            "寄贈(きぞう)",
             "donation, presentation"
-        ],
-        "notation": "寄贈(きぞう)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "説(と)く",
             "to explain, to advocate, to preach, to persuade"
-        ],
-        "notation": "説(と)く"
+        ]
     },
     {
         "name": "zoukyou",
         "trans": [
+            "増強(ぞうきょう)",
             "augment, reinforce, increase"
-        ],
-        "notation": "増強(ぞうきょう)"
+        ]
     },
     {
         "name": "pea",
         "trans": [
+            "ペア",
             "pair, pear"
-        ],
-        "notation": "ペア"
+        ]
     },
     {
         "name": "setsunai",
         "trans": [
+            "切(せつ)ない",
             "painful, trying, oppressive, suffocating"
-        ],
-        "notation": "切(せつ)ない"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "観(かん)",
             "look, appearance, spectacle"
-        ],
-        "notation": "観(かん)"
+        ]
     },
     {
         "name": "mekuru",
         "trans": [
+            "捲(めく)る",
             "verb suffix to indicate reckless abandon to the activity"
-        ],
-        "notation": "捲(めく)る"
+        ]
     },
     {
         "name": "kaiaku",
         "trans": [
+            "改悪(かいあく)",
             "deterioration, changing for the worse"
-        ],
-        "notation": "改悪(かいあく)"
+        ]
     },
     {
         "name": "saikutsu",
         "trans": [
+            "採掘(さいくつ)",
             "mining"
-        ],
-        "notation": "採掘(さいくつ)"
+        ]
     },
     {
         "name": "hankan",
         "trans": [
+            "反感(はんかん)",
             "antipathy, revolt, animosity"
-        ],
-        "notation": "反感(はんかん)"
+        ]
     },
     {
         "name": "fungai",
         "trans": [
+            "憤慨(ふんがい)",
             "indignation, resentment"
-        ],
-        "notation": "憤慨(ふんがい)"
+        ]
     },
     {
         "name": "genyu",
         "trans": [
+            "原油(げんゆ)",
             "crude oil"
-        ],
-        "notation": "原油(げんゆ)"
+        ]
     },
     {
         "name": "hatsu",
         "trans": [
+            "初(はつ)",
             "first, new"
-        ],
-        "notation": "初(はつ)"
+        ]
     },
     {
         "name": "settei",
         "trans": [
+            "設定(せってい)",
             "establishment, creation"
-        ],
-        "notation": "設定(せってい)"
+        ]
     },
     {
         "name": "mochikiri",
         "trans": [
+            "持(も)ち切(き)り",
             "hot topic, talk of the town"
-        ],
-        "notation": "持(も)ち切(き)り"
+        ]
     },
     {
         "name": "chouri",
         "trans": [
+            "調理(ちょうり)",
             "cooking"
-        ],
-        "notation": "調理(ちょうり)"
+        ]
     },
     {
         "name": "chikushou",
         "trans": [
+            "畜生(ちくしょう)",
             "beast, brute, damn"
-        ],
-        "notation": "畜生(ちくしょう)"
+        ]
     },
     {
         "name": "hatsujou",
         "trans": [
+            "発条(はつじょう)",
             "spring (e.g. coil leaf)"
-        ],
-        "notation": "発条(はつじょう)"
+        ]
     },
     {
         "name": "osamaru",
         "trans": [
+            "納(おさ)まる",
             "to be obtained, to end, to settle into, to fit into, to be settled, to be paid, to be delivered"
-        ],
-        "notation": "納(おさ)まる"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "加味(かみ)",
             "seasoning, flavoring"
-        ],
-        "notation": "加味(かみ)"
+        ]
     },
     {
         "name": "butsugi",
         "trans": [
+            "物議(ぶつぎ)",
             "public discussion (criticism)"
-        ],
-        "notation": "物議(ぶつぎ)"
+        ]
     },
     {
         "name": "geri",
         "trans": [
+            "下痢(げり)",
             "diarrhoea"
-        ],
-        "notation": "下痢(げり)"
+        ]
     },
     {
         "name": "shiagari",
         "trans": [
+            "仕上(しあ)がり",
             "finish, end, completion"
-        ],
-        "notation": "仕上(しあ)がり"
+        ]
     },
     {
         "name": "chakumoku",
         "trans": [
+            "着目(ちゃくもく)",
             "attention"
-        ],
-        "notation": "着目(ちゃくもく)"
+        ]
     },
     {
         "name": "sonokata",
         "trans": [
+            "其(その)方(かた)",
             "over there, the other"
-        ],
-        "notation": "其(その)方(かた)"
+        ]
     },
     {
         "name": "hinkon",
         "trans": [
+            "貧困(ひんこん)",
             "poverty, lack"
-        ],
-        "notation": "貧困(ひんこん)"
+        ]
     },
     {
         "name": "komoru",
         "trans": [
+            "篭(こも)る",
             "to seclude oneself, to be confined in, to be implied, to be stuffy"
-        ],
-        "notation": "篭(こも)る"
+        ]
     },
     {
         "name": "marumeru",
         "trans": [
+            "丸(まる)める",
             "to make round, to round off, to roll up, to curl up, to seduce, to cajole, to explain away"
-        ],
-        "notation": "丸(まる)める"
+        ]
     },
     {
         "name": "tenchi",
         "trans": [
+            "天地(てんち)",
             "heaven and earth, the universe, nature, top and bottom, realm, sphere, world"
-        ],
-        "notation": "天地(てんち)"
+        ]
     },
     {
         "name": "totsujo",
         "trans": [
+            "突如(とつじょ)",
             "suddenly, all of a sudden"
-        ],
-        "notation": "突如(とつじょ)"
+        ]
     },
     {
         "name": "sousa",
         "trans": [
+            "捜査(そうさ)",
             "search (esp. in criminal investigations), investigation"
-        ],
-        "notation": "捜査(そうさ)"
+        ]
     },
     {
         "name": "kansei",
         "trans": [
+            "歓声(かんせい)",
             "cheer, shout of joy"
-        ],
-        "notation": "歓声(かんせい)"
+        ]
     },
     {
         "name": "bouei",
         "trans": [
+            "防衛(ぼうえい)",
             "defense, protection, self-defense"
-        ],
-        "notation": "防衛(ぼうえい)"
+        ]
     },
     {
         "name": "jisa",
         "trans": [
+            "時差(じさ)",
             "time difference"
-        ],
-        "notation": "時差(じさ)"
+        ]
     },
     {
         "name": "omomuku",
         "trans": [
+            "赴(おもむ)く",
             "to go, to proceed, to repair to, to become"
-        ],
-        "notation": "赴(おもむ)く"
+        ]
     },
     {
         "name": "maki",
         "trans": [
+            "巻(まき)",
             "volume"
-        ],
-        "notation": "巻(まき)"
+        ]
     },
     {
         "name": "doujou",
         "trans": [
+            "同情(どうじょう)",
             "sympathy, compassion, sympathize, pity, feel for"
-        ],
-        "notation": "同情(どうじょう)"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "酸(さん)",
             "acid"
-        ],
-        "notation": "酸(さん)"
+        ]
     },
     {
         "name": "toraeru",
         "trans": [
+            "捕(と)らえる",
             "to seize, to grasp, to capture, to arrest"
-        ],
-        "notation": "捕(と)らえる"
+        ]
     },
     {
         "name": "jitai",
         "trans": [
+            "辞退(じたい)",
             "refusal"
-        ],
-        "notation": "辞退(じたい)"
+        ]
     },
     {
         "name": "kyouretsu",
         "trans": [
+            "強烈(きょうれつ)",
             "strong, intense, severe"
-        ],
-        "notation": "強烈(きょうれつ)"
+        ]
     },
     {
         "name": "kuku",
         "trans": [
+            "区々(くく)",
             "1. several, various, divergent, conflicting, different, diverse, 2. trivial"
-        ],
-        "notation": "区々(くく)"
+        ]
     },
     {
         "name": "yorufukashi",
         "trans": [
+            "夜(よる)更(ふ)かし",
             "staying up late, keeping late hours, sitting up late at night, nighthawk"
-        ],
-        "notation": "夜(よる)更(ふ)かし"
+        ]
     },
     {
         "name": "yuniiku",
         "trans": [
+            "ユニーク",
             "unique"
-        ],
-        "notation": "ユニーク"
+        ]
     },
     {
         "name": "sho",
         "trans": [
+            "諸(しょ)",
             "various, many, several"
-        ],
-        "notation": "諸(しょ)"
+        ]
     },
     {
         "name": "kaikaku",
         "trans": [
+            "改革(かいかく)",
             "reform, reformation, innovation"
-        ],
-        "notation": "改革(かいかく)"
+        ]
     },
     {
         "name": "roupu",
         "trans": [
+            "ロープ",
             "rope"
-        ],
-        "notation": "ロープ"
+        ]
     },
     {
         "name": "hachimitsu",
         "trans": [
+            "蜂蜜(はちみつ)",
             "honey"
-        ],
-        "notation": "蜂蜜(はちみつ)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "止(と)まる",
             "to be limited to"
-        ],
-        "notation": "止(と)まる"
+        ]
     },
     {
         "name": "kousou",
         "trans": [
+            "構想(こうそう)",
             "plan, plot, idea, conception"
-        ],
-        "notation": "構想(こうそう)"
+        ]
     },
     {
         "name": "taiken",
         "trans": [
+            "体験(たいけん)",
             "personal experience"
-        ],
-        "notation": "体験(たいけん)"
+        ]
     },
     {
         "name": "gakugei",
         "trans": [
+            "学芸(がくげい)",
             "arts and sciences, liberal arts"
-        ],
-        "notation": "学芸(がくげい)"
+        ]
     },
     {
         "name": "mudan",
         "trans": [
+            "無断(むだん)",
             "without permission, without notice"
-        ],
-        "notation": "無断(むだん)"
+        ]
     },
     {
         "name": "tekkiri",
         "trans": [
+            "てっきり",
             "surely, certainly, beyond doubt"
-        ],
-        "notation": "てっきり"
+        ]
     },
     {
         "name": "joucho",
         "trans": [
+            "情緒(じょうちょ)",
             "emotion, feeling"
-        ],
-        "notation": "情緒(じょうちょ)"
+        ]
     },
     {
         "name": "pointo",
         "trans": [
+            "ポイント",
             "point"
-        ],
-        "notation": "ポイント"
+        ]
     },
     {
         "name": "tadoru",
         "trans": [
+            "辿(たど)る",
             "to follow (road), to pursue (course), to follow up"
-        ],
-        "notation": "辿(たど)る"
+        ]
     },
     {
         "name": "sugu",
         "trans": [
+            "直(す)ぐ",
             "immediately, soon, easily, right (near), honest, upright"
-        ],
-        "notation": "直(す)ぐ"
+        ]
     },
     {
         "name": "houken",
         "trans": [
+            "封建(ほうけん)",
             "feudalistic"
-        ],
-        "notation": "封建(ほうけん)"
+        ]
     },
     {
         "name": "hekieki",
         "trans": [
+            "辟易(へきえき)",
             "wince, shrink back, succumbing to, being frightened, disconcerted"
-        ],
-        "notation": "辟易(へきえき)"
+        ]
     },
     {
         "name": "nyuansu",
         "trans": [
+            "ニュアンス",
             "nuance"
-        ],
-        "notation": "ニュアンス"
+        ]
     },
     {
         "name": "kyouka",
         "trans": [
+            "教科(きょうか)",
             "subject, curriculum"
-        ],
-        "notation": "教科(きょうか)"
+        ]
     },
     {
         "name": "tou",
         "trans": [
+            "問(と)う",
             "to ask, to question, to charge (i.e. with a crime), to accuse, without regard to (neg)"
-        ],
-        "notation": "問(と)う"
+        ]
     },
     {
         "name": "akaji",
         "trans": [
+            "赤字(あかじ)",
             "deficit, go in the red"
-        ],
-        "notation": "赤字(あかじ)"
+        ]
     },
     {
         "name": "hisoka",
         "trans": [
+            "密(ひそ)か",
             "secret, private, surreptitious"
-        ],
-        "notation": "密(ひそ)か"
+        ]
     },
     {
         "name": "mijika",
         "trans": [
+            "身近(みぢか)",
             "near oneself, close to one, familiar"
-        ],
-        "notation": "身近(みぢか)"
+        ]
     },
     {
         "name": "mitsumori",
         "trans": [
+            "見積(みつも)り",
             "estimation, quotation"
-        ],
-        "notation": "見積(みつも)り"
+        ]
     },
     {
         "name": "gobusata",
         "trans": [
+            "ご無沙汰(ぶさた)",
             "not writing or contacting for a while"
-        ],
-        "notation": "ご無沙汰(ぶさた)"
+        ]
     },
     {
         "name": "soredemo",
         "trans": [
+            "其(それ)でも",
             "but (still), and yet, nevertheless, even so, notwithstanding"
-        ],
-        "notation": "其(それ)でも"
+        ]
     },
     {
         "name": "gairai",
         "trans": [
+            "外来(がいらい)",
             "imported, outpatient clinic"
-        ],
-        "notation": "外来(がいらい)"
+        ]
     },
     {
         "name": "onwa",
         "trans": [
+            "温和(おんわ)",
             "gentle, mild, moderate"
-        ],
-        "notation": "温和(おんわ)"
+        ]
     },
     {
         "name": "shinbou",
         "trans": [
+            "辛抱(しんぼう)",
             "patience, endurance"
-        ],
-        "notation": "辛抱(しんぼう)"
+        ]
     },
     {
         "name": "mesu",
         "trans": [
+            "召(め)す",
             "to call, to send for, to put on, to wear, to take (a bath), to ride in, to buy, to eat, to drink, to catch (a"
-        ],
-        "notation": "召(め)す"
+        ]
     },
     {
         "name": "haisen",
         "trans": [
+            "敗戦(はいせん)",
             "defeat, losing a war"
-        ],
-        "notation": "敗戦(はいせん)"
+        ]
     },
     {
         "name": "ei",
         "trans": [
+            "えい",
             "ray (fish)"
-        ],
-        "notation": "えい"
+        ]
     },
     {
         "name": "hazu",
         "trans": [
+            "筈(はず)",
             "it should be so"
-        ],
-        "notation": "筈(はず)"
+        ]
     },
     {
         "name": "yokushitsu",
         "trans": [
+            "浴室(よくしつ)",
             "bathroom, bath"
-        ],
-        "notation": "浴室(よくしつ)"
+        ]
     },
     {
         "name": "yogen",
         "trans": [
+            "予言(よげん)",
             "prediction, promise, prognostication"
-        ],
-        "notation": "予言(よげん)"
+        ]
     },
     {
         "name": "kyakkan",
         "trans": [
+            "客観(きゃっかん)",
             "objective"
-        ],
-        "notation": "客観(きゃっかん)"
+        ]
     },
     {
         "name": "ginou",
         "trans": [
+            "技能(ぎのう)",
             "technical skill, ability, capacity"
-        ],
-        "notation": "技能(ぎのう)"
+        ]
     },
     {
         "name": "kokorozasu",
         "trans": [
+            "志(こころざ)す",
             "to plan, to intend, to aspire to, to set aims (sights on)"
-        ],
-        "notation": "志(こころざ)す"
+        ]
     },
     {
         "name": "atomawashi",
         "trans": [
+            "後回(あとまわ)し",
             "putting off, postponing"
-        ],
-        "notation": "後回(あとまわ)し"
+        ]
     },
     {
         "name": "denrai",
         "trans": [
+            "伝来(でんらい)",
             "ancestral, hereditary, imported, transmitted, handed down"
-        ],
-        "notation": "伝来(でんらい)"
+        ]
     },
     {
         "name": "masani",
         "trans": [
+            "正(まさ)に",
             "correctly, surely"
-        ],
-        "notation": "正(まさ)に"
+        ]
     },
     {
         "name": "nakayubi",
         "trans": [
+            "中指(なかゆび)",
             "middle finger"
-        ],
-        "notation": "中指(なかゆび)"
+        ]
     },
     {
         "name": "katto",
         "trans": [
+            "カット",
             "cut, cutting"
-        ],
-        "notation": "カット"
+        ]
     },
     {
         "name": "kawaii",
         "trans": [
+            "可愛(かわい)い",
             "pretty, cute, lovely, charming, dear, darling, pet"
-        ],
-        "notation": "可愛(かわい)い"
+        ]
     },
     {
         "name": "fuyamagiru",
         "trans": [
+            "不(ふ)山(やま)戯(ぎ)る",
             "to romp, to gambol, to frolic, to joke, to make fun of, to flirt"
-        ],
-        "notation": "不(ふ)山(やま)戯(ぎ)る"
+        ]
     },
     {
         "name": "chosho",
         "trans": [
+            "著書(ちょしょ)",
             "literary work, book"
-        ],
-        "notation": "著書(ちょしょ)"
+        ]
     },
     {
         "name": "hidori",
         "trans": [
+            "日取(ひど)り",
             "fixed date, appointed day"
-        ],
-        "notation": "日取(ひど)り"
+        ]
     },
     {
         "name": "rebaa",
         "trans": [
+            "レバー",
             "lever, liver"
-        ],
-        "notation": "レバー"
+        ]
     },
     {
         "name": "mise",
         "trans": [
+            "店(みせ)",
             "store, shop, establishment"
-        ],
-        "notation": "店(みせ)"
+        ]
     },
     {
         "name": "toutatsu",
         "trans": [
+            "到達(とうたつ)",
             "reaching, attaining, arrival"
-        ],
-        "notation": "到達(とうたつ)"
+        ]
     },
     {
         "name": "oroka",
         "trans": [
+            "疎(おろ)か",
             "neglect, negligence, carelessness"
-        ],
-        "notation": "疎(おろ)か"
+        ]
     },
     {
         "name": "ryuutsuu",
         "trans": [
+            "流通(りゅうつう)",
             "circulation of money or goods, flow of water or air, distribution"
-        ],
-        "notation": "流通(りゅうつう)"
+        ]
     },
     {
         "name": "ikou",
         "trans": [
+            "移行(いこう)",
             "switching over to"
-        ],
-        "notation": "移行(いこう)"
+        ]
     },
     {
         "name": "hodokosu",
         "trans": [
+            "施(ほどこ)す",
             "to donate, to give, to conduct, to apply, to perform"
-        ],
-        "notation": "施(ほどこ)す"
+        ]
     },
     {
         "name": "seisaku",
         "trans": [
+            "政策(せいさく)",
             "political measures, policy"
-        ],
-        "notation": "政策(せいさく)"
+        ]
     },
     {
         "name": "osore",
         "trans": [
+            "恐(おそ)れ",
             "fear, horror"
-        ],
-        "notation": "恐(おそ)れ"
+        ]
     },
     {
         "name": "shuei",
         "trans": [
+            "守衛(しゅえい)",
             "security guard, doorkeeper"
-        ],
-        "notation": "守衛(しゅえい)"
+        ]
     },
     {
         "name": "tsukuri",
         "trans": [
+            "造(つく)り",
             "make up, structure, physique"
-        ],
-        "notation": "造(つく)り"
+        ]
     },
     {
         "name": "sounan",
         "trans": [
+            "遭難(そうなん)",
             "disaster, shipwreck, accident"
-        ],
-        "notation": "遭難(そうなん)"
+        ]
     },
     {
         "name": "hizuke",
         "trans": [
+            "日付(ひづけ)",
             "date, dating"
-        ],
-        "notation": "日付(ひづけ)"
+        ]
     },
     {
         "name": "suiden",
         "trans": [
+            "水田(すいでん)",
             "(water-filled) paddy field"
-        ],
-        "notation": "水田(すいでん)"
+        ]
     },
     {
         "name": "suke",
         "trans": [
+            "助(すけ)",
             "help, rescue, assistant"
-        ],
-        "notation": "助(すけ)"
+        ]
     },
     {
         "name": "hatashite",
         "trans": [
+            "果(は)たして",
             "as was expected, really"
-        ],
-        "notation": "果(は)たして"
+        ]
     },
     {
         "name": "shinshi",
         "trans": [
+            "紳士(しんし)",
             "gentleman"
-        ],
-        "notation": "紳士(しんし)"
+        ]
     },
     {
         "name": "tsukaimichi",
         "trans": [
+            "使(つか)い道(みち)",
             "use"
-        ],
-        "notation": "使(つか)い道(みち)"
+        ]
     },
     {
         "name": "todaeru",
         "trans": [
+            "途絶(とだ)える",
             "to stop, to cease, to come to an end"
-        ],
-        "notation": "途絶(とだ)える"
+        ]
     },
     {
         "name": "kyou",
         "trans": [
+            "供(きょう)",
             "offer, present, submit, serve (a meal), supply"
-        ],
-        "notation": "供(きょう)"
+        ]
     },
     {
         "name": "kouchou",
         "trans": [
+            "好調(こうちょう)",
             "favourable, promising, satisfactory, in good shape"
-        ],
-        "notation": "好調(こうちょう)"
+        ]
     },
     {
         "name": "hen",
         "trans": [
+            "編(へん)",
             "compilation, editing, completed poem, book, part of book"
-        ],
-        "notation": "編(へん)"
+        ]
     },
     {
         "name": "gasshiri",
         "trans": [
+            "がっしり",
             "firmly, solidly, tough"
-        ],
-        "notation": "がっしり"
+        ]
     },
     {
         "name": "nenryou",
         "trans": [
+            "燃料(ねんりょう)",
             "fuel"
-        ],
-        "notation": "燃料(ねんりょう)"
+        ]
     },
     {
         "name": "ara",
         "trans": [
+            "あら",
             "oh, ah, saw-edged perch (Niphon spinosus)"
-        ],
-        "notation": "あら"
+        ]
     },
     {
         "name": "pajama",
         "trans": [
+            "パジャマ",
             "pajamas, pyjamas"
-        ],
-        "notation": "パジャマ"
+        ]
     },
     {
         "name": "okagesamade",
         "trans": [
+            "お蔭様(かげさま)で",
             "Thanks to god, thanks to you"
-        ],
-        "notation": "お蔭様(かげさま)で"
+        ]
     },
     {
         "name": "tojou",
         "trans": [
+            "途上(とじょう)",
             "en route, half way"
-        ],
-        "notation": "途上(とじょう)"
+        ]
     },
     {
         "name": "naritatsu",
         "trans": [
+            "成(な)り立(た)つ",
             "to conclude, to consist of, to be practical (logical feasible viable), to hold true"
-        ],
-        "notation": "成(な)り立(た)つ"
+        ]
     },
     {
         "name": "chikei",
         "trans": [
+            "地形(ちけい)",
             "terrain, geographical features, topography"
-        ],
-        "notation": "地形(ちけい)"
+        ]
     },
     {
         "name": "teitai",
         "trans": [
+            "停滞(ていたい)",
             "stagnation, tie-up, congestion, retention, accumulation, falling into arrears"
-        ],
-        "notation": "停滞(ていたい)"
+        ]
     },
     {
         "name": "dote",
         "trans": [
+            "土手(どて)",
             "embankment, bank"
-        ],
-        "notation": "土手(どて)"
+        ]
     },
     {
         "name": "kerai",
         "trans": [
+            "家来(けらい)",
             "retainer, retinue, servant"
-        ],
-        "notation": "家来(けらい)"
+        ]
     },
     {
         "name": "risoku",
         "trans": [
+            "利息(りそく)",
             "interest (bank)"
-        ],
-        "notation": "利息(りそく)"
+        ]
     },
     {
         "name": "infomeeshon",
         "trans": [
+            "インフォメーション",
             "information"
-        ],
-        "notation": "インフォメーション"
+        ]
     },
     {
         "name": "take",
         "trans": [
+            "丈(たけ)",
             "only, just, as"
-        ],
-        "notation": "丈(たけ)"
+        ]
     },
     {
         "name": "sedai",
         "trans": [
+            "世代(せだい)",
             "generation, the world, the age"
-        ],
-        "notation": "世代(せだい)"
+        ]
     },
     {
         "name": "tobari",
         "trans": [
+            "帳(とばり)",
             "curtain"
-        ],
-        "notation": "帳(とばり)"
+        ]
     },
     {
         "name": "chikusan",
         "trans": [
+            "畜産(ちくさん)",
             "animal husbandry"
-        ],
-        "notation": "畜産(ちくさん)"
+        ]
     },
     {
         "name": "kyousaku",
         "trans": [
+            "凶作(きょうさく)",
             "bad harvest, poor crop"
-        ],
-        "notation": "凶作(きょうさく)"
+        ]
     },
     {
         "name": "nittou",
         "trans": [
+            "日当(にっとう)",
             "daily allowance"
-        ],
-        "notation": "日当(にっとう)"
+        ]
     },
     {
         "name": "suteki",
         "trans": [
+            "素敵(すてき)",
             "lovely, dreamy, beautiful, great, fantastic, superb, cool, capital"
-        ],
-        "notation": "素敵(すてき)"
+        ]
     },
     {
         "name": "toboshii",
         "trans": [
+            "乏(とぼ)しい",
             "meagre, scarce, limited, destitute, hard up, scanty, poor"
-        ],
-        "notation": "乏(とぼ)しい"
+        ]
     },
     {
         "name": "assari",
         "trans": [
+            "あっさり",
             "easily, readily, quickly"
-        ],
-        "notation": "あっさり"
+        ]
     },
     {
         "name": "mohan",
         "trans": [
+            "模範(もはん)",
             "exemplar, exemplification, exemplum, model, example"
-        ],
-        "notation": "模範(もはん)"
+        ]
     },
     {
         "name": "funin",
         "trans": [
+            "赴任(ふにん)",
             "(proceeding to) new appointment"
-        ],
-        "notation": "赴任(ふにん)"
+        ]
     },
     {
         "name": "zai",
         "trans": [
+            "財(ざい)",
             "fortune, riches"
-        ],
-        "notation": "財(ざい)"
+        ]
     },
     {
         "name": "hyougo",
         "trans": [
+            "標語(ひょうご)",
             "motto, slogan, catchword"
-        ],
-        "notation": "標語(ひょうご)"
+        ]
     },
     {
         "name": "denaoshi",
         "trans": [
+            "出直(でなお)し",
             "adjustment, touch up"
-        ],
-        "notation": "出直(でなお)し"
+        ]
     },
     {
         "name": "itazura",
         "trans": [
+            "悪戯(いたずら)",
             "tease, prank, trick, practical joke, mischief"
-        ],
-        "notation": "悪戯(いたずら)"
+        ]
     },
     {
         "name": "zakka",
         "trans": [
+            "雑貨(ざっか)",
             "miscellaneous goods, general goods, sundries"
-        ],
-        "notation": "雑貨(ざっか)"
+        ]
     },
     {
         "name": "matsuru",
         "trans": [
+            "奉(まつ)る",
             "to offer, to present, to revere, to do respectfully"
-        ],
-        "notation": "奉(まつ)る"
+        ]
     },
     {
         "name": "kyohi",
         "trans": [
+            "拒否(きょひ)",
             "denial, veto, rejection, refusal"
-        ],
-        "notation": "拒否(きょひ)"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "玉(たま)",
             "king (shogi)"
-        ],
-        "notation": "玉(たま)"
+        ]
     },
     {
         "name": "takusan",
         "trans": [
+            "沢山(たくさん)",
             "many, a lot, much"
-        ],
-        "notation": "沢山(たくさん)"
+        ]
     },
     {
         "name": "chuushou",
         "trans": [
+            "中傷(ちゅうしょう)",
             "slander, libel, defamation"
-        ],
-        "notation": "中傷(ちゅうしょう)"
+        ]
     },
     {
         "name": "kichitto",
         "trans": [
+            "きちっと",
             "exactly, perfectly"
-        ],
-        "notation": "きちっと"
+        ]
     },
     {
         "name": "buntan",
         "trans": [
+            "分担(ぶんたん)",
             "apportionment, sharing"
-        ],
-        "notation": "分担(ぶんたん)"
+        ]
     },
     {
         "name": "kottouhin",
         "trans": [
+            "骨董(こっとう)品(ひん)",
             "curio"
-        ],
-        "notation": "骨董(こっとう)品(ひん)"
+        ]
     },
     {
         "name": "shiinto",
         "trans": [
+            "しいんと",
             "silent (as the grave), (deathly) quiet"
-        ],
-        "notation": "しいんと"
+        ]
     },
     {
         "name": "ninmei",
         "trans": [
+            "任命(にんめい)",
             "appointment, nomination, ordination, commission, designation"
-        ],
-        "notation": "任命(にんめい)"
+        ]
     },
     {
         "name": "wariate",
         "trans": [
+            "割(わ)り当(あ)て",
             "allotment, assignment, allocation, quota, rationing"
-        ],
-        "notation": "割(わ)り当(あ)て"
+        ]
     },
     {
         "name": "kasabaru",
         "trans": [
+            "嵩張(かさば)る",
             "to be bulky, to be unwieldy, to grow voluminous"
-        ],
-        "notation": "嵩張(かさば)る"
+        ]
     },
     {
         "name": "noirouze",
         "trans": [
+            "ノイローゼ",
             "(de:) (n) neurosis (de: Neurose)"
-        ],
-        "notation": "ノイローゼ"
+        ]
     },
     {
         "name": "kyuusen",
         "trans": [
+            "休戦(きゅうせん)",
             "truce, armistice"
-        ],
-        "notation": "休戦(きゅうせん)"
+        ]
     },
     {
         "name": "shirizoku",
         "trans": [
+            "退(しりぞ)く",
             "to retreat, to recede, to withdraw"
-        ],
-        "notation": "退(しりぞ)く"
+        ]
     },
     {
         "name": "kyoukun",
         "trans": [
+            "教訓(きょうくん)",
             "lesson, precept, moral instruction"
-        ],
-        "notation": "教訓(きょうくん)"
+        ]
     },
     {
         "name": "shougeki",
         "trans": [
+            "衝撃(しょうげき)",
             "shock, crash, impact, ballistic"
-        ],
-        "notation": "衝撃(しょうげき)"
+        ]
     },
     {
         "name": "tsuri",
         "trans": [
+            "釣(つ)り",
             "fishing, angling"
-        ],
-        "notation": "釣(つ)り"
+        ]
     },
     {
         "name": "saibou",
         "trans": [
+            "細胞(さいぼう)",
             "cell (biology)"
-        ],
-        "notation": "細胞(さいぼう)"
+        ]
     },
     {
         "name": "hidarihodo",
         "trans": [
+            "左(ひだり)程(ほど)",
             "(not) very, (not) much"
-        ],
-        "notation": "左(ひだり)程(ほど)"
+        ]
     },
     {
         "name": "tachiyoru",
         "trans": [
+            "立(た)ち寄(よ)る",
             "to stop by, to drop in for a short visit"
-        ],
-        "notation": "立(た)ち寄(よ)る"
+        ]
     },
     {
         "name": "jiga",
         "trans": [
+            "自我(じが)",
             "self, the ego"
-        ],
-        "notation": "自我(じが)"
+        ]
     },
     {
         "name": "kigai",
         "trans": [
+            "危害(きがい)",
             "injury, harm, danger"
-        ],
-        "notation": "危害(きがい)"
+        ]
     },
     {
         "name": "bikkuri",
         "trans": [
+            "吃驚(びっくり)",
             "be surprised, be amazed, be frightened, astonishment"
-        ],
-        "notation": "吃驚(びっくり)"
+        ]
     },
     {
         "name": "shubi",
         "trans": [
+            "守備(しゅび)",
             "defense"
-        ],
-        "notation": "守備(しゅび)"
+        ]
     },
     {
         "name": "douryoku",
         "trans": [
+            "動力(どうりょく)",
             "power, motive power, dynamic force"
-        ],
-        "notation": "動力(どうりょく)"
+        ]
     },
     {
         "name": "hisashii",
         "trans": [
+            "久(ひさ)しい",
             "long, long-continued, old (story)"
-        ],
-        "notation": "久(ひさ)しい"
+        ]
     },
     {
         "name": "kaibou",
         "trans": [
+            "解剖(かいぼう)",
             "dissection, autopsy"
-        ],
-        "notation": "解剖(かいぼう)"
+        ]
     },
     {
         "name": "rousui",
         "trans": [
+            "老衰(ろうすい)",
             "senility, senile decay"
-        ],
-        "notation": "老衰(ろうすい)"
+        ]
     },
     {
         "name": "touki",
         "trans": [
+            "陶器(とうき)",
             "pottery, ceramics"
-        ],
-        "notation": "陶器(とうき)"
+        ]
     },
     {
         "name": "ookata",
         "trans": [
+            "大方(おおかた)",
             "perhaps, almost all, majority"
-        ],
-        "notation": "大方(おおかた)"
+        ]
     },
     {
         "name": "appu",
         "trans": [
+            "アップ",
             "up"
-        ],
-        "notation": "アップ"
+        ]
     },
     {
         "name": "share",
         "trans": [
+            "洒落(しゃれ)",
             "frank, open-hearted"
-        ],
-        "notation": "洒落(しゃれ)"
+        ]
     },
     {
         "name": "bungo",
         "trans": [
+            "文語(ぶんご)",
             "written language, literary language"
-        ],
-        "notation": "文語(ぶんご)"
+        ]
     },
     {
         "name": "soukin",
         "trans": [
+            "送金(そうきん)",
             "remittance, sending money"
-        ],
-        "notation": "送金(そうきん)"
+        ]
     },
     {
         "name": "sugi",
         "trans": [
+            "過(す)ぎ",
             "past, after"
-        ],
-        "notation": "過(す)ぎ"
+        ]
     },
     {
         "name": "taikou",
         "trans": [
+            "対抗(たいこう)",
             "opposition, antagonism"
-        ],
-        "notation": "対抗(たいこう)"
+        ]
     },
     {
         "name": "chouchou",
         "trans": [
+            "丁々(ちょうちょう)",
             "clashing of swords, felling of trees, ringing of an ax"
-        ],
-        "notation": "丁々(ちょうちょう)"
+        ]
     },
     {
         "name": "yakou",
         "trans": [
+            "夜行(やこう)",
             "walking around at night, night train, night travel"
-        ],
-        "notation": "夜行(やこう)"
+        ]
     },
     {
         "name": "junkyuu",
         "trans": [
+            "準急(じゅんきゅう)",
             "local express (train slower than an express)"
-        ],
-        "notation": "準急(じゅんきゅう)"
+        ]
     },
     {
         "name": "enjinia",
         "trans": [
+            "エンジニア",
             "engineer"
-        ],
-        "notation": "エンジニア"
+        ]
     },
     {
         "name": "kyuukoto",
         "trans": [
+            "旧(きゅう)事(こと)",
             "past events, bygones"
-        ],
-        "notation": "旧(きゅう)事(こと)"
+        ]
     },
     {
         "name": "boudou",
         "trans": [
+            "暴動(ぼうどう)",
             "insurrection, rebellion, revolt, riot, uprising"
-        ],
-        "notation": "暴動(ぼうどう)"
+        ]
     },
     {
         "name": "mijime",
         "trans": [
+            "惨(みじ)め",
             "miserable"
-        ],
-        "notation": "惨(みじ)め"
+        ]
     },
     {
         "name": "bakabakashii",
         "trans": [
+            "馬鹿馬鹿(ばかばか)しい",
             "stupid"
-        ],
-        "notation": "馬鹿馬鹿(ばかばか)しい"
+        ]
     },
     {
         "name": "sekimu",
         "trans": [
+            "責務(せきむ)",
             "duty, obligation"
-        ],
-        "notation": "責務(せきむ)"
+        ]
     },
     {
         "name": "sonouchi",
         "trans": [
+            "その内(うち)",
             "eventually, sooner or later, of the previously mentioned"
-        ],
-        "notation": "その内(うち)"
+        ]
     },
     {
         "name": "nami",
         "trans": [
+            "並(な)み",
             "average, medium, common, ordinary"
-        ],
-        "notation": "並(な)み"
+        ]
     },
     {
         "name": "taihen",
         "trans": [
+            "対辺(たいへん)",
             "(geometrical) opposite side"
-        ],
-        "notation": "対辺(たいへん)"
+        ]
     },
     {
         "name": "bakarashii",
         "trans": [
+            "馬鹿(ばか)らしい",
             "absurd"
-        ],
-        "notation": "馬鹿(ばか)らしい"
+        ]
     },
     {
         "name": "konokoro",
         "trans": [
+            "この頃(ころ)",
             "recently"
-        ],
-        "notation": "この頃(ころ)"
+        ]
     },
     {
         "name": "shikkari",
         "trans": [
+            "確(しっか)り",
             "firmly, tightly, reliable, level-headed, steady"
-        ],
-        "notation": "確(しっか)り"
+        ]
     },
     {
         "name": "tegiwa",
         "trans": [
+            "手際(てぎわ)",
             "performance, skill, tact"
-        ],
-        "notation": "手際(てぎわ)"
+        ]
     },
     {
         "name": "koukai",
         "trans": [
+            "後悔(こうかい)",
             "regret, repentance"
-        ],
-        "notation": "後悔(こうかい)"
+        ]
     },
     {
         "name": "ikinari",
         "trans": [
+            "行(い)き成(な)り",
             "suddenly"
-        ],
-        "notation": "行(い)き成(な)り"
+        ]
     },
     {
         "name": "kuttsuku",
         "trans": [
+            "くっ付(つ)く",
             "to adhere to, to keep close to"
-        ],
-        "notation": "くっ付(つ)く"
+        ]
     },
     {
         "name": "gawa",
         "trans": [
+            "側(がわ)",
             "side, row, surroundings, part, (watch) case"
-        ],
-        "notation": "側(がわ)"
+        ]
     },
     {
         "name": "hikiokosu",
         "trans": [
+            "引(ひ)き起(お)こす",
             "to cause"
-        ],
-        "notation": "引(ひ)き起(お)こす"
+        ]
     },
     {
         "name": "inki",
         "trans": [
+            "陰気(いんき)",
             "gloom, melancholy"
-        ],
-        "notation": "陰気(いんき)"
+        ]
     },
     {
         "name": "honba",
         "trans": [
+            "本場(ほんば)",
             "home, habitat, center, best place, genuine"
-        ],
-        "notation": "本場(ほんば)"
+        ]
     },
     {
         "name": "shimiru",
         "trans": [
+            "染(し)みる",
             "to pierce, to permeate"
-        ],
-        "notation": "染(し)みる"
+        ]
     },
     {
         "name": "shinjou",
         "trans": [
+            "心情(しんじょう)",
             "mentality"
-        ],
-        "notation": "心情(しんじょう)"
+        ]
     },
     {
         "name": "chimaku",
         "trans": [
+            "散(ち)蒔(ま)く",
             "to disseminate, to scatter, to give money freely"
-        ],
-        "notation": "散(ち)蒔(ま)く"
+        ]
     },
     {
         "name": "hanran",
         "trans": [
+            "反乱(はんらん)",
             "insurrection, mutiny, rebellion, revolt, uprising"
-        ],
-        "notation": "反乱(はんらん)"
+        ]
     },
     {
         "name": "oi",
         "trans": [
+            "甥(おい)",
             "nephew"
-        ],
-        "notation": "甥(おい)"
+        ]
     },
     {
         "name": "kyuukyoku",
         "trans": [
+            "究極(きゅうきょく)",
             "ultimate, final, eventual"
-        ],
-        "notation": "究極(きゅうきょく)"
+        ]
     },
     {
         "name": "meichuu",
         "trans": [
+            "命中(めいちゅう)",
             "a hit"
-        ],
-        "notation": "命中(めいちゅう)"
+        ]
     },
     {
         "name": "ateru",
         "trans": [
+            "宛(あ)てる",
             "to address"
-        ],
-        "notation": "宛(あ)てる"
+        ]
     },
     {
         "name": "ko",
         "trans": [
+            "故(こ)",
             "the late (deceased)"
-        ],
-        "notation": "故(こ)"
+        ]
     },
     {
         "name": "shougou",
         "trans": [
+            "照合(しょうごう)",
             "collation, comparison"
-        ],
-        "notation": "照合(しょうごう)"
+        ]
     },
     {
         "name": "choukou",
         "trans": [
+            "聴講(ちょうこう)",
             "lecture attendance, auditing"
-        ],
-        "notation": "聴講(ちょうこう)"
+        ]
     },
     {
         "name": "gakusetsu",
         "trans": [
+            "学説(がくせつ)",
             "theory"
-        ],
-        "notation": "学説(がくせつ)"
+        ]
     },
     {
         "name": "yobitomeru",
         "trans": [
+            "呼(よ)び止(と)める",
             "to challenge, to call somebody to halt"
-        ],
-        "notation": "呼(よ)び止(と)める"
+        ]
     },
     {
         "name": "gizou",
         "trans": [
+            "偽造(ぎぞう)",
             "forgery, falsification, fabrication, counterfeiting"
-        ],
-        "notation": "偽造(ぎぞう)"
+        ]
     },
     {
         "name": "tsuyoki",
         "trans": [
+            "強気(つよき)",
             "great, grand"
-        ],
-        "notation": "強気(つよき)"
+        ]
     },
     {
         "name": "sangaku",
         "trans": [
+            "山岳(さんがく)",
             "mountains"
-        ],
-        "notation": "山岳(さんがく)"
+        ]
     },
     {
         "name": "sumasu",
         "trans": [
+            "済(す)ます",
             "to finish, to get it over with, to settle, to conclude, to pay back"
-        ],
-        "notation": "済(す)ます"
+        ]
     },
     {
         "name": "shimai",
         "trans": [
+            "姉妹(しまい)",
             "sisters"
-        ],
-        "notation": "姉妹(しまい)"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "証人(しょうにん)",
             "witness"
-        ],
-        "notation": "証人(しょうにん)"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "権(けん)",
             "authority, the right (to do something)"
-        ],
-        "notation": "権(けん)"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "死(し)",
             "death, decease"
-        ],
-        "notation": "死(し)"
+        ]
     },
     {
         "name": "rakkan",
         "trans": [
+            "楽観(らっかん)",
             "optimism"
-        ],
-        "notation": "楽観(らっかん)"
+        ]
     },
     {
         "name": "bengi",
         "trans": [
+            "便宜(べんぎ)",
             "convenience, accommodation, advantage, expedience"
-        ],
-        "notation": "便宜(べんぎ)"
+        ]
     },
     {
         "name": "fukkou",
         "trans": [
+            "復興(ふっこう)",
             "revival, renaissance, reconstruction"
-        ],
-        "notation": "復興(ふっこう)"
+        ]
     },
     {
         "name": "gousei",
         "trans": [
+            "合成(ごうせい)",
             "synthesis, composition, synthetic, composite, mixed, combined, compound"
-        ],
-        "notation": "合成(ごうせい)"
+        ]
     },
     {
         "name": "ukaru",
         "trans": [
+            "受(う)かる",
             "to pass (examination)"
-        ],
-        "notation": "受(う)かる"
+        ]
     },
     {
         "name": "soushoku",
         "trans": [
+            "装飾(そうしょく)",
             "ornament"
-        ],
-        "notation": "装飾(そうしょく)"
+        ]
     },
     {
         "name": "midareru",
         "trans": [
+            "乱(みだ)れる",
             "to get confused, to be disordered, to be disturbed"
-        ],
-        "notation": "乱(みだ)れる"
+        ]
     },
     {
         "name": "oogesa",
         "trans": [
+            "大(おお)げさ",
             "grandiose, exaggerated"
-        ],
-        "notation": "大(おお)げさ"
+        ]
     },
     {
         "name": "kamae",
         "trans": [
+            "構(かま)え",
             "posture, pose, style"
-        ],
-        "notation": "構(かま)え"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "福(ふく)",
             "good fortune"
-        ],
-        "notation": "福(ふく)"
+        ]
     },
     {
         "name": "zatsu",
         "trans": [
+            "雑(ざつ)",
             "rough, crude"
-        ],
-        "notation": "雑(ざつ)"
+        ]
     },
     {
         "name": "shakou",
         "trans": [
+            "社交(しゃこう)",
             "social life, social intercourse"
-        ],
-        "notation": "社交(しゃこう)"
+        ]
     },
     {
         "name": "ayumi",
         "trans": [
+            "歩(あゆ)み",
             "walking"
-        ],
-        "notation": "歩(あゆ)み"
+        ]
     },
     {
         "name": "otomo",
         "trans": [
+            "お供(とも)",
             "attendant, companion"
-        ],
-        "notation": "お供(とも)"
+        ]
     },
     {
         "name": "donaru",
         "trans": [
+            "怒鳴(どな)る",
             "to shout, to yell"
-        ],
-        "notation": "怒鳴(どな)る"
+        ]
     },
     {
         "name": "itameru",
         "trans": [
+            "炒(いた)める",
             "to stir-fry"
-        ],
-        "notation": "炒(いた)める"
+        ]
     },
     {
         "name": "shouchou",
         "trans": [
+            "象徴(しょうちょう)",
             "symbol"
-        ],
-        "notation": "象徴(しょうちょう)"
+        ]
     },
     {
         "name": "tousotsu",
         "trans": [
+            "統率(とうそつ)",
             "command, lead, generalship, leadership"
-        ],
-        "notation": "統率(とうそつ)"
+        ]
     },
     {
         "name": "mau",
         "trans": [
+            "舞(ま)う",
             "to dance, to flutter about, to revolve"
-        ],
-        "notation": "舞(ま)う"
+        ]
     },
     {
         "name": "kontesuto",
         "trans": [
+            "コンテスト",
             "contest"
-        ],
-        "notation": "コンテスト"
+        ]
     },
     {
         "name": "saitaku",
         "trans": [
+            "採択(さいたく)",
             "adoption, selection, choice"
-        ],
-        "notation": "採択(さいたく)"
+        ]
     },
     {
         "name": "kyoukan",
         "trans": [
+            "共感(きょうかん)",
             "sympathy, response"
-        ],
-        "notation": "共感(きょうかん)"
+        ]
     },
     {
         "name": "kamitsu",
         "trans": [
+            "過密(かみつ)",
             "crowded"
-        ],
-        "notation": "過密(かみつ)"
+        ]
     },
     {
         "name": "chokuchoku",
         "trans": [
+            "ちょくちょく",
             "often, frequently, now and then, occasionally"
-        ],
-        "notation": "ちょくちょく"
+        ]
     },
     {
         "name": "okurasu",
         "trans": [
+            "遅(おく)らす",
             "to retard, to delay"
-        ],
-        "notation": "遅(おく)らす"
+        ]
     },
     {
         "name": "kyojuu",
         "trans": [
+            "居住(きょじゅう)",
             "residence"
-        ],
-        "notation": "居住(きょじゅう)"
+        ]
     },
     {
         "name": "janken",
         "trans": [
+            "じゃん拳(けん)",
             "rock-scissors-paper game"
-        ],
-        "notation": "じゃん拳(けん)"
+        ]
     },
     {
         "name": "yuubou",
         "trans": [
+            "有望(ゆうぼう)",
             "good prospects, full of hope, promising"
-        ],
-        "notation": "有望(ゆうぼう)"
+        ]
     },
     {
         "name": "shobatsu",
         "trans": [
+            "処罰(しょばつ)",
             "punishment"
-        ],
-        "notation": "処罰(しょばつ)"
+        ]
     },
     {
         "name": "kijutsu",
         "trans": [
+            "記述(きじゅつ)",
             "describing, descriptor"
-        ],
-        "notation": "記述(きじゅつ)"
+        ]
     },
     {
         "name": "uzu",
         "trans": [
+            "渦(うず)",
             "swirl"
-        ],
-        "notation": "渦(うず)"
+        ]
     },
     {
         "name": "ijikuru",
         "trans": [
+            "弄(いじく)る",
             "to touch, to tamper with"
-        ],
-        "notation": "弄(いじく)る"
+        ]
     },
     {
         "name": "ruuru",
         "trans": [
+            "ルール",
             "rule"
-        ],
-        "notation": "ルール"
+        ]
     },
     {
         "name": "hatsugen",
         "trans": [
+            "発言(はつげん)",
             "utterance, speech, proposal"
-        ],
-        "notation": "発言(はつげん)"
+        ]
     },
     {
         "name": "kekkaku",
         "trans": [
+            "結核(けっかく)",
             "tuberculosis, tubercule"
-        ],
-        "notation": "結核(けっかく)"
+        ]
     },
     {
         "name": "tan",
         "trans": [
+            "歎(たん)",
             "grief, sigh, lamentation"
-        ],
-        "notation": "歎(たん)"
+        ]
     },
     {
         "name": "kyuuji",
         "trans": [
+            "給仕(きゅうじ)",
             "office boy (girl), page, waiter"
-        ],
-        "notation": "給仕(きゅうじ)"
+        ]
     },
     {
         "name": "satoru",
         "trans": [
+            "悟(さと)る",
             "to attain enlightenment, to perceive, to understand, to discern"
-        ],
-        "notation": "悟(さと)る"
+        ]
     },
     {
         "name": "kyoukou",
         "trans": [
+            "強行(きょうこう)",
             "forcing, enforcement"
-        ],
-        "notation": "強行(きょうこう)"
+        ]
     },
     {
         "name": "hegasu",
         "trans": [
+            "剥(へ)がす",
             "to tear off, to peel off, to rip off, to strip off, to skin, to flay, to disrobe, to deprive of, to detach, t"
-        ],
-        "notation": "剥(へ)がす"
+        ]
     },
     {
         "name": "sendai",
         "trans": [
+            "先代(せんだい)",
             "family predecessor, previous age, previous generation"
-        ],
-        "notation": "先代(せんだい)"
+        ]
     },
     {
         "name": "kake",
         "trans": [
+            "賭(か)け",
             "betting, gambling, a gamble"
-        ],
-        "notation": "賭(か)け"
+        ]
     },
     {
         "name": "aidea",
         "trans": [
+            "アイデア",
             "idea"
-        ],
-        "notation": "アイデア"
+        ]
     },
     {
         "name": "kei",
         "trans": [
+            "系(けい)",
             "system, lineage, group"
-        ],
-        "notation": "系(けい)"
+        ]
     },
     {
         "name": "honno",
         "trans": [
+            "本(ほん)の",
             "mere, only, just"
-        ],
-        "notation": "本(ほん)の"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "尾(お)",
             "tail, ridge"
-        ],
-        "notation": "尾(お)"
+        ]
     },
     {
         "name": "ateji",
         "trans": [
+            "当(あ)て字(じ)",
             "phonetic-equivalent character, substitute character"
-        ],
-        "notation": "当(あ)て字(じ)"
+        ]
     },
     {
         "name": "hanga",
         "trans": [
+            "版画(はんが)",
             "art print"
-        ],
-        "notation": "版画(はんが)"
+        ]
     },
     {
         "name": "besutoseraa",
         "trans": [
+            "ベストセラー",
             "best-seller"
-        ],
-        "notation": "ベストセラー"
+        ]
     },
     {
         "name": "furyou",
         "trans": [
+            "不良(ふりょう)",
             "badness, delinquent, inferiority, failure"
-        ],
-        "notation": "不良(ふりょう)"
+        ]
     },
     {
         "name": "issai",
         "trans": [
+            "一切(いっさい)",
             "all, everything, without exception, the whole, entirely, absolutely"
-        ],
-        "notation": "一切(いっさい)"
+        ]
     },
     {
         "name": "kairyou",
         "trans": [
+            "改良(かいりょう)",
             "improvement, reform"
-        ],
-        "notation": "改良(かいりょう)"
+        ]
     },
     {
         "name": "ichijirushii",
         "trans": [
+            "著(いちじる)しい",
             "remarkable, considerable"
-        ],
-        "notation": "著(いちじる)しい"
+        ]
     },
     {
         "name": "shuu",
         "trans": [
+            "周(しゅう)",
             "circuit, lap, circumference, vicinity, Chou (dynasty)"
-        ],
-        "notation": "周(しゅう)"
+        ]
     },
     {
         "name": "houshutsu",
         "trans": [
+            "放出(ほうしゅつ)",
             "release, emit"
-        ],
-        "notation": "放出(ほうしゅつ)"
+        ]
     },
     {
         "name": "gaikan",
         "trans": [
+            "外観(がいかん)",
             "appearance, exterior, facade"
-        ],
-        "notation": "外観(がいかん)"
+        ]
     },
     {
         "name": "arawareru",
         "trans": [
+            "現(あら)われる",
             "to appear, to come in sight, to become visible, to come out, to embody, to materialize, to express oneself"
-        ],
-        "notation": "現(あら)われる"
+        ]
     },
     {
         "name": "kyouchou",
         "trans": [
+            "協調(きょうちょう)",
             "co-operation, conciliation, harmony, firm (market) tone"
-        ],
-        "notation": "協調(きょうちょう)"
+        ]
     },
     {
         "name": "amagu",
         "trans": [
+            "雨具(あまぐ)",
             "rain gear"
-        ],
-        "notation": "雨具(あまぐ)"
+        ]
     },
     {
         "name": "zankoku",
         "trans": [
+            "残酷(ざんこく)",
             "cruelty, harshness"
-        ],
-        "notation": "残酷(ざんこく)"
+        ]
     },
     {
         "name": "ryokaku",
         "trans": [
+            "旅客(りょかく)",
             "passenger (transport)"
-        ],
-        "notation": "旅客(りょかく)"
+        ]
     },
     {
         "name": "zen",
         "trans": [
+            "禅(ぜん)",
             "Zen (Buddhism)"
-        ],
-        "notation": "禅(ぜん)"
+        ]
     },
     {
         "name": "aruiha",
         "trans": [
+            "或(ある)いは",
             "or, possibly"
-        ],
-        "notation": "或(ある)いは"
+        ]
     },
     {
         "name": "izon",
         "trans": [
+            "依存(いぞん)",
             "dependence, dependent, reliance"
-        ],
-        "notation": "依存(いぞん)"
+        ]
     },
     {
         "name": "gun",
         "trans": [
+            "群(ぐん)",
             "group (math)"
-        ],
-        "notation": "群(ぐん)"
+        ]
     },
     {
         "name": "shinkoku",
         "trans": [
+            "申告(しんこく)",
             "report, statement, filing a return, notification"
-        ],
-        "notation": "申告(しんこく)"
+        ]
     },
     {
         "name": "monotarinai",
         "trans": [
+            "物足(ものた)りない",
             "unsatisfied, unsatisfactory"
-        ],
-        "notation": "物足(ものた)りない"
+        ]
     },
     {
         "name": "kyacchi",
         "trans": [
+            "キャッチ",
             "catch"
-        ],
-        "notation": "キャッチ"
+        ]
     },
     {
         "name": "aratamaru",
         "trans": [
+            "改(あらた)まる",
             "to be renewed"
-        ],
-        "notation": "改(あらた)まる"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "伐(き)",
             "strike, attack, punish"
-        ],
-        "notation": "伐(き)"
+        ]
     },
     {
         "name": "shirushi",
         "trans": [
+            "印(しるし)",
             "seal, stamp, mark, print"
-        ],
-        "notation": "印(しるし)"
+        ]
     },
     {
         "name": "kyasha",
         "trans": [
+            "華奢(きゃしゃ)",
             "luxury, pomp, delicate, slender, gorgeous"
-        ],
-        "notation": "華奢(きゃしゃ)"
+        ]
     },
     {
         "name": "tanpa",
         "trans": [
+            "短波(たんぱ)",
             "short wave"
-        ],
-        "notation": "短波(たんぱ)"
+        ]
     },
     {
         "name": "tenji",
         "trans": [
+            "展示(てんじ)",
             "exhibition, display"
-        ],
-        "notation": "展示(てんじ)"
+        ]
     },
     {
         "name": "oteage",
         "trans": [
+            "お手上(てあ)げ",
             "all over, given in, given up hope, bring to knees"
-        ],
-        "notation": "お手上(てあ)げ"
+        ]
     },
     {
         "name": "tanken",
         "trans": [
+            "探検(たんけん)",
             "exploration, expedition"
-        ],
-        "notation": "探検(たんけん)"
+        ]
     },
     {
         "name": "tende",
         "trans": [
+            "てんで",
             "(not) at all, altogether, entirely"
-        ],
-        "notation": "てんで"
+        ]
     },
     {
         "name": "bairitsu",
         "trans": [
+            "倍率(ばいりつ)",
             "diameter, magnification"
-        ],
-        "notation": "倍率(ばいりつ)"
+        ]
     },
     {
         "name": "kaihatsu",
         "trans": [
+            "開発(かいはつ)",
             "development, exploitation"
-        ],
-        "notation": "開発(かいはつ)"
+        ]
     },
     {
         "name": "manukareru",
         "trans": [
+            "免(まぬか)れる",
             "to escape from, to be rescued from, to avoid, to evade, to avert, to elude, to be exempted, to be relieved"
-        ],
-        "notation": "免(まぬか)れる"
+        ]
     },
     {
         "name": "shinryou",
         "trans": [
+            "診療(しんりょう)",
             "medical examination and treatment, diagnosis"
-        ],
-        "notation": "診療(しんりょう)"
+        ]
     },
     {
         "name": "fairu",
         "trans": [
+            "ファイル",
             "file"
-        ],
-        "notation": "ファイル"
+        ]
     },
     {
         "name": "bumon",
         "trans": [
+            "部門(ぶもん)",
             "class, group, category, department, field, branch"
-        ],
-        "notation": "部門(ぶもん)"
+        ]
     },
     {
         "name": "utsuro",
         "trans": [
+            "空(うつ)ろ",
             "blank, cavity, hollow, empty (space)"
-        ],
-        "notation": "空(うつ)ろ"
+        ]
     },
     {
         "name": "bu",
         "trans": [
+            "部(ぶ)",
             "department, part, category, counter for copies of a newspaper or magazine"
-        ],
-        "notation": "部(ぶ)"
+        ]
     },
     {
         "name": "manjou",
         "trans": [
+            "満場(まんじょう)",
             "unanimous, whole audience"
-        ],
-        "notation": "満場(まんじょう)"
+        ]
     },
     {
         "name": "gairyaku",
         "trans": [
+            "概略(がいりゃく)",
             "outline, summary, gist, in brief"
-        ],
-        "notation": "概略(がいりゃく)"
+        ]
     },
     {
         "name": "seijou",
         "trans": [
+            "正常(せいじょう)",
             "normalcy, normality, normal"
-        ],
-        "notation": "正常(せいじょう)"
+        ]
     },
     {
         "name": "surechigai",
         "trans": [
+            "擦(す)れ違(ちが)い",
             "chance encounter"
-        ],
-        "notation": "擦(す)れ違(ちが)い"
+        ]
     },
     {
         "name": "gakureki",
         "trans": [
+            "学歴(がくれき)",
             "academic background"
-        ],
-        "notation": "学歴(がくれき)"
+        ]
     },
     {
         "name": "fuu",
         "trans": [
+            "封(ふう)",
             "seal"
-        ],
-        "notation": "封(ふう)"
+        ]
     },
     {
         "name": "zuruzuru",
         "trans": [
+            "ずるずる",
             "sound or act of dragging, loose, inconclusive but unwanted situation, trailingly"
-        ],
-        "notation": "ずるずる"
+        ]
     },
     {
         "name": "taiketsu",
         "trans": [
+            "対決(たいけつ)",
             "confrontation, showdown"
-        ],
-        "notation": "対決(たいけつ)"
+        ]
     },
     {
         "name": "oishii",
         "trans": [
+            "美味(おい)しい",
             "delicious, tasty"
-        ],
-        "notation": "美味(おい)しい"
+        ]
     },
     {
         "name": "outomachikku",
         "trans": [
+            "オートマチック",
             "automatic"
-        ],
-        "notation": "オートマチック"
+        ]
     },
     {
         "name": "ryoukai",
         "trans": [
+            "了解(りょうかい)",
             "comprehension, consent, understanding, roger (on the radio)"
-        ],
-        "notation": "了解(りょうかい)"
+        ]
     },
     {
         "name": "hen",
         "trans": [
+            "偏(へん)",
             "side, left radical of a character, inclining, inclining toward, biased"
-        ],
-        "notation": "偏(へん)"
+        ]
     },
     {
         "name": "nananichi",
         "trans": [
+            "七(なな)日(にち)",
             "seven days, the seventh day (of the month)"
-        ],
-        "notation": "七(なな)日(にち)"
+        ]
     },
     {
         "name": "giwaku",
         "trans": [
+            "疑惑(ぎわく)",
             "doubt, misgivings, distrust, suspicion"
-        ],
-        "notation": "疑惑(ぎわく)"
+        ]
     },
     {
         "name": "uchiawaseru",
         "trans": [
+            "打(う)ち合(あ)わせる",
             "to knock together, to arrange"
-        ],
-        "notation": "打(う)ち合(あ)わせる"
+        ]
     },
     {
         "name": "kanyou",
         "trans": [
+            "慣用(かんよう)",
             "common, customary"
-        ],
-        "notation": "慣用(かんよう)"
+        ]
     },
     {
         "name": "torinozoku",
         "trans": [
+            "取(と)り除(のぞ)く",
             "to remove, to take away, to set apart"
-        ],
-        "notation": "取(と)り除(のぞ)く"
+        ]
     },
     {
         "name": "tegakeru",
         "trans": [
+            "手掛(てが)ける",
             "to handle, to manage, to work with, to rear, to look after, to have experience with"
-        ],
-        "notation": "手掛(てが)ける"
+        ]
     },
     {
         "name": "dodai",
         "trans": [
+            "土台(どだい)",
             "foundation, base, basis"
-        ],
-        "notation": "土台(どだい)"
+        ]
     },
     {
         "name": "tsutsumu",
         "trans": [
+            "包(つつ)む",
             "to be engulfed in, to be enveloped by, to wrap up, to tuck in, to pack, to do up, to cover with, to dress i"
-        ],
-        "notation": "包(つつ)む"
+        ]
     },
     {
         "name": "iroiro",
         "trans": [
+            "色々(いろいろ)",
             "various"
-        ],
-        "notation": "色々(いろいろ)"
+        ]
     },
     {
         "name": "doujou",
         "trans": [
+            "道場(どうじょう)",
             "dojo, hall used for martial arts training, mandala"
-        ],
-        "notation": "道場(どうじょう)"
+        ]
     },
     {
         "name": "daiyou",
         "trans": [
+            "代用(だいよう)",
             "substitution"
-        ],
-        "notation": "代用(だいよう)"
+        ]
     },
     {
         "name": "tamaranai",
         "trans": [
+            "堪(たま)らない",
             "intolerable, unbearable, unendurable"
-        ],
-        "notation": "堪(たま)らない"
+        ]
     },
     {
         "name": "naze",
         "trans": [
+            "何故(なぜ)",
             "why, how"
-        ],
-        "notation": "何故(なぜ)"
+        ]
     },
     {
         "name": "zaiko",
         "trans": [
+            "在庫(ざいこ)",
             "stockpile, stock"
-        ],
-        "notation": "在庫(ざいこ)"
+        ]
     },
     {
         "name": "soeru",
         "trans": [
+            "添(そ)える",
             "to add to, to attach, to append, to accompany, to garnish, to imitate, to annex"
-        ],
-        "notation": "添(そ)える"
+        ]
     },
     {
         "name": "garu",
         "trans": [
+            "がる",
             "feel"
-        ],
-        "notation": "がる"
+        ]
     },
     {
         "name": "kakumei",
         "trans": [
+            "革命(かくめい)",
             "revolution"
-        ],
-        "notation": "革命(かくめい)"
+        ]
     },
     {
         "name": "daiichi",
         "trans": [
+            "第(だい)一(いち)",
             "first, foremost, # 1"
-        ],
-        "notation": "第(だい)一(いち)"
+        ]
     },
     {
         "name": "kegarawashii",
         "trans": [
+            "汚(けが)らわしい",
             "filthy, unfair"
-        ],
-        "notation": "汚(けが)らわしい"
+        ]
     },
     {
         "name": "shudou",
         "trans": [
+            "主導(しゅどう)",
             "main leadership"
-        ],
-        "notation": "主導(しゅどう)"
+        ]
     },
     {
         "name": "kyoushuu",
         "trans": [
+            "教習(きょうしゅう)",
             "training, instruction"
-        ],
-        "notation": "教習(きょうしゅう)"
+        ]
     },
     {
         "name": "hoken",
         "trans": [
+            "保険(ほけん)",
             "insurance, guarantee"
-        ],
-        "notation": "保険(ほけん)"
+        ]
     },
     {
         "name": "tatemae",
         "trans": [
+            "建前(たてまえ)",
             "face, official stance, public position or attitude (as opposed to private thoughts)"
-        ],
-        "notation": "建前(たてまえ)"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "刊行(かんこう)",
             "publication, issue"
-        ],
-        "notation": "刊行(かんこう)"
+        ]
     },
     {
         "name": "ate",
         "trans": [
+            "当(あ)て",
             "object, aim, end, hopes, expectations"
-        ],
-        "notation": "当(あ)て"
+        ]
     },
     {
         "name": "sanbi",
         "trans": [
+            "賛美(さんび)",
             "praise, adoration, glorification"
-        ],
-        "notation": "賛美(さんび)"
+        ]
     },
     {
         "name": "biirusu",
         "trans": [
+            "ビールス",
             "virus"
-        ],
-        "notation": "ビールス"
+        ]
     },
     {
         "name": "kiri",
         "trans": [
+            "桐(きり)",
             "paulownia tree"
-        ],
-        "notation": "桐(きり)"
+        ]
     },
     {
         "name": "yappari",
         "trans": [
+            "矢(や)張(っぱ)り",
             "also, as I thought, still, in spite of, absolutely"
-        ],
-        "notation": "矢(や)張(っぱ)り"
+        ]
     },
     {
         "name": "tabou",
         "trans": [
+            "多忙(たぼう)",
             "busy, pressure of work"
-        ],
-        "notation": "多忙(たぼう)"
+        ]
     },
     {
         "name": "moukeru",
         "trans": [
+            "設(もう)ける",
             "to create, to establish"
-        ],
-        "notation": "設(もう)ける"
+        ]
     },
     {
         "name": "naosara",
         "trans": [
+            "尚更(なおさら)",
             "all the more, still less"
-        ],
-        "notation": "尚更(なおさら)"
+        ]
     },
     {
         "name": "shuhou",
         "trans": [
+            "手法(しゅほう)",
             "technique"
-        ],
-        "notation": "手法(しゅほう)"
+        ]
     },
     {
         "name": "shitto",
         "trans": [
+            "嫉妬(しっと)",
             "jealousy"
-        ],
-        "notation": "嫉妬(しっと)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "杯(はい)",
             "wine cups"
-        ],
-        "notation": "杯(はい)"
+        ]
     },
     {
         "name": "boyakeru",
         "trans": [
+            "ぼやける",
             "to become dim, to become blurred"
-        ],
-        "notation": "ぼやける"
+        ]
     },
     {
         "name": "nogasu",
         "trans": [
+            "逃(のが)す",
             "to let loose, to set free, to let escape"
-        ],
-        "notation": "逃(のが)す"
+        ]
     },
     {
         "name": "koujou",
         "trans": [
+            "向上(こうじょう)",
             "elevation, rise, improvement, advancement, progress"
-        ],
-        "notation": "向上(こうじょう)"
+        ]
     },
     {
         "name": "yaru",
         "trans": [
+            "遣(や)る",
             "to do, to have sexual intercourse, to kill, to give (to inferiors animals etc.), to dispatch (a letter"
-        ],
-        "notation": "遣(や)る"
+        ]
     },
     {
         "name": "fushin",
         "trans": [
+            "不振(ふしん)",
             "dullness, depression, slump, stagnation"
-        ],
-        "notation": "不振(ふしん)"
+        ]
     },
     {
         "name": "tenkan",
         "trans": [
+            "転換(てんかん)",
             "convert, divert"
-        ],
-        "notation": "転換(てんかん)"
+        ]
     },
     {
         "name": "donata",
         "trans": [
+            "何方(どなた)",
             "which, who"
-        ],
-        "notation": "何方(どなた)"
+        ]
     },
     {
         "name": "miki",
         "trans": [
+            "幹(みき)",
             "(tree) trunk"
-        ],
-        "notation": "幹(みき)"
+        ]
     },
     {
         "name": "teikyou",
         "trans": [
+            "提供(ていきょう)",
             "offer, tender, program sponsoring, furnishing"
-        ],
-        "notation": "提供(ていきょう)"
+        ]
     },
     {
         "name": "iyoku",
         "trans": [
+            "意欲(いよく)",
             "will, desire, ambition"
-        ],
-        "notation": "意欲(いよく)"
+        ]
     },
     {
         "name": "shutai",
         "trans": [
+            "主体(しゅたい)",
             "subject, main constituent"
-        ],
-        "notation": "主体(しゅたい)"
+        ]
     },
     {
         "name": "dassuru",
         "trans": [
+            "脱(だっ)する",
             "to escape from, to get out"
-        ],
-        "notation": "脱(だっ)する"
+        ]
     },
     {
         "name": "juujitsu",
         "trans": [
+            "充実(じゅうじつ)",
             "fullness, completion, perfection, substantiality, enrichment"
-        ],
-        "notation": "充実(じゅうじつ)"
+        ]
     },
     {
         "name": "osakini",
         "trans": [
+            "お先(さき)に",
             "before, ahead, previously"
-        ],
-        "notation": "お先(さき)に"
+        ]
     },
     {
         "name": "fukameru",
         "trans": [
+            "深(ふか)める",
             "to deepen, to heighten, to intensify"
-        ],
-        "notation": "深(ふか)める"
+        ]
     },
     {
         "name": "hinshu",
         "trans": [
+            "品種(ひんしゅ)",
             "brand, kind, description"
-        ],
-        "notation": "品種(ひんしゅ)"
+        ]
     },
     {
         "name": "seinen",
         "trans": [
+            "成年(せいねん)",
             "majority, adult age"
-        ],
-        "notation": "成年(せいねん)"
+        ]
     },
     {
         "name": "torokeru",
         "trans": [
+            "蕩(とろ)ける",
             "to be enchanted with"
-        ],
-        "notation": "蕩(とろ)ける"
+        ]
     },
     {
         "name": "shizuku",
         "trans": [
+            "雫(しずく)",
             "drop (of water)"
-        ],
-        "notation": "雫(しずく)"
+        ]
     },
     {
         "name": "shinnyuusei",
         "trans": [
+            "新入生(しんにゅうせい)",
             "freshman, first-year student"
-        ],
-        "notation": "新入生(しんにゅうせい)"
+        ]
     },
     {
         "name": "tamani",
         "trans": [
+            "偶(たま)に",
             "occasionally, once in a while"
-        ],
-        "notation": "偶(たま)に"
+        ]
     },
     {
         "name": "kokoromiru",
         "trans": [
+            "試(こころ)みる",
             "to try, to test"
-        ],
-        "notation": "試(こころ)みる"
+        ]
     },
     {
         "name": "kyaria",
         "trans": [
+            "キャリア",
             "career, career government employee"
-        ],
-        "notation": "キャリア"
+        ]
     },
     {
         "name": "motarasu",
         "trans": [
+            "齎(もたら)す",
             "to bring, to take, to bring about"
-        ],
-        "notation": "齎(もたら)す"
+        ]
     },
     {
         "name": "harappa",
         "trans": [
+            "原(はら)っぱ",
             "open field, empty lot, plain"
-        ],
-        "notation": "原(はら)っぱ"
+        ]
     },
     {
         "name": "yayakoshii",
         "trans": [
+            "ややこしい",
             "puzzling, tangled, complicated, complex"
-        ],
-        "notation": "ややこしい"
+        ]
     },
     {
         "name": "toriatsukai",
         "trans": [
+            "取(と)り扱(あつか)い",
             "treatment, service, handling, management"
-        ],
-        "notation": "取(と)り扱(あつか)い"
+        ]
     },
     {
         "name": "tebiki",
         "trans": [
+            "手引(てび)き",
             "guidance, guide, introduction"
-        ],
-        "notation": "手引(てび)き"
+        ]
     },
     {
         "name": "choukaku",
         "trans": [
+            "聴覚(ちょうかく)",
             "the sense of hearing"
-        ],
-        "notation": "聴覚(ちょうかく)"
+        ]
     },
     {
         "name": "haigo",
         "trans": [
+            "背後(はいご)",
             "back, rear"
-        ],
-        "notation": "背後(はいご)"
+        ]
     },
     {
         "name": "shinyou",
         "trans": [
+            "屎尿(しにょう)",
             "excreta, raw sewage, human waste, night soil"
-        ],
-        "notation": "屎尿(しにょう)"
+        ]
     },
     {
         "name": "gougi",
         "trans": [
+            "合議(ごうぎ)",
             "consultation, conference"
-        ],
-        "notation": "合議(ごうぎ)"
+        ]
     },
     {
         "name": "channeru",
         "trans": [
+            "チャンネル",
             "a channel"
-        ],
-        "notation": "チャンネル"
+        ]
     },
     {
         "name": "enkatsu",
         "trans": [
+            "円滑(えんかつ)",
             "harmony, smoothness"
-        ],
-        "notation": "円滑(えんかつ)"
+        ]
     },
     {
         "name": "hate",
         "trans": [
+            "果(は)て",
             "the end, the extremity, the limit(s), the result"
-        ],
-        "notation": "果(は)て"
+        ]
     },
     {
         "name": "baikin",
         "trans": [
+            "黴菌(ばいきん)",
             "bacteria, germ(s)"
-        ],
-        "notation": "黴菌(ばいきん)"
+        ]
     },
     {
         "name": "oukee",
         "trans": [
+            "オーケー",
             "OK"
-        ],
-        "notation": "オーケー"
+        ]
     },
     {
         "name": "shikashinagara",
         "trans": [
+            "然(しか)しながら",
             "nevertheless, however"
-        ],
-        "notation": "然(しか)しながら"
+        ]
     },
     {
         "name": "oyoso",
         "trans": [
+            "凡(およ)そ",
             "about, roughly, as a rule, approximately"
-        ],
-        "notation": "凡(およ)そ"
+        ]
     },
     {
         "name": "napukin",
         "trans": [
+            "ナプキン",
             "napkin"
-        ],
-        "notation": "ナプキン"
+        ]
     },
     {
         "name": "kiki",
         "trans": [
+            "危機(きき)",
             "crisis"
-        ],
-        "notation": "危機(きき)"
+        ]
     },
     {
         "name": "iikagen",
         "trans": [
+            "いい加減(かげん)",
             "moderate, right, random, not thorough, vague, irresponsible, halfhearted"
-        ],
-        "notation": "いい加減(かげん)"
+        ]
     },
     {
         "name": "nafuda",
         "trans": [
+            "名札(なふだ)",
             "name plate, name tag"
-        ],
-        "notation": "名札(なふだ)"
+        ]
     },
     {
         "name": "hangeki",
         "trans": [
+            "反撃(はんげき)",
             "counterattack, counteroffensive, counterblow"
-        ],
-        "notation": "反撃(はんげき)"
+        ]
     },
     {
         "name": "ikkyoni",
         "trans": [
+            "一挙(いっきょ)に",
             "at a stroke, with a single swoop"
-        ],
-        "notation": "一挙(いっきょ)に"
+        ]
     },
     {
         "name": "moshikasuruto",
         "trans": [
+            "若(も)しかすると",
             "perhaps, maybe, by some chance"
-        ],
-        "notation": "若(も)しかすると"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "織(お)る",
             "to weave"
-        ],
-        "notation": "織(お)る"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "し",
             "10^24 (kanji is JIS X 0212 kuten 4906), septillion (American), quadrillion (British)"
-        ],
-        "notation": "し"
+        ]
     },
     {
         "name": "kussetsu",
         "trans": [
+            "屈折(くっせつ)",
             "bending, indentation, refraction"
-        ],
-        "notation": "屈折(くっせつ)"
+        ]
     },
     {
         "name": "omutsu",
         "trans": [
+            "お襁褓(むつ)",
             "diaper, nappy"
-        ],
-        "notation": "お襁褓(むつ)"
+        ]
     },
     {
         "name": "otouto",
         "trans": [
+            "弟(おとうと)",
             "younger brother"
-        ],
-        "notation": "弟(おとうと)"
+        ]
     },
     {
         "name": "rakunou",
         "trans": [
+            "酪農(らくのう)",
             "dairy (farm)"
-        ],
-        "notation": "酪農(らくのう)"
+        ]
     },
     {
         "name": "itaku",
         "trans": [
+            "委託(いたく)",
             "consign (goods (for sale) to a firm), entrust (person with something), commit"
-        ],
-        "notation": "委託(いたく)"
+        ]
     },
     {
         "name": "gijidou",
         "trans": [
+            "議事堂(ぎじどう)",
             "Diet building"
-        ],
-        "notation": "議事堂(ぎじどう)"
+        ]
     },
     {
         "name": "minogasu",
         "trans": [
+            "見逃(みのが)す",
             "to miss, to overlook, to leave at large"
-        ],
-        "notation": "見逃(みのが)す"
+        ]
     },
     {
         "name": "mitasu",
         "trans": [
+            "満(み)たす",
             "to satisfy, to ingratiate, to fill, to fulfill"
-        ],
-        "notation": "満(み)たす"
+        ]
     },
     {
         "name": "onaidoshi",
         "trans": [
+            "同(おな)い年(どし)",
             "of the same age"
-        ],
-        "notation": "同(おな)い年(どし)"
+        ]
     },
     {
         "name": "tokoroga",
         "trans": [
+            "所(ところ)が",
             "however, while, even if"
-        ],
-        "notation": "所(ところ)が"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "策(さく)",
             "plan, policy"
-        ],
-        "notation": "策(さく)"
+        ]
     },
     {
         "name": "toriatsukau",
         "trans": [
+            "取(と)り扱(あつか)う",
             "to treat, to handle, to deal in"
-        ],
-        "notation": "取(と)り扱(あつか)う"
+        ]
     },
     {
         "name": "jouryuu",
         "trans": [
+            "蒸留(じょうりゅう)",
             "distillation"
-        ],
-        "notation": "蒸留(じょうりゅう)"
+        ]
     },
     {
         "name": "hatsu",
         "trans": [
+            "発(はつ)",
             "departure, beginning, counter for gunshots"
-        ],
-        "notation": "発(はつ)"
+        ]
     },
     {
         "name": "umekomu",
         "trans": [
+            "埋(う)め込(こ)む",
             "to bury"
-        ],
-        "notation": "埋(う)め込(こ)む"
+        ]
     },
     {
         "name": "ukeireru",
         "trans": [
+            "受(う)け入(い)れる",
             "to accept, to receive"
-        ],
-        "notation": "受(う)け入(い)れる"
+        ]
     },
     {
         "name": "shuugiin",
         "trans": [
+            "衆議院(しゅうぎいん)",
             "Lower House, House of Representatives"
-        ],
-        "notation": "衆議院(しゅうぎいん)"
+        ]
     },
     {
         "name": "buka",
         "trans": [
+            "部下(ぶか)",
             "subordinate person"
-        ],
-        "notation": "部下(ぶか)"
+        ]
     },
     {
         "name": "ippen",
         "trans": [
+            "一変(いっぺん)",
             "complete change, about-face"
-        ],
-        "notation": "一変(いっぺん)"
+        ]
     },
     {
         "name": "kakato",
         "trans": [
+            "踵(かかと)",
             "(shoe) heel"
-        ],
-        "notation": "踵(かかと)"
+        ]
     },
     {
         "name": "toraburu",
         "trans": [
+            "トラブル",
             "trouble (sometimes used as a verb)"
-        ],
-        "notation": "トラブル"
+        ]
     },
     {
         "name": "ago",
         "trans": [
+            "顎(あご)",
             "chin"
-        ],
-        "notation": "顎(あご)"
+        ]
     },
     {
         "name": "kappatsu",
         "trans": [
+            "活発(かっぱつ)",
             "vigor, active"
-        ],
-        "notation": "活発(かっぱつ)"
+        ]
     },
     {
         "name": "namari",
         "trans": [
+            "鉛(なまり)",
             "lead (the metal)"
-        ],
-        "notation": "鉛(なまり)"
+        ]
     },
     {
         "name": "orimono",
         "trans": [
+            "織物(おりもの)",
             "textile, fabric"
-        ],
-        "notation": "織物(おりもの)"
+        ]
     },
     {
         "name": "shousuu",
         "trans": [
+            "少数(しょうすう)",
             "minority, few"
-        ],
-        "notation": "少数(しょうすう)"
+        ]
     },
     {
         "name": "unyu",
         "trans": [
+            "運輸(うんゆ)",
             "transportation"
-        ],
-        "notation": "運輸(うんゆ)"
+        ]
     },
     {
         "name": "mura",
         "trans": [
+            "斑(むら)",
             "spots, speckles, mottles"
-        ],
-        "notation": "斑(むら)"
+        ]
     },
     {
         "name": "aidagara",
         "trans": [
+            "間柄(あいだがら)",
             "relation(ship)"
-        ],
-        "notation": "間柄(あいだがら)"
+        ]
     },
     {
         "name": "senkyo",
         "trans": [
+            "選挙(せんきょ)",
             "election"
-        ],
-        "notation": "選挙(せんきょ)"
+        ]
     },
     {
         "name": "sengen",
         "trans": [
+            "宣言(せんげん)",
             "declaration, proclamation, announcement"
-        ],
-        "notation": "宣言(せんげん)"
+        ]
     },
     {
         "name": "tsumazuku",
         "trans": [
+            "躓(つまず)く",
             "to stumble, to trip"
-        ],
-        "notation": "躓(つまず)く"
+        ]
     },
     {
         "name": "hinan",
         "trans": [
+            "避難(ひなん)",
             "taking refuge, finding shelter"
-        ],
-        "notation": "避難(ひなん)"
+        ]
     },
     {
         "name": "kumiawaseru",
         "trans": [
+            "組(く)み合(あ)わせる",
             "to join together, to combine, to join up"
-        ],
-        "notation": "組(く)み合(あ)わせる"
+        ]
     },
     {
         "name": "zureru",
         "trans": [
+            "ずれる",
             "to slide, to slip off"
-        ],
-        "notation": "ずれる"
+        ]
     },
     {
         "name": "zadankai",
         "trans": [
+            "座談(ざだん)会(かい)",
             "symposium, round-table discussion"
-        ],
-        "notation": "座談(ざだん)会(かい)"
+        ]
     },
     {
         "name": "nikushin",
         "trans": [
+            "肉親(にくしん)",
             "blood relationship, blood relative"
-        ],
-        "notation": "肉親(にくしん)"
+        ]
     },
     {
         "name": "annojou",
         "trans": [
+            "案(あん)の定(じょう)",
             "sure enough, as usual"
-        ],
-        "notation": "案(あん)の定(じょう)"
+        ]
     },
     {
         "name": "tsukusu",
         "trans": [
+            "尽(つ)くす",
             "to exhaust, to run out, to serve (a person), to befriend"
-        ],
-        "notation": "尽(つ)くす"
+        ]
     },
     {
         "name": "iyadou",
         "trans": [
+            "厭(いや)々",
             "unwillingly, grudgingly, shaking head in refusal (to children)"
-        ],
-        "notation": "厭(いや)々"
+        ]
     },
     {
         "name": "dezaato",
         "trans": [
+            "デザート",
             "dessert"
-        ],
-        "notation": "デザート"
+        ]
     },
     {
         "name": "kuizu",
         "trans": [
+            "クイズ",
             "quiz"
-        ],
-        "notation": "クイズ"
+        ]
     },
     {
         "name": "sutorobo",
         "trans": [
+            "ストロボ",
             "stroboscope (lit: strobo), strobe lamp, stroboscopic lamp"
-        ],
-        "notation": "ストロボ"
+        ]
     },
     {
         "name": "kosei",
         "trans": [
+            "個性(こせい)",
             "individuality, personality, idiosyncrasy"
-        ],
-        "notation": "個性(こせい)"
+        ]
     },
     {
         "name": "habamu",
         "trans": [
+            "阻(はば)む",
             "to keep someone from doing, to stop, to prevent, to check, to hinder, to obstruct, to oppose, to thwart"
-        ],
-        "notation": "阻(はば)む"
+        ]
     },
     {
         "name": "someru",
         "trans": [
+            "染(そ)める",
             "to dye, to colour"
-        ],
-        "notation": "染(そ)める"
+        ]
     },
     {
         "name": "enshuu",
         "trans": [
+            "演習(えんしゅう)",
             "practice, exercises, manoeuvers"
-        ],
-        "notation": "演習(えんしゅう)"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "管(かん)",
             "pipe, tube"
-        ],
-        "notation": "管(かん)"
+        ]
     },
     {
         "name": "kokkou",
         "trans": [
+            "国交(こっこう)",
             "diplomatic relations"
-        ],
-        "notation": "国交(こっこう)"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "件(けん)",
             "example, precedent, the usual, the said, the above-mentioned, (man) in question"
-        ],
-        "notation": "件(けん)"
+        ]
     },
     {
         "name": "sokushin",
         "trans": [
+            "促進(そくしん)",
             "promotion, acceleration, encouragement, facilitation, spurring on"
-        ],
-        "notation": "促進(そくしん)"
+        ]
     },
     {
         "name": "shoumei",
         "trans": [
+            "照明(しょうめい)",
             "illumination"
-        ],
-        "notation": "照明(しょうめい)"
+        ]
     },
     {
         "name": "rouryoku",
         "trans": [
+            "労力(ろうりょく)",
             "labour, effort, toil, trouble"
-        ],
-        "notation": "労力(ろうりょく)"
+        ]
     },
     {
         "name": "tsunoru",
         "trans": [
+            "募(つの)る",
             "to invite, to solicit help participation etc"
-        ],
-        "notation": "募(つの)る"
+        ]
     },
     {
         "name": "ansei",
         "trans": [
+            "安静(あんせい)",
             "rest"
-        ],
-        "notation": "安静(あんせい)"
+        ]
     },
     {
         "name": "makasu",
         "trans": [
+            "負(ま)かす",
             "to defeat"
-        ],
-        "notation": "負(ま)かす"
+        ]
     },
     {
         "name": "seme",
         "trans": [
+            "攻(せ)め",
             "attack, offence"
-        ],
-        "notation": "攻(せ)め"
+        ]
     },
     {
         "name": "fukin",
         "trans": [
+            "布巾(ふきん)",
             "tea-towel, dish cloth"
-        ],
-        "notation": "布巾(ふきん)"
+        ]
     },
     {
         "name": "narabini",
         "trans": [
+            "並(なら)びに",
             "and"
-        ],
-        "notation": "並(なら)びに"
+        ]
     },
     {
         "name": "uten",
         "trans": [
+            "雨天(うてん)",
             "rainy weather"
-        ],
-        "notation": "雨天(うてん)"
+        ]
     },
     {
         "name": "gansou",
         "trans": [
+            "含嗽(がんそう)",
             "gargle, rinse mouth"
-        ],
-        "notation": "含嗽(がんそう)"
+        ]
     },
     {
         "name": "sokonau",
         "trans": [
+            "損(そこ)なう",
             "to harm, to hurt, to injure, to damage, to fail in doing"
-        ],
-        "notation": "損(そこ)なう"
+        ]
     },
     {
         "name": "matagagaru",
         "trans": [
+            "跨(またが)がる",
             "to extend over or into, to straddle"
-        ],
-        "notation": "跨(またが)がる"
+        ]
     },
     {
         "name": "gareeji",
         "trans": [
+            "ガレージ",
             "garage (at house)"
-        ],
-        "notation": "ガレージ"
+        ]
     },
     {
         "name": "renchuu",
         "trans": [
+            "連中(れんちゅう)",
             "colleagues, company, a lot"
-        ],
-        "notation": "連中(れんちゅう)"
+        ]
     },
     {
         "name": "goubuku",
         "trans": [
+            "降伏(ごうぶく)",
             "capitulation, surrender, submission"
-        ],
-        "notation": "降伏(ごうぶく)"
+        ]
     },
     {
         "name": "senjutsu",
         "trans": [
+            "戦術(せんじゅつ)",
             "tactics"
-        ],
-        "notation": "戦術(せんじゅつ)"
+        ]
     },
     {
         "name": "irui",
         "trans": [
+            "衣類(いるい)",
             "clothes, clothing, garments"
-        ],
-        "notation": "衣類(いるい)"
+        ]
     },
     {
         "name": "shuuryou",
         "trans": [
+            "修了(しゅうりょう)",
             "completion (of a course)"
-        ],
-        "notation": "修了(しゅうりょう)"
+        ]
     },
     {
         "name": "shitsugi",
         "trans": [
+            "質疑(しつぎ)",
             "question"
-        ],
-        "notation": "質疑(しつぎ)"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "作(さく)",
             "a work, a harvest"
-        ],
-        "notation": "作(さく)"
+        ]
     },
     {
         "name": "hokyou",
         "trans": [
+            "補強(ほきょう)",
             "compensation, reinforcement"
-        ],
-        "notation": "補強(ほきょう)"
+        ]
     },
     {
         "name": "chuufuku",
         "trans": [
+            "中腹(ちゅうふく)",
             "irritated, offended"
-        ],
-        "notation": "中腹(ちゅうふく)"
+        ]
     },
     {
         "name": "machidooshii",
         "trans": [
+            "待(ま)ち遠(どお)しい",
             "looking forward to"
-        ],
-        "notation": "待(ま)ち遠(どお)しい"
+        ]
     },
     {
         "name": "tsurigane",
         "trans": [
+            "釣鐘(つりがね)",
             "hanging bell"
-        ],
-        "notation": "釣鐘(つりがね)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "止(と)める",
             "to stop, to cease, to put an end to"
-        ],
-        "notation": "止(と)める"
+        ]
     },
     {
         "name": "kamubakku",
         "trans": [
+            "カムバック",
             "comeback"
-        ],
-        "notation": "カムバック"
+        ]
     },
     {
         "name": "segare",
         "trans": [
+            "伜(せがれ)",
             "son, my son"
-        ],
-        "notation": "伜(せがれ)"
+        ]
     },
     {
         "name": "kotogara",
         "trans": [
+            "事柄(ことがら)",
             "matter, thing, affair, circumstance"
-        ],
-        "notation": "事柄(ことがら)"
+        ]
     },
     {
         "name": "yasui",
         "trans": [
+            "易(やす)い",
             "easy"
-        ],
-        "notation": "易(やす)い"
+        ]
     },
     {
         "name": "kikon",
         "trans": [
+            "既婚(きこん)",
             "marriage, married"
-        ],
-        "notation": "既婚(きこん)"
+        ]
     },
     {
         "name": "kaijo",
         "trans": [
+            "解除(かいじょ)",
             "cancellation, rescinding, release, calling off"
-        ],
-        "notation": "解除(かいじょ)"
+        ]
     },
     {
         "name": "tahou",
         "trans": [
+            "他方(たほう)",
             "another side, different direction, (on) the other hand"
-        ],
-        "notation": "他方(たほう)"
+        ]
     },
     {
         "name": "unagasu",
         "trans": [
+            "促(うなが)す",
             "to urge, to press, to suggest, to demand, to stimulate, to quicken, to incite, to invite (attention to)"
-        ],
-        "notation": "促(うなが)す"
+        ]
     },
     {
         "name": "soredeha",
         "trans": [
+            "其(それ)では",
             "in that situation, well then ..."
-        ],
-        "notation": "其(それ)では"
+        ]
     },
     {
         "name": "tomi",
         "trans": [
+            "富(とみ)",
             "wealth, fortune"
-        ],
-        "notation": "富(とみ)"
+        ]
     },
     {
         "name": "fugou",
         "trans": [
+            "富豪(ふごう)",
             "wealthy person, millionaire"
-        ],
-        "notation": "富豪(ふごう)"
+        ]
     },
     {
         "name": "sententeki",
         "trans": [
+            "先天的(せんてんてき)",
             "a priori, inborn, innate, inherent, congenital, hereditary"
-        ],
-        "notation": "先天的(せんてんてき)"
+        ]
     },
     {
         "name": "doukan",
         "trans": [
+            "同感(どうかん)",
             "agreement, same opinion, same feeling, sympathy, concurrence"
-        ],
-        "notation": "同感(どうかん)"
+        ]
     },
     {
         "name": "suri",
         "trans": [
+            "刷(す)り",
             "printing"
-        ],
-        "notation": "刷(す)り"
+        ]
     },
     {
         "name": "netsui",
         "trans": [
+            "熱意(ねつい)",
             "zeal, enthusiasm"
-        ],
-        "notation": "熱意(ねつい)"
+        ]
     },
     {
         "name": "daihon",
         "trans": [
+            "台本(だいほん)",
             "libretto, scenario"
-        ],
-        "notation": "台本(だいほん)"
+        ]
     },
     {
         "name": "mefuta",
         "trans": [
+            "目(め)蓋(ふた)",
             "eyelid"
-        ],
-        "notation": "目(め)蓋(ふた)"
+        ]
     },
     {
         "name": "oshaberi",
         "trans": [
+            "お喋(しゃべ)り",
             "chattering, talk, idle talk, chat, chitchat, gossip, chatty, talkative, chatterbox, blabbermouth"
-        ],
-        "notation": "お喋(しゃべ)り"
+        ]
     },
     {
         "name": "orenji",
         "trans": [
+            "オレンジ",
             "an orange"
-        ],
-        "notation": "オレンジ"
+        ]
     },
     {
         "name": "tentai",
         "trans": [
+            "天体(てんたい)",
             "heavenly body"
-        ],
-        "notation": "天体(てんたい)"
+        ]
     },
     {
         "name": "joshi",
         "trans": [
+            "助詞(じょし)",
             "particle, postposition"
-        ],
-        "notation": "助詞(じょし)"
+        ]
     },
     {
         "name": "tenken",
         "trans": [
+            "点検(てんけん)",
             "inspection, examination, checking"
-        ],
-        "notation": "点検(てんけん)"
+        ]
     },
     {
         "name": "shochi",
         "trans": [
+            "処置(しょち)",
             "treatment"
-        ],
-        "notation": "処置(しょち)"
+        ]
     },
     {
         "name": "todokooru",
         "trans": [
+            "滞(とどこお)る",
             "to stagnate, to be delayed"
-        ],
-        "notation": "滞(とどこお)る"
+        ]
     },
     {
         "name": "uketomeru",
         "trans": [
+            "受(う)け止(と)める",
             "to catch, to stop the blow, to react to, to take"
-        ],
-        "notation": "受(う)け止(と)める"
+        ]
     },
     {
         "name": "marude",
         "trans": [
+            "丸(まる)で",
             "quite, entirely, completely, at all, as if, as though, so to speak"
-        ],
-        "notation": "丸(まる)で"
+        ]
     },
     {
         "name": "haiguusha",
         "trans": [
+            "配偶(はいぐう)者(しゃ)",
             "spouse, wife, husband"
-        ],
-        "notation": "配偶(はいぐう)者(しゃ)"
+        ]
     },
     {
         "name": "junjiru",
         "trans": [
+            "準(じゅん)じる",
             "to follow, to conform, to apply to"
-        ],
-        "notation": "準(じゅん)じる"
+        ]
     },
     {
         "name": "nagoyaka",
         "trans": [
+            "和(なご)やか",
             "mild, calm, gentle, quiet, harmonious"
-        ],
-        "notation": "和(なご)やか"
+        ]
     },
     {
         "name": "fuzoku",
         "trans": [
+            "付属(ふぞく)",
             "attached, belonging, affiliated, annexed, associated, subordinate, incidental, dependent, auxiliary"
-        ],
-        "notation": "付属(ふぞく)"
+        ]
     },
     {
         "name": "kigeki",
         "trans": [
+            "喜劇(きげき)",
             "comedy, funny show"
-        ],
-        "notation": "喜劇(きげき)"
+        ]
     },
     {
         "name": "chou",
         "trans": [
+            "庁(ちょう)",
             "government office"
-        ],
-        "notation": "庁(ちょう)"
+        ]
     },
     {
         "name": "shusse",
         "trans": [
+            "出世(しゅっせ)",
             "promotion, successful career, eminence"
-        ],
-        "notation": "出世(しゅっせ)"
+        ]
     },
     {
         "name": "shoujo",
         "trans": [
+            "少女(しょうじょ)",
             "daughter, young lady, virgin, maiden, little girl"
-        ],
-        "notation": "少女(しょうじょ)"
+        ]
     },
     {
         "name": "donkan",
         "trans": [
+            "鈍感(どんかん)",
             "thickheadedness, stolidity"
-        ],
-        "notation": "鈍感(どんかん)"
+        ]
     },
     {
         "name": "omoshiroi",
         "trans": [
+            "面白(おもしろ)い",
             "interesting, amusing"
-        ],
-        "notation": "面白(おもしろ)い"
+        ]
     },
     {
         "name": "gessha",
         "trans": [
+            "月謝(げっしゃ)",
             "monthly tuition fee"
-        ],
-        "notation": "月謝(げっしゃ)"
+        ]
     },
     {
         "name": "kareno",
         "trans": [
+            "彼(かれ)の",
             "that over there"
-        ],
-        "notation": "彼(かれ)の"
+        ]
     },
     {
         "name": "kinko",
         "trans": [
+            "金庫(きんこ)",
             "safe, vault, treasury, provider of funds"
-        ],
-        "notation": "金庫(きんこ)"
+        ]
     },
     {
         "name": "hareru",
         "trans": [
+            "腫(は)れる",
             "to swell (from inflammation), to become swollen"
-        ],
-        "notation": "腫(は)れる"
+        ]
     },
     {
         "name": "ogoru",
         "trans": [
+            "傲(おご)る",
             "to be proud"
-        ],
-        "notation": "傲(おご)る"
+        ]
     },
     {
         "name": "fuben",
         "trans": [
+            "不便(ふべん)",
             "pity, compassion"
-        ],
-        "notation": "不便(ふべん)"
+        ]
     },
     {
         "name": "narubeku",
         "trans": [
+            "成(な)るべく",
             "as much as possible"
-        ],
-        "notation": "成(な)るべく"
+        ]
     },
     {
         "name": "kairyuu",
         "trans": [
+            "海流(かいりゅう)",
             "ocean current"
-        ],
-        "notation": "海流(かいりゅう)"
+        ]
     },
     {
         "name": "santakurousu",
         "trans": [
+            "サンタクロース",
             "Santa Claus"
-        ],
-        "notation": "サンタクロース"
+        ]
     },
     {
         "name": "chakushu",
         "trans": [
+            "着手(ちゃくしゅ)",
             "embarkation, launch"
-        ],
-        "notation": "着手(ちゃくしゅ)"
+        ]
     },
     {
         "name": "nenshou",
         "trans": [
+            "燃焼(ねんしょう)",
             "burning, combustion"
-        ],
-        "notation": "燃焼(ねんしょう)"
+        ]
     },
     {
         "name": "teibou",
         "trans": [
+            "堤防(ていぼう)",
             "bank, weir"
-        ],
-        "notation": "堤防(ていぼう)"
+        ]
     },
     {
         "name": "biryou",
         "trans": [
+            "微量(びりょう)",
             "minuscule amount, extremely small quantity"
-        ],
-        "notation": "微量(びりょう)"
+        ]
     },
     {
         "name": "chuusen",
         "trans": [
+            "抽選(ちゅうせん)",
             "lottery, raffle, drawing (of lots)"
-        ],
-        "notation": "抽選(ちゅうせん)"
+        ]
     },
     {
         "name": "torimazeru",
         "trans": [
+            "取(と)り混(ま)ぜる",
             "to mix, to put together"
-        ],
-        "notation": "取(と)り混(ま)ぜる"
+        ]
     },
     {
         "name": "masaru",
         "trans": [
+            "勝(まさ)る",
             "to excel, to surpass, to outrival"
-        ],
-        "notation": "勝(まさ)る"
+        ]
     },
     {
         "name": "shomin",
         "trans": [
+            "庶民(しょみん)",
             "masses, common people"
-        ],
-        "notation": "庶民(しょみん)"
+        ]
     },
     {
         "name": "jouka",
         "trans": [
+            "城下(じょうか)",
             "land near the castle"
-        ],
-        "notation": "城下(じょうか)"
+        ]
     },
     {
         "name": "saiketsu",
         "trans": [
+            "採決(さいけつ)",
             "vote, roll call"
-        ],
-        "notation": "採決(さいけつ)"
+        ]
     },
     {
         "name": "saizu",
         "trans": [
+            "サイズ",
             "size"
-        ],
-        "notation": "サイズ"
+        ]
     },
     {
         "name": "juutan",
         "trans": [
+            "絨毯(じゅうたん)",
             "carpet"
-        ],
-        "notation": "絨毯(じゅうたん)"
+        ]
     },
     {
         "name": "ji",
         "trans": [
+            "字(じ)",
             "section of village"
-        ],
-        "notation": "字(じ)"
+        ]
     },
     {
         "name": "sorehodo",
         "trans": [
+            "其(それ)程(ほど)",
             "to that degree, extent"
-        ],
-        "notation": "其(それ)程(ほど)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "盾(たて)",
             "shield, buckler, escutcheon, pretext"
-        ],
-        "notation": "盾(たて)"
+        ]
     },
     {
         "name": "kono",
         "trans": [
+            "此(こ)の",
             "this"
-        ],
-        "notation": "此(こ)の"
+        ]
     },
     {
         "name": "mikon",
         "trans": [
+            "未婚(みこん)",
             "unmarried"
-        ],
-        "notation": "未婚(みこん)"
+        ]
     },
     {
         "name": "burei",
         "trans": [
+            "無礼(ぶれい)",
             "impolite, rude"
-        ],
-        "notation": "無礼(ぶれい)"
+        ]
     },
     {
         "name": "jiritsu",
         "trans": [
+            "自立(じりつ)",
             "independence, self-reliance"
-        ],
-        "notation": "自立(じりつ)"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "吐(は)く",
             "1. to breathe, 2. to tell (lies), 3. to vomit, to disgorge"
-        ],
-        "notation": "吐(は)く"
+        ]
     },
     {
         "name": "kabi",
         "trans": [
+            "華美(かび)",
             "pomp, splendor, gaudiness"
-        ],
-        "notation": "華美(かび)"
+        ]
     },
     {
         "name": "oidasu",
         "trans": [
+            "追(お)い出(だ)す",
             "to expel, to drive out"
-        ],
-        "notation": "追(お)い出(だ)す"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "仙(せん)",
             "hermit, wizard"
-        ],
-        "notation": "仙(せん)"
+        ]
     },
     {
         "name": "senryoku",
         "trans": [
+            "戦力(せんりょく)",
             "war potential"
-        ],
-        "notation": "戦力(せんりょく)"
+        ]
     },
     {
         "name": "kikaku",
         "trans": [
+            "規格(きかく)",
             "standard, norm"
-        ],
-        "notation": "規格(きかく)"
+        ]
     },
     {
         "name": "hina",
         "trans": [
+            "雛(ひな)",
             "young bird, chick, doll"
-        ],
-        "notation": "雛(ひな)"
+        ]
     },
     {
         "name": "toomawari",
         "trans": [
+            "遠回(とおまわ)り",
             "detour, roundabout way"
-        ],
-        "notation": "遠回(とおまわ)り"
+        ]
     },
     {
         "name": "kyuushoku",
         "trans": [
+            "給食(きゅうしょく)",
             "school lunch, providing a meal"
-        ],
-        "notation": "給食(きゅうしょく)"
+        ]
     },
     {
         "name": "mabataki",
         "trans": [
+            "瞬(まばた)き",
             "wink, twinkling (of stars), flicker (of light)"
-        ],
-        "notation": "瞬(まばた)き"
+        ]
     },
     {
         "name": "awasu",
         "trans": [
+            "合(あ)わす",
             "to join together, to face, to unite, to be opposite, to combine, to connect, to add up, to mix, to match, to"
-        ],
-        "notation": "合(あ)わす"
+        ]
     },
     {
         "name": "douteki",
         "trans": [
+            "動的(どうてき)",
             "dynamic, kinetic"
-        ],
-        "notation": "動的(どうてき)"
+        ]
     },
     {
         "name": "kibo",
         "trans": [
+            "規模(きぼ)",
             "scale, scope, plan, structure"
-        ],
-        "notation": "規模(きぼ)"
+        ]
     },
     {
         "name": "tsumaru",
         "trans": [
+            "詰(つま)る",
             "to rebuke, to scold, to tell off"
-        ],
-        "notation": "詰(つま)る"
+        ]
     },
     {
         "name": "tobira",
         "trans": [
+            "扉(とびら)",
             "door, opening"
-        ],
-        "notation": "扉(とびら)"
+        ]
     },
     {
         "name": "shikashi",
         "trans": [
+            "然(しか)し",
             "however, but"
-        ],
-        "notation": "然(しか)し"
+        ]
     },
     {
         "name": "moru",
         "trans": [
+            "漏(も)る",
             "to leak, to run out"
-        ],
-        "notation": "漏(も)る"
+        ]
     },
     {
         "name": "kachiku",
         "trans": [
+            "家畜(かちく)",
             "domestic animals, livestock, cattle"
-        ],
-        "notation": "家畜(かちく)"
+        ]
     },
     {
         "name": "aburae",
         "trans": [
+            "油絵(あぶらえ)",
             "oil painting"
-        ],
-        "notation": "油絵(あぶらえ)"
+        ]
     },
     {
         "name": "suguru",
         "trans": [
+            "傑(すぐる)",
             "excellence"
-        ],
-        "notation": "傑(すぐる)"
+        ]
     },
     {
         "name": "nen",
         "trans": [
+            "念(ねん)",
             "sense, idea, thought, feeling, desire, concern, attention, care"
-        ],
-        "notation": "念(ねん)"
+        ]
     },
     {
         "name": "seiki",
         "trans": [
+            "正規(せいき)",
             "regular, legal, formal, established, legitimate"
-        ],
-        "notation": "正規(せいき)"
+        ]
     },
     {
         "name": "kashigeru",
         "trans": [
+            "可(か)成(しげる)",
             "considerably, fairly, quite"
-        ],
-        "notation": "可(か)成(しげる)"
+        ]
     },
     {
         "name": "houtei",
         "trans": [
+            "法廷(ほうてい)",
             "courtroom"
-        ],
-        "notation": "法廷(ほうてい)"
+        ]
     },
     {
         "name": "youfuu",
         "trans": [
+            "洋風(ようふう)",
             "western style"
-        ],
-        "notation": "洋風(ようふう)"
+        ]
     },
     {
         "name": "nekaseru",
         "trans": [
+            "寝(ね)かせる",
             "to put to bed, to lay down, to ferment"
-        ],
-        "notation": "寝(ね)かせる"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "役(やく)",
             "war, campaign, battle"
-        ],
-        "notation": "役(やく)"
+        ]
     },
     {
         "name": "yusaburu",
         "trans": [
+            "揺(ゆ)さぶる",
             "to shake, to jolt, to rock, to swing"
-        ],
-        "notation": "揺(ゆ)さぶる"
+        ]
     },
     {
         "name": "kimariwarui",
         "trans": [
+            "決(き)まり悪(わる)い",
             "feeling awkward, being ashamed"
-        ],
-        "notation": "決(き)まり悪(わる)い"
+        ]
     },
     {
         "name": "zou",
         "trans": [
+            "象(ぞう)",
             "phenomenon"
-        ],
-        "notation": "象(ぞう)"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "市(し)",
             "market, fair"
-        ],
-        "notation": "市(し)"
+        ]
     },
     {
         "name": "menjo",
         "trans": [
+            "免除(めんじょ)",
             "exemption, exoneration, discharge"
-        ],
-        "notation": "免除(めんじょ)"
+        ]
     },
     {
         "name": "tokuyuu",
         "trans": [
+            "特有(とくゆう)",
             "characteristic (of), peculiar (to)"
-        ],
-        "notation": "特有(とくゆう)"
+        ]
     },
     {
         "name": "ensen",
         "trans": [
+            "沿線(えんせん)",
             "along railway line"
-        ],
-        "notation": "沿線(えんせん)"
+        ]
     },
     {
         "name": "kagou",
         "trans": [
+            "化合(かごう)",
             "chemical combination"
-        ],
-        "notation": "化合(かごう)"
+        ]
     },
     {
         "name": "riten",
         "trans": [
+            "利点(りてん)",
             "advantage, point in favor"
-        ],
-        "notation": "利点(りてん)"
+        ]
     },
     {
         "name": "hairu",
         "trans": [
+            "入(はい)る",
             "to get in, to go in, to come in, to flow into, to set, to set in"
-        ],
-        "notation": "入(はい)る"
+        ]
     },
     {
         "name": "uchikiru",
         "trans": [
+            "打(う)ち切(き)る",
             "to stop, to abort, to discontinue, to close"
-        ],
-        "notation": "打(う)ち切(き)る"
+        ]
     },
     {
         "name": "ketsugi",
         "trans": [
+            "決議(けつぎ)",
             "resolution, vote, decision"
-        ],
-        "notation": "決議(けつぎ)"
+        ]
     },
     {
         "name": "hairetsu",
         "trans": [
+            "配列(はいれつ)",
             "arrangement, array (programming)"
-        ],
-        "notation": "配列(はいれつ)"
+        ]
     },
     {
         "name": "hishi",
         "trans": [
+            "彼此(ひし)",
             "one thing or another, this and that, this or that"
-        ],
-        "notation": "彼此(ひし)"
+        ]
     },
     {
         "name": "taeru",
         "trans": [
+            "耐(た)える",
             "to bear, to endure"
-        ],
-        "notation": "耐(た)える"
+        ]
     },
     {
         "name": "ka",
         "trans": [
+            "科(か)",
             "department, section"
-        ],
-        "notation": "科(か)"
+        ]
     },
     {
         "name": "nanto",
         "trans": [
+            "何(なん)と",
             "what, how, whatever"
-        ],
-        "notation": "何(なん)と"
+        ]
     },
     {
         "name": "metsubou",
         "trans": [
+            "滅亡(めつぼう)",
             "downfall, ruin, collapse, destruction"
-        ],
-        "notation": "滅亡(めつぼう)"
+        ]
     },
     {
         "name": "seiyaku",
         "trans": [
+            "制約(せいやく)",
             "limitation, restriction, condition, constraints"
-        ],
-        "notation": "制約(せいやく)"
+        ]
     },
     {
         "name": "shigai",
         "trans": [
+            "市街(しがい)",
             "urban areas, the streets, town, city"
-        ],
-        "notation": "市街(しがい)"
+        ]
     },
     {
         "name": "shibomu",
         "trans": [
+            "萎(しぼ)む",
             "to wither, to fade (away), to shrivel, to wilt"
-        ],
-        "notation": "萎(しぼ)む"
+        ]
     },
     {
         "name": "ya",
         "trans": [
+            "矢(や)",
             "arrow"
-        ],
-        "notation": "矢(や)"
+        ]
     },
     {
         "name": "sodachi",
         "trans": [
+            "育(そだ)ち",
             "breeding, growth"
-        ],
-        "notation": "育(そだ)ち"
+        ]
     },
     {
         "name": "kigane",
         "trans": [
+            "気兼(きが)ね",
             "hesitance, diffidence, feeling constraint, fear of troubling someone, having scruples about doing someth"
-        ],
-        "notation": "気兼(きが)ね"
+        ]
     },
     {
         "name": "chaku",
         "trans": [
+            "着(ちゃく)",
             "counter for suits of clothing, arriving at .."
-        ],
-        "notation": "着(ちゃく)"
+        ]
     },
     {
         "name": "kichoumen",
         "trans": [
+            "几帳面(きちょうめん)",
             "methodical, punctual, steady"
-        ],
-        "notation": "几帳面(きちょうめん)"
+        ]
     },
     {
         "name": "doukyuu",
         "trans": [
+            "同級(どうきゅう)",
             "the same grade, same class"
-        ],
-        "notation": "同級(どうきゅう)"
+        ]
     },
     {
         "name": "kiwamete",
         "trans": [
+            "極(きわ)めて",
             "exceedingly, extremely"
-        ],
-        "notation": "極(きわ)めて"
+        ]
     },
     {
         "name": "gankyuu",
         "trans": [
+            "眼球(がんきゅう)",
             "eyeball"
-        ],
-        "notation": "眼球(がんきゅう)"
+        ]
     },
     {
         "name": "kaotsuki",
         "trans": [
+            "顔付(かおつ)き",
             "(outward) looks, features, face, countenance, expression"
-        ],
-        "notation": "顔付(かおつ)き"
+        ]
     },
     {
         "name": "shinjuu",
         "trans": [
+            "心中(しんじゅう)",
             "double suicide, lovers suicide"
-        ],
-        "notation": "心中(しんじゅう)"
+        ]
     },
     {
         "name": "weetoresu",
         "trans": [
+            "ウェートレス",
             "waitress"
-        ],
-        "notation": "ウェートレス"
+        ]
     },
     {
         "name": "gozaimasu",
         "trans": [
+            "ご座(ざ)います",
             "to be (polite), to exist"
-        ],
-        "notation": "ご座(ざ)います"
+        ]
     },
     {
         "name": "shiru",
         "trans": [
+            "著(しる)",
             "counter for suits of clothing, arriving at .."
-        ],
-        "notation": "著(しる)"
+        ]
     },
     {
         "name": "nazukeru",
         "trans": [
+            "名付(なづ)ける",
             "to name (someone)"
-        ],
-        "notation": "名付(なづ)ける"
+        ]
     },
     {
         "name": "miren",
         "trans": [
+            "未練(みれん)",
             "lingering affection, attachment, regret(s), reluctance"
-        ],
-        "notation": "未練(みれん)"
+        ]
     },
     {
         "name": "nagedasu",
         "trans": [
+            "投(な)げ出(だ)す",
             "to throw down, to abandon, to sacrifice, to throw out"
-        ],
-        "notation": "投(な)げ出(だ)す"
+        ]
     },
     {
         "name": "dowasure",
         "trans": [
+            "度忘(どわす)れ",
             "lapse of memory, forget for a moment"
-        ],
-        "notation": "度忘(どわす)れ"
+        ]
     },
     {
         "name": "kangai",
         "trans": [
+            "感慨(かんがい)",
             "strong feelings, deep emotion"
-        ],
-        "notation": "感慨(かんがい)"
+        ]
     },
     {
         "name": "gensaku",
         "trans": [
+            "原作(げんさく)",
             "original work"
-        ],
-        "notation": "原作(げんさく)"
+        ]
     },
     {
         "name": "kojireru",
         "trans": [
+            "拗(こじ)れる",
             "to get complicated, to grow worse"
-        ],
-        "notation": "拗(こじ)れる"
+        ]
     },
     {
         "name": "taishoku",
         "trans": [
+            "退職(たいしょく)",
             "retirement (from office)"
-        ],
-        "notation": "退職(たいしょく)"
+        ]
     },
     {
         "name": "musubitsukeru",
         "trans": [
+            "結(むす)び付(つ)ける",
             "to combine, to join, to tie on, to attach with a knot"
-        ],
-        "notation": "結(むす)び付(つ)ける"
+        ]
     },
     {
         "name": "ukemi",
         "trans": [
+            "受身(うけみ)",
             "passive, passive voice"
-        ],
-        "notation": "受身(うけみ)"
+        ]
     },
     {
         "name": "tsubuyaku",
         "trans": [
+            "呟(つぶや)く",
             "to mutter, to murmur"
-        ],
-        "notation": "呟(つぶや)く"
+        ]
     },
     {
         "name": "shikin",
         "trans": [
+            "資金(しきん)",
             "funds, capital"
-        ],
-        "notation": "資金(しきん)"
+        ]
     },
     {
         "name": "oikomu",
         "trans": [
+            "追(お)い込(こ)む",
             "to herd, to corner, to drive"
-        ],
-        "notation": "追(お)い込(こ)む"
+        ]
     },
     {
         "name": "nijimu",
         "trans": [
+            "滲(にじ)む",
             "to run, to blur, to spread, to blot, to ooze"
-        ],
-        "notation": "滲(にじ)む"
+        ]
     },
     {
         "name": "hyakkajiten",
         "trans": [
+            "百科(ひゃっか)事典(じてん)",
             "encyclopedia"
-        ],
-        "notation": "百科(ひゃっか)事典(じてん)"
+        ]
     },
     {
         "name": "koudan",
         "trans": [
+            "公団(こうだん)",
             "public corporation"
-        ],
-        "notation": "公団(こうだん)"
+        ]
     },
     {
         "name": "donata",
         "trans": [
+            "何方(どなた)",
             "who?"
-        ],
-        "notation": "何方(どなた)"
+        ]
     },
     {
         "name": "tsuya",
         "trans": [
+            "艶(つや)",
             "charming, fascinating, voluptuous"
-        ],
-        "notation": "艶(つや)"
+        ]
     },
     {
         "name": "zoushin",
         "trans": [
+            "増進(ぞうしん)",
             "promoting, increase, advance"
-        ],
-        "notation": "増進(ぞうしん)"
+        ]
     },
     {
         "name": "nenkan",
         "trans": [
+            "年鑑(ねんかん)",
             "yearbook"
-        ],
-        "notation": "年鑑(ねんかん)"
+        ]
     },
     {
         "name": "dai",
         "trans": [
+            "第(だい)",
             "ordinal"
-        ],
-        "notation": "第(だい)"
+        ]
     },
     {
         "name": "kamaeru",
         "trans": [
+            "構(かま)える",
             "to set up"
-        ],
-        "notation": "構(かま)える"
+        ]
     },
     {
         "name": "regyuraa",
         "trans": [
+            "レギュラー",
             "regular"
-        ],
-        "notation": "レギュラー"
+        ]
     },
     {
         "name": "kakou",
         "trans": [
+            "加工(かこう)",
             "manufacturing, processing, treatment"
-        ],
-        "notation": "加工(かこう)"
+        ]
     },
     {
         "name": "fukyou",
         "trans": [
+            "不況(ふきょう)",
             "recession, depression, slump"
-        ],
-        "notation": "不況(ふきょう)"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "働(どう)",
             "work, labor"
-        ],
-        "notation": "働(どう)"
+        ]
     },
     {
         "name": "chanoyu",
         "trans": [
+            "茶(ちゃ)の湯(ゆ)",
             "tea ceremony"
-        ],
-        "notation": "茶(ちゃ)の湯(ゆ)"
+        ]
     },
     {
         "name": "chinden",
         "trans": [
+            "沈殿(ちんでん)",
             "precipitation, settlement"
-        ],
-        "notation": "沈殿(ちんでん)"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "無効(むこう)",
             "invalid, no effect, unavailable"
-        ],
-        "notation": "無効(むこう)"
+        ]
     },
     {
         "name": "keiki",
         "trans": [
+            "計器(けいき)",
             "meter, gauge"
-        ],
-        "notation": "計器(けいき)"
+        ]
     },
     {
         "name": "norikae",
         "trans": [
+            "乗(の)り換(か)え",
             "transfer (trains buses etc.)"
-        ],
-        "notation": "乗(の)り換(か)え"
+        ]
     },
     {
         "name": "houshi",
         "trans": [
+            "奉仕(ほうし)",
             "attendance, service"
-        ],
-        "notation": "奉仕(ほうし)"
+        ]
     },
     {
         "name": "zesei",
         "trans": [
+            "是正(ぜせい)",
             "correction, revision"
-        ],
-        "notation": "是正(ぜせい)"
+        ]
     },
     {
         "name": "sozai",
         "trans": [
+            "素材(そざい)",
             "raw materials, subject matter"
-        ],
-        "notation": "素材(そざい)"
+        ]
     },
     {
         "name": "munen",
         "trans": [
+            "無念(むねん)",
             "chagrin, regret"
-        ],
-        "notation": "無念(むねん)"
+        ]
     },
     {
         "name": "kudoi",
         "trans": [
+            "諄(くど)い",
             "verbose, importunate, heavy (taste)"
-        ],
-        "notation": "諄(くど)い"
+        ]
     },
     {
         "name": "sumasu",
         "trans": [
+            "澄(す)ます",
             "to clear, to make clear, to be unruffled, to look unconcerned, to look demure, look prim, put on airs"
-        ],
-        "notation": "澄(す)ます"
+        ]
     },
     {
         "name": "kowata",
         "trans": [
+            "木綿(こわた)",
             "cotton"
-        ],
-        "notation": "木綿(こわた)"
+        ]
     },
     {
         "name": "kokuhaku",
         "trans": [
+            "告白(こくはく)",
             "confession, acknowledgement"
-        ],
-        "notation": "告白(こくはく)"
+        ]
     },
     {
         "name": "sango",
         "trans": [
+            "産後(さんご)",
             "postpartum, after childbirth"
-        ],
-        "notation": "産後(さんご)"
+        ]
     },
     {
         "name": "suchiimu",
         "trans": [
+            "スチーム",
             "steam"
-        ],
-        "notation": "スチーム"
+        ]
     },
     {
         "name": "hanshoku",
         "trans": [
+            "繁殖(はんしょく)",
             "breed, multiply, increase, propagation"
-        ],
-        "notation": "繁殖(はんしょく)"
+        ]
     },
     {
         "name": "bunsan",
         "trans": [
+            "分散(ぶんさん)",
             "dispersion, decentralization, variance (statistics)"
-        ],
-        "notation": "分散(ぶんさん)"
+        ]
     },
     {
         "name": "kaisai",
         "trans": [
+            "開催(かいさい)",
             "holding a meeting, open an exhibition"
-        ],
-        "notation": "開催(かいさい)"
+        ]
     },
     {
         "name": "danryoku",
         "trans": [
+            "弾力(だんりょく)",
             "elasticity, flexibility"
-        ],
-        "notation": "弾力(だんりょく)"
+        ]
     },
     {
         "name": "nageku",
         "trans": [
+            "嘆(なげ)く",
             "to sigh, to lament, to grieve"
-        ],
-        "notation": "嘆(なげ)く"
+        ]
     },
     {
         "name": "hozo",
         "trans": [
+            "臍(ほぞ)",
             "navel, belly-button"
-        ],
-        "notation": "臍(ほぞ)"
+        ]
     },
     {
         "name": "tsuranuku",
         "trans": [
+            "貫(つらぬ)く",
             "to go through"
-        ],
-        "notation": "貫(つらぬ)く"
+        ]
     },
     {
         "name": "sanfujinka",
         "trans": [
+            "産婦人科(さんふじんか)",
             "maternity and gynecology department"
-        ],
-        "notation": "産婦人科(さんふじんか)"
+        ]
     },
     {
         "name": "tetsubou",
         "trans": [
+            "鉄棒(てつぼう)",
             "iron rod, crowbar, horizontal bar (gymnastics)"
-        ],
-        "notation": "鉄棒(てつぼう)"
+        ]
     },
     {
         "name": "bokushi",
         "trans": [
+            "牧師(ぼくし)",
             "pastor, minister, clergyman"
-        ],
-        "notation": "牧師(ぼくし)"
+        ]
     },
     {
         "name": "subashikoi",
         "trans": [
+            "すばしこい",
             "nimble, smart, quick"
-        ],
-        "notation": "すばしこい"
+        ]
     },
     {
         "name": "soukou",
         "trans": [
+            "走行(そうこう)",
             "running a wheeled vehicle (e.g. car), traveling"
-        ],
-        "notation": "走行(そうこう)"
+        ]
     },
     {
         "name": "kakutoku",
         "trans": [
+            "獲得(かくとく)",
             "acquisition, possession"
-        ],
-        "notation": "獲得(かくとく)"
+        ]
     },
     {
         "name": "mezamashii",
         "trans": [
+            "目覚(めざま)しい",
             "brilliant, splendid, striking, remarkable"
-        ],
-        "notation": "目覚(めざま)しい"
+        ]
     },
     {
         "name": "azawarau",
         "trans": [
+            "あざ笑(わら)う",
             "to sneer at, to ridicule"
-        ],
-        "notation": "あざ笑(わら)う"
+        ]
     },
     {
         "name": "obiyakasu",
         "trans": [
+            "脅(おびや)かす",
             "to threaten, to coerce"
-        ],
-        "notation": "脅(おびや)かす"
+        ]
     },
     {
         "name": "kimatsu",
         "trans": [
+            "期末(きまつ)",
             "end of term"
-        ],
-        "notation": "期末(きまつ)"
+        ]
     },
     {
         "name": "komento",
         "trans": [
+            "コメント",
             "comment"
-        ],
-        "notation": "コメント"
+        ]
     },
     {
         "name": "shikamo",
         "trans": [
+            "然(しか)も",
             "with gusto, with satisfaction"
-        ],
-        "notation": "然(しか)も"
+        ]
     },
     {
         "name": "ashi",
         "trans": [
+            "葦(あし)",
             "reed, bulrush"
-        ],
-        "notation": "葦(あし)"
+        ]
     },
     {
         "name": "susume",
         "trans": [
+            "勧(すす)め",
             "recommendation, advice, encouragement"
-        ],
-        "notation": "勧(すす)め"
+        ]
     },
     {
         "name": "wazurawashii",
         "trans": [
+            "煩(わずら)わしい",
             "troublesome, annoying, complicated"
-        ],
-        "notation": "煩(わずら)わしい"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "辺(あた)り",
             "(in the) neighbourhood, vicinity, nearby"
-        ],
-        "notation": "辺(あた)り"
+        ]
     },
     {
         "name": "taoyaka",
         "trans": [
+            "嫋(たおや)か",
             "supple, flexible, elastic"
-        ],
-        "notation": "嫋(たおや)か"
+        ]
     },
     {
         "name": "hairyo",
         "trans": [
+            "配慮(はいりょ)",
             "consideration, concern, forethought"
-        ],
-        "notation": "配慮(はいりょ)"
+        ]
     },
     {
         "name": "nedaru",
         "trans": [
+            "強請(ねだ)る",
             "to tease, to coax, to solicit, to demand"
-        ],
-        "notation": "強請(ねだ)る"
+        ]
     },
     {
         "name": "awateru",
         "trans": [
+            "慌(あわ)てる",
             "to become confused (disconcerted disorganized)"
-        ],
-        "notation": "慌(あわ)てる"
+        ]
     },
     {
         "name": "kiiro",
         "trans": [
+            "黄色(きいろ)",
             "yellow"
-        ],
-        "notation": "黄色(きいろ)"
+        ]
     },
     {
         "name": "buzaa",
         "trans": [
+            "ブザー",
             "buzzer"
-        ],
-        "notation": "ブザー"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "先行(せんこう)",
             "preceding, going first"
-        ],
-        "notation": "先行(せんこう)"
+        ]
     },
     {
         "name": "shibou",
         "trans": [
+            "脂肪(しぼう)",
             "fat, grease, blubber"
-        ],
-        "notation": "脂肪(しぼう)"
+        ]
     },
     {
         "name": "sa",
         "trans": [
+            "佐(さ)",
             "help"
-        ],
-        "notation": "佐(さ)"
+        ]
     },
     {
         "name": "tairu",
         "trans": [
+            "タイル",
             "tile"
-        ],
-        "notation": "タイル"
+        ]
     },
     {
         "name": "kyuukutsu",
         "trans": [
+            "窮屈(きゅうくつ)",
             "narrow, tight, stiff, rigid, uneasy, formal, constrained"
-        ],
-        "notation": "窮屈(きゅうくつ)"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "慣行(かんこう)",
             "customary practice, habit, traditional event"
-        ],
-        "notation": "慣行(かんこう)"
+        ]
     },
     {
         "name": "boufuu",
         "trans": [
+            "暴風(ぼうふう)",
             "storm, windstorm, gale"
-        ],
-        "notation": "暴風(ぼうふう)"
+        ]
     },
     {
         "name": "osshassharu",
         "trans": [
+            "仰(おっしゃ)っしゃる",
             "to say, to speak, to tell, to talk"
-        ],
-        "notation": "仰(おっしゃ)っしゃる"
+        ]
     },
     {
         "name": "yaya",
         "trans": [
+            "稍(やや)",
             "a little, partially, somewhat, a short time, a while"
-        ],
-        "notation": "稍(やや)"
+        ]
     },
     {
         "name": "ore",
         "trans": [
+            "俺(おれ)",
             "I (ego) (boastful first-person pronoun)"
-        ],
-        "notation": "俺(おれ)"
+        ]
     },
     {
         "name": "tenkai",
         "trans": [
+            "転回(てんかい)",
             "revolution, rotation"
-        ],
-        "notation": "転回(てんかい)"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "実(み)",
             "truth, reality, sincerity, fidelity, kindness, faith, substance, essence"
-        ],
-        "notation": "実(み)"
+        ]
     },
     {
         "name": "tenkou",
         "trans": [
+            "転校(てんこう)",
             "change schools"
-        ],
-        "notation": "転校(てんこう)"
+        ]
     },
     {
         "name": "toribun",
         "trans": [
+            "取(と)り分(ぶん)",
             "especially, above all"
-        ],
-        "notation": "取(と)り分(ぶん)"
+        ]
     },
     {
         "name": "iji",
         "trans": [
+            "意地(いじ)",
             "disposition, spirit, willpower, obstinacy, backbone, appetite"
-        ],
-        "notation": "意地(いじ)"
+        ]
     },
     {
         "name": "kakuho",
         "trans": [
+            "確保(かくほ)",
             "guarantee, ensure, maintain, insure, secure"
-        ],
-        "notation": "確保(かくほ)"
+        ]
     },
     {
         "name": "buutsu",
         "trans": [
+            "ブーツ",
             "boots"
-        ],
-        "notation": "ブーツ"
+        ]
     },
     {
         "name": "eki",
         "trans": [
+            "液(えき)",
             "liquid, fluid"
-        ],
-        "notation": "液(えき)"
+        ]
     },
     {
         "name": "gaishou",
         "trans": [
+            "外相(がいしょう)",
             "Foreign Minister"
-        ],
-        "notation": "外相(がいしょう)"
+        ]
     },
     {
         "name": "nanimo",
         "trans": [
+            "何(なに)も",
             "nothing"
-        ],
-        "notation": "何(なに)も"
+        ]
     },
     {
         "name": "tounin",
         "trans": [
+            "当人(とうにん)",
             "the one concerned, the said person"
-        ],
-        "notation": "当人(とうにん)"
+        ]
     },
     {
         "name": "kokusan",
         "trans": [
+            "国産(こくさん)",
             "domestic products"
-        ],
-        "notation": "国産(こくさん)"
+        ]
     },
     {
         "name": "shinryaku",
         "trans": [
+            "侵略(しんりゃく)",
             "aggression, invasion, raid"
-        ],
-        "notation": "侵略(しんりゃく)"
+        ]
     },
     {
         "name": "susumi",
         "trans": [
+            "進(すす)み",
             "progress"
-        ],
-        "notation": "進(すす)み"
+        ]
     },
     {
         "name": "baishou",
         "trans": [
+            "賠償(ばいしょう)",
             "reparations, indemnity, compensation"
-        ],
-        "notation": "賠償(ばいしょう)"
+        ]
     },
     {
         "name": "bijutsu",
         "trans": [
+            "美術(びじゅつ)",
             "art, fine arts"
-        ],
-        "notation": "美術(びじゅつ)"
+        ]
     },
     {
         "name": "joukuu",
         "trans": [
+            "上空(じょうくう)",
             "sky, the skies, high-altitude sky, upper air"
-        ],
-        "notation": "上空(じょうくう)"
+        ]
     },
     {
         "name": "honki",
         "trans": [
+            "本気(ほんき)",
             "seriousness, truth, sanctity"
-        ],
-        "notation": "本気(ほんき)"
+        ]
     },
     {
         "name": "hikaeshitsu",
         "trans": [
+            "控室(ひかえしつ)",
             "waiting room"
-        ],
-        "notation": "控室(ひかえしつ)"
+        ]
     },
     {
         "name": "sanjou",
         "trans": [
+            "参上(さんじょう)",
             "calling on, visiting"
-        ],
-        "notation": "参上(さんじょう)"
+        ]
     },
     {
         "name": "ichiichi",
         "trans": [
+            "一々(いちいち)",
             "one by one, separately"
-        ],
-        "notation": "一々(いちいち)"
+        ]
     },
     {
         "name": "yosou",
         "trans": [
+            "予想(よそう)",
             "expectation, anticipation, prediction, forecast"
-        ],
-        "notation": "予想(よそう)"
+        ]
     },
     {
         "name": "kyuuen",
         "trans": [
+            "救援(きゅうえん)",
             "relief, rescue, reinforcement"
-        ],
-        "notation": "救援(きゅうえん)"
+        ]
     },
     {
         "name": "shimotsukasa",
         "trans": [
+            "下(しも)吏(つかさ)",
             "lower official"
-        ],
-        "notation": "下(しも)吏(つかさ)"
+        ]
     },
     {
         "name": "sokkenai",
         "trans": [
+            "素(そ)っ気(け)ない",
             "cold, short, curt, blunt"
-        ],
-        "notation": "素(そ)っ気(け)ない"
+        ]
     },
     {
         "name": "igi",
         "trans": [
+            "異議(いぎ)",
             "objection, dissent, protest"
-        ],
-        "notation": "異議(いぎ)"
+        ]
     },
     {
         "name": "sawaru",
         "trans": [
+            "障(さわ)る",
             "to hinder, to interfere with, to affect, to do one harm, to be harmful to"
-        ],
-        "notation": "障(さわ)る"
+        ]
     },
     {
         "name": "tousei",
         "trans": [
+            "統制(とうせい)",
             "regulation, control"
-        ],
-        "notation": "統制(とうせい)"
+        ]
     },
     {
         "name": "igamu",
         "trans": [
+            "歪(いが)む",
             "to warp, to swerve, to deflect, to be crooked, to be distorted, to be bent, to incline, to slant, to be perv"
-        ],
-        "notation": "歪(いが)む"
+        ]
     },
     {
         "name": "furoku",
         "trans": [
+            "付録(ふろく)",
             "appendix, supplement"
-        ],
-        "notation": "付録(ふろく)"
+        ]
     },
     {
         "name": "yo",
         "trans": [
+            "依(よ)",
             "depending on"
-        ],
-        "notation": "依(よ)"
+        ]
     },
     {
         "name": "buruu",
         "trans": [
+            "ブルー",
             "blue"
-        ],
-        "notation": "ブルー"
+        ]
     },
     {
         "name": "susugu",
         "trans": [
+            "濯(すす)ぐ",
             "to rinse, to wash out"
-        ],
-        "notation": "濯(すす)ぐ"
+        ]
     },
     {
         "name": "ganjou",
         "trans": [
+            "頑丈(がんじょう)",
             "solid, firm, stout, burly, strong, sturdy"
-        ],
-        "notation": "頑丈(がんじょう)"
+        ]
     },
     {
         "name": "meiyo",
         "trans": [
+            "名誉(めいよ)",
             "honor, credit, prestige"
-        ],
-        "notation": "名誉(めいよ)"
+        ]
     },
     {
         "name": "kando",
         "trans": [
+            "感度(かんど)",
             "sensitivity, severity (quake)"
-        ],
-        "notation": "感度(かんど)"
+        ]
     },
     {
         "name": "mochi",
         "trans": [
+            "持(も)ち",
             "1. hold, charge, keep possession, in charge, 2. wear, durability, life, draw, 3. usage (suff)"
-        ],
-        "notation": "持(も)ち"
+        ]
     },
     {
         "name": "joukyaku",
         "trans": [
+            "乗客(じょうきゃく)",
             "passenger"
-        ],
-        "notation": "乗客(じょうきゃく)"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "枠(わく)",
             "frame, slide"
-        ],
-        "notation": "枠(わく)"
+        ]
     },
     {
         "name": "ate",
         "trans": [
+            "宛(あて)",
             "addressed to"
-        ],
-        "notation": "宛(あて)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "振興(しんこう)",
             "promotion, encouragement"
-        ],
-        "notation": "振興(しんこう)"
+        ]
     },
     {
         "name": "oshimu",
         "trans": [
+            "惜(お)しむ",
             "to be frugal, to value, to regret"
-        ],
-        "notation": "惜(お)しむ"
+        ]
     },
     {
         "name": "supeesu",
         "trans": [
+            "スペース",
             "space"
-        ],
-        "notation": "スペース"
+        ]
     },
     {
         "name": "shoumou",
         "trans": [
+            "消耗(しょうもう)",
             "exhaustion, consumption"
-        ],
-        "notation": "消耗(しょうもう)"
+        ]
     },
     {
         "name": "kogitte",
         "trans": [
+            "小切手(こぎって)",
             "cheque, check"
-        ],
-        "notation": "小切手(こぎって)"
+        ]
     },
     {
         "name": "okasu",
         "trans": [
+            "侵(おか)す",
             "to invade, to raid, to trespass, to violate, to intrude on"
-        ],
-        "notation": "侵(おか)す"
+        ]
     },
     {
         "name": "daitan",
         "trans": [
+            "大胆(だいたん)",
             "bold, daring, audacious"
-        ],
-        "notation": "大胆(だいたん)"
+        ]
     },
     {
         "name": "tanpakushitsu",
         "trans": [
+            "蛋白(たんぱく)質(しつ)",
             "protein"
-        ],
-        "notation": "蛋白(たんぱく)質(しつ)"
+        ]
     },
     {
         "name": "kimei",
         "trans": [
+            "記名(きめい)",
             "signature, register"
-        ],
-        "notation": "記名(きめい)"
+        ]
     },
     {
         "name": "akashi",
         "trans": [
+            "証(あかし)",
             "proof, evidence"
-        ],
-        "notation": "証(あかし)"
+        ]
     },
     {
         "name": "haisui",
         "trans": [
+            "排水(はいすい)",
             "drainage"
-        ],
-        "notation": "排水(はいすい)"
+        ]
     },
     {
         "name": "emono",
         "trans": [
+            "獲物(えもの)",
             "game, spoils, trophy"
-        ],
-        "notation": "獲物(えもの)"
+        ]
     },
     {
         "name": "muko",
         "trans": [
+            "婿(むこ)",
             "son-in-law"
-        ],
-        "notation": "婿(むこ)"
+        ]
     },
     {
         "name": "oshare",
         "trans": [
+            "お洒落(しゃれ)",
             "smartly dressed, someone smartly dressed, fashion-conscious"
-        ],
-        "notation": "お洒落(しゃれ)"
+        ]
     },
     {
         "name": "sakaeru",
         "trans": [
+            "栄(さか)える",
             "to prosper, to flourish"
-        ],
-        "notation": "栄(さか)える"
+        ]
     },
     {
         "name": "suishin",
         "trans": [
+            "推進(すいしん)",
             "propulsion, driving force"
-        ],
-        "notation": "推進(すいしん)"
+        ]
     },
     {
         "name": "maneki",
         "trans": [
+            "招(まね)き",
             "invitation"
-        ],
-        "notation": "招(まね)き"
+        ]
     },
     {
         "name": "soudai",
         "trans": [
+            "壮大(そうだい)",
             "magnificent, grand, majestic, splendid"
-        ],
-        "notation": "壮大(そうだい)"
+        ]
     },
     {
         "name": "kawarukawaru",
         "trans": [
+            "代(か)わる代(か)わる",
             "alternately"
-        ],
-        "notation": "代(か)わる代(か)わる"
+        ]
     },
     {
         "name": "benron",
         "trans": [
+            "弁論(べんろん)",
             "discussion, debate, argument"
-        ],
-        "notation": "弁論(べんろん)"
+        ]
     },
     {
         "name": "omonzuru",
         "trans": [
+            "重(おも)んずる",
             "to honor, to respect, to esteem, to prize"
-        ],
-        "notation": "重(おも)んずる"
+        ]
     },
     {
         "name": "toshisei",
         "trans": [
+            "年(とし)生(せい)",
             "pupil in .... year, student in .... year"
-        ],
-        "notation": "年(とし)生(せい)"
+        ]
     },
     {
         "name": "mujaki",
         "trans": [
+            "無邪気(むじゃき)",
             "innocence, simple-mindedness"
-        ],
-        "notation": "無邪気(むじゃき)"
+        ]
     },
     {
         "name": "umeboshi",
         "trans": [
+            "梅干(うめぼし)",
             "dried plum"
-        ],
-        "notation": "梅干(うめぼし)"
+        ]
     },
     {
         "name": "shikake",
         "trans": [
+            "仕掛(しか)け",
             "device, trick, mechanism, gadget, (small) scale, half finished, commencement, set up, challenge"
-        ],
-        "notation": "仕掛(しか)け"
+        ]
     },
     {
         "name": "teiji",
         "trans": [
+            "提示(ていじ)",
             "presentation, exhibit, suggest, citation"
-        ],
-        "notation": "提示(ていじ)"
+        ]
     },
     {
         "name": "koriru",
         "trans": [
+            "懲(こ)りる",
             "to learn by experience, to be disgusted with"
-        ],
-        "notation": "懲(こ)りる"
+        ]
     },
     {
         "name": "shiten",
         "trans": [
+            "視点(してん)",
             "opinion, point of view, visual point"
-        ],
-        "notation": "視点(してん)"
+        ]
     },
     {
         "name": "mannin",
         "trans": [
+            "万(まん)人(にん)",
             "all people, everybody, 10000 people"
-        ],
-        "notation": "万(まん)人(にん)"
+        ]
     },
     {
         "name": "kobosu",
         "trans": [
+            "零(こぼ)す",
             "to spill"
-        ],
-        "notation": "零(こぼ)す"
+        ]
     },
     {
         "name": "keibetsu",
         "trans": [
+            "軽蔑(けいべつ)",
             "scorn, disdain"
-        ],
-        "notation": "軽蔑(けいべつ)"
+        ]
     },
     {
         "name": "kiken",
         "trans": [
+            "棄権(きけん)",
             "abstain from voting, renunciation of a right"
-        ],
-        "notation": "棄権(きけん)"
+        ]
     },
     {
         "name": "yamu",
         "trans": [
+            "病(や)む",
             "to fall ill, to be ill"
-        ],
-        "notation": "病(や)む"
+        ]
     },
     {
         "name": "meisan",
         "trans": [
+            "名産(めいさん)",
             "noted product"
-        ],
-        "notation": "名産(めいさん)"
+        ]
     },
     {
         "name": "unmei",
         "trans": [
+            "運命(うんめい)",
             "fate"
-        ],
-        "notation": "運命(うんめい)"
+        ]
     },
     {
         "name": "atsumaru",
         "trans": [
+            "集(あつ)まる",
             "to gather, to collect, to assemble"
-        ],
-        "notation": "集(あつ)まる"
+        ]
     },
     {
         "name": "oupun",
         "trans": [
+            "オープン",
             "open"
-        ],
-        "notation": "オープン"
+        ]
     },
     {
         "name": "han",
         "trans": [
+            "判(はん)",
             "size (of paper or books)"
-        ],
-        "notation": "判(はん)"
+        ]
     },
     {
         "name": "sagaku",
         "trans": [
+            "差額(さがく)",
             "balance, difference, margin"
-        ],
-        "notation": "差額(さがく)"
+        ]
     },
     {
         "name": "noko",
         "trans": [
+            "鋸(のこ)",
             "saw"
-        ],
-        "notation": "鋸(のこ)"
+        ]
     },
     {
         "name": "moyoosu",
         "trans": [
+            "催(もよお)す",
             "to hold (a meeting), to give (a dinner), to feel, to show signs of, to develop symptoms of, to feel (sick"
-        ],
-        "notation": "催(もよお)す"
+        ]
     },
     {
         "name": "haji",
         "trans": [
+            "恥(はじ)",
             "shame, embarrassment"
-        ],
-        "notation": "恥(はじ)"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "馴(な)らす",
             "to domesticate, to tame"
-        ],
-        "notation": "馴(な)らす"
+        ]
     },
     {
         "name": "furuwaseru",
         "trans": [
+            "震(ふる)わせる",
             "to be shaking, to be trembling"
-        ],
-        "notation": "震(ふる)わせる"
+        ]
     },
     {
         "name": "jou",
         "trans": [
+            "情(じょう)",
             "feelings, emotion, passion"
-        ],
-        "notation": "情(じょう)"
+        ]
     },
     {
         "name": "nakahodo",
         "trans": [
+            "中程(なかほど)",
             "middle, midway"
-        ],
-        "notation": "中程(なかほど)"
+        ]
     },
     {
         "name": "kinshi",
         "trans": [
+            "近視(きんし)",
             "shortsightedness"
-        ],
-        "notation": "近視(きんし)"
+        ]
     },
     {
         "name": "zahyou",
         "trans": [
+            "座標(ざひょう)",
             "coordinate(s)"
-        ],
-        "notation": "座標(ざひょう)"
+        ]
     },
     {
         "name": "koyomi",
         "trans": [
+            "暦(こよみ)",
             "calendar, almanac"
-        ],
-        "notation": "暦(こよみ)"
+        ]
     },
     {
         "name": "gaki",
         "trans": [
+            "画(が)期(き)",
             "epoch-making"
-        ],
-        "notation": "画(が)期(き)"
+        ]
     },
     {
         "name": "bannou",
         "trans": [
+            "万能(ばんのう)",
             "all-purpose, almighty, omnipotent"
-        ],
-        "notation": "万能(ばんのう)"
+        ]
     },
     {
         "name": "oyobi",
         "trans": [
+            "及(およ)び",
             "and, as well as"
-        ],
-        "notation": "及(およ)び"
+        ]
     },
     {
         "name": "yagu",
         "trans": [
+            "夜具(やぐ)",
             "bedding"
-        ],
-        "notation": "夜具(やぐ)"
+        ]
     },
     {
         "name": "tsukiau",
         "trans": [
+            "付(つ)き合(あ)う",
             "to associate with, to keep company with, to get on with"
-        ],
-        "notation": "付(つ)き合(あ)う"
+        ]
     },
     {
         "name": "koshiraeru",
         "trans": [
+            "拵(こしら)える",
             "to make, to manufacture"
-        ],
-        "notation": "拵(こしら)える"
+        ]
     },
     {
         "name": "ereganto",
         "trans": [
+            "エレガント",
             "elegant"
-        ],
-        "notation": "エレガント"
+        ]
     },
     {
         "name": "shinsa",
         "trans": [
+            "審査(しんさ)",
             "judging, inspection, examination, investigation"
-        ],
-        "notation": "審査(しんさ)"
+        ]
     },
     {
         "name": "metsuki",
         "trans": [
+            "目付(めつ)き",
             "look, expression of the eyes, eyes"
-        ],
-        "notation": "目付(めつ)き"
+        ]
     },
     {
         "name": "bisshori",
         "trans": [
+            "びっしょり",
             "wet through, drenched"
-        ],
-        "notation": "びっしょり"
+        ]
     },
     {
         "name": "narenareshii",
         "trans": [
+            "馴(な)れ馴(な)れしい",
             "over-familiar"
-        ],
-        "notation": "馴(な)れ馴(な)れしい"
+        ]
     },
     {
         "name": "kankoku",
         "trans": [
+            "勧告(かんこく)",
             "advice, counsel, remonstrance, recommendation"
-        ],
-        "notation": "勧告(かんこく)"
+        ]
     },
     {
         "name": "jigyou",
         "trans": [
+            "事業(じぎょう)",
             "project, enterprise, business, industry, operations"
-        ],
-        "notation": "事業(じぎょう)"
+        ]
     },
     {
         "name": "houki",
         "trans": [
+            "放棄(ほうき)",
             "abandonment, renunciation, abdication (responsibility right)"
-        ],
-        "notation": "放棄(ほうき)"
+        ]
     },
     {
         "name": "horyo",
         "trans": [
+            "捕虜(ほりょ)",
             "prisoner (of war)"
-        ],
-        "notation": "捕虜(ほりょ)"
+        ]
     },
     {
         "name": "katamukeru",
         "trans": [
+            "傾(かたむ)ける",
             "to incline, to list, to bend, to lean, to tip, to tilt, to slant, to concentrate on, to ruin (a country), to"
-        ],
-        "notation": "傾(かたむ)ける"
+        ]
     },
     {
         "name": "jikou",
         "trans": [
+            "事項(じこう)",
             "matter, item, facts"
-        ],
-        "notation": "事項(じこう)"
+        ]
     },
     {
         "name": "joushi",
         "trans": [
+            "上司(じょうし)",
             "superior authorities, boss"
-        ],
-        "notation": "上司(じょうし)"
+        ]
     },
     {
         "name": "kodawaru",
         "trans": [
+            "こだわる",
             "to fuss over, to be particular about, to be concerned about"
-        ],
-        "notation": "こだわる"
+        ]
     },
     {
         "name": "mezameru",
         "trans": [
+            "目覚(めざ)める",
             "to wake up"
-        ],
-        "notation": "目覚(めざ)める"
+        ]
     },
     {
         "name": "gokuraku",
         "trans": [
+            "極楽(ごくらく)",
             "paradise"
-        ],
-        "notation": "極楽(ごくらく)"
+        ]
     },
     {
         "name": "sakebi",
         "trans": [
+            "叫(さけ)び",
             "shout, scream, outcry"
-        ],
-        "notation": "叫(さけ)び"
+        ]
     },
     {
         "name": "renmei",
         "trans": [
+            "連盟(れんめい)",
             "league, union, alliance"
-        ],
-        "notation": "連盟(れんめい)"
+        ]
     },
     {
         "name": "fujun",
         "trans": [
+            "不順(ふじゅん)",
             "irregularity, unseasonableness"
-        ],
-        "notation": "不順(ふじゅん)"
+        ]
     },
     {
         "name": "housu",
         "trans": [
+            "ホース",
             "hose"
-        ],
-        "notation": "ホース"
+        ]
     },
     {
         "name": "hagemu",
         "trans": [
+            "励(はげ)む",
             "to be zealous, to brace oneself, to endeavour, to strive, to make an effort"
-        ],
-        "notation": "励(はげ)む"
+        ]
     },
     {
         "name": "keikai",
         "trans": [
+            "軽快(けいかい)",
             "rhythmical (e.g. melody), casual (e.g. dress), light, nimble"
-        ],
-        "notation": "軽快(けいかい)"
+        ]
     },
     {
         "name": "karou",
         "trans": [
+            "過労(かろう)",
             "overwork, strain"
-        ],
-        "notation": "過労(かろう)"
+        ]
     },
     {
         "name": "nezumi",
         "trans": [
+            "鼠(ねずみ)",
             "1. mouse, rat, 2. dark gray, slate color"
-        ],
-        "notation": "鼠(ねずみ)"
+        ]
     },
     {
         "name": "sorasu",
         "trans": [
+            "逸(そ)らす",
             "to turn away, to avert"
-        ],
-        "notation": "逸(そ)らす"
+        ]
     },
     {
         "name": "myuujikku",
         "trans": [
+            "ミュージック",
             "music"
-        ],
-        "notation": "ミュージック"
+        ]
     },
     {
         "name": "janbo",
         "trans": [
+            "ジャンボ",
             "jumbo"
-        ],
-        "notation": "ジャンボ"
+        ]
     },
     {
         "name": "hitteki",
         "trans": [
+            "匹敵(ひってき)",
             "comparing with, match, rival, equal"
-        ],
-        "notation": "匹敵(ひってき)"
+        ]
     },
     {
         "name": "shuushuu",
         "trans": [
+            "収集(しゅうしゅう)",
             "gathering up, collection, accumulation"
-        ],
-        "notation": "収集(しゅうしゅう)"
+        ]
     },
     {
         "name": "heishi",
         "trans": [
+            "兵士(へいし)",
             "soldier"
-        ],
-        "notation": "兵士(へいし)"
+        ]
     },
     {
         "name": "wabun",
         "trans": [
+            "和文(わぶん)",
             "Japanese text, sentence in Japanese"
-        ],
-        "notation": "和文(わぶん)"
+        ]
     },
     {
         "name": "uridasu",
         "trans": [
+            "売(う)り出(だ)す",
             "to put on sale, to market, to become popular"
-        ],
-        "notation": "売(う)り出(だ)す"
+        ]
     },
     {
         "name": "ganko",
         "trans": [
+            "頑固(がんこ)",
             "stubbornness, obstinacy"
-        ],
-        "notation": "頑固(がんこ)"
+        ]
     },
     {
         "name": "kakutei",
         "trans": [
+            "確定(かくてい)",
             "definition (math), decision, settlement"
-        ],
-        "notation": "確定(かくてい)"
+        ]
     },
     {
         "name": "ketsugou",
         "trans": [
+            "結合(けつごう)",
             "combination, union"
-        ],
-        "notation": "結合(けつごう)"
+        ]
     },
     {
         "name": "shinario",
         "trans": [
+            "シナリオ",
             "scenario"
-        ],
-        "notation": "シナリオ"
+        ]
     },
     {
         "name": "dentatsu",
         "trans": [
+            "伝達(でんたつ)",
             "transmission (e.g. news), communication, delivery"
-        ],
-        "notation": "伝達(でんたつ)"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "胴(どう)",
             "trunk, body, frame"
-        ],
-        "notation": "胴(どう)"
+        ]
     },
     {
         "name": "tsukai",
         "trans": [
+            "遣(つか)い",
             "mission, simple task, doing"
-        ],
-        "notation": "遣(つか)い"
+        ]
     },
     {
         "name": "hikou",
         "trans": [
+            "非行(ひこう)",
             "delinquency, misconduct"
-        ],
-        "notation": "非行(ひこう)"
+        ]
     },
     {
         "name": "tomobataraki",
         "trans": [
+            "共働(ともばたら)き",
             "dual income"
-        ],
-        "notation": "共働(ともばたら)き"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "階(かい)",
             "-floor (counter), stories"
-        ],
-        "notation": "階(かい)"
+        ]
     },
     {
         "name": "-chou",
         "trans": [
+            "-超(ちょう)",
             "super-, ultra-, hyper"
-        ],
-        "notation": "-超(ちょう)"
+        ]
     },
     {
         "name": "kayui",
         "trans": [
+            "痒(かゆ)い",
             "itchy, itching"
-        ],
-        "notation": "痒(かゆ)い"
+        ]
     },
     {
         "name": "bunan",
         "trans": [
+            "無難(ぶなん)",
             "safety, security"
-        ],
-        "notation": "無難(ぶなん)"
+        ]
     },
     {
         "name": "sousu",
         "trans": [
+            "ソース",
             "source"
-        ],
-        "notation": "ソース"
+        ]
     },
     {
         "name": "koueki",
         "trans": [
+            "交易(こうえき)",
             "trade, commerce"
-        ],
-        "notation": "交易(こうえき)"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "志向(しこう)",
             "intention, aim"
-        ],
-        "notation": "志向(しこう)"
+        ]
     },
     {
         "name": "mizo",
         "trans": [
+            "溝(みぞ)",
             "10^38, hundred undecillion (American), hundred sextillion (British)"
-        ],
-        "notation": "溝(みぞ)"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "磁気(じき)",
             "magnetism"
-        ],
-        "notation": "磁気(じき)"
+        ]
     },
     {
         "name": "ikkou",
         "trans": [
+            "一向(いっこう)",
             "earnestly"
-        ],
-        "notation": "一向(いっこう)"
+        ]
     },
     {
         "name": "koufu",
         "trans": [
+            "交付(こうふ)",
             "delivering, furnishing (with copies)"
-        ],
-        "notation": "交付(こうふ)"
+        ]
     },
     {
         "name": "hitoiki",
         "trans": [
+            "一息(ひといき)",
             "puffy, a breath, a pause, an effort"
-        ],
-        "notation": "一息(ひといき)"
+        ]
     },
     {
         "name": "torihiki",
         "trans": [
+            "取(と)り引(ひ)き",
             "transactions, dealings, business"
-        ],
-        "notation": "取(と)り引(ひ)き"
+        ]
     },
     {
         "name": "yawarageru",
         "trans": [
+            "和(やわ)らげる",
             "to soften, to moderate, to relieve"
-        ],
-        "notation": "和(やわ)らげる"
+        ]
     },
     {
         "name": "azayaka",
         "trans": [
+            "鮮(あざ)やか",
             "vivid, clear, brilliant"
-        ],
-        "notation": "鮮(あざ)やか"
+        ]
     },
     {
         "name": "mouteru",
         "trans": [
+            "モーテル",
             "motel"
-        ],
-        "notation": "モーテル"
+        ]
     },
     {
         "name": "shingari",
         "trans": [
+            "殿(しんがり)",
             "rear, rear unit guard"
-        ],
-        "notation": "殿(しんがり)"
+        ]
     },
     {
         "name": "nadakai",
         "trans": [
+            "名高(なだか)い",
             "famous, celebrated, well-known"
-        ],
-        "notation": "名高(なだか)い"
+        ]
     },
     {
         "name": "mitooshi",
         "trans": [
+            "見通(みとお)し",
             "perspective, unobstructed view, outlook, forecast, prospect, insight"
-        ],
-        "notation": "見通(みとお)し"
+        ]
     },
     {
         "name": "koboreru",
         "trans": [
+            "零(こぼ)れる",
             "to overflow, to spill"
-        ],
-        "notation": "零(こぼ)れる"
+        ]
     },
     {
         "name": "toutei",
         "trans": [
+            "到底(とうてい)",
             "(cannot) possibly"
-        ],
-        "notation": "到底(とうてい)"
+        ]
     },
     {
         "name": "kobetsu",
         "trans": [
+            "個別(こべつ)",
             "particular case"
-        ],
-        "notation": "個別(こべつ)"
+        ]
     },
     {
         "name": "katameru",
         "trans": [
+            "固(かた)める",
             "to harden, to freeze, to fortify"
-        ],
-        "notation": "固(かた)める"
+        ]
     },
     {
         "name": "bakuro",
         "trans": [
+            "暴露(ばくろ)",
             "disclosure, exposure, revelation"
-        ],
-        "notation": "暴露(ばくろ)"
+        ]
     },
     {
         "name": "furonto",
         "trans": [
+            "フロント",
             "front"
-        ],
-        "notation": "フロント"
+        ]
     },
     {
         "name": "kidate",
         "trans": [
+            "気立(きだ)て",
             "disposition, nature"
-        ],
-        "notation": "気立(きだ)て"
+        ]
     },
     {
         "name": "udon",
         "trans": [
+            "饂飩(うどん)",
             "noodles (Japanese)"
-        ],
-        "notation": "饂飩(うどん)"
+        ]
     },
     {
         "name": "katamuku",
         "trans": [
+            "傾(かたむ)く",
             "lean, incline"
-        ],
-        "notation": "傾(かたむ)く"
+        ]
     },
     {
         "name": "matagu",
         "trans": [
+            "跨(また)ぐ",
             "to straddle"
-        ],
-        "notation": "跨(また)ぐ"
+        ]
     },
     {
         "name": "maeoki",
         "trans": [
+            "前置(まえお)き",
             "preface, introduction"
-        ],
-        "notation": "前置(まえお)き"
+        ]
     },
     {
         "name": "mikai",
         "trans": [
+            "未開(みかい)",
             "savage land, backward region, uncivilized"
-        ],
-        "notation": "未開(みかい)"
+        ]
     },
     {
         "name": "kanshoku",
         "trans": [
+            "感触(かんしょく)",
             "sense of touch, feeling, sensation"
-        ],
-        "notation": "感触(かんしょく)"
+        ]
     },
     {
         "name": "nukasu",
         "trans": [
+            "抜(ぬ)かす",
             "to omit, to leave out"
-        ],
-        "notation": "抜(ぬ)かす"
+        ]
     },
     {
         "name": "ryoushou",
         "trans": [
+            "了承(りょうしょう)",
             "acknowledgement, understanding (e.g. please be understanding of the mess during our renovation)"
-        ],
-        "notation": "了承(りょうしょう)"
+        ]
     },
     {
         "name": "utsuwa",
         "trans": [
+            "器(うつわ)",
             "bowl, vessel, container"
-        ],
-        "notation": "器(うつわ)"
+        ]
     },
     {
         "name": "baa",
         "trans": [
+            "バー",
             "bar"
-        ],
-        "notation": "バー"
+        ]
     },
     {
         "name": "renjitsu",
         "trans": [
+            "連日(れんじつ)",
             "every day, prolonged"
-        ],
-        "notation": "連日(れんじつ)"
+        ]
     },
     {
         "name": "netsuryou",
         "trans": [
+            "熱量(ねつりょう)",
             "temperature"
-        ],
-        "notation": "熱量(ねつりょう)"
+        ]
     },
     {
         "name": "genkou",
         "trans": [
+            "現行(げんこう)",
             "present, current, in operation"
-        ],
-        "notation": "現行(げんこう)"
+        ]
     },
     {
         "name": "sadamaru",
         "trans": [
+            "定(さだ)まる",
             "to become settled, to be fixed"
-        ],
-        "notation": "定(さだ)まる"
+        ]
     },
     {
         "name": "dasshutsu",
         "trans": [
+            "脱出(だっしゅつ)",
             "escape"
-        ],
-        "notation": "脱出(だっしゅつ)"
+        ]
     },
     {
         "name": "chingin",
         "trans": [
+            "賃金(ちんぎん)",
             "wages"
-        ],
-        "notation": "賃金(ちんぎん)"
+        ]
     },
     {
         "name": "kisai",
         "trans": [
+            "記載(きさい)",
             "mention, entry"
-        ],
-        "notation": "記載(きさい)"
+        ]
     },
     {
         "name": "kureru",
         "trans": [
+            "呉(く)れる",
             "to give, to let one have, to do for one, to be given"
-        ],
-        "notation": "呉(く)れる"
+        ]
     },
     {
         "name": "himihimi",
         "trans": [
+            "泌(ひ)み泌(ひ)み",
             "keenly, deeply, heartily"
-        ],
-        "notation": "泌(ひ)み泌(ひ)み"
+        ]
     },
     {
         "name": "ikou",
         "trans": [
+            "意向(いこう)",
             "intention, idea, inclination"
-        ],
-        "notation": "意向(いこう)"
+        ]
     },
     {
         "name": "chuuwa",
         "trans": [
+            "中和(ちゅうわ)",
             "neutralize, counteract"
-        ],
-        "notation": "中和(ちゅうわ)"
+        ]
     },
     {
         "name": "kougi",
         "trans": [
+            "抗議(こうぎ)",
             "protest, objection"
-        ],
-        "notation": "抗議(こうぎ)"
+        ]
     },
     {
         "name": "shiya",
         "trans": [
+            "視野(しや)",
             "field of vision, outlook"
-        ],
-        "notation": "視野(しや)"
+        ]
     },
     {
         "name": "shuukei",
         "trans": [
+            "集計(しゅうけい)",
             "totalization, aggregate"
-        ],
-        "notation": "集計(しゅうけい)"
+        ]
     },
     {
         "name": "shippo",
         "trans": [
+            "尻尾(しっぽ)",
             "tail (animal)"
-        ],
-        "notation": "尻尾(しっぽ)"
+        ]
     },
     {
         "name": "nanjidemo",
         "trans": [
+            "何(なん)時(じ)でも",
             "(at) any time, always, at all times, never (neg), whenever"
-        ],
-        "notation": "何(なん)時(じ)でも"
+        ]
     },
     {
         "name": "arabu",
         "trans": [
+            "アラブ",
             "Arab"
-        ],
-        "notation": "アラブ"
+        ]
     },
     {
         "name": "yuushi",
         "trans": [
+            "融資(ゆうし)",
             "financing, loan"
-        ],
-        "notation": "融資(ゆうし)"
+        ]
     },
     {
         "name": "aka",
         "trans": [
+            "亜(あ)科(か)",
             "suborder, subfamily"
-        ],
-        "notation": "亜(あ)科(か)"
+        ]
     },
     {
         "name": "ganseki",
         "trans": [
+            "岩石(がんせき)",
             "rock"
-        ],
-        "notation": "岩石(がんせき)"
+        ]
     },
     {
         "name": "kokorozashi",
         "trans": [
+            "志(こころざし)",
             "will, intention, motive"
-        ],
-        "notation": "志(こころざし)"
+        ]
     },
     {
         "name": "odoodo",
         "trans": [
+            "おどおど",
             "coweringly, hesitantly"
-        ],
-        "notation": "おどおど"
+        ]
     },
     {
         "name": "juufun",
         "trans": [
+            "十(じゅう)分(ふん)",
             "10 minutes"
-        ],
-        "notation": "十(じゅう)分(ふん)"
+        ]
     },
     {
         "name": "keireki",
         "trans": [
+            "経歴(けいれき)",
             "personal history, career"
-        ],
-        "notation": "経歴(けいれき)"
+        ]
     },
     {
         "name": "kotai",
         "trans": [
+            "固体(こたい)",
             "solid (body)"
-        ],
-        "notation": "固体(こたい)"
+        ]
     },
     {
         "name": "iyani",
         "trans": [
+            "いやに",
             "awfully, terribly"
-        ],
-        "notation": "いやに"
+        ]
     },
     {
         "name": "bin",
         "trans": [
+            "瓶(びん)",
             "earthenware pot"
-        ],
-        "notation": "瓶(びん)"
+        ]
     },
     {
         "name": "yokusei",
         "trans": [
+            "抑制(よくせい)",
             "suppression"
-        ],
-        "notation": "抑制(よくせい)"
+        ]
     },
     {
         "name": "kyougi",
         "trans": [
+            "協議(きょうぎ)",
             "conference, consultation, discussion, negotiation"
-        ],
-        "notation": "協議(きょうぎ)"
+        ]
     },
     {
         "name": "fuzu",
         "trans": [
+            "不(ふ)図(ず)",
             "suddenly, casually, accidentally, incidentally, unexpectedly, unintentionally"
-        ],
-        "notation": "不(ふ)図(ず)"
+        ]
     },
     {
         "name": "umu",
         "trans": [
+            "産(う)む",
             "to give birth, to deliver, to produce"
-        ],
-        "notation": "産(う)む"
+        ]
     },
     {
         "name": "kura",
         "trans": [
+            "蔵(くら)",
             "warehouse, cellar, magazine, granary, godown, depository, treasury, elevator"
-        ],
-        "notation": "蔵(くら)"
+        ]
     },
     {
         "name": "rokuni",
         "trans": [
+            "碌(ろく)に",
             "well, enough, sufficient"
-        ],
-        "notation": "碌(ろく)に"
+        ]
     },
     {
         "name": "seitou",
         "trans": [
+            "正当(せいとう)",
             "just, justifiable, right, due, proper, equitable, reasonable, legitimate, lawful"
-        ],
-        "notation": "正当(せいとう)"
+        ]
     },
     {
         "name": "hirou",
         "trans": [
+            "疲労(ひろう)",
             "fatigue, weariness"
-        ],
-        "notation": "疲労(ひろう)"
+        ]
     },
     {
         "name": "nenrin",
         "trans": [
+            "年輪(ねんりん)",
             "annual tree ring"
-        ],
-        "notation": "年輪(ねんりん)"
+        ]
     },
     {
         "name": "otsu",
         "trans": [
+            "乙(おつ)",
             "1. strange, quaint, stylish, chic, spicy, queer, witty, tasty, romantic, 2. 2nd in rank, second sign of the"
-        ],
-        "notation": "乙(おつ)"
+        ]
     },
     {
         "name": "kikou",
         "trans": [
+            "機構(きこう)",
             "mechanism, organization"
-        ],
-        "notation": "機構(きこう)"
+        ]
     },
     {
         "name": "teigi",
         "trans": [
+            "定義(ていぎ)",
             "definition"
-        ],
-        "notation": "定義(ていぎ)"
+        ]
     },
     {
         "name": "surechigau",
         "trans": [
+            "すれ違(ちが)う",
             "to pass by one another, to disagree, to miss each other"
-        ],
-        "notation": "すれ違(ちが)う"
+        ]
     },
     {
         "name": "omedetau",
         "trans": [
+            "お目出度(めでた)う",
             "(ateji) (int) (uk) Congratulations!, an auspicious occasion!"
-        ],
-        "notation": "お目出度(めでた)う"
+        ]
     },
     {
         "name": "reizou",
         "trans": [
+            "冷蔵(れいぞう)",
             "cold storage, refrigeration"
-        ],
-        "notation": "冷蔵(れいぞう)"
+        ]
     },
     {
         "name": "azamuku",
         "trans": [
+            "欺(あざむ)く",
             "to deceive"
-        ],
-        "notation": "欺(あざむ)く"
+        ]
     },
     {
         "name": "gentei",
         "trans": [
+            "限定(げんてい)",
             "limit, restriction"
-        ],
-        "notation": "限定(げんてい)"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "料(りょう)",
             "material, charge, rate, fee"
-        ],
-        "notation": "料(りょう)"
+        ]
     },
     {
         "name": "kontorasuto",
         "trans": [
+            "コントラスト",
             "contrast"
-        ],
-        "notation": "コントラスト"
+        ]
     },
     {
         "name": "tanomi",
         "trans": [
+            "頼(たの)み",
             "request, favor, reliance, dependence"
-        ],
-        "notation": "頼(たの)み"
+        ]
     },
     {
         "name": "kemuru",
         "trans": [
+            "煙(けむ)る",
             "to smoke (e.g. fire)"
-        ],
-        "notation": "煙(けむ)る"
+        ]
     },
     {
         "name": "misebirakasu",
         "trans": [
+            "見(み)せびらかす",
             "to show off, to flaunt"
-        ],
-        "notation": "見(み)せびらかす"
+        ]
     },
     {
         "name": "doraibuin",
         "trans": [
+            "ドライブイン",
             "drive in"
-        ],
-        "notation": "ドライブイン"
+        ]
     },
     {
         "name": "otosu",
         "trans": [
+            "落(お)とす",
             "to drop, to lose, to let fall"
-        ],
-        "notation": "落(お)とす"
+        ]
     },
     {
         "name": "kihan",
         "trans": [
+            "規範(きはん)",
             "model, standard, pattern, norm, criterion, example"
-        ],
-        "notation": "規範(きはん)"
+        ]
     },
     {
         "name": "iza",
         "trans": [
+            "いざ",
             "now, come (now), well, crucial moment"
-        ],
-        "notation": "いざ"
+        ]
     },
     {
         "name": "ryoushiki",
         "trans": [
+            "良識(りょうしき)",
             "good sense"
-        ],
-        "notation": "良識(りょうしき)"
+        ]
     },
     {
         "name": "tamau",
         "trans": [
+            "給(たま)う",
             "to receive, to grant"
-        ],
-        "notation": "給(たま)う"
+        ]
     },
     {
         "name": "nobe",
         "trans": [
+            "延(の)べ",
             "futures, credit (buying), stretching, total"
-        ],
-        "notation": "延(の)べ"
+        ]
     },
     {
         "name": "shataku",
         "trans": [
+            "社宅(しゃたく)",
             "company owned house"
-        ],
-        "notation": "社宅(しゃたく)"
+        ]
     },
     {
         "name": "rentai",
         "trans": [
+            "連帯(れんたい)",
             "solidarity"
-        ],
-        "notation": "連帯(れんたい)"
+        ]
     },
     {
         "name": "ninin",
         "trans": [
+            "二(に)人(にん)",
             "two persons, two people, pair, couple"
-        ],
-        "notation": "二(に)人(にん)"
+        ]
     },
     {
         "name": "seremonii",
         "trans": [
+            "セレモニー",
             "ceremony"
-        ],
-        "notation": "セレモニー"
+        ]
     },
     {
         "name": "hidoi",
         "trans": [
+            "酷(ひど)い",
             "cruel, awful, severe, very bad, serious, terrible, heavy, violent"
-        ],
-        "notation": "酷(ひど)い"
+        ]
     },
     {
         "name": "menboku",
         "trans": [
+            "面目(めんぼく)",
             "face, honour, reputation, prestige, dignity, credit"
-        ],
-        "notation": "面目(めんぼく)"
+        ]
     },
     {
         "name": "miri",
         "trans": [
+            "ミリ",
             "milli-, 10^-3"
-        ],
-        "notation": "ミリ"
+        ]
     },
     {
         "name": "bunshi",
         "trans": [
+            "分子(ぶんし)",
             "numerator, molecule"
-        ],
-        "notation": "分子(ぶんし)"
+        ]
     },
     {
         "name": "tan",
         "trans": [
+            "単(たん)",
             "one layer, single"
-        ],
-        "notation": "単(たん)"
+        ]
     },
     {
         "name": "kajiru",
         "trans": [
+            "噛(かじ)る",
             "to chew, to bite (at), to gnaw, to nibble, to munch, to crunch, to have a smattering of"
-        ],
-        "notation": "噛(かじ)る"
+        ]
     },
     {
         "name": "osaeru",
         "trans": [
+            "押(お)さえる",
             "to stop, to restrain, to seize, to repress, to suppress, to press down"
-        ],
-        "notation": "押(お)さえる"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "欠(か)く",
             "to lack, to break, to crack, to chip"
-        ],
-        "notation": "欠(か)く"
+        ]
     },
     {
         "name": "muchi",
         "trans": [
+            "無知(むち)",
             "ignorance"
-        ],
-        "notation": "無知(むち)"
+        ]
     },
     {
         "name": "gansho",
         "trans": [
+            "願書(がんしょ)",
             "written application or petition"
-        ],
-        "notation": "願書(がんしょ)"
+        ]
     },
     {
         "name": "kanazuchi",
         "trans": [
+            "金槌(かなづち)",
             "1. (iron) hammer, 2. punishment"
-        ],
-        "notation": "金槌(かなづち)"
+        ]
     },
     {
         "name": "soreyue",
         "trans": [
+            "其(それ)故(ゆえ)",
             "therefore, for that reason, so"
-        ],
-        "notation": "其(それ)故(ゆえ)"
+        ]
     },
     {
         "name": "obitadashii",
         "trans": [
+            "夥(おびただ)しい",
             "abundantly, innumerably"
-        ],
-        "notation": "夥(おびただ)しい"
+        ]
     },
     {
         "name": "ryuu",
         "trans": [
+            "流(りゅう)",
             "styleof, method of, manner of"
-        ],
-        "notation": "流(りゅう)"
+        ]
     },
     {
         "name": "ronri",
         "trans": [
+            "論理(ろんり)",
             "logic"
-        ],
-        "notation": "論理(ろんり)"
+        ]
     },
     {
         "name": "ketobasu",
         "trans": [
+            "蹴飛(けと)ばす",
             "to kick away, to kick off, to kick (someone), to refuse, to reject"
-        ],
-        "notation": "蹴飛(けと)ばす"
+        ]
     },
     {
         "name": "subayai",
         "trans": [
+            "素早(すばや)い",
             "fast, quick, prompt, agile"
-        ],
-        "notation": "素早(すばや)い"
+        ]
     },
     {
         "name": "banme",
         "trans": [
+            "番(ばん)目(め)",
             "cardinal number suffix"
-        ],
-        "notation": "番(ばん)目(め)"
+        ]
     },
     {
         "name": "shihou",
         "trans": [
+            "司法(しほう)",
             "administration of justice"
-        ],
-        "notation": "司法(しほう)"
+        ]
     },
     {
         "name": "taikaku",
         "trans": [
+            "体格(たいかく)",
             "physique, constitution"
-        ],
-        "notation": "体格(たいかく)"
+        ]
     },
     {
         "name": "koutai",
         "trans": [
+            "後退(こうたい)",
             "retreat, backspace (BS)"
-        ],
-        "notation": "後退(こうたい)"
+        ]
     },
     {
         "name": "kata",
         "trans": [
+            "過多(かた)",
             "excess, superabundance"
-        ],
-        "notation": "過多(かた)"
+        ]
     },
     {
         "name": "kitaeru",
         "trans": [
+            "鍛(きた)える",
             "to forge, to drill, to temper, to train, to discipline"
-        ],
-        "notation": "鍛(きた)える"
+        ]
     },
     {
         "name": "tensai",
         "trans": [
+            "天才(てんさい)",
             "genius, prodigy, natural gift"
-        ],
-        "notation": "天才(てんさい)"
+        ]
     },
     {
         "name": "shintai",
         "trans": [
+            "身体(しんたい)",
             "the body"
-        ],
-        "notation": "身体(しんたい)"
+        ]
     },
     {
         "name": "mai",
         "trans": [
+            "毎(まい)",
             "each respectively"
-        ],
-        "notation": "毎(まい)"
+        ]
     },
     {
         "name": "nottoru",
         "trans": [
+            "乗(の)っ取(と)る",
             "to capture, to occupy, to usurp"
-        ],
-        "notation": "乗(の)っ取(と)る"
+        ]
     },
     {
         "name": "futtou",
         "trans": [
+            "沸騰(ふっとう)",
             "boiling, seething"
-        ],
-        "notation": "沸騰(ふっとう)"
+        ]
     },
     {
         "name": "jari",
         "trans": [
+            "砂利(じゃり)",
             "gravel, ballast, pebbles"
-        ],
-        "notation": "砂利(じゃり)"
+        ]
     },
     {
         "name": "patokaa",
         "trans": [
+            "パトカー",
             "patrol car"
-        ],
-        "notation": "パトカー"
+        ]
     },
     {
         "name": "ichimoku",
         "trans": [
+            "一目(いちもく)",
             "a glance, a look, a glimpse"
-        ],
-        "notation": "一目(いちもく)"
+        ]
     },
     {
         "name": "kayu",
         "trans": [
+            "粥(かゆ)",
             "(rice) gruel"
-        ],
-        "notation": "粥(かゆ)"
+        ]
     },
     {
         "name": "hitojichi",
         "trans": [
+            "人質(ひとじち)",
             "hostage, prisoner"
-        ],
-        "notation": "人質(ひとじち)"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "商人(しょうにん)",
             "trader, shopkeeper, merchant"
-        ],
-        "notation": "商人(しょうにん)"
+        ]
     },
     {
         "name": "risei",
         "trans": [
+            "理性(りせい)",
             "reason, sense"
-        ],
-        "notation": "理性(りせい)"
+        ]
     },
     {
         "name": "toorikakaru",
         "trans": [
+            "通(とお)りかかる",
             "to happen to pass by"
-        ],
-        "notation": "通(とお)りかかる"
+        ]
     },
     {
         "name": "yokubou",
         "trans": [
+            "欲望(よくぼう)",
             "desire, appetite"
-        ],
-        "notation": "欲望(よくぼう)"
+        ]
     },
     {
         "name": "fu",
         "trans": [
+            "歩(ふ)",
             "pawn (in chess or shogi)"
-        ],
-        "notation": "歩(ふ)"
+        ]
     },
     {
         "name": "tanka",
         "trans": [
+            "短歌(たんか)",
             "tanka, 31-syllable Japanese poem"
-        ],
-        "notation": "短歌(たんか)"
+        ]
     },
     {
         "name": "konkyo",
         "trans": [
+            "根拠(こんきょ)",
             "basis, foundation"
-        ],
-        "notation": "根拠(こんきょ)"
+        ]
     },
     {
         "name": "kairo",
         "trans": [
+            "回路(かいろ)",
             "circuit (electric)"
-        ],
-        "notation": "回路(かいろ)"
+        ]
     },
     {
         "name": "waribiki",
         "trans": [
+            "割引(わりび)き",
             "discount, reduction, rebate, tenths discounted"
-        ],
-        "notation": "割引(わりび)き"
+        ]
     },
     {
         "name": "tsumari",
         "trans": [
+            "詰(つ)まり",
             "in short, in brief, in other words, that is to say, in the long run, after all, blockade, stuffing, ultimate"
-        ],
-        "notation": "詰(つ)まり"
+        ]
     },
     {
         "name": "daasu",
         "trans": [
+            "ダース",
             "dozen"
-        ],
-        "notation": "ダース"
+        ]
     },
     {
         "name": "chakushoku",
         "trans": [
+            "着色(ちゃくしょく)",
             "colouring, coloring"
-        ],
-        "notation": "着色(ちゃくしょく)"
+        ]
     },
     {
         "name": "apurouchi",
         "trans": [
+            "アプローチ",
             "approach (in golf)"
-        ],
-        "notation": "アプローチ"
+        ]
     },
     {
         "name": "tsuyomeru",
         "trans": [
+            "強(つよ)める",
             "to strengthen, to emphasize"
-        ],
-        "notation": "強(つよ)める"
+        ]
     },
     {
         "name": "gou",
         "trans": [
+            "号(ごう)",
             "number, issue"
-        ],
-        "notation": "号(ごう)"
+        ]
     },
     {
         "name": "akogare",
         "trans": [
+            "憧(あこが)れ",
             "yearning, longing, aspiration"
-        ],
-        "notation": "憧(あこが)れ"
+        ]
     },
     {
         "name": "gunshuu",
         "trans": [
+            "群集(ぐんしゅう)",
             "(social) group, crowd, throng, mob, multitude"
-        ],
-        "notation": "群集(ぐんしゅう)"
+        ]
     },
     {
         "name": "dekoreeshon",
         "trans": [
+            "デコレーション",
             "decoration"
-        ],
-        "notation": "デコレーション"
+        ]
     },
     {
         "name": "jouzu",
         "trans": [
+            "上手(じょうず)",
             "1. upper part, upper stream, left side (of a stage), 2. skillful (only in comparisons), dexterity (on"
-        ],
-        "notation": "上手(じょうず)"
+        ]
     },
     {
         "name": "ayafuya",
         "trans": [
+            "あやふや",
             "uncertain, vague, ambiguous"
-        ],
-        "notation": "あやふや"
+        ]
     },
     {
         "name": "arasu",
         "trans": [
+            "荒(あ)らす",
             "to lay waste, to devastate, to damage, to invade, to break into"
-        ],
-        "notation": "荒(あ)らす"
+        ]
     },
     {
         "name": "uchikomu",
         "trans": [
+            "打(う)ち込(こ)む",
             "to drive in (e.g. nail stake), to devote oneself to, to shoot into, to smash, to throw into, to cast int"
-        ],
-        "notation": "打(う)ち込(こ)む"
+        ]
     },
     {
         "name": "kirei",
         "trans": [
+            "奇麗(きれい)",
             "pretty, clean, nice, tidy, beautiful, fair"
-        ],
-        "notation": "奇麗(きれい)"
+        ]
     },
     {
         "name": "kogecha",
         "trans": [
+            "焦(こ)げ茶(ちゃ)",
             "black tea"
-        ],
-        "notation": "焦(こ)げ茶(ちゃ)"
+        ]
     },
     {
         "name": "tejou",
         "trans": [
+            "手錠(てじょう)",
             "handcuffs, manacles"
-        ],
-        "notation": "手錠(てじょう)"
+        ]
     },
     {
         "name": "nanitozo",
         "trans": [
+            "何卒(なにとぞ)",
             "please, kindly, by all means"
-        ],
-        "notation": "何卒(なにとぞ)"
+        ]
     },
     {
         "name": "samurai",
         "trans": [
+            "侍(さむらい)",
             "Samurai, warrior"
-        ],
-        "notation": "侍(さむらい)"
+        ]
     },
     {
         "name": "shinjitsu",
         "trans": [
+            "真実(しんじつ)",
             "truth, reality"
-        ],
-        "notation": "真実(しんじつ)"
+        ]
     },
     {
         "name": "nayami",
         "trans": [
+            "悩(なや)み",
             "trouble(s), worry, distress, anguish, agony, problem"
-        ],
-        "notation": "悩(なや)み"
+        ]
     },
     {
         "name": "itamu",
         "trans": [
+            "痛(いた)む",
             "to hurt, to feel a pain, to be injured"
-        ],
-        "notation": "痛(いた)む"
+        ]
     },
     {
         "name": "norikomu",
         "trans": [
+            "乗(の)り込(こ)む",
             "to board, to embark on, to get into (a car), to ship (passengers), to man (a ship), to help (someone) int"
-        ],
-        "notation": "乗(の)り込(こ)む"
+        ]
     },
     {
         "name": "ryouritsu",
         "trans": [
+            "両立(りょうりつ)",
             "compatibility, coexistence, standing together"
-        ],
-        "notation": "両立(りょうりつ)"
+        ]
     },
     {
         "name": "kokorogake",
         "trans": [
+            "心掛(こころが)け",
             "readiness, intention, aim"
-        ],
-        "notation": "心掛(こころが)け"
+        ]
     },
     {
         "name": "sokusuru",
         "trans": [
+            "即(そく)する",
             "to conform to, to agree with, to be adapted to, to be based on"
-        ],
-        "notation": "即(そく)する"
+        ]
     },
     {
         "name": "kuttsukeru",
         "trans": [
+            "くっ付(つ)ける",
             "to attach"
-        ],
-        "notation": "くっ付(つ)ける"
+        ]
     },
     {
         "name": "juritsu",
         "trans": [
+            "樹立(じゅりつ)",
             "establish, create"
-        ],
-        "notation": "樹立(じゅりつ)"
+        ]
     },
     {
         "name": "haruka",
         "trans": [
+            "遥(はる)か",
             "far, far-away, distant, remote, far off"
-        ],
-        "notation": "遥(はる)か"
+        ]
     },
     {
         "name": "saibai",
         "trans": [
+            "栽培(さいばい)",
             "cultivation"
-        ],
-        "notation": "栽培(さいばい)"
+        ]
     },
     {
         "name": "sangiin",
         "trans": [
+            "参議院(さんぎいん)",
             "House of Councillors"
-        ],
-        "notation": "参議院(さんぎいん)"
+        ]
     },
     {
         "name": "kanmuryou",
         "trans": [
+            "感無量(かんむりょう)",
             "deep feeling, inexpressible feeling, filled with emotion"
-        ],
-        "notation": "感無量(かんむりょう)"
+        ]
     },
     {
         "name": "mushiru",
         "trans": [
+            "毟(むし)る",
             "to pluck, to pick, to tear"
-        ],
-        "notation": "毟(むし)る"
+        ]
     },
     {
         "name": "shicchou",
         "trans": [
+            "失調(しっちょう)",
             "lack of harmony"
-        ],
-        "notation": "失調(しっちょう)"
+        ]
     },
     {
         "name": "omomuki",
         "trans": [
+            "趣(おもむき)",
             "meaning, tenor, gist, effect, appearance, taste, grace, charm, refinement"
-        ],
-        "notation": "趣(おもむき)"
+        ]
     },
     {
         "name": "hakkutsu",
         "trans": [
+            "発掘(はっくつ)",
             "excavation, exhumation"
-        ],
-        "notation": "発掘(はっくつ)"
+        ]
     },
     {
         "name": "choudai",
         "trans": [
+            "長大(ちょうだい)",
             "very long, great length"
-        ],
-        "notation": "長大(ちょうだい)"
+        ]
     },
     {
         "name": "sueru",
         "trans": [
+            "据(す)える",
             "to set (table), to lay (foundation), to place (gun), to apply (moxa)"
-        ],
-        "notation": "据(す)える"
+        ]
     },
     {
         "name": "kitei",
         "trans": [
+            "規定(きてい)",
             "regulation, provisions"
-        ],
-        "notation": "規定(きてい)"
+        ]
     },
     {
         "name": "moguru",
         "trans": [
+            "潜(もぐ)る",
             "1. to drive, to pass through, 2. to evade, to hide, 3. to dive (into or under water), to go undergro"
-        ],
-        "notation": "潜(もぐ)る"
+        ]
     },
     {
         "name": "hama",
         "trans": [
+            "浜(はま)",
             "beach, seashore"
-        ],
-        "notation": "浜(はま)"
+        ]
     },
     {
         "name": "ukabu",
         "trans": [
+            "浮(う)かぶ",
             "to float, to rise to surface, to come to mind"
-        ],
-        "notation": "浮(う)かぶ"
+        ]
     },
     {
         "name": "seijuku",
         "trans": [
+            "成熟(せいじゅく)",
             "maturity, ripeness"
-        ],
-        "notation": "成熟(せいじゅく)"
+        ]
     },
     {
         "name": "tsubo",
         "trans": [
+            "壷(つぼ)",
             "tsubo jar, pot, vase"
-        ],
-        "notation": "壷(つぼ)"
+        ]
     },
     {
         "name": "doboku",
         "trans": [
+            "土木(どぼく)",
             "public works"
-        ],
-        "notation": "土木(どぼく)"
+        ]
     },
     {
         "name": "ryoukou",
         "trans": [
+            "良好(りょうこう)",
             "favorable, satisfactory"
-        ],
-        "notation": "良好(りょうこう)"
+        ]
     },
     {
         "name": "keika",
         "trans": [
+            "経過(けいか)",
             "passage, expiration, progress"
-        ],
-        "notation": "経過(けいか)"
+        ]
     },
     {
         "name": "hiratai",
         "trans": [
+            "平(ひら)たい",
             "flat, even, level, simple, plain"
-        ],
-        "notation": "平(ひら)たい"
+        ]
     },
     {
         "name": "nettou",
         "trans": [
+            "熱湯(ねっとう)",
             "boiling water"
-        ],
-        "notation": "熱湯(ねっとう)"
+        ]
     },
     {
         "name": "genso",
         "trans": [
+            "元素(げんそ)",
             "chemical element"
-        ],
-        "notation": "元素(げんそ)"
+        ]
     },
     {
         "name": "gainen",
         "trans": [
+            "概念(がいねん)",
             "general idea, concept, notion"
-        ],
-        "notation": "概念(がいねん)"
+        ]
     },
     {
         "name": "tashizan",
         "trans": [
+            "足(た)し算(ざん)",
             "addition"
-        ],
-        "notation": "足(た)し算(ざん)"
+        ]
     },
     {
         "name": "chiryou",
         "trans": [
+            "治療(ちりょう)",
             "medical treatment"
-        ],
-        "notation": "治療(ちりょう)"
+        ]
     },
     {
         "name": "ichihai",
         "trans": [
+            "一(いち)敗(はい)",
             "one defeat"
-        ],
-        "notation": "一(いち)敗(はい)"
+        ]
     },
     {
         "name": "toge",
         "trans": [
+            "刺(とげ)",
             "thorn, splinter, spine, biting words"
-        ],
-        "notation": "刺(とげ)"
+        ]
     },
     {
         "name": "tanki",
         "trans": [
+            "短気(たんき)",
             "quick temper"
-        ],
-        "notation": "短気(たんき)"
+        ]
     },
     {
         "name": "hanabanashii",
         "trans": [
+            "華々しい(はなばなしい)",
             "brilliant, magnificent, spectacular"
-        ],
-        "notation": "華々しい(はなばなしい)"
+        ]
     },
     {
         "name": "satsujin",
         "trans": [
+            "殺人(さつじん)",
             "murder"
-        ],
-        "notation": "殺人(さつじん)"
+        ]
     },
     {
         "name": "kougaku",
         "trans": [
+            "工学(こうがく)",
             "engineering"
-        ],
-        "notation": "工学(こうがく)"
+        ]
     },
     {
         "name": "yakuba",
         "trans": [
+            "役場(やくば)",
             "town hall"
-        ],
-        "notation": "役場(やくば)"
+        ]
     },
     {
         "name": "boruto",
         "trans": [
+            "ボルト",
             "volt, bolt"
-        ],
-        "notation": "ボルト"
+        ]
     },
     {
         "name": "tsuki",
         "trans": [
+            "付(つ)き",
             "attached to, impression, sociality, appearance, furnished with, under, to"
-        ],
-        "notation": "付(つ)き"
+        ]
     },
     {
         "name": "yasumeru",
         "trans": [
+            "休(やす)める",
             "to rest, to suspend, to give relief"
-        ],
-        "notation": "休(やす)める"
+        ]
     },
     {
         "name": "giketsu",
         "trans": [
+            "議決(ぎけつ)",
             "resolution, decision, vote"
-        ],
-        "notation": "議決(ぎけつ)"
+        ]
     },
     {
         "name": "houjiru",
         "trans": [
+            "報(ほう)じる",
             "to inform, to report"
-        ],
-        "notation": "報(ほう)じる"
+        ]
     },
     {
         "name": "orienteeshon",
         "trans": [
+            "オリエンテーション",
             "orientation"
-        ],
-        "notation": "オリエンテーション"
+        ]
     },
     {
         "name": "yokyou",
         "trans": [
+            "余興(よきょう)",
             "side show, entertainment"
-        ],
-        "notation": "余興(よきょう)"
+        ]
     },
     {
         "name": "nega",
         "trans": [
+            "ネガ",
             "(photographic) negative"
-        ],
-        "notation": "ネガ"
+        ]
     },
     {
         "name": "tsukuri",
         "trans": [
+            "作(つく)り",
             "make-up, sliced raw fish"
-        ],
-        "notation": "作(つく)り"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "興業(こうぎょう)",
             "industrial enterprise"
-        ],
-        "notation": "興業(こうぎょう)"
+        ]
     },
     {
         "name": "naibu",
         "trans": [
+            "内部(ないぶ)",
             "interior, inside, internal"
-        ],
-        "notation": "内部(ないぶ)"
+        ]
     },
     {
         "name": "sonoue",
         "trans": [
+            "その上(うえ)",
             "in addition, furthermore"
-        ],
-        "notation": "その上(うえ)"
+        ]
     },
     {
         "name": "shoukyo",
         "trans": [
+            "消去(しょうきょ)",
             "elimination, erasing, dying out, melting away"
-        ],
-        "notation": "消去(しょうきょ)"
+        ]
     },
     {
         "name": "shimai",
         "trans": [
+            "仕舞(しまい)",
             "end, termination, informal (Noh play)"
-        ],
-        "notation": "仕舞(しまい)"
+        ]
     },
     {
         "name": "batto",
         "trans": [
+            "バット",
             "bat, vat"
-        ],
-        "notation": "バット"
+        ]
     },
     {
         "name": "mosaku",
         "trans": [
+            "模索(もさく)",
             "groping (for)"
-        ],
-        "notation": "模索(もさく)"
+        ]
     },
     {
         "name": "zuratto",
         "trans": [
+            "ずらっと",
             "in a line, in a row"
-        ],
-        "notation": "ずらっと"
+        ]
     },
     {
         "name": "odoroki",
         "trans": [
+            "驚(おどろ)き",
             "surprise, astonishment, wonder"
-        ],
-        "notation": "驚(おどろ)き"
+        ]
     },
     {
         "name": "beesu",
         "trans": [
+            "ベース",
             "base, bass"
-        ],
-        "notation": "ベース"
+        ]
     },
     {
         "name": "denen",
         "trans": [
+            "田園(でんえん)",
             "country, rural districts"
-        ],
-        "notation": "田園(でんえん)"
+        ]
     },
     {
         "name": "togu",
         "trans": [
+            "研(と)ぐ",
             "to sharpen, to grind, to scour, to hone, to polish, to wash (rice)"
-        ],
-        "notation": "研(と)ぐ"
+        ]
     },
     {
         "name": "gaisetsu",
         "trans": [
+            "概説(がいせつ)",
             "general statement, outline"
-        ],
-        "notation": "概説(がいせつ)"
+        ]
     },
     {
         "name": "gan",
         "trans": [
+            "癌(がん)",
             "cancer"
-        ],
-        "notation": "癌(がん)"
+        ]
     },
     {
         "name": "nairan",
         "trans": [
+            "内乱(ないらん)",
             "civil war, insurrection, rebellion, domestic conflict"
-        ],
-        "notation": "内乱(ないらん)"
+        ]
     },
     {
         "name": "fushin",
         "trans": [
+            "不審(ふしん)",
             "incomplete understanding, doubt, question, distrust, suspicion, strangeness, infidelity"
-        ],
-        "notation": "不審(ふしん)"
+        ]
     },
     {
         "name": "gyoumu",
         "trans": [
+            "業務(ぎょうむ)",
             "business, affairs, duties, work"
-        ],
-        "notation": "業務(ぎょうむ)"
+        ]
     },
     {
         "name": "sai",
         "trans": [
+            "再(さい)",
             "re-, again, repeated"
-        ],
-        "notation": "再(さい)"
+        ]
     },
     {
         "name": "myougonichi",
         "trans": [
+            "明後日(みょうごにち)",
             "day after tomorrow"
-        ],
-        "notation": "明後日(みょうごにち)"
+        ]
     },
     {
         "name": "katawara",
         "trans": [
+            "傍(かたわ)ら",
             "beside(s), while, nearby"
-        ],
-        "notation": "傍(かたわ)ら"
+        ]
     },
     {
         "name": "muron",
         "trans": [
+            "無論(むろん)",
             "of course, naturally"
-        ],
-        "notation": "無論(むろん)"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "副(ふく)",
             "especially, above all"
-        ],
-        "notation": "副(ふく)"
+        ]
     },
     {
         "name": "daketsu",
         "trans": [
+            "妥結(だけつ)",
             "agreement"
-        ],
-        "notation": "妥結(だけつ)"
+        ]
     },
     {
         "name": "komyunikeeshon",
         "trans": [
+            "コミュニケーション",
             "communication"
-        ],
-        "notation": "コミュニケーション"
+        ]
     },
     {
         "name": "kimajime",
         "trans": [
+            "生真面目(きまじめ)",
             "too serious, person who is too serious, honesty, sincerity"
-        ],
-        "notation": "生真面目(きまじめ)"
+        ]
     },
     {
         "name": "onozukara",
         "trans": [
+            "自(おの)ずから",
             "naturally, as a matter of course"
-        ],
-        "notation": "自(おの)ずから"
+        ]
     },
     {
         "name": "kodoku",
         "trans": [
+            "孤独(こどく)",
             "isolation, loneliness, solitude"
-        ],
-        "notation": "孤独(こどく)"
+        ]
     },
     {
         "name": "sutoresu",
         "trans": [
+            "ストレス",
             "stress"
-        ],
-        "notation": "ストレス"
+        ]
     },
     {
         "name": "kyori",
         "trans": [
+            "距離(きょり)",
             "distance, range"
-        ],
-        "notation": "距離(きょり)"
+        ]
     },
     {
         "name": "doumei",
         "trans": [
+            "同盟(どうめい)",
             "alliance, union, league"
-        ],
-        "notation": "同盟(どうめい)"
+        ]
     },
     {
         "name": "kashou",
         "trans": [
+            "火傷(かしょう)",
             "burn, scald"
-        ],
-        "notation": "火傷(かしょう)"
+        ]
     },
     {
         "name": "tarumu",
         "trans": [
+            "弛(たる)む",
             "to slacken, to loosen, to relax"
-        ],
-        "notation": "弛(たる)む"
+        ]
     },
     {
         "name": "raijou",
         "trans": [
+            "来場(らいじょう)",
             "attendance"
-        ],
-        "notation": "来場(らいじょう)"
+        ]
     },
     {
         "name": "sakusen",
         "trans": [
+            "作戦(さくせん)",
             "military or naval operations, tactics, strategy"
-        ],
-        "notation": "作戦(さくせん)"
+        ]
     },
     {
         "name": "keisei",
         "trans": [
+            "形成(けいせい)",
             "formation"
-        ],
-        "notation": "形成(けいせい)"
+        ]
     },
     {
         "name": "aburu",
         "trans": [
+            "炙(あぶ)る",
             "to scorch"
-        ],
-        "notation": "炙(あぶ)る"
+        ]
     },
     {
         "name": "toriaezu",
         "trans": [
+            "取(と)りあえず",
             "at once, first of all, for the time being"
-        ],
-        "notation": "取(と)りあえず"
+        ]
     },
     {
         "name": "unyou",
         "trans": [
+            "運用(うんよう)",
             "making use of, application, investment, practical use"
-        ],
-        "notation": "運用(うんよう)"
+        ]
     },
     {
         "name": "kenmei",
         "trans": [
+            "賢明(けんめい)",
             "wisdom, intelligence, prudence"
-        ],
-        "notation": "賢明(けんめい)"
+        ]
     },
     {
         "name": "eisha",
         "trans": [
+            "映写(えいしゃ)",
             "projection"
-        ],
-        "notation": "映写(えいしゃ)"
+        ]
     },
     {
         "name": "sumimasen",
         "trans": [
+            "済(す)みません",
             "sorry, excuse me"
-        ],
-        "notation": "済(す)みません"
+        ]
     },
     {
         "name": "nae",
         "trans": [
+            "苗(なえ)",
             "rice seedling"
-        ],
-        "notation": "苗(なえ)"
+        ]
     },
     {
         "name": "keikai",
         "trans": [
+            "警戒(けいかい)",
             "warning, admonition, vigilance"
-        ],
-        "notation": "警戒(けいかい)"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "銅(どう)",
             "copper"
-        ],
-        "notation": "銅(どう)"
+        ]
     },
     {
         "name": "inui",
         "trans": [
+            "乾(いぬい)",
             "dried, cured"
-        ],
-        "notation": "乾(いぬい)"
+        ]
     },
     {
         "name": "panku",
         "trans": [
+            "パンク",
             "1. (abbr) puncture, bursting, 2. punk"
-        ],
-        "notation": "パンク"
+        ]
     },
     {
         "name": "katometa",
         "trans": [
+            "加(か)留(とめ)多(た)",
             "(pt:) (n) playing cards (pt: carta)"
-        ],
-        "notation": "加(か)留(とめ)多(た)"
+        ]
     },
     {
         "name": "korasu",
         "trans": [
+            "凝(こ)らす",
             "to freeze, to congeal"
-        ],
-        "notation": "凝(こ)らす"
+        ]
     },
     {
         "name": "yakushoku",
         "trans": [
+            "役職(やくしょく)",
             "post, managerial position, official position"
-        ],
-        "notation": "役職(やくしょく)"
+        ]
     },
     {
         "name": "tsugeru",
         "trans": [
+            "告(つ)げる",
             "to inform"
-        ],
-        "notation": "告(つ)げる"
+        ]
     },
     {
         "name": "koko",
         "trans": [
+            "個々(ここ)",
             "individual, one by one"
-        ],
-        "notation": "個々(ここ)"
+        ]
     },
     {
         "name": "biri",
         "trans": [
+            "びり",
             "last on the list, at the bottom"
-        ],
-        "notation": "びり"
+        ]
     },
     {
         "name": "shikkaku",
         "trans": [
+            "失格(しっかく)",
             "disqualification, elimination, incapacity (legal)"
-        ],
-        "notation": "失格(しっかく)"
+        ]
     },
     {
         "name": "missetsu",
         "trans": [
+            "密接(みっせつ)",
             "related, connected, close, intimate"
-        ],
-        "notation": "密接(みっせつ)"
+        ]
     },
     {
         "name": "gomakasu",
         "trans": [
+            "誤魔化(ごまか)す",
             "to deceive, to falsify, to misrepresent"
-        ],
-        "notation": "誤魔化(ごまか)す"
+        ]
     },
     {
         "name": "gaisuru",
         "trans": [
+            "害(がい)する",
             "to injure, to damage, to harm, to kill, to hinder"
-        ],
-        "notation": "害(がい)する"
+        ]
     },
     {
         "name": "torishiraberu",
         "trans": [
+            "取(と)り調(しら)べる",
             "to investigate, to examine"
-        ],
-        "notation": "取(と)り調(しら)べる"
+        ]
     },
     {
         "name": "gake",
         "trans": [
+            "崖(がけ)",
             "cliff"
-        ],
-        "notation": "崖(がけ)"
+        ]
     },
     {
         "name": "uragaeshi",
         "trans": [
+            "裏返(うらがえ)し",
             "inside out, upside down"
-        ],
-        "notation": "裏返(うらがえ)し"
+        ]
     },
     {
         "name": "nouchi",
         "trans": [
+            "農地(のうち)",
             "agricultural land"
-        ],
-        "notation": "農地(のうち)"
+        ]
     },
     {
         "name": "danna",
         "trans": [
+            "旦那(だんな)",
             "master (of house), husband (informal)"
-        ],
-        "notation": "旦那(だんな)"
+        ]
     },
     {
         "name": "setsujitsu",
         "trans": [
+            "切実(せつじつ)",
             "compelling, serious, severe, acute, earnest, pressing, urgent"
-        ],
-        "notation": "切実(せつじつ)"
+        ]
     },
     {
         "name": "moushide",
         "trans": [
+            "申出(もうしで)",
             "proposal, request, claim, report, notice"
-        ],
-        "notation": "申出(もうしで)"
+        ]
     },
     {
         "name": "kyouin",
         "trans": [
+            "教員(きょういん)",
             "teaching staff"
-        ],
-        "notation": "教員(きょういん)"
+        ]
     },
     {
         "name": "teisai",
         "trans": [
+            "体裁(ていさい)",
             "decency, style, form, appearance, show, get-up, format"
-        ],
-        "notation": "体裁(ていさい)"
+        ]
     },
     {
         "name": "genzou",
         "trans": [
+            "現像(げんぞう)",
             "developing (film)"
-        ],
-        "notation": "現像(げんぞう)"
+        ]
     },
     {
         "name": "kaitei",
         "trans": [
+            "改訂(かいてい)",
             "revision"
-        ],
-        "notation": "改訂(かいてい)"
+        ]
     },
     {
         "name": "koushin",
         "trans": [
+            "行進(こうしん)",
             "march, parade"
-        ],
-        "notation": "行進(こうしん)"
+        ]
     },
     {
         "name": "sunawachi",
         "trans": [
+            "即(すなわ)ち",
             "that is, namely, i.e."
-        ],
-        "notation": "即(すなわ)ち"
+        ]
     },
     {
         "name": "shazetsu",
         "trans": [
+            "謝絶(しゃぜつ)",
             "refusal"
-        ],
-        "notation": "謝絶(しゃぜつ)"
+        ]
     },
     {
         "name": "osoraku",
         "trans": [
+            "恐(おそ)らく",
             "perhaps"
-        ],
-        "notation": "恐(おそ)らく"
+        ]
     },
     {
         "name": "senryou",
         "trans": [
+            "占領(せんりょう)",
             "occupation, capture, possession, have a room to oneself"
-        ],
-        "notation": "占領(せんりょう)"
+        ]
     },
     {
         "name": "koseki",
         "trans": [
+            "戸籍(こせき)",
             "census, family register"
-        ],
-        "notation": "戸籍(こせき)"
+        ]
     },
     {
         "name": "hikan",
         "trans": [
+            "悲観(ひかん)",
             "pessimism, disappointment"
-        ],
-        "notation": "悲観(ひかん)"
+        ]
     },
     {
         "name": "touroku",
         "trans": [
+            "登録(とうろく)",
             "registration, register, entry, record"
-        ],
-        "notation": "登録(とうろく)"
+        ]
     },
     {
         "name": "komayaka",
         "trans": [
+            "細(こま)やか",
             "friendly"
-        ],
-        "notation": "細(こま)やか"
+        ]
     },
     {
         "name": "nairiku",
         "trans": [
+            "内陸(ないりく)",
             "inland"
-        ],
-        "notation": "内陸(ないりく)"
+        ]
     },
     {
         "name": "kouzui",
         "trans": [
+            "洪水(こうずい)",
             "flood"
-        ],
-        "notation": "洪水(こうずい)"
+        ]
     },
     {
         "name": "momo",
         "trans": [
+            "腿(もも)",
             "thigh, femur"
-        ],
-        "notation": "腿(もも)"
+        ]
     },
     {
         "name": "houwa",
         "trans": [
+            "飽和(ほうわ)",
             "saturation"
-        ],
-        "notation": "飽和(ほうわ)"
+        ]
     },
     {
         "name": "tsumori",
         "trans": [
+            "積(つ)もり",
             "intention, plan"
-        ],
-        "notation": "積(つ)もり"
+        ]
     },
     {
         "name": "moshikashitara",
         "trans": [
+            "若(も)しかしたら",
             "perhaps, maybe, by some chance"
-        ],
-        "notation": "若(も)しかしたら"
+        ]
     },
     {
         "name": "fushou",
         "trans": [
+            "負傷(ふしょう)",
             "injury, wound"
-        ],
-        "notation": "負傷(ふしょう)"
+        ]
     },
     {
         "name": "shinsou",
         "trans": [
+            "真相(しんそう)",
             "truth, real situation"
-        ],
-        "notation": "真相(しんそう)"
+        ]
     },
     {
         "name": "rippou",
         "trans": [
+            "立法(りっぽう)",
             "legislation, lawmaking"
-        ],
-        "notation": "立法(りっぽう)"
+        ]
     },
     {
         "name": "rikon",
         "trans": [
+            "利根(りこん)",
             "intelligence"
-        ],
-        "notation": "利根(りこん)"
+        ]
     },
     {
         "name": "tsurikawa",
         "trans": [
+            "吊(つ)り革(かわ)",
             "strap"
-        ],
-        "notation": "吊(つ)り革(かわ)"
+        ]
     },
     {
         "name": "youeki",
         "trans": [
+            "溶液(ようえき)",
             "solution (liquid)"
-        ],
-        "notation": "溶液(ようえき)"
+        ]
     },
     {
         "name": "hossoku",
         "trans": [
+            "発足(ほっそく)",
             "starting, inauguration"
-        ],
-        "notation": "発足(ほっそく)"
+        ]
     },
     {
         "name": "kyoku",
         "trans": [
+            "曲(きょく)",
             "tune, piece of music"
-        ],
-        "notation": "曲(きょく)"
+        ]
     },
     {
         "name": "shoudaku",
         "trans": [
+            "承諾(しょうだく)",
             "consent, acquiescence, agreement"
-        ],
-        "notation": "承諾(しょうだく)"
+        ]
     },
     {
         "name": "kenyou",
         "trans": [
+            "兼用(けんよう)",
             "multi-use, combined use, combination, serving two purposes"
-        ],
-        "notation": "兼用(けんよう)"
+        ]
     },
     {
         "name": "tousan",
         "trans": [
+            "倒産(とうさん)",
             "(corporate) bankruptcy, insolvency"
-        ],
-        "notation": "倒産(とうさん)"
+        ]
     },
     {
         "name": "shinsei",
         "trans": [
+            "神聖(しんせい)",
             "holiness, sacredness, dignity"
-        ],
-        "notation": "神聖(しんせい)"
+        ]
     },
     {
         "name": "jinzai",
         "trans": [
+            "人材(じんざい)",
             "man of talent"
-        ],
-        "notation": "人材(じんざい)"
+        ]
     },
     {
         "name": "hassei",
         "trans": [
+            "発生(はっせい)",
             "outbreak, spring forth, occurrence, incidence, origin"
-        ],
-        "notation": "発生(はっせい)"
+        ]
     },
     {
         "name": "koko",
         "trans": [
+            "箇箇(ここ)",
             "individual, separate"
-        ],
-        "notation": "箇箇(ここ)"
+        ]
     },
     {
         "name": "kifuu",
         "trans": [
+            "気風(きふう)",
             "character, traits, ethos"
-        ],
-        "notation": "気風(きふう)"
+        ]
     },
     {
         "name": "misemono",
         "trans": [
+            "見(み)せ物(もの)",
             "show, exhibition"
-        ],
-        "notation": "見(み)せ物(もの)"
+        ]
     },
     {
         "name": "bujoku",
         "trans": [
+            "侮辱(ぶじょく)",
             "insult, contempt, slight"
-        ],
-        "notation": "侮辱(ぶじょく)"
+        ]
     },
     {
         "name": "seishun",
         "trans": [
+            "青春(せいしゅん)",
             "youth, springtime of life, adolescent"
-        ],
-        "notation": "青春(せいしゅん)"
+        ]
     },
     {
         "name": "herikudaru",
         "trans": [
+            "謙(へりくだ)る",
             "to deprecate oneself and praise the listener"
-        ],
-        "notation": "謙(へりくだ)る"
+        ]
     },
     {
         "name": "butsuzou",
         "trans": [
+            "仏像(ぶつぞう)",
             "Buddhist image (statue)"
-        ],
-        "notation": "仏像(ぶつぞう)"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "下位(かい)",
             "low rank, subordinate, lower order (e.g. byte)"
-        ],
-        "notation": "下位(かい)"
+        ]
     },
     {
         "name": "zoushou",
         "trans": [
+            "蔵相(ぞうしょう)",
             "Minister of Finance"
-        ],
-        "notation": "蔵相(ぞうしょう)"
+        ]
     },
     {
         "name": "jokou",
         "trans": [
+            "徐行(じょこう)",
             "going slowly"
-        ],
-        "notation": "徐行(じょこう)"
+        ]
     },
     {
         "name": "juurai",
         "trans": [
+            "従来(じゅうらい)",
             "up to now, so far, traditional"
-        ],
-        "notation": "従来(じゅうらい)"
+        ]
     },
     {
         "name": "mai",
         "trans": [
+            "枚(まい)",
             "counter for flat objects (e.g. sheets of paper)"
-        ],
-        "notation": "枚(まい)"
+        ]
     },
     {
         "name": "iyashii",
         "trans": [
+            "卑(いや)しい",
             "greedy, vulgar, shabby, humble, base, mean, vile"
-        ],
-        "notation": "卑(いや)しい"
+        ]
     },
     {
         "name": "hikiageru",
         "trans": [
+            "引(ひ)き上(あ)げる",
             "to withdraw, to leave, to pull out, to retire"
-        ],
-        "notation": "引(ひ)き上(あ)げる"
+        ]
     },
     {
         "name": "teppen",
         "trans": [
+            "鉄片(てっぺん)",
             "iron scraps"
-        ],
-        "notation": "鉄片(てっぺん)"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "協会(きょうかい)",
             "association, society, organization"
-        ],
-        "notation": "協会(きょうかい)"
+        ]
     },
     {
         "name": "neji",
         "trans": [
+            "捻子(ねじ)",
             "screw, helix, spiral"
-        ],
-        "notation": "捻子(ねじ)"
+        ]
     },
     {
         "name": "tenka",
         "trans": [
+            "点火(てんか)",
             "ignition, lighting, set fire to"
-        ],
-        "notation": "点火(てんか)"
+        ]
     },
     {
         "name": "satto",
         "trans": [
+            "さっと",
             "quickly, suddenly"
-        ],
-        "notation": "さっと"
+        ]
     },
     {
         "name": "jitsujou",
         "trans": [
+            "実情(じつじょう)",
             "real condition, actual circumstances, actual state of affairs"
-        ],
-        "notation": "実情(じつじょう)"
+        ]
     },
     {
         "name": "karadatsuki",
         "trans": [
+            "体(からだ)付(つ)き",
             "body build, figure"
-        ],
-        "notation": "体(からだ)付(つ)き"
+        ]
     },
     {
         "name": "zeppan",
         "trans": [
+            "絶版(ぜっぱん)",
             "out of print"
-        ],
-        "notation": "絶版(ぜっぱん)"
+        ]
     },
     {
         "name": "kyozetsu",
         "trans": [
+            "拒絶(きょぜつ)",
             "refusal, rejection"
-        ],
-        "notation": "拒絶(きょぜつ)"
+        ]
     },
     {
         "name": "osokutomo",
         "trans": [
+            "遅(おそ)くとも",
             "at the latest"
-        ],
-        "notation": "遅(おそ)くとも"
+        ]
     },
     {
         "name": "chuukei",
         "trans": [
+            "中継(ちゅうけい)",
             "relay, hook-up"
-        ],
-        "notation": "中継(ちゅうけい)"
+        ]
     },
     {
         "name": "majieru",
         "trans": [
+            "交(まじ)える",
             "to mix, to converse with, to cross (swords)"
-        ],
-        "notation": "交(まじ)える"
+        ]
     },
     {
         "name": "wazawaza",
         "trans": [
+            "態(わざ)々",
             "expressly, specially, doing something especially rather than incidentally"
-        ],
-        "notation": "態(わざ)々"
+        ]
     },
     {
         "name": "ittei",
         "trans": [
+            "一定(いってい)",
             "fixed, settled, definite, uniform, regularized, defined, standardized, certain, prescribed"
-        ],
-        "notation": "一定(いってい)"
+        ]
     },
     {
         "name": "itadaki",
         "trans": [
+            "頂(いただき)",
             "(top of) head, summit, spire"
-        ],
-        "notation": "頂(いただき)"
+        ]
     },
     {
         "name": "kanran",
         "trans": [
+            "観覧(かんらん)",
             "viewing"
-        ],
-        "notation": "観覧(かんらん)"
+        ]
     },
     {
         "name": "jinmin",
         "trans": [
+            "人民(じんみん)",
             "people, public"
-        ],
-        "notation": "人民(じんみん)"
+        ]
     },
     {
         "name": "shitateru",
         "trans": [
+            "仕立(した)てる",
             "to tailor, to make, to prepare, to train, to send (a messenger)"
-        ],
-        "notation": "仕立(した)てる"
+        ]
     },
     {
         "name": "matomari",
         "trans": [
+            "纏(まと)まり",
             "conclusion, settlement, consistency"
-        ],
-        "notation": "纏(まと)まり"
+        ]
     },
     {
         "name": "nyuushou",
         "trans": [
+            "入賞(にゅうしょう)",
             "winning a prize or place (in a contest)"
-        ],
-        "notation": "入賞(にゅうしょう)"
+        ]
     },
     {
         "name": "taipisuto",
         "trans": [
+            "タイピスト",
             "typist"
-        ],
-        "notation": "タイピスト"
+        ]
     },
     {
         "name": "kosuru",
         "trans": [
+            "擦(こす)る",
             "to touch lightly, to take a percentage (from)"
-        ],
-        "notation": "擦(こす)る"
+        ]
     },
     {
         "name": "shintei",
         "trans": [
+            "進呈(しんてい)",
             "presentation"
-        ],
-        "notation": "進呈(しんてい)"
+        ]
     },
     {
         "name": "ankouru",
         "trans": [
+            "アンコール",
             "encore"
-        ],
-        "notation": "アンコール"
+        ]
     },
     {
         "name": "gacchiri",
         "trans": [
+            "がっちり",
             "solidly built, tightly, shrewd, calculating"
-        ],
-        "notation": "がっちり"
+        ]
     },
     {
         "name": "shiyuu",
         "trans": [
+            "私有(しゆう)",
             "private ownership"
-        ],
-        "notation": "私有(しゆう)"
+        ]
     },
     {
         "name": "chokkan",
         "trans": [
+            "直感(ちょっかん)",
             "intuition"
-        ],
-        "notation": "直感(ちょっかん)"
+        ]
     },
     {
         "name": "haken",
         "trans": [
+            "派遣(はけん)",
             "dispatch, send"
-        ],
-        "notation": "派遣(はけん)"
+        ]
     },
     {
         "name": "shiage",
         "trans": [
+            "仕上(しあ)げ",
             "end, finishing touches, being finished"
-        ],
-        "notation": "仕上(しあ)げ"
+        ]
     },
     {
         "name": "itsunomanika",
         "trans": [
+            "何時(いつ)の間(ま)にか",
             "before one knows, unnoticed, unawares"
-        ],
-        "notation": "何時(いつ)の間(ま)にか"
+        ]
     },
     {
         "name": "takamaru",
         "trans": [
+            "高(たか)まる",
             "to rise, to swell, to be promoted"
-        ],
-        "notation": "高(たか)まる"
+        ]
     },
     {
         "name": "katamuku",
         "trans": [
+            "傾(かたむ)く",
             "to incline toward, to slant, to lurch, to heel over, to be disposed to, to trend toward, to be prone to, to"
-        ],
-        "notation": "傾(かたむ)く"
+        ]
     },
     {
         "name": "yuubi",
         "trans": [
+            "優美(ゆうび)",
             "grace, refinement, elegance"
-        ],
-        "notation": "優美(ゆうび)"
+        ]
     },
     {
         "name": "usotsuki",
         "trans": [
+            "嘘(うそ)つき",
             "liar (sometimes said with not much seriousness), fibber"
-        ],
-        "notation": "嘘(うそ)つき"
+        ]
     },
     {
         "name": "kaigo",
         "trans": [
+            "介護(かいご)",
             "nursing"
-        ],
-        "notation": "介護(かいご)"
+        ]
     },
     {
         "name": "kore",
         "trans": [
+            "此(こ)れ",
             "this"
-        ],
-        "notation": "此(こ)れ"
+        ]
     },
     {
         "name": "sokuzani",
         "trans": [
+            "即座(そくざ)に",
             "immediately, right away"
-        ],
-        "notation": "即座(そくざ)に"
+        ]
     },
     {
         "name": "kirikaeru",
         "trans": [
+            "切(き)り替(か)える",
             "to change, to exchange, to convert, to renew, to throw a switch, to replace, to switch over"
-        ],
-        "notation": "切(き)り替(か)える"
+        ]
     },
     {
         "name": "tehon",
         "trans": [
+            "手本(てほん)",
             "model, pattern"
-        ],
-        "notation": "手本(てほん)"
+        ]
     },
     {
         "name": "shuugeki",
         "trans": [
+            "襲撃(しゅうげき)",
             "attack, charge, raid"
-        ],
-        "notation": "襲撃(しゅうげき)"
+        ]
     },
     {
         "name": "benshou",
         "trans": [
+            "弁償(べんしょう)",
             "next word, compensation, reparation, indemnity, reimbursement"
-        ],
-        "notation": "弁償(べんしょう)"
+        ]
     },
     {
         "name": "hyakkajiten",
         "trans": [
+            "百科辞典(ひゃっかじてん)",
             "encyclopedia"
-        ],
-        "notation": "百科辞典(ひゃっかじてん)"
+        ]
     },
     {
         "name": "fukoku",
         "trans": [
+            "布告(ふこく)",
             "edict, ordinance, proclamation"
-        ],
-        "notation": "布告(ふこく)"
+        ]
     },
     {
         "name": "jiten",
         "trans": [
+            "自転(じてん)",
             "rotation, spin"
-        ],
-        "notation": "自転(じてん)"
+        ]
     },
     {
         "name": "hanjou",
         "trans": [
+            "繁盛(はんじょう)",
             "prosperity, flourishing, thriving"
-        ],
-        "notation": "繁盛(はんじょう)"
+        ]
     },
     {
         "name": "ko",
         "trans": [
+            "児(こ)",
             "child, the young of animals"
-        ],
-        "notation": "児(こ)"
+        ]
     },
     {
         "name": "ikusei",
         "trans": [
+            "育成(いくせい)",
             "rearing, training, nurture, cultivation, promotion"
-        ],
-        "notation": "育成(いくせい)"
+        ]
     },
     {
         "name": "ryakudatsu",
         "trans": [
+            "略奪(りゃくだつ)",
             "pillage, plunder, looting, robbery"
-        ],
-        "notation": "略奪(りゃくだつ)"
+        ]
     },
     {
         "name": "yamuwoenai",
         "trans": [
+            "止(や)むを得(え)ない",
             "cannot be helped, unavoidable"
-        ],
-        "notation": "止(や)むを得(え)ない"
+        ]
     },
     {
         "name": "ryoken",
         "trans": [
+            "旅券(りょけん)",
             "passport"
-        ],
-        "notation": "旅券(りょけん)"
+        ]
     },
     {
         "name": "shuuyou",
         "trans": [
+            "収容(しゅうよう)",
             "accommodation, reception, seating, housing, custody, admission, entering (in a dictionary)"
-        ],
-        "notation": "収容(しゅうよう)"
+        ]
     },
     {
         "name": "oiru",
         "trans": [
+            "老(お)いる",
             "to age, to grow old"
-        ],
-        "notation": "老(お)いる"
+        ]
     },
     {
         "name": "itameru",
         "trans": [
+            "痛(いた)める",
             "to hurt, to injure, to cause pain, to worry, to bother, to afflict, to be grieved over"
-        ],
-        "notation": "痛(いた)める"
+        ]
     },
     {
         "name": "konki",
         "trans": [
+            "根気(こんき)",
             "patience, perseverance, energy"
-        ],
-        "notation": "根気(こんき)"
+        ]
     },
     {
         "name": "shotoku",
         "trans": [
+            "所得(しょとく)",
             "income, earnings"
-        ],
-        "notation": "所得(しょとく)"
+        ]
     },
     {
         "name": "taibou",
         "trans": [
+            "待望(たいぼう)",
             "expectant waiting"
-        ],
-        "notation": "待望(たいぼう)"
+        ]
     },
     {
         "name": "gakkuri",
         "trans": [
+            "がっくり",
             "heartbroken"
-        ],
-        "notation": "がっくり"
+        ]
     },
     {
         "name": "hirumeshi",
         "trans": [
+            "昼飯(ひるめし)",
             "lunch, midday meal"
-        ],
-        "notation": "昼飯(ひるめし)"
+        ]
     },
     {
         "name": "sei",
         "trans": [
+            "製(せい)",
             "-made, make"
-        ],
-        "notation": "製(せい)"
+        ]
     },
     {
         "name": "toi",
         "trans": [
+            "問(とい)",
             "problem, question"
-        ],
-        "notation": "問(とい)"
+        ]
     },
     {
         "name": "hitosuji",
         "trans": [
+            "一筋(ひとすじ)",
             "a line, earnestly, blindly, straightforwardly"
-        ],
-        "notation": "一筋(ひとすじ)"
+        ]
     },
     {
         "name": "kishimu",
         "trans": [
+            "軋(きし)む",
             "to jar, to creak, to grate"
-        ],
-        "notation": "軋(きし)む"
+        ]
     },
     {
         "name": "obiru",
         "trans": [
+            "帯(お)びる",
             "to wear, to carry, to be entrusted, to have, to take on, to have a trace of, to be tinged with"
-        ],
-        "notation": "帯(お)びる"
+        ]
     },
     {
         "name": "furyoku",
         "trans": [
+            "浮力(ふりょく)",
             "buoyancy, floating power"
-        ],
-        "notation": "浮力(ふりょく)"
+        ]
     },
     {
         "name": "kubiwa",
         "trans": [
+            "首輪(くびわ)",
             "necklace, choker"
-        ],
-        "notation": "首輪(くびわ)"
+        ]
     },
     {
         "name": "shikeru",
         "trans": [
+            "湿気(しけ)る",
             "to be damp, to be moist"
-        ],
-        "notation": "湿気(しけ)る"
+        ]
     },
     {
         "name": "yagai",
         "trans": [
+            "野外(やがい)",
             "fields, outskirts, open air, suburbs"
-        ],
-        "notation": "野外(やがい)"
+        ]
     },
     {
         "name": "doukou",
         "trans": [
+            "動向(どうこう)",
             "trend, tendency, movement, attitude"
-        ],
-        "notation": "動向(どうこう)"
+        ]
     },
     {
         "name": "tsuneru",
         "trans": [
+            "抓(つね)る",
             "to pinch"
-        ],
-        "notation": "抓(つね)る"
+        ]
     },
     {
         "name": "setai",
         "trans": [
+            "世帯(せたい)",
             "household"
-        ],
-        "notation": "世帯(せたい)"
+        ]
     },
     {
         "name": "haijo",
         "trans": [
+            "排除(はいじょ)",
             "exclusion, removal, rejection"
-        ],
-        "notation": "排除(はいじょ)"
+        ]
     },
     {
         "name": "shindo",
         "trans": [
+            "進度(しんど)",
             "progress"
-        ],
-        "notation": "進度(しんど)"
+        ]
     },
     {
         "name": "meibo",
         "trans": [
+            "名簿(めいぼ)",
             "register of names"
-        ],
-        "notation": "名簿(めいぼ)"
+        ]
     },
     {
         "name": "seisai",
         "trans": [
+            "制裁(せいさい)",
             "restraint, sanctions, punishment"
-        ],
-        "notation": "制裁(せいさい)"
+        ]
     },
     {
         "name": "gurai",
         "trans": [
+            "ぐらい",
             "approximately"
-        ],
-        "notation": "ぐらい"
+        ]
     },
     {
         "name": "tenkyo",
         "trans": [
+            "転居(てんきょ)",
             "moving, changing residence"
-        ],
-        "notation": "転居(てんきょ)"
+        ]
     },
     {
         "name": "nikayou",
         "trans": [
+            "似通(にかよ)う",
             "to resemble closely"
-        ],
-        "notation": "似通(にかよ)う"
+        ]
     },
     {
         "name": "hinto",
         "trans": [
+            "ヒント",
             "hint"
-        ],
-        "notation": "ヒント"
+        ]
     },
     {
         "name": "neru",
         "trans": [
+            "練(ね)る",
             "to knead, to work over, to polish up"
-        ],
-        "notation": "練(ね)る"
+        ]
     },
     {
         "name": "ganrai",
         "trans": [
+            "元来(がんらい)",
             "originally, primarily, essentially, logically, naturally"
-        ],
-        "notation": "元来(がんらい)"
+        ]
     },
     {
         "name": "chouwa",
         "trans": [
+            "調和(ちょうわ)",
             "harmony"
-        ],
-        "notation": "調和(ちょうわ)"
+        ]
     },
     {
         "name": "houmuru",
         "trans": [
+            "葬(ほうむ)る",
             "to bury, to inter, to entomb, to consign to oblivion, to shelve"
-        ],
-        "notation": "葬(ほうむ)る"
+        ]
     },
     {
         "name": "bunri",
         "trans": [
+            "分離(ぶんり)",
             "separation, detachment, segregation, isolation"
-        ],
-        "notation": "分離(ぶんり)"
+        ]
     },
     {
         "name": "kaikyuu",
         "trans": [
+            "階級(かいきゅう)",
             "class, rank, grade"
-        ],
-        "notation": "階級(かいきゅう)"
+        ]
     },
     {
         "name": "makasu",
         "trans": [
+            "任(まか)す",
             "to entrust, to leave to a person"
-        ],
-        "notation": "任(まか)す"
+        ]
     },
     {
         "name": "kabuto",
         "trans": [
+            "甲(かぶと)",
             "1st in rank, first sign of the Chinese calendar, shell, instep, grade A"
-        ],
-        "notation": "甲(かぶと)"
+        ]
     },
     {
         "name": "michi",
         "trans": [
+            "未知(みち)",
             "not yet known"
-        ],
-        "notation": "未知(みち)"
+        ]
     },
     {
         "name": "raberu",
         "trans": [
+            "ラベル",
             "label"
-        ],
-        "notation": "ラベル"
+        ]
     },
     {
         "name": "udemae",
         "trans": [
+            "腕前(うでまえ)",
             "ability, skill, facility"
-        ],
-        "notation": "腕前(うでまえ)"
+        ]
     },
     {
         "name": "hamabe",
         "trans": [
+            "浜辺(はまべ)",
             "beach, foreshore"
-        ],
-        "notation": "浜辺(はまべ)"
+        ]
     },
     {
         "name": "chouhen",
         "trans": [
+            "長編(ちょうへん)",
             "long (e.g. novel film)"
-        ],
-        "notation": "長編(ちょうへん)"
+        ]
     },
     {
         "name": "nasakebukai",
         "trans": [
+            "情(なさ)け深(ぶか)い",
             "tender-hearted, compassionate"
-        ],
-        "notation": "情(なさ)け深(ぶか)い"
+        ]
     },
     {
         "name": "eizou",
         "trans": [
+            "映像(えいぞう)",
             "reflection, image"
-        ],
-        "notation": "映像(えいぞう)"
+        ]
     },
     {
         "name": "shishuu",
         "trans": [
+            "刺繍(ししゅう)",
             "embroidery"
-        ],
-        "notation": "刺繍(ししゅう)"
+        ]
     },
     {
         "name": "nejireru",
         "trans": [
+            "捻(ね)じれる",
             "to twist, to wrench, to screw"
-        ],
-        "notation": "捻(ね)じれる"
+        ]
     },
     {
         "name": "housha",
         "trans": [
+            "放射(ほうしゃ)",
             "radiation, emission"
-        ],
-        "notation": "放射(ほうしゃ)"
+        ]
     },
     {
         "name": "hiritsu",
         "trans": [
+            "比率(ひりつ)",
             "ratio, proportion, percentage"
-        ],
-        "notation": "比率(ひりつ)"
+        ]
     },
     {
         "name": "binbou",
         "trans": [
+            "貧乏(びんぼう)",
             "poverty, destitute, poor"
-        ],
-        "notation": "貧乏(びんぼう)"
+        ]
     },
     {
         "name": "kenzai",
         "trans": [
+            "健在(けんざい)",
             "in good health, well"
-        ],
-        "notation": "健在(けんざい)"
+        ]
     },
     {
         "name": "dan",
         "trans": [
+            "壇(だん)",
             "1. platform, podium, rostrum, 2. (arch) mandala"
-        ],
-        "notation": "壇(だん)"
+        ]
     },
     {
         "name": "uchiwa",
         "trans": [
+            "団扇(うちわ)",
             "fan"
-        ],
-        "notation": "団扇(うちわ)"
+        ]
     },
     {
         "name": "haikei",
         "trans": [
+            "拝啓(はいけい)",
             "Dear (so and so)"
-        ],
-        "notation": "拝啓(はいけい)"
+        ]
     },
     {
         "name": "akarui",
         "trans": [
+            "明(あか)るい",
             "bright, cheerful"
-        ],
-        "notation": "明(あか)るい"
+        ]
     },
     {
         "name": "shikei",
         "trans": [
+            "死刑(しけい)",
             "death penalty, capital punishment"
-        ],
-        "notation": "死刑(しけい)"
+        ]
     },
     {
         "name": "tenbou",
         "trans": [
+            "展望(てんぼう)",
             "view, outlook, prospect"
-        ],
-        "notation": "展望(てんぼう)"
+        ]
     },
     {
         "name": "shindou",
         "trans": [
+            "振動(しんどう)",
             "oscillation, vibration"
-        ],
-        "notation": "振動(しんどう)"
+        ]
     },
     {
         "name": "suigen",
         "trans": [
+            "水源(すいげん)",
             "source of river, fountainhead"
-        ],
-        "notation": "水源(すいげん)"
+        ]
     },
     {
         "name": "shibashiba",
         "trans": [
+            "屡(しばしば)",
             "often, again and again, frequently"
-        ],
-        "notation": "屡(しばしば)"
+        ]
     },
     {
         "name": "shimau",
         "trans": [
+            "仕舞(しま)う",
             "to finish, to close, to do something completely, to put away, to put an end to"
-        ],
-        "notation": "仕舞(しま)う"
+        ]
     },
     {
         "name": "jousei",
         "trans": [
+            "情勢(じょうせい)",
             "state of things, condition, situation"
-        ],
-        "notation": "情勢(じょうせい)"
+        ]
     },
     {
         "name": "kishou",
         "trans": [
+            "気象(きしょう)",
             "weather, climate"
-        ],
-        "notation": "気象(きしょう)"
+        ]
     },
     {
         "name": "yokufukai",
         "trans": [
+            "欲(よく)深(ふか)い",
             "greedy"
-        ],
-        "notation": "欲(よく)深(ふか)い"
+        ]
     },
     {
         "name": "katsute",
         "trans": [
+            "嘗(かつ)て",
             "once, ever"
-        ],
-        "notation": "嘗(かつ)て"
+        ]
     },
     {
         "name": "hansha",
         "trans": [
+            "反射(はんしゃ)",
             "reflection, reverberation"
-        ],
-        "notation": "反射(はんしゃ)"
+        ]
     },
     {
         "name": "nizukuri",
         "trans": [
+            "荷造(にづく)り",
             "packing, baling, crating"
-        ],
-        "notation": "荷造(にづく)り"
+        ]
     },
     {
         "name": "shuuchaku",
         "trans": [
+            "執着(しゅうちゃく)",
             "attachment, adhesion, tenacity"
-        ],
-        "notation": "執着(しゅうちゃく)"
+        ]
     },
     {
         "name": "saeru",
         "trans": [
+            "冴(さ)える",
             "to be clear, to be serene, to be cold, to be skillful"
-        ],
-        "notation": "冴(さ)える"
+        ]
     },
     {
         "name": "toukou",
         "trans": [
+            "登校(とうこう)",
             "attendance (at school)"
-        ],
-        "notation": "登校(とうこう)"
+        ]
     },
     {
         "name": "okubyou",
         "trans": [
+            "臆病(おくびょう)",
             "cowardice, timidity"
-        ],
-        "notation": "臆病(おくびょう)"
+        ]
     },
     {
         "name": "hanketsu",
         "trans": [
+            "判決(はんけつ)",
             "judicial decision, judgement, sentence, decree"
-        ],
-        "notation": "判決(はんけつ)"
+        ]
     },
     {
         "name": "toritateru",
         "trans": [
+            "取(と)り立(た)てる",
             "to collect, to extort, to appoint, to promote"
-        ],
-        "notation": "取(と)り立(た)てる"
+        ]
     },
     {
         "name": "tsumamu",
         "trans": [
+            "摘(つま)む",
             "to pinch, to hold, to pick up"
-        ],
-        "notation": "摘(つま)む"
+        ]
     },
     {
         "name": "sore",
         "trans": [
+            "其(そ)れ",
             "it, that"
-        ],
-        "notation": "其(そ)れ"
+        ]
     },
     {
         "name": "dounyuu",
         "trans": [
+            "導入(どうにゅう)",
             "introduction, bringing in, leading in"
-        ],
-        "notation": "導入(どうにゅう)"
+        ]
     },
     {
         "name": "jishoku",
         "trans": [
+            "辞職(じしょく)",
             "resignation"
-        ],
-        "notation": "辞職(じしょく)"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "商(しょう)",
             "quotient"
-        ],
-        "notation": "商(しょう)"
+        ]
     },
     {
         "name": "tabitabi",
         "trans": [
+            "度々(たびたび)",
             "often, repeatedly, frequently"
-        ],
-        "notation": "度々(たびたび)"
+        ]
     },
     {
         "name": "shusai",
         "trans": [
+            "主催(しゅさい)",
             "organization, sponsorship"
-        ],
-        "notation": "主催(しゅさい)"
+        ]
     },
     {
         "name": "miwatasu",
         "trans": [
+            "見渡(みわた)す",
             "to look out over, to survey (scene), to take an extensive view of"
-        ],
-        "notation": "見渡(みわた)す"
+        ]
     },
     {
         "name": "hatsumimi",
         "trans": [
+            "初耳(はつみみ)",
             "something heard for the first time"
-        ],
-        "notation": "初耳(はつみみ)"
+        ]
     },
     {
         "name": "dessan",
         "trans": [
+            "デッサン",
             "(fr:) (n) rough sketch (fr: dessin)"
-        ],
-        "notation": "デッサン"
+        ]
     },
     {
         "name": "kanben",
         "trans": [
+            "勘弁(かんべん)",
             "pardon, forgiveness, forbearance"
-        ],
-        "notation": "勘弁(かんべん)"
+        ]
     },
     {
         "name": "shaberu",
         "trans": [
+            "喋(しゃべ)る",
             "to talk, to chat, to chatter"
-        ],
-        "notation": "喋(しゃべ)る"
+        ]
     },
     {
         "name": "kawaisou",
         "trans": [
+            "可哀想(かわいそう)",
             "poor, pitiable, pathetic"
-        ],
-        "notation": "可哀想(かわいそう)"
+        ]
     },
     {
         "name": "kouri",
         "trans": [
+            "小売(こうり)",
             "retail"
-        ],
-        "notation": "小売(こうり)"
+        ]
     },
     {
         "name": "watto",
         "trans": [
+            "ワット",
             "watt"
-        ],
-        "notation": "ワット"
+        ]
     },
     {
         "name": "oideninaru",
         "trans": [
+            "お出(い)でになる",
             "to be"
-        ],
-        "notation": "お出(い)でになる"
+        ]
     },
     {
         "name": "bunsho",
         "trans": [
+            "文書(ぶんしょ)",
             "document, writing, letter, note, records, archives"
-        ],
-        "notation": "文書(ぶんしょ)"
+        ]
     },
     {
         "name": "fudousan",
         "trans": [
+            "不動産(ふどうさん)",
             "real estate"
-        ],
-        "notation": "不動産(ふどうさん)"
+        ]
     },
     {
         "name": "ranru",
         "trans": [
+            "藍(らん)褸(る)",
             "rag, scrap, tattered clothes, fault (esp. in a pretense), defect, run-down or junky"
-        ],
-        "notation": "藍(らん)褸(る)"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "例(れい)",
             "instance, example, case, precedent, experience, custom, usage, parallel, illustration"
-        ],
-        "notation": "例(れい)"
+        ]
     },
     {
         "name": "hatsubyou",
         "trans": [
+            "発病(はつびょう)",
             "attack (disease)"
-        ],
-        "notation": "発病(はつびょう)"
+        ]
     },
     {
         "name": "torimodosu",
         "trans": [
+            "取(と)り戻(もど)す",
             "to take back, to regain"
-        ],
-        "notation": "取(と)り戻(もど)す"
+        ]
     },
     {
         "name": "shikaushite",
         "trans": [
+            "然(しか)うして",
             "and, like that"
-        ],
-        "notation": "然(しか)うして"
+        ]
     },
     {
         "name": "yuusei",
         "trans": [
+            "優勢(ゆうせい)",
             "superiority, superior power, predominance, preponderance"
-        ],
-        "notation": "優勢(ゆうせい)"
+        ]
     },
     {
         "name": "mukuchi",
         "trans": [
+            "無口(むくち)",
             "reticence"
-        ],
-        "notation": "無口(むくち)"
+        ]
     },
     {
         "name": "zubunure",
         "trans": [
+            "ずぶ濡(ぬ)れ",
             "soaked, dripping wet"
-        ],
-        "notation": "ずぶ濡(ぬ)れ"
+        ]
     },
     {
         "name": "zonzai",
         "trans": [
+            "ぞんざい",
             "rude, careless, slovenly"
-        ],
-        "notation": "ぞんざい"
+        ]
     },
     {
         "name": "yashiki",
         "trans": [
+            "屋敷(やしき)",
             "mansion"
-        ],
-        "notation": "屋敷(やしき)"
+        ]
     },
     {
         "name": "kessoku",
         "trans": [
+            "結束(けっそく)",
             "union, unity"
-        ],
-        "notation": "結束(けっそく)"
+        ]
     },
     {
         "name": "hitoshi",
         "trans": [
+            "等(ひとし)",
             "et cetera, etc., and the like"
-        ],
-        "notation": "等(ひとし)"
+        ]
     },
     {
         "name": "sazukeru",
         "trans": [
+            "授(さづ)ける",
             "to grant, to award, to teach"
-        ],
-        "notation": "授(さづ)ける"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "返(かえ)る",
             "to return, to come back, to go back"
-        ],
-        "notation": "返(かえ)る"
+        ]
     },
     {
         "name": "oroka",
         "trans": [
+            "愚(おろ)か",
             "foolish, stupid"
-        ],
-        "notation": "愚(おろ)か"
+        ]
     },
     {
         "name": "iryou",
         "trans": [
+            "衣料(いりょう)",
             "clothing"
-        ],
-        "notation": "衣料(いりょう)"
+        ]
     },
     {
         "name": "endan",
         "trans": [
+            "縁談(えんだん)",
             "marriage proposal, engagement"
-        ],
-        "notation": "縁談(えんだん)"
+        ]
     },
     {
         "name": "shiyounin",
         "trans": [
+            "使用人(しようにん)",
             "employee, servant"
-        ],
-        "notation": "使用人(しようにん)"
+        ]
     },
     {
         "name": "yousei",
         "trans": [
+            "要請(ようせい)",
             "claim, demand, request, application"
-        ],
-        "notation": "要請(ようせい)"
+        ]
     },
     {
         "name": "kanningu",
         "trans": [
+            "カンニング",
             "cunning, cheat"
-        ],
-        "notation": "カンニング"
+        ]
     },
     {
         "name": "seika",
         "trans": [
+            "成果(せいか)",
             "results, fruits"
-        ],
-        "notation": "成果(せいか)"
+        ]
     },
     {
         "name": "gakufu",
         "trans": [
+            "楽譜(がくふ)",
             "score (music)"
-        ],
-        "notation": "楽譜(がくふ)"
+        ]
     },
     {
         "name": "joushou",
         "trans": [
+            "上昇(じょうしょう)",
             "rising, ascending, climbing"
-        ],
-        "notation": "上昇(じょうしょう)"
+        ]
     },
     {
         "name": "chomei",
         "trans": [
+            "著名(ちょめい)",
             "well-known, noted, celebrated"
-        ],
-        "notation": "著名(ちょめい)"
+        ]
     },
     {
         "name": "fusai",
         "trans": [
+            "負債(ふさい)",
             "debt, liabilities"
-        ],
-        "notation": "負債(ふさい)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "清算(せいさん)",
             "liquidation, settlement"
-        ],
-        "notation": "清算(せいさん)"
+        ]
     },
     {
         "name": "hachisu",
         "trans": [
+            "蓮(はちす)",
             "lotus"
-        ],
-        "notation": "蓮(はちす)"
+        ]
     },
     {
         "name": "suisen",
         "trans": [
+            "水洗(すいせん)",
             "flushing"
-        ],
-        "notation": "水洗(すいせん)"
+        ]
     },
     {
         "name": "hibi",
         "trans": [
+            "日々(ひび)",
             "every day, daily, day after day"
-        ],
-        "notation": "日々(ひび)"
+        ]
     },
     {
         "name": "uttoushii",
         "trans": [
+            "鬱陶(うっとう)しい",
             "gloomy, depressing"
-        ],
-        "notation": "鬱陶(うっとう)しい"
+        ]
     },
     {
         "name": "tsukiru",
         "trans": [
+            "尽(つ)きる",
             "to be used up, to be run out, to be exhausted, to be consumed, to come to an end"
-        ],
-        "notation": "尽(つ)きる"
+        ]
     },
     {
         "name": "hatenai",
         "trans": [
+            "果(はて)ない",
             "fleeting, transient, short-lived, momentary, vain, fickle, miserable, empty, ephemeral"
-        ],
-        "notation": "果(はて)ない"
+        ]
     },
     {
         "name": "yoshi",
         "trans": [
+            "美(よし)",
             "beauty"
-        ],
-        "notation": "美(よし)"
+        ]
     },
     {
         "name": "botsubotsu",
         "trans": [
+            "ぼつぼつ",
             "gradually, here and there, spots, pimples"
-        ],
-        "notation": "ぼつぼつ"
+        ]
     },
     {
         "name": "tamari",
         "trans": [
+            "溜(た)まり",
             "collected things, gathering place, arrears"
-        ],
-        "notation": "溜(た)まり"
+        ]
     },
     {
         "name": "tsuu",
         "trans": [
+            "通(つう)",
             "connoisseur, counter for letters"
-        ],
-        "notation": "通(つう)"
+        ]
     },
     {
         "name": "karute",
         "trans": [
+            "カルテ",
             "(de:) (n) clinical records (de: Karte)"
-        ],
-        "notation": "カルテ"
+        ]
     },
     {
         "name": "mata",
         "trans": [
+            "股(また)",
             "groin, crotch, thigh"
-        ],
-        "notation": "股(また)"
+        ]
     },
     {
         "name": "akaakagojitsu",
         "trans": [
+            "明々(あかあか)後日(ごじつ)",
             "two days after tomorrow"
-        ],
-        "notation": "明々(あかあか)後日(ごじつ)"
+        ]
     },
     {
         "name": "geppu",
         "trans": [
+            "月賦(げっぷ)",
             "monthly installment"
-        ],
-        "notation": "月賦(げっぷ)"
+        ]
     },
     {
         "name": "hikitoru",
         "trans": [
+            "引(ひ)き取(と)る",
             "to take charge of, to take over, to retire to a private place"
-        ],
-        "notation": "引(ひ)き取(と)る"
+        ]
     },
     {
         "name": "kanyuu",
         "trans": [
+            "勧誘(かんゆう)",
             "invitation, solicitation, canvassing, inducement, persuasion, encouragement"
-        ],
-        "notation": "勧誘(かんゆう)"
+        ]
     },
     {
         "name": "moroi",
         "trans": [
+            "脆(もろ)い",
             "brittle, fragile, tender-hearted"
-        ],
-        "notation": "脆(もろ)い"
+        ]
     },
     {
         "name": "ami",
         "trans": [
+            "網(あみ)",
             "net, network"
-        ],
-        "notation": "網(あみ)"
+        ]
     },
     {
         "name": "seiteki",
         "trans": [
+            "静的(せいてき)",
             "static"
-        ],
-        "notation": "静的(せいてき)"
+        ]
     },
     {
         "name": "hangaa",
         "trans": [
+            "ハンガー",
             "hangar, (coat) hanger, hunger"
-        ],
-        "notation": "ハンガー"
+        ]
     },
     {
         "name": "jou",
         "trans": [
+            "尉(じょう)",
             "jailer, old man, rank, company officer"
-        ],
-        "notation": "尉(じょう)"
+        ]
     },
     {
         "name": "afureru",
         "trans": [
+            "溢(あふ)れる",
             "to flood, to overflow, to brim over"
-        ],
-        "notation": "溢(あふ)れる"
+        ]
     },
     {
         "name": "kyouzon",
         "trans": [
+            "共存(きょうぞん)",
             "coexistence"
-        ],
-        "notation": "共存(きょうぞん)"
+        ]
     },
     {
         "name": "ai",
         "trans": [
+            "相(あい)",
             "together, mutually, fellow"
-        ],
-        "notation": "相(あい)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "格(かく)",
             "status, character, case"
-        ],
-        "notation": "格(かく)"
+        ]
     },
     {
         "name": "akachan",
         "trans": [
+            "赤(あか)ちゃん",
             "baby, infant"
-        ],
-        "notation": "赤(あか)ちゃん"
+        ]
     },
     {
         "name": "seiryoku",
         "trans": [
+            "勢力(せいりょく)",
             "influence, power, might, strength, potency, force, energy"
-        ],
-        "notation": "勢力(せいりょく)"
+        ]
     },
     {
         "name": "chiteki",
         "trans": [
+            "知的(ちてき)",
             "intellectual"
-        ],
-        "notation": "知的(ちてき)"
+        ]
     },
     {
         "name": "gehin",
         "trans": [
+            "下品(げひん)",
             "inferior article"
-        ],
-        "notation": "下品(げひん)"
+        ]
     },
     {
         "name": "dare",
         "trans": [
+            "誰(だれ)",
             "adjectival suffix for a person"
-        ],
-        "notation": "誰(だれ)"
+        ]
     },
     {
         "name": "bishou",
         "trans": [
+            "微笑(びしょう)",
             "smile"
-        ],
-        "notation": "微笑(びしょう)"
+        ]
     },
     {
         "name": "shozai",
         "trans": [
+            "所在(しょざい)",
             "whereabouts"
-        ],
-        "notation": "所在(しょざい)"
+        ]
     },
     {
         "name": "wabi",
         "trans": [
+            "詫(わ)び",
             "apology"
-        ],
-        "notation": "詫(わ)び"
+        ]
     },
     {
         "name": "sumanai",
         "trans": [
+            "済(す)まない",
             "sorry (phrase)"
-        ],
-        "notation": "済(す)まない"
+        ]
     },
     {
         "name": "renai",
         "trans": [
+            "恋愛(れんあい)",
             "love, love-making, passion, emotion, affections"
-        ],
-        "notation": "恋愛(れんあい)"
+        ]
     },
     {
         "name": "kansan",
         "trans": [
+            "換算(かんさん)",
             "conversion, change, exchange"
-        ],
-        "notation": "換算(かんさん)"
+        ]
     },
     {
         "name": "hokoru",
         "trans": [
+            "誇(ほこ)る",
             "to boast of, to be proud of"
-        ],
-        "notation": "誇(ほこ)る"
+        ]
     },
     {
         "name": "yuka",
         "trans": [
+            "床(ゆか)",
             "bed, sickbed, alcove, padding"
-        ],
-        "notation": "床(ゆか)"
+        ]
     },
     {
         "name": "genten",
         "trans": [
+            "減点(げんてん)",
             "subtract, give a demerit"
-        ],
-        "notation": "減点(げんてん)"
+        ]
     },
     {
         "name": "omawarisan",
         "trans": [
+            "お巡(まわ)りさん",
             "policeman (friendly term)"
-        ],
-        "notation": "お巡(まわ)りさん"
+        ]
     },
     {
         "name": "sashizu",
         "trans": [
+            "指図(さしず)",
             "instruction, mandate"
-        ],
-        "notation": "指図(さしず)"
+        ]
     },
     {
         "name": "kotatsu",
         "trans": [
+            "火燵(こたつ)",
             "table with heater, (orig) charcoal brazier in a floor well"
-        ],
-        "notation": "火燵(こたつ)"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "諮(はか)る",
             "to consult with, to confer"
-        ],
-        "notation": "諮(はか)る"
+        ]
     },
     {
         "name": "sakini",
         "trans": [
+            "先(さき)に",
             "before, earlier than, ahead, beyond, away, previously, recently"
-        ],
-        "notation": "先(さき)に"
+        ]
     },
     {
         "name": "zure",
         "trans": [
+            "ずれ",
             "gap, slippage"
-        ],
-        "notation": "ずれ"
+        ]
     },
     {
         "name": "yoshiashi",
         "trans": [
+            "善(よ)し悪(あ)し",
             "good or bad, merits or demerits, quality, suitability"
-        ],
-        "notation": "善(よ)し悪(あ)し"
+        ]
     },
     {
         "name": "osai",
         "trans": [
+            "お菜(さい)",
             "side dish, accompaniment for rice dishes"
-        ],
-        "notation": "お菜(さい)"
+        ]
     },
     {
         "name": "ukeire",
         "trans": [
+            "受(う)け入(い)れ",
             "receiving, acceptance"
-        ],
-        "notation": "受(う)け入(い)れ"
+        ]
     },
     {
         "name": "aiso",
         "trans": [
+            "愛想(あいそ)",
             "civility, courtesy, compliments, sociability, graces"
-        ],
-        "notation": "愛想(あいそ)"
+        ]
     },
     {
         "name": "seijitsu",
         "trans": [
+            "誠実(せいじつ)",
             "sincere, honest, faithful"
-        ],
-        "notation": "誠実(せいじつ)"
+        ]
     },
     {
         "name": "taishuu",
         "trans": [
+            "大衆(たいしゅう)",
             "general public"
-        ],
-        "notation": "大衆(たいしゅう)"
+        ]
     },
     {
         "name": "toukyuu",
         "trans": [
+            "等級(とうきゅう)",
             "grade, class"
-        ],
-        "notation": "等級(とうきゅう)"
+        ]
     },
     {
         "name": "karoujite",
         "trans": [
+            "辛(かろ)うじて",
             "barely, narrowly, just manage to do st"
-        ],
-        "notation": "辛(かろ)うじて"
+        ]
     },
     {
         "name": "mon",
         "trans": [
+            "門(もん)",
             "gate"
-        ],
-        "notation": "門(もん)"
+        ]
     },
     {
         "name": "intaachenji",
         "trans": [
+            "インターチェンジ",
             "interchange"
-        ],
-        "notation": "インターチェンジ"
+        ]
     },
     {
         "name": "akaramu",
         "trans": [
+            "赤(あか)らむ",
             "to become red, to redden, to blush"
-        ],
-        "notation": "赤(あか)らむ"
+        ]
     },
     {
         "name": "firutaa",
         "trans": [
+            "フィルター",
             "(camera) filter"
-        ],
-        "notation": "フィルター"
+        ]
     },
     {
         "name": "mokuroku",
         "trans": [
+            "目録(もくろく)",
             "catalogue, catalog, list"
-        ],
-        "notation": "目録(もくろく)"
+        ]
     },
     {
         "name": "mensuru",
         "trans": [
+            "面(めん)する",
             "to face on, to look out on to"
-        ],
-        "notation": "面(めん)する"
+        ]
     },
     {
         "name": "tewake",
         "trans": [
+            "手分(てわ)け",
             "division of labour"
-        ],
-        "notation": "手分(てわ)け"
+        ]
     },
     {
         "name": "chousen",
         "trans": [
+            "挑戦(ちょうせん)",
             "challenge, defiance"
-        ],
-        "notation": "挑戦(ちょうせん)"
+        ]
     },
     {
         "name": "hokaku",
         "trans": [
+            "捕獲(ほかく)",
             "capture, seizure"
-        ],
-        "notation": "捕獲(ほかく)"
+        ]
     },
     {
         "name": "ochitsuki",
         "trans": [
+            "落(お)ち着(つ)き",
             "calm, composure"
-        ],
-        "notation": "落(お)ち着(つ)き"
+        ]
     },
     {
         "name": "ikken",
         "trans": [
+            "一見(いっけん)",
             "unfamiliar, never before met"
-        ],
-        "notation": "一見(いっけん)"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "当(あ)たり",
             "hit, success, reaching the mark, per ..., vicinity, neighborhood"
-        ],
-        "notation": "当(あ)たり"
+        ]
     },
     {
         "name": "kounyuu",
         "trans": [
+            "購入(こうにゅう)",
             "purchase, buy"
-        ],
-        "notation": "購入(こうにゅう)"
+        ]
     },
     {
         "name": "daiben",
         "trans": [
+            "代弁(だいべん)",
             "pay by proxy, act for another, speak for another"
-        ],
-        "notation": "代弁(だいべん)"
+        ]
     },
     {
         "name": "ryakugo",
         "trans": [
+            "略語(りゃくご)",
             "abbreviation, acronym"
-        ],
-        "notation": "略語(りゃくご)"
+        ]
     },
     {
         "name": "shinchiku",
         "trans": [
+            "新築(しんちく)",
             "new building, new construction"
-        ],
-        "notation": "新築(しんちく)"
+        ]
     },
     {
         "name": "todoke",
         "trans": [
+            "届(とど)け",
             "report, notification, registration"
-        ],
-        "notation": "届(とど)け"
+        ]
     },
     {
         "name": "umaretsuki",
         "trans": [
+            "生(う)まれつき",
             "by nature, by birth, native"
-        ],
-        "notation": "生(う)まれつき"
+        ]
     },
     {
         "name": "togeru",
         "trans": [
+            "遂(と)げる",
             "to accomplish, to achieve, to carry out"
-        ],
-        "notation": "遂(と)げる"
+        ]
     },
     {
         "name": "sonzoku",
         "trans": [
+            "存続(そんぞく)",
             "duration, continuance"
-        ],
-        "notation": "存続(そんぞく)"
+        ]
     },
     {
         "name": "nanka",
         "trans": [
+            "なんか",
             "things like ..., or something like that .. (often derogatory)"
-        ],
-        "notation": "なんか"
+        ]
     },
     {
         "name": "fuusa",
         "trans": [
+            "封鎖(ふうさ)",
             "blockade, freezing (funds)"
-        ],
-        "notation": "封鎖(ふうさ)"
+        ]
     },
     {
         "name": "wari",
         "trans": [
+            "割(わり)",
             "divide, cut, halve, separate, split, rip, break, crack, smash, dilute"
-        ],
-        "notation": "割(わり)"
+        ]
     },
     {
         "name": "totonoeru",
         "trans": [
+            "整(ととの)える",
             "to put in order, to get ready, to arrange, to adjust"
-        ],
-        "notation": "整(ととの)える"
+        ]
     },
     {
         "name": "akkenai",
         "trans": [
+            "呆気(あっけ)ない",
             "not enough, too quick (short long etc.)"
-        ],
-        "notation": "呆気(あっけ)ない"
+        ]
     },
     {
         "name": "tougou",
         "trans": [
+            "統合(とうごう)",
             "integration, unification, synthesis"
-        ],
-        "notation": "統合(とうごう)"
+        ]
     },
     {
         "name": "yuuetsu",
         "trans": [
+            "優越(ゆうえつ)",
             "supremacy, predominance, being superior to"
-        ],
-        "notation": "優越(ゆうえつ)"
+        ]
     },
     {
         "name": "maizou",
         "trans": [
+            "埋蔵(まいぞう)",
             "buried property, treasure trove"
-        ],
-        "notation": "埋蔵(まいぞう)"
+        ]
     },
     {
         "name": "ketsui",
         "trans": [
+            "決意(けつい)",
             "decision, determination"
-        ],
-        "notation": "決意(けつい)"
+        ]
     },
     {
         "name": "kaiun",
         "trans": [
+            "海運(かいうん)",
             "maritime, marine transportation"
-        ],
-        "notation": "海運(かいうん)"
+        ]
     },
     {
         "name": "dasaku",
         "trans": [
+            "駄作(ださく)",
             "poor work, rubbish"
-        ],
-        "notation": "駄作(ださく)"
+        ]
     },
     {
         "name": "asamashii",
         "trans": [
+            "浅(あさ)ましい",
             "wretched, miserable, shameful, mean, despicable, abject"
-        ],
-        "notation": "浅(あさ)ましい"
+        ]
     },
     {
         "name": "shukuga",
         "trans": [
+            "祝賀(しゅくが)",
             "celebration, congratulations"
-        ],
-        "notation": "祝賀(しゅくが)"
+        ]
     },
     {
         "name": "kokuren",
         "trans": [
+            "国連(こくれん)",
             "U.N., United Nations"
-        ],
-        "notation": "国連(こくれん)"
+        ]
     },
     {
         "name": "tesuu",
         "trans": [
+            "手数(てすう)",
             "number of moves, trouble"
-        ],
-        "notation": "手数(てすう)"
+        ]
     },
     {
         "name": "kanten",
         "trans": [
+            "観点(かんてん)",
             "point of view"
-        ],
-        "notation": "観点(かんてん)"
+        ]
     },
     {
         "name": "zuuzuushii",
         "trans": [
+            "図々しい(ずうずうしい)",
             "impudent, shameless"
-        ],
-        "notation": "図々しい(ずうずうしい)"
+        ]
     },
     {
         "name": "yangu",
         "trans": [
+            "ヤング",
             "young"
-        ],
-        "notation": "ヤング"
+        ]
     },
     {
         "name": "sabaku",
         "trans": [
+            "裁(さば)く",
             "to judge"
-        ],
-        "notation": "裁(さば)く"
+        ]
     },
     {
         "name": "gotearai",
         "trans": [
+            "御(ご)手洗(てあら)い",
             "toilet, restroom, lavatory, bathroom (US)"
-        ],
-        "notation": "御(ご)手洗(てあら)い"
+        ]
     },
     {
         "name": "kaseki",
         "trans": [
+            "化石(かせき)",
             "fossil, petrifaction, fossilization"
-        ],
-        "notation": "化石(かせき)"
+        ]
     },
     {
         "name": "han",
         "trans": [
+            "判(はん)",
             "seal, stamp, monogram signature, judgment"
-        ],
-        "notation": "判(はん)"
+        ]
     },
     {
         "name": "isshin",
         "trans": [
+            "一心(いっしん)",
             "one mind, wholeheartedness, the whole heart"
-        ],
-        "notation": "一心(いっしん)"
+        ]
     },
     {
         "name": "toppa",
         "trans": [
+            "突破(とっぱ)",
             "breaking through, breakthrough, penetration"
-        ],
-        "notation": "突破(とっぱ)"
+        ]
     },
     {
         "name": "heiretsu",
         "trans": [
+            "並列(へいれつ)",
             "arrangement, parallel, abreast"
-        ],
-        "notation": "並列(へいれつ)"
+        ]
     },
     {
         "name": "koubai",
         "trans": [
+            "購買(こうばい)",
             "purchase, buy"
-        ],
-        "notation": "購買(こうばい)"
+        ]
     },
     {
         "name": "yaritogeru",
         "trans": [
+            "やり遂(と)げる",
             "to accomplish"
-        ],
-        "notation": "やり遂(と)げる"
+        ]
     },
     {
         "name": "foumu",
         "trans": [
+            "フォーム",
             "foam, form"
-        ],
-        "notation": "フォーム"
+        ]
     },
     {
         "name": "mannaka",
         "trans": [
+            "真(ま)ん中(なか)",
             "middle, centre, mid-way"
-        ],
-        "notation": "真(ま)ん中(なか)"
+        ]
     },
     {
         "name": "koyou",
         "trans": [
+            "雇用(こよう)",
             "employment (long term), hire"
-        ],
-        "notation": "雇用(こよう)"
+        ]
     },
     {
         "name": "shirizokeru",
         "trans": [
+            "退(しりぞ)ける",
             "to repel, to drive away"
-        ],
-        "notation": "退(しりぞ)ける"
+        ]
     },
     {
         "name": "satsu",
         "trans": [
+            "冊(さつ)",
             "counter for books"
-        ],
-        "notation": "冊(さつ)"
+        ]
     },
     {
         "name": "kyousei",
         "trans": [
+            "強制(きょうせい)",
             "obligation, coercion, compulsion, enforcement"
-        ],
-        "notation": "強制(きょうせい)"
+        ]
     },
     {
         "name": "yuukan",
         "trans": [
+            "勇敢(ゆうかん)",
             "bravery, heroism, gallantry"
-        ],
-        "notation": "勇敢(ゆうかん)"
+        ]
     },
     {
         "name": "shisetsu",
         "trans": [
+            "施設(しせつ)",
             "institution, establishment, facility, (army) engineer"
-        ],
-        "notation": "施設(しせつ)"
+        ]
     },
     {
         "name": "hitogara",
         "trans": [
+            "人柄(ひとがら)",
             "personality, character, personal appearance, gentility"
-        ],
-        "notation": "人柄(ひとがら)"
+        ]
     },
     {
         "name": "kanjin",
         "trans": [
+            "肝心(かんじん)",
             "essential, fundamental, crucial, vital, main"
-        ],
-        "notation": "肝心(かんじん)"
+        ]
     },
     {
         "name": "gensoku",
         "trans": [
+            "原則(げんそく)",
             "principle, general rule"
-        ],
-        "notation": "原則(げんそく)"
+        ]
     },
     {
         "name": "kousou",
         "trans": [
+            "抗争(こうそう)",
             "dispute, resistance"
-        ],
-        "notation": "抗争(こうそう)"
+        ]
     },
     {
         "name": "kenryoku",
         "trans": [
+            "権力(けんりょく)",
             "power, authority, influence"
-        ],
-        "notation": "権力(けんりょく)"
+        ]
     },
     {
         "name": "jou",
         "trans": [
+            "状(じょう)",
             "shape"
-        ],
-        "notation": "状(じょう)"
+        ]
     },
     {
         "name": "awaa",
         "trans": [
+            "アワー",
             "hour"
-        ],
-        "notation": "アワー"
+        ]
     },
     {
         "name": "keihi",
         "trans": [
+            "経費(けいひ)",
             "expenses, cost, outlay"
-        ],
-        "notation": "経費(けいひ)"
+        ]
     },
     {
         "name": "tokuten",
         "trans": [
+            "得点(とくてん)",
             "score, points made, marks obtained, runs"
-        ],
-        "notation": "得点(とくてん)"
+        ]
     },
     {
         "name": "kaishuu",
         "trans": [
+            "回収(かいしゅう)",
             "collection, recovery"
-        ],
-        "notation": "回収(かいしゅう)"
+        ]
     },
     {
         "name": "youken",
         "trans": [
+            "用件(ようけん)",
             "business"
-        ],
-        "notation": "用件(ようけん)"
+        ]
     },
     {
         "name": "yattsukeru",
         "trans": [
+            "やっ付(つ)ける",
             "to beat"
-        ],
-        "notation": "やっ付(つ)ける"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "収支(しゅうし)",
             "income and expenditure"
-        ],
-        "notation": "収支(しゅうし)"
+        ]
     },
     {
         "name": "tairitsu",
         "trans": [
+            "対立(たいりつ)",
             "confrontation, opposition, antagonism"
-        ],
-        "notation": "対立(たいりつ)"
+        ]
     },
     {
         "name": "nasaru",
         "trans": [
+            "為(な)さる",
             "to do"
-        ],
-        "notation": "為(な)さる"
+        ]
     },
     {
         "name": "kikaku",
         "trans": [
+            "企画(きかく)",
             "planning, project"
-        ],
-        "notation": "企画(きかく)"
+        ]
     },
     {
         "name": "moreru",
         "trans": [
+            "漏(も)れる",
             "to leak out, to escape, to come through, to shine through, to filter out, to be omitted"
-        ],
-        "notation": "漏(も)れる"
+        ]
     },
     {
         "name": "keii",
         "trans": [
+            "経緯(けいい)",
             "1. details, whole story, sequence of events, particulars, how it started, how things got this way, 2. c"
-        ],
-        "notation": "経緯(けいい)"
+        ]
     },
     {
         "name": "socchoku",
         "trans": [
+            "率直(そっちょく)",
             "frankness, candour, openheartedness"
-        ],
-        "notation": "率直(そっちょく)"
+        ]
     },
     {
         "name": "fumei",
         "trans": [
+            "不明(ふめい)",
             "unknown, obscure, indistinct, uncertain, ambiguous, ignorant, lack of wisdom, anonymous, unidentified"
-        ],
-        "notation": "不明(ふめい)"
+        ]
     },
     {
         "name": "komu",
         "trans": [
+            "混(こ)む",
             "to be crowded"
-        ],
-        "notation": "混(こ)む"
+        ]
     },
     {
         "name": "seizen",
         "trans": [
+            "整然(せいぜん)",
             "orderly, regular, well-organized, trim, accurate"
-        ],
-        "notation": "整然(せいぜん)"
+        ]
     },
     {
         "name": "ninjou",
         "trans": [
+            "人情(にんじょう)",
             "humanity, empathy, kindness, sympathy, human nature, common sense, customs and manners"
-        ],
-        "notation": "人情(にんじょう)"
+        ]
     },
     {
         "name": "soubi",
         "trans": [
+            "装備(そうび)",
             "equipment"
-        ],
-        "notation": "装備(そうび)"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "幕(まく)",
             "curtain, bunting, act (in play)"
-        ],
-        "notation": "幕(まく)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "進行(しんこう)",
             "advance"
-        ],
-        "notation": "進行(しんこう)"
+        ]
     },
     {
         "name": "namami",
         "trans": [
+            "生身(なまみ)",
             "living flesh, flesh and blood, the quick"
-        ],
-        "notation": "生身(なまみ)"
+        ]
     },
     {
         "name": "doui",
         "trans": [
+            "同意(どうい)",
             "agreement, consent, same meaning, same opinion, approval"
-        ],
-        "notation": "同意(どうい)"
+        ]
     },
     {
         "name": "kanso",
         "trans": [
+            "簡素(かんそ)",
             "simplicity, plain"
-        ],
-        "notation": "簡素(かんそ)"
+        ]
     },
     {
         "name": "imin",
         "trans": [
+            "移民(いみん)",
             "emigration, immigration, emigrant, immigrant"
-        ],
-        "notation": "移民(いみん)"
+        ]
     },
     {
         "name": "secchuu",
         "trans": [
+            "折衷(せっちゅう)",
             "compromise, cross, blending, eclecticism"
-        ],
-        "notation": "折衷(せっちゅう)"
+        ]
     },
     {
         "name": "iiwake",
         "trans": [
+            "言(い)い訳(わけ)",
             "excuse, explanation"
-        ],
-        "notation": "言(い)い訳(わけ)"
+        ]
     },
     {
         "name": "tekiou",
         "trans": [
+            "適応(てきおう)",
             "adaptation, accommodation, conformity"
-        ],
-        "notation": "適応(てきおう)"
+        ]
     },
     {
         "name": "youshiki",
         "trans": [
+            "様式(ようしき)",
             "style, form, pattern"
-        ],
-        "notation": "様式(ようしき)"
+        ]
     },
     {
         "name": "aa",
         "trans": [
+            "嗚呼(ああ)",
             "Ah!, Oh!, Alas!"
-        ],
-        "notation": "嗚呼(ああ)"
+        ]
     },
     {
         "name": "koushuu",
         "trans": [
+            "講習(こうしゅう)",
             "short course, training"
-        ],
-        "notation": "講習(こうしゅう)"
+        ]
     },
     {
         "name": "jazu",
         "trans": [
+            "ジャズ",
             "jazz"
-        ],
-        "notation": "ジャズ"
+        ]
     },
     {
         "name": "tatoe",
         "trans": [
+            "例(たと)え",
             "example, even if, if, though, although"
-        ],
-        "notation": "例(たと)え"
+        ]
     },
     {
         "name": "genshou",
         "trans": [
+            "減少(げんしょう)",
             "decrease, reduction, decline"
-        ],
-        "notation": "減少(げんしょう)"
+        ]
     },
     {
         "name": "ikari",
         "trans": [
+            "怒(いか)り",
             "anger, hatred"
-        ],
-        "notation": "怒(いか)り"
+        ]
     },
     {
         "name": "bouzen",
         "trans": [
+            "呆然(ぼうぜん)",
             "dumbfounded, overcome with surprise, in blank amazement"
-        ],
-        "notation": "呆然(ぼうぜん)"
+        ]
     },
     {
         "name": "hazumu",
         "trans": [
+            "弾(はず)む",
             "to spring, to bound, to bounce, to be stimulated, to be encouraged, to get lively, to treat oneself to, to"
-        ],
-        "notation": "弾(はず)む"
+        ]
     },
     {
         "name": "tamerau",
         "trans": [
+            "躊躇(ためら)う",
             "to hesitate"
-        ],
-        "notation": "躊躇(ためら)う"
+        ]
     },
     {
         "name": "kakuritsu",
         "trans": [
+            "確立(かくりつ)",
             "establishment"
-        ],
-        "notation": "確立(かくりつ)"
+        ]
     },
     {
         "name": "mesu",
         "trans": [
+            "雌(めす)",
             "female (animal)"
-        ],
-        "notation": "雌(めす)"
+        ]
     },
     {
         "name": "genten",
         "trans": [
+            "原点(げんてん)",
             "origin (coordinates), starting point"
-        ],
-        "notation": "原点(げんてん)"
+        ]
     },
     {
         "name": "sutareru",
         "trans": [
+            "廃(すた)れる",
             "to go out of use, to become obsolete, to die out, to go out of fashion"
-        ],
-        "notation": "廃(すた)れる"
+        ]
     },
     {
         "name": "haretsu",
         "trans": [
+            "破裂(はれつ)",
             "explosion, rupture, break off"
-        ],
-        "notation": "破裂(はれつ)"
+        ]
     },
     {
         "name": "sunnari",
         "trans": [
+            "すんなり",
             "pass with no objection, slim, slender"
-        ],
-        "notation": "すんなり"
+        ]
     },
     {
         "name": "yokin",
         "trans": [
+            "預金(よきん)",
             "deposit, bank account"
-        ],
-        "notation": "預金(よきん)"
+        ]
     },
     {
         "name": "honnou",
         "trans": [
+            "本能(ほんのう)",
             "instinct"
-        ],
-        "notation": "本能(ほんのう)"
+        ]
     },
     {
         "name": "zeimusho",
         "trans": [
+            "税務署(ぜいむしょ)",
             "tax office"
-        ],
-        "notation": "税務署(ぜいむしょ)"
+        ]
     },
     {
         "name": "kikin",
         "trans": [
+            "基金(ききん)",
             "fund, foundation"
-        ],
-        "notation": "基金(ききん)"
+        ]
     },
     {
         "name": "naniyori",
         "trans": [
+            "何(なに)より",
             "most, best"
-        ],
-        "notation": "何(なに)より"
+        ]
     },
     {
         "name": "magokoro",
         "trans": [
+            "真心(まごころ)",
             "sincerity, devotion"
-        ],
-        "notation": "真心(まごころ)"
+        ]
     },
     {
         "name": "shitabi",
         "trans": [
+            "下火(したび)",
             "burning low, waning, declining"
-        ],
-        "notation": "下火(したび)"
+        ]
     },
     {
         "name": "hiki",
         "trans": [
+            "匹(ひき)",
             "head, small animal counter, roll of cloth"
-        ],
-        "notation": "匹(ひき)"
+        ]
     },
     {
         "name": "sonshitsu",
         "trans": [
+            "損失(そんしつ)",
             "loss"
-        ],
-        "notation": "損失(そんしつ)"
+        ]
     },
     {
         "name": "heiki",
         "trans": [
+            "兵器(へいき)",
             "arms, weapons, ordinance"
-        ],
-        "notation": "兵器(へいき)"
+        ]
     },
     {
         "name": "sori",
         "trans": [
+            "反(そ)り",
             "warp, curvature, curve, arch"
-        ],
-        "notation": "反(そ)り"
+        ]
     },
     {
         "name": "megumu",
         "trans": [
+            "恵(めぐ)む",
             "to bless, to show mercy to"
-        ],
-        "notation": "恵(めぐ)む"
+        ]
     },
     {
         "name": "kawaigaru",
         "trans": [
+            "可愛(かわい)がる",
             "to love, to be affectionate"
-        ],
-        "notation": "可愛(かわい)がる"
+        ]
     },
     {
         "name": "temawashi",
         "trans": [
+            "手回(てまわ)し",
             "preparations, arrangements"
-        ],
-        "notation": "手回(てまわ)し"
+        ]
     },
     {
         "name": "tawaa",
         "trans": [
+            "タワー",
             "tower"
-        ],
-        "notation": "タワー"
+        ]
     },
     {
         "name": "sugasugashii",
         "trans": [
+            "清々しい(すがすがしい)",
             "fresh, refreshing"
-        ],
-        "notation": "清々しい(すがすがしい)"
+        ]
     },
     {
         "name": "musubitsuki",
         "trans": [
+            "結(むす)び付(つ)き",
             "connection, relation"
-        ],
-        "notation": "結(むす)び付(つ)き"
+        ]
     },
     {
         "name": "toriyoseru",
         "trans": [
+            "取(と)り寄(よ)せる",
             "to order, to send away for"
-        ],
-        "notation": "取(と)り寄(よ)せる"
+        ]
     },
     {
         "name": "morasu",
         "trans": [
+            "漏(も)らす",
             "to let leak, to reveal"
-        ],
-        "notation": "漏(も)らす"
+        ]
     },
     {
         "name": "kidou",
         "trans": [
+            "軌道(きどう)",
             "orbit, railroad track"
-        ],
-        "notation": "軌道(きどう)"
+        ]
     },
     {
         "name": "tochuu",
         "trans": [
+            "途中(とちゅう)",
             "on the way, en route"
-        ],
-        "notation": "途中(とちゅう)"
+        ]
     },
     {
         "name": "sensai",
         "trans": [
+            "戦災(せんさい)",
             "war damage"
-        ],
-        "notation": "戦災(せんさい)"
+        ]
     },
     {
         "name": "keigen",
         "trans": [
+            "軽減(けいげん)",
             "abatement"
-        ],
-        "notation": "軽減(けいげん)"
+        ]
     },
     {
         "name": "noukou",
         "trans": [
+            "農耕(のうこう)",
             "farming, agriculture"
-        ],
-        "notation": "農耕(のうこう)"
+        ]
     },
     {
         "name": "zankin",
         "trans": [
+            "残金(ざんきん)",
             "remaining money"
-        ],
-        "notation": "残金(ざんきん)"
+        ]
     },
     {
         "name": "owaru",
         "trans": [
+            "終(お)わる",
             "to finish, to close"
-        ],
-        "notation": "終(お)わる"
+        ]
     },
     {
         "name": "jishu",
         "trans": [
+            "自主(じしゅ)",
             "independence, autonomy"
-        ],
-        "notation": "自主(じしゅ)"
+        ]
     },
     {
         "name": "dekai",
         "trans": [
+            "でかい",
             "huge"
-        ],
-        "notation": "でかい"
+        ]
     },
     {
         "name": "kiyoraka",
         "trans": [
+            "清(きよ)らか",
             "clean, pure, chaste"
-        ],
-        "notation": "清(きよ)らか"
+        ]
     },
     {
         "name": "mohou",
         "trans": [
+            "模倣(もほう)",
             "imitation, copying"
-        ],
-        "notation": "模倣(もほう)"
+        ]
     },
     {
         "name": "shoji",
         "trans": [
+            "所持(しょじ)",
             "possession, owning"
-        ],
-        "notation": "所持(しょじ)"
+        ]
     },
     {
         "name": "rokuna",
         "trans": [
+            "碌(ろく)な",
             "satisfactory, decent"
-        ],
-        "notation": "碌(ろく)な"
+        ]
     },
     {
         "name": "katsu",
         "trans": [
+            "且(か)つ",
             "yet, and"
-        ],
-        "notation": "且(か)つ"
+        ]
     },
     {
         "name": "aima",
         "trans": [
+            "合間(あいま)",
             "interval"
-        ],
-        "notation": "合間(あいま)"
+        ]
     },
     {
         "name": "kakei",
         "trans": [
+            "家計(かけい)",
             "household economy, family finances"
-        ],
-        "notation": "家計(かけい)"
+        ]
     },
     {
         "name": "kemutai",
         "trans": [
+            "煙(けむ)たい",
             "smoky, feeling awkward"
-        ],
-        "notation": "煙(けむ)たい"
+        ]
     },
     {
         "name": "shisatsu",
         "trans": [
+            "視察(しさつ)",
             "inspection, observation"
-        ],
-        "notation": "視察(しさつ)"
+        ]
     },
     {
         "name": "temoto",
         "trans": [
+            "手元(てもと)",
             "on hand, at hand, at home"
-        ],
-        "notation": "手元(てもと)"
+        ]
     },
     {
         "name": "jikaku",
         "trans": [
+            "自覚(じかく)",
             "self-conscious"
-        ],
-        "notation": "自覚(じかく)"
+        ]
     },
     {
         "name": "hiketsu",
         "trans": [
+            "否決(ひけつ)",
             "rejection, negation, voting down"
-        ],
-        "notation": "否決(ひけつ)"
+        ]
     },
     {
         "name": "kana",
         "trans": [
+            "哉(かな)",
             "question mark"
-        ],
-        "notation": "哉(かな)"
+        ]
     },
     {
         "name": "tenjou",
         "trans": [
+            "天井(てんじょう)",
             "ceiling, ceiling price"
-        ],
-        "notation": "天井(てんじょう)"
+        ]
     },
     {
         "name": "mimai",
         "trans": [
+            "見舞(みまい)",
             "enquiry, expression of sympathy, expression of concern"
-        ],
-        "notation": "見舞(みまい)"
+        ]
     },
     {
         "name": "bochi",
         "trans": [
+            "墓地(ぼち)",
             "cemetery, graveyard"
-        ],
-        "notation": "墓地(ぼち)"
+        ]
     },
     {
         "name": "sue",
         "trans": [
+            "末(すえ)",
             "top end, tip"
-        ],
-        "notation": "末(すえ)"
+        ]
     },
     {
         "name": "honbun",
         "trans": [
+            "本文(ほんぶん)",
             "text (of document), body (of letter)"
-        ],
-        "notation": "本文(ほんぶん)"
+        ]
     },
     {
         "name": "kinkou",
         "trans": [
+            "均衡(きんこう)",
             "equilibrium, balance"
-        ],
-        "notation": "均衡(きんこう)"
+        ]
     },
     {
         "name": "hamigaki",
         "trans": [
+            "歯磨(はみがき)",
             "dentifrice, toothpaste"
-        ],
-        "notation": "歯磨(はみがき)"
+        ]
     },
     {
         "name": "yowameru",
         "trans": [
+            "弱(よわ)める",
             "to weaken"
-        ],
-        "notation": "弱(よわ)める"
+        ]
     },
     {
         "name": "jou",
         "trans": [
+            "嬢(じょう)",
             "young woman"
-        ],
-        "notation": "嬢(じょう)"
+        ]
     },
     {
         "name": "sonawaru",
         "trans": [
+            "備(そな)わる",
             "to be furnished with, to be endowed with, to possess, to be among, to be one of, to be possessed of"
-        ],
-        "notation": "備(そな)わる"
+        ]
     },
     {
         "name": "hason",
         "trans": [
+            "破損(はそん)",
             "damage"
-        ],
-        "notation": "破損(はそん)"
+        ]
     },
     {
         "name": "gessori",
         "trans": [
+            "げっそり",
             "being disheartened, losing weight"
-        ],
-        "notation": "げっそり"
+        ]
     },
     {
         "name": "uketsugu",
         "trans": [
+            "受(う)け継(つ)ぐ",
             "to inherit, to succeed, to take over"
-        ],
-        "notation": "受(う)け継(つ)ぐ"
+        ]
     },
     {
         "name": "unchin",
         "trans": [
+            "運賃(うんちん)",
             "freight rates, shipping expenses, fare"
-        ],
-        "notation": "運賃(うんちん)"
+        ]
     },
     {
         "name": "minari",
         "trans": [
+            "身(み)なり",
             "personal appearance"
-        ],
-        "notation": "身(み)なり"
+        ]
     },
     {
         "name": "minshuku",
         "trans": [
+            "民宿(みんしゅく)",
             "private home providing lodging for travelers"
-        ],
-        "notation": "民宿(みんしゅく)"
+        ]
     },
     {
         "name": "bokin",
         "trans": [
+            "募金(ぼきん)",
             "fund-raising, collection of funds"
-        ],
-        "notation": "募金(ぼきん)"
+        ]
     },
     {
         "name": "oboe",
         "trans": [
+            "覚(おぼ)え",
             "memory, sense, experience"
-        ],
-        "notation": "覚(おぼ)え"
+        ]
     },
     {
         "name": "kawaru",
         "trans": [
+            "代(か)わる",
             "to take the place of, to relieve, to be substituted for, to be exchanged, to change places with, to take"
-        ],
-        "notation": "代(か)わる"
+        ]
     },
     {
         "name": "tamekitari",
         "trans": [
+            "為(ため)来(きた)り",
             "customs"
-        ],
-        "notation": "為(ため)来(きた)り"
+        ]
     },
     {
         "name": "roumaji",
         "trans": [
+            "ローマ字(じ)",
             "romanization, Roman letters"
-        ],
-        "notation": "ローマ字(じ)"
+        ]
     },
     {
         "name": "maaku",
         "trans": [
+            "マーク",
             "mark"
-        ],
-        "notation": "マーク"
+        ]
     },
     {
         "name": "tsuraneru",
         "trans": [
+            "連(つら)ねる",
             "to link, to join, to put together"
-        ],
-        "notation": "連(つら)ねる"
+        ]
     },
     {
         "name": "take",
         "trans": [
+            "丈(たけ)",
             "height, stature, length, measure, all (one has)"
-        ],
-        "notation": "丈(たけ)"
+        ]
     },
     {
         "name": "aogu",
         "trans": [
+            "仰(あお)ぐ",
             "to look up (to), to respect, to depend on, to ask for, to seek, to revere, to drink, to take"
-        ],
-        "notation": "仰(あお)ぐ"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "さん",
             "Mr or Mrs"
-        ],
-        "notation": "さん"
+        ]
     },
     {
         "name": "saji",
         "trans": [
+            "些事(さじ)",
             "something small or petty, trifle"
-        ],
-        "notation": "些事(さじ)"
+        ]
     },
     {
         "name": "kanreki",
         "trans": [
+            "還暦(かんれき)",
             "60th birthday"
-        ],
-        "notation": "還暦(かんれき)"
+        ]
     },
     {
         "name": "warikomu",
         "trans": [
+            "割(わ)り込(こ)む",
             "to cut in, to thrust oneself into, to wedge oneself in, to muscle in on, to interrupt, to disturb"
-        ],
-        "notation": "割(わ)り込(こ)む"
+        ]
     },
     {
         "name": "aka",
         "trans": [
+            "垢(あか)",
             "dirt, filth"
-        ],
-        "notation": "垢(あか)"
+        ]
     },
     {
         "name": "shousai",
         "trans": [
+            "詳細(しょうさい)",
             "detail, particulars"
-        ],
-        "notation": "詳細(しょうさい)"
+        ]
     },
     {
         "name": "yayuu",
         "trans": [
+            "揶揄(やゆ)う",
             "to ridicule, to tease, to banter with, to make fun of"
-        ],
-        "notation": "揶揄(やゆ)う"
+        ]
     },
     {
         "name": "shuueki",
         "trans": [
+            "収益(しゅうえき)",
             "earnings, proceeds, returns"
-        ],
-        "notation": "収益(しゅうえき)"
+        ]
     },
     {
         "name": "sakeru",
         "trans": [
+            "裂(さ)ける",
             "to split, to tear, to burst"
-        ],
-        "notation": "裂(さ)ける"
+        ]
     },
     {
         "name": "kanwa",
         "trans": [
+            "緩和(かんわ)",
             "relief, mitigation"
-        ],
-        "notation": "緩和(かんわ)"
+        ]
     },
     {
         "name": "shikujiru",
         "trans": [
+            "しくじる",
             "to fail, to fall through, to blunder"
-        ],
-        "notation": "しくじる"
+        ]
     },
     {
         "name": "torikae",
         "trans": [
+            "取(と)り替(か)え",
             "swap, exchange"
-        ],
-        "notation": "取(と)り替(か)え"
+        ]
     },
     {
         "name": "zerii",
         "trans": [
+            "ゼリー",
             "1. jelly, 2. Jerry"
-        ],
-        "notation": "ゼリー"
+        ]
     },
     {
         "name": "ten",
         "trans": [
+            "天(てん)",
             "heavenly, imperial"
-        ],
-        "notation": "天(てん)"
+        ]
     },
     {
         "name": "byousha",
         "trans": [
+            "描写(びょうしゃ)",
             "depiction, description, portrayal"
-        ],
-        "notation": "描写(びょうしゃ)"
+        ]
     },
     {
         "name": "kontei",
         "trans": [
+            "根底(こんてい)",
             "root, basis, foundation"
-        ],
-        "notation": "根底(こんてい)"
+        ]
     },
     {
         "name": "fundan",
         "trans": [
+            "ふんだん",
             "plentiful, abundant, lavish"
-        ],
-        "notation": "ふんだん"
+        ]
     },
     {
         "name": "housaku",
         "trans": [
+            "豊作(ほうさく)",
             "abundant harvest, bumper crop"
-        ],
-        "notation": "豊作(ほうさく)"
+        ]
     },
     {
         "name": "yamai",
         "trans": [
+            "病(やまい)",
             "illness, disease"
-        ],
-        "notation": "病(やまい)"
+        ]
     },
     {
         "name": "momeru",
         "trans": [
+            "揉(も)める",
             "to disagree, to dispute"
-        ],
-        "notation": "揉(も)める"
+        ]
     },
     {
         "name": "nyou",
         "trans": [
+            "尿(にょう)",
             "urine"
-        ],
-        "notation": "尿(にょう)"
+        ]
     },
     {
         "name": "seifuku",
         "trans": [
+            "制服(せいふく)",
             "uniform"
-        ],
-        "notation": "制服(せいふく)"
+        ]
     },
     {
         "name": "teinen",
         "trans": [
+            "定年(ていねん)",
             "retirement age"
-        ],
-        "notation": "定年(ていねん)"
+        ]
     },
     {
         "name": "himei",
         "trans": [
+            "悲鳴(ひめい)",
             "shriek, scream"
-        ],
-        "notation": "悲鳴(ひめい)"
+        ]
     },
     {
         "name": "tensen",
         "trans": [
+            "点線(てんせん)",
             "dotted line, perforated line"
-        ],
-        "notation": "点線(てんせん)"
+        ]
     },
     {
         "name": "sagaru",
         "trans": [
+            "下(さ)がる",
             "to hang down, to abate, to retire, to fall, to step back"
-        ],
-        "notation": "下(さ)がる"
+        ]
     },
     {
         "name": "mashite",
         "trans": [
+            "況(ま)して",
             "still more, still less (with neg. verb), to say nothing of, not to mention"
-        ],
-        "notation": "況(ま)して"
+        ]
     },
     {
         "name": "horobosu",
         "trans": [
+            "滅(ほろ)ぼす",
             "to destroy, to overthrow, to wreck, to ruin"
-        ],
-        "notation": "滅(ほろ)ぼす"
+        ]
     },
     {
         "name": "myaku",
         "trans": [
+            "脈(みゃく)",
             "pulse"
-        ],
-        "notation": "脈(みゃく)"
+        ]
     },
     {
         "name": "kyuuden",
         "trans": [
+            "宮殿(きゅうでん)",
             "palace"
-        ],
-        "notation": "宮殿(きゅうでん)"
+        ]
     },
     {
         "name": "saikuru",
         "trans": [
+            "サイクル",
             "cycle"
-        ],
-        "notation": "サイクル"
+        ]
     },
     {
         "name": "seidaku",
         "trans": [
+            "清濁(せいだく)",
             "good and evil, purity and impurity"
-        ],
-        "notation": "清濁(せいだく)"
+        ]
     },
     {
         "name": "mitomeru",
         "trans": [
+            "認(みと)める",
             "to write up"
-        ],
-        "notation": "認(みと)める"
+        ]
     },
     {
         "name": "fukumen",
         "trans": [
+            "覆面(ふくめん)",
             "mask, veil, disguise"
-        ],
-        "notation": "覆面(ふくめん)"
+        ]
     },
     {
         "name": "muimi",
         "trans": [
+            "無(む)意味(いみ)",
             "nonsense, no meaning"
-        ],
-        "notation": "無(む)意味(いみ)"
+        ]
     },
     {
         "name": "yougo",
         "trans": [
+            "養護(ようご)",
             "protection, nursing, protective care"
-        ],
-        "notation": "養護(ようご)"
+        ]
     },
     {
         "name": "uketsukeru",
         "trans": [
+            "受(う)け付(つ)ける",
             "to be accepted, to receive (an application)"
-        ],
-        "notation": "受(う)け付(つ)ける"
+        ]
     },
     {
         "name": "youhou",
         "trans": [
+            "用法(ようほう)",
             "directions, rules of use"
-        ],
-        "notation": "用法(ようほう)"
+        ]
     },
     {
         "name": "saegiru",
         "trans": [
+            "遮(さえぎ)る",
             "to interrupt, to intercept, to obstruct"
-        ],
-        "notation": "遮(さえぎ)る"
+        ]
     },
     {
         "name": "aikawarazu",
         "trans": [
+            "相変(あいか)わらず",
             "as ever, as usual, the same"
-        ],
-        "notation": "相変(あいか)わらず"
+        ]
     },
     {
         "name": "goei",
         "trans": [
+            "護衛(ごえい)",
             "guard, convoy, escort"
-        ],
-        "notation": "護衛(ごえい)"
+        ]
     },
     {
         "name": "kuchizusamu",
         "trans": [
+            "口(くち)ずさむ",
             "to hum something, to sing to oneself"
-        ],
-        "notation": "口(くち)ずさむ"
+        ]
     },
     {
         "name": "chakuriku",
         "trans": [
+            "着陸(ちゃくりく)",
             "landing, alighting, touch down"
-        ],
-        "notation": "着陸(ちゃくりく)"
+        ]
     },
     {
         "name": "koushou",
         "trans": [
+            "交渉(こうしょう)",
             "negotiations, discussions, connection"
-        ],
-        "notation": "交渉(こうしょう)"
+        ]
     },
     {
         "name": "zou",
         "trans": [
+            "像(ぞう)",
             "statue, image, figure, picture, portrait"
-        ],
-        "notation": "像(ぞう)"
+        ]
     },
     {
         "name": "hinpan",
         "trans": [
+            "頻繁(ひんぱん)",
             "frequency"
-        ],
-        "notation": "頻繁(ひんぱん)"
+        ]
     },
     {
         "name": "kigaru",
         "trans": [
+            "気軽(きがる)",
             "cheerful, buoyant, lighthearted"
-        ],
-        "notation": "気軽(きがる)"
+        ]
     },
     {
         "name": "hajirau",
         "trans": [
+            "恥(は)じらう",
             "to feel shy, to be bashful, to blush"
-        ],
-        "notation": "恥(は)じらう"
+        ]
     },
     {
         "name": "minzoku",
         "trans": [
+            "民族(みんぞく)",
             "people, race, nation, racial customs, folk customs"
-        ],
-        "notation": "民族(みんぞく)"
+        ]
     },
     {
         "name": "utsushi",
         "trans": [
+            "写(うつ)し",
             "copy, duplicate, facsimile, transcript"
-        ],
-        "notation": "写(うつ)し"
+        ]
     },
     {
         "name": "kyuuryou",
         "trans": [
+            "丘陵(きゅうりょう)",
             "hill"
-        ],
-        "notation": "丘陵(きゅうりょう)"
+        ]
     },
     {
         "name": "tanitsu",
         "trans": [
+            "単一(たんいつ)",
             "single, simple, sole, individual, unitory"
-        ],
-        "notation": "単一(たんいつ)"
+        ]
     },
     {
         "name": "kumikomu",
         "trans": [
+            "組(く)み込(こ)む",
             "to insert, to include, to cut in (printing)"
-        ],
-        "notation": "組(く)み込(こ)む"
+        ]
     },
     {
         "name": "tsuranaru",
         "trans": [
+            "連(つら)なる",
             "to extend, to stretch out, to stand in a row"
-        ],
-        "notation": "連(つら)なる"
+        ]
     },
     {
         "name": "kokubou",
         "trans": [
+            "国防(こくぼう)",
             "national defence"
-        ],
-        "notation": "国防(こくぼう)"
+        ]
     },
     {
         "name": "mabushii",
         "trans": [
+            "眩(まぶ)しい",
             "dazzling, radiant"
-        ],
-        "notation": "眩(まぶ)しい"
+        ]
     },
     {
         "name": "atotsugi",
         "trans": [
+            "跡継(あとつ)ぎ",
             "heir, successor"
-        ],
-        "notation": "跡継(あとつ)ぎ"
+        ]
     },
     {
         "name": "sekkusu",
         "trans": [
+            "セックス",
             "sexual intercourse"
-        ],
-        "notation": "セックス"
+        ]
     },
     {
         "name": "arasuji",
         "trans": [
+            "粗筋(あらすじ)",
             "outline, summary"
-        ],
-        "notation": "粗筋(あらすじ)"
+        ]
     },
     {
         "name": "kangen",
         "trans": [
+            "還元(かんげん)",
             "resolution, reduction, return to origins"
-        ],
-        "notation": "還元(かんげん)"
+        ]
     },
     {
         "name": "sayounara",
         "trans": [
+            "左様(さよう)なら",
             "good-bye"
-        ],
-        "notation": "左様(さよう)なら"
+        ]
     },
     {
         "name": "zaigen",
         "trans": [
+            "財源(ざいげん)",
             "source of funds, resources, finances"
-        ],
-        "notation": "財源(ざいげん)"
+        ]
     },
     {
         "name": "seihou",
         "trans": [
+            "製法(せいほう)",
             "manufacturing method, recipe, formula"
-        ],
-        "notation": "製法(せいほう)"
+        ]
     },
     {
         "name": "buttainai",
         "trans": [
+            "物体(ぶったい)ない",
             "too good, more than one deserves, wasteful, sacrilegious, unworthy of"
-        ],
-        "notation": "物体(ぶったい)ない"
+        ]
     },
     {
         "name": "kinzuru",
         "trans": [
+            "禁(きん)ずる",
             "to forbid, to suppress"
-        ],
-        "notation": "禁(きん)ずる"
+        ]
     },
     {
         "name": "sanbutsu",
         "trans": [
+            "産物(さんぶつ)",
             "product, result, fruit"
-        ],
-        "notation": "産物(さんぶつ)"
+        ]
     },
     {
         "name": "ga",
         "trans": [
+            "画(が)",
             "stroke"
-        ],
-        "notation": "画(が)"
+        ]
     },
     {
         "name": "gogen",
         "trans": [
+            "語源(ごげん)",
             "word root, word derivation, etymology"
-        ],
-        "notation": "語源(ごげん)"
+        ]
     },
     {
         "name": "tojimari",
         "trans": [
+            "戸締(とじま)り",
             "closing up, fastening the doors"
-        ],
-        "notation": "戸締(とじま)り"
+        ]
     },
     {
         "name": "nayamashii",
         "trans": [
+            "悩(なや)ましい",
             "seductive, melancholy, languid"
-        ],
-        "notation": "悩(なや)ましい"
+        ]
     },
     {
         "name": "jizai",
         "trans": [
+            "自在(じざい)",
             "freely, at will"
-        ],
-        "notation": "自在(じざい)"
+        ]
     },
     {
         "name": "merodii",
         "trans": [
+            "メロディー",
             "melody"
-        ],
-        "notation": "メロディー"
+        ]
     },
     {
         "name": "kakitori",
         "trans": [
+            "書(か)き取(と)り",
             "dictation"
-        ],
-        "notation": "書(か)き取(と)り"
+        ]
     },
     {
         "name": "saiken",
         "trans": [
+            "再建(さいけん)",
             "rebuilding, reconstruction, rehabilitation"
-        ],
-        "notation": "再建(さいけん)"
+        ]
     },
     {
         "name": "yokan",
         "trans": [
+            "予感(よかん)",
             "presentiment, premonition"
-        ],
-        "notation": "予感(よかん)"
+        ]
     },
     {
         "name": "moriagaru",
         "trans": [
+            "盛(も)り上(あ)がる",
             "to rouse, to swell, to rise"
-        ],
-        "notation": "盛(も)り上(あ)がる"
+        ]
     },
     {
         "name": "funshitsu",
         "trans": [
+            "紛失(ふんしつ)",
             "losing something"
-        ],
-        "notation": "紛失(ふんしつ)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "館(たて)",
             "1. mansion, small castle"
-        ],
-        "notation": "館(たて)"
+        ]
     },
     {
         "name": "yuurei",
         "trans": [
+            "幽霊(ゆうれい)",
             "ghost, specter, apparition, phantom"
-        ],
-        "notation": "幽霊(ゆうれい)"
+        ]
     },
     {
         "name": "shika",
         "trans": [
+            "歯科(しか)",
             "dentistry"
-        ],
-        "notation": "歯科(しか)"
+        ]
     },
     {
         "name": "ikashite",
         "trans": [
+            "如何(いか)して",
             "why?, for what reason, how, in what way, for what purpose, what for"
-        ],
-        "notation": "如何(いか)して"
+        ]
     },
     {
         "name": "yuuutsu",
         "trans": [
+            "憂鬱(ゆううつ)",
             "depression, melancholy, dejection, gloom"
-        ],
-        "notation": "憂鬱(ゆううつ)"
+        ]
     },
     {
         "name": "otsukai",
         "trans": [
+            "お使(つか)い",
             "errand"
-        ],
-        "notation": "お使(つか)い"
+        ]
     },
     {
         "name": "koukyo",
         "trans": [
+            "皇居(こうきょ)",
             "Imperial Palace"
-        ],
-        "notation": "皇居(こうきょ)"
+        ]
     },
     {
         "name": "shutsudou",
         "trans": [
+            "出動(しゅつどう)",
             "sailing, marching, going out"
-        ],
-        "notation": "出動(しゅつどう)"
+        ]
     },
     {
         "name": "kimagure",
         "trans": [
+            "気(き)まぐれ",
             "whim, caprice, whimsy, fickle, moody, uneven temper"
-        ],
-        "notation": "気(き)まぐれ"
+        ]
     },
     {
         "name": "houdou",
         "trans": [
+            "報道(ほうどう)",
             "information, report"
-        ],
-        "notation": "報道(ほうどう)"
+        ]
     },
     {
         "name": "hisashiburi",
         "trans": [
+            "久(ひさ)し振(ぶ)り",
             "after a long time"
-        ],
-        "notation": "久(ひさ)し振(ぶ)り"
+        ]
     },
     {
         "name": "renji",
         "trans": [
+            "レンジ",
             "range, stove"
-        ],
-        "notation": "レンジ"
+        ]
     },
     {
         "name": "mechakucha",
         "trans": [
+            "滅茶苦茶(めちゃくちゃ)",
             "absurd, unreasonable, excessive, messed up, spoiled, wreaked"
-        ],
-        "notation": "滅茶苦茶(めちゃくちゃ)"
+        ]
     },
     {
         "name": "seiten",
         "trans": [
+            "晴天(せいてん)",
             "fine weather"
-        ],
-        "notation": "晴天(せいてん)"
+        ]
     },
     {
         "name": "soukan",
         "trans": [
+            "創刊(そうかん)",
             "launching (e.g. newspaper), first issue"
-        ],
-        "notation": "創刊(そうかん)"
+        ]
     },
     {
         "name": "kyougaku",
         "trans": [
+            "共学(きょうがく)",
             "coeducation"
-        ],
-        "notation": "共学(きょうがく)"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "三(さん)",
             "(num) three"
-        ],
-        "notation": "三(さん)"
+        ]
     },
     {
         "name": "houshanou",
         "trans": [
+            "放射能(ほうしゃのう)",
             "radioactivity"
-        ],
-        "notation": "放射能(ほうしゃのう)"
+        ]
     },
     {
         "name": "yousei",
         "trans": [
+            "養成(ようせい)",
             "training, development"
-        ],
-        "notation": "養成(ようせい)"
+        ]
     },
     {
         "name": "kengen",
         "trans": [
+            "権限(けんげん)",
             "power, authority, jurisdiction"
-        ],
-        "notation": "権限(けんげん)"
+        ]
     },
     {
         "name": "bunbo",
         "trans": [
+            "分母(ぶんぼ)",
             "denominator"
-        ],
-        "notation": "分母(ぶんぼ)"
+        ]
     },
     {
         "name": "shitashirabe",
         "trans": [
+            "下調(したしら)べ",
             "preliminary investigation, preparation"
-        ],
-        "notation": "下調(したしら)べ"
+        ]
     },
     {
         "name": "sukoyaka",
         "trans": [
+            "健(すこ)やか",
             "vigorous, healthy, sound"
-        ],
-        "notation": "健(すこ)やか"
+        ]
     },
     {
         "name": "nozomashii",
         "trans": [
+            "望(のぞ)ましい",
             "desirable, hoped for"
-        ],
-        "notation": "望(のぞ)ましい"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "弾(ひ)く",
             "to flip, to snap"
-        ],
-        "notation": "弾(ひ)く"
+        ]
     },
     {
         "name": "mouten",
         "trans": [
+            "盲点(もうてん)",
             "blind spot"
-        ],
-        "notation": "盲点(もうてん)"
+        ]
     },
     {
         "name": "sochi",
         "trans": [
+            "措置(そち)",
             "measure, step"
-        ],
-        "notation": "措置(そち)"
+        ]
     },
     {
         "name": "ichibubun",
         "trans": [
+            "一部分(いちぶぶん)",
             "a part"
-        ],
-        "notation": "一部分(いちぶぶん)"
+        ]
     },
     {
         "name": "jinsoku",
         "trans": [
+            "迅速(じんそく)",
             "quick, fast, rapid, swift, prompt"
-        ],
-        "notation": "迅速(じんそく)"
+        ]
     },
     {
         "name": "iken",
         "trans": [
+            "異見(いけん)",
             "different opinion, objection"
-        ],
-        "notation": "異見(いけん)"
+        ]
     },
     {
         "name": "hankyou",
         "trans": [
+            "反響(はんきょう)",
             "echo, reverberation, repercussion, reaction, influence"
-        ],
-        "notation": "反響(はんきょう)"
+        ]
     },
     {
         "name": "shuju",
         "trans": [
+            "種々(しゅじゅ)",
             "variety"
-        ],
-        "notation": "種々(しゅじゅ)"
+        ]
     },
     {
         "name": "nokinami",
         "trans": [
+            "軒並(のきな)み",
             "row of houses"
-        ],
-        "notation": "軒並(のきな)み"
+        ]
     },
     {
         "name": "nisemono",
         "trans": [
+            "贋物(にせもの)",
             "imitation, counterfeit, forgery, sham"
-        ],
-        "notation": "贋物(にせもの)"
+        ]
     },
     {
         "name": "houru",
         "trans": [
+            "ホール",
             "hall, hole"
-        ],
-        "notation": "ホール"
+        ]
     },
     {
         "name": "nao",
         "trans": [
+            "尚(なお)",
             "furthermore, still, yet, more, still more, greater, further, less"
-        ],
-        "notation": "尚(なお)"
+        ]
     },
     {
         "name": "hitome",
         "trans": [
+            "人目(ひとめ)",
             "glimpse, public gaze"
-        ],
-        "notation": "人目(ひとめ)"
+        ]
     },
     {
         "name": "ninshin",
         "trans": [
+            "妊娠(にんしん)",
             "conception, pregnancy"
-        ],
-        "notation": "妊娠(にんしん)"
+        ]
     },
     {
         "name": "toho",
         "trans": [
+            "徒歩(とほ)",
             "walking, going on foot"
-        ],
-        "notation": "徒歩(とほ)"
+        ]
     },
     {
         "name": "kanshi",
         "trans": [
+            "監視(かんし)",
             "observation, guarding, inspection, surveillance"
-        ],
-        "notation": "監視(かんし)"
+        ]
     },
     {
         "name": "ikigomu",
         "trans": [
+            "意気込(いきご)む",
             "to be enthusiastic about"
-        ],
-        "notation": "意気込(いきご)む"
+        ]
     },
     {
         "name": "koui",
         "trans": [
+            "好意(こうい)",
             "good will, favor, courtesy"
-        ],
-        "notation": "好意(こうい)"
+        ]
     },
     {
         "name": "tansu",
         "trans": [
+            "箪笥(たんす)",
             "chest of drawers"
-        ],
-        "notation": "箪笥(たんす)"
+        ]
     },
     {
         "name": "yatsu",
         "trans": [
+            "奴(やつ)",
             "servant, fellow"
-        ],
-        "notation": "奴(やつ)"
+        ]
     },
     {
         "name": "kotei",
         "trans": [
+            "固定(こてい)",
             "fixation"
-        ],
-        "notation": "固定(こてい)"
+        ]
     },
     {
         "name": "nou",
         "trans": [
+            "脳(のう)",
             "brain, memory"
-        ],
-        "notation": "脳(のう)"
+        ]
     },
     {
         "name": "demonsutoreeshon",
         "trans": [
+            "デモンストレーション",
             "demonstration"
-        ],
-        "notation": "デモンストレーション"
+        ]
     },
     {
         "name": "senchaku",
         "trans": [
+            "先着(せんちゃく)",
             "first arrival"
-        ],
-        "notation": "先着(せんちゃく)"
+        ]
     },
     {
         "name": "itsu",
         "trans": [
+            "何時(いつ)",
             "when, how soon"
-        ],
-        "notation": "何時(いつ)"
+        ]
     },
     {
         "name": "kaso",
         "trans": [
+            "過疎(かそ)",
             "depopulation"
-        ],
-        "notation": "過疎(かそ)"
+        ]
     },
     {
         "name": "tejun",
         "trans": [
+            "手順(てじゅん)",
             "process, procedure, protocol"
-        ],
-        "notation": "手順(てじゅん)"
+        ]
     },
     {
         "name": "nigedasu",
         "trans": [
+            "逃(に)げ出(だ)す",
             "to run away, to escape from"
-        ],
-        "notation": "逃(に)げ出(だ)す"
+        ]
     },
     {
         "name": "iriguchi",
         "trans": [
+            "入口(いりぐち)",
             "entrance, gate, approach, mouth"
-        ],
-        "notation": "入口(いりぐち)"
+        ]
     },
     {
         "name": "shibaraku",
         "trans": [
+            "暫(しばら)く",
             "little while"
-        ],
-        "notation": "暫(しばら)く"
+        ]
     },
     {
         "name": "koujo",
         "trans": [
+            "控除(こうじょ)",
             "subsidy, deduction"
-        ],
-        "notation": "控除(こうじょ)"
+        ]
     },
     {
         "name": "kaban",
         "trans": [
+            "下番(かばん)",
             "going off duty"
-        ],
-        "notation": "下番(かばん)"
+        ]
     },
     {
         "name": "hagu",
         "trans": [
+            "剥(は)ぐ",
             "to tear off, to peel off, to rip off, to strip off, to skin, to flay, to disrobe, to deprive of"
-        ],
-        "notation": "剥(は)ぐ"
+        ]
     },
     {
         "name": "yuuyake",
         "trans": [
+            "夕焼(ゆうや)け",
             "sunset"
-        ],
-        "notation": "夕焼(ゆうや)け"
+        ]
     },
     {
         "name": "ne",
         "trans": [
+            "値(ね)",
             "value, price, cost, worth, merit"
-        ],
-        "notation": "値(ね)"
+        ]
     },
     {
         "name": "shudai",
         "trans": [
+            "主題(しゅだい)",
             "subject, theme, motif"
-        ],
-        "notation": "主題(しゅだい)"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "と",
             "1. if (conjunction), 2. promoted pawn (shogi) (abbr)"
-        ],
-        "notation": "と"
+        ]
     },
     {
         "name": "gosa",
         "trans": [
+            "誤差(ごさ)",
             "error"
-        ],
-        "notation": "誤差(ごさ)"
+        ]
     },
     {
         "name": "setsuzokushi",
         "trans": [
+            "接続詞(せつぞくし)",
             "conjunction"
-        ],
-        "notation": "接続詞(せつぞくし)"
+        ]
     },
     {
         "name": "shiyou",
         "trans": [
+            "仕様(しよう)",
             "way, method, resource, remedy, (technical) specification"
-        ],
-        "notation": "仕様(しよう)"
+        ]
     },
     {
         "name": "kutabireru",
         "trans": [
+            "草臥(くたび)れる",
             "to get tired, to wear out"
-        ],
-        "notation": "草臥(くたび)れる"
+        ]
     },
     {
         "name": "rippou",
         "trans": [
+            "立方(りっぽう)",
             "dancing (geisha)"
-        ],
-        "notation": "立方(りっぽう)"
+        ]
     },
     {
         "name": "omoitsuki",
         "trans": [
+            "思(おも)い付(つ)き",
             "plan, idea, suggestion"
-        ],
-        "notation": "思(おも)い付(つ)き"
+        ]
     },
     {
         "name": "saisan",
         "trans": [
+            "採算(さいさん)",
             "profit"
-        ],
-        "notation": "採算(さいさん)"
+        ]
     },
     {
         "name": "chitsujo",
         "trans": [
+            "秩序(ちつじょ)",
             "order, regularity, system, method"
-        ],
-        "notation": "秩序(ちつじょ)"
+        ]
     },
     {
         "name": "kogu",
         "trans": [
+            "漕(こ)ぐ",
             "to row, to scull, to pedal"
-        ],
-        "notation": "漕(こ)ぐ"
+        ]
     },
     {
         "name": "buryoku",
         "trans": [
+            "武力(ぶりょく)",
             "armed might, military power, the sword, force"
-        ],
-        "notation": "武力(ぶりょく)"
+        ]
     },
     {
         "name": "yashinau",
         "trans": [
+            "養(やしな)う",
             "to rear, to maintain, to cultivate"
-        ],
-        "notation": "養(やしな)う"
+        ]
     },
     {
         "name": "fusawashii",
         "trans": [
+            "相応(ふさわ)しい",
             "appropriate"
-        ],
-        "notation": "相応(ふさわ)しい"
+        ]
     },
     {
         "name": "taimen",
         "trans": [
+            "対面(たいめん)",
             "interview, meeting"
-        ],
-        "notation": "対面(たいめん)"
+        ]
     },
     {
         "name": "hikizuru",
         "trans": [
+            "引(ひ)きずる",
             "to seduce, to drag along, to pull, to prolong, to support"
-        ],
-        "notation": "引(ひ)きずる"
+        ]
     },
     {
         "name": "omocha",
         "trans": [
+            "玩具(おもちゃ)",
             "toy"
-        ],
-        "notation": "玩具(おもちゃ)"
+        ]
     },
     {
         "name": "torishimaru",
         "trans": [
+            "取(と)り締(し)まる",
             "to manage, to control, to supervise"
-        ],
-        "notation": "取(と)り締(し)まる"
+        ]
     },
     {
         "name": "meishou",
         "trans": [
+            "名称(めいしょう)",
             "name"
-        ],
-        "notation": "名称(めいしょう)"
+        ]
     },
     {
         "name": "mizuke",
         "trans": [
+            "水気(みずけ)",
             "1. moisture, dampness, vapor, 2. dropsy, edema"
-        ],
-        "notation": "水気(みずけ)"
+        ]
     },
     {
         "name": "isei",
         "trans": [
+            "異性(いせい)",
             "the opposite sex"
-        ],
-        "notation": "異性(いせい)"
+        ]
     },
     {
         "name": "ro",
         "trans": [
+            "露(ろ)",
             "dew"
-        ],
-        "notation": "露(ろ)"
+        ]
     },
     {
         "name": "shitaji",
         "trans": [
+            "下地(したじ)",
             "groundwork, foundation, inclination, aptitude, elementary knowledge of, grounding in, prearrangement, spade"
-        ],
-        "notation": "下地(したじ)"
+        ]
     },
     {
         "name": "sutorou",
         "trans": [
+            "ストロー",
             "straw"
-        ],
-        "notation": "ストロー"
+        ]
     },
     {
         "name": "chuugaeri",
         "trans": [
+            "宙返(ちゅうがえ)り",
             "somersault, looping-the-loop"
-        ],
-        "notation": "宙返(ちゅうがえ)り"
+        ]
     },
     {
         "name": "hikkakeru",
         "trans": [
+            "引(ひ)っ掛(か)ける",
             "1. to hang (something) on (something), to throw on (clothes), 2. to hook, to catch, to trap, to ensnar"
-        ],
-        "notation": "引(ひ)っ掛(か)ける"
+        ]
     },
     {
         "name": "hito",
         "trans": [
+            "人(ひと)",
             "man, person, people"
-        ],
-        "notation": "人(ひと)"
+        ]
     },
     {
         "name": "shousuru",
         "trans": [
+            "称(しょう)する",
             "to pretend, to take the name of, to feign, to purport"
-        ],
-        "notation": "称(しょう)する"
+        ]
     },
     {
         "name": "kouen",
         "trans": [
+            "公演(こうえん)",
             "public performance"
-        ],
-        "notation": "公演(こうえん)"
+        ]
     },
     {
         "name": "kanpeki",
         "trans": [
+            "完璧(かんぺき)",
             "perfection, completeness, flawless"
-        ],
-        "notation": "完璧(かんぺき)"
+        ]
     },
     {
         "name": "sadameru",
         "trans": [
+            "定(さだ)める",
             "to decide, to establish, to determine"
-        ],
-        "notation": "定(さだ)める"
+        ]
     },
     {
         "name": "shinabiru",
         "trans": [
+            "萎(しな)びる",
             "to wilt, to fade"
-        ],
-        "notation": "萎(しな)びる"
+        ]
     },
     {
         "name": "shohan",
         "trans": [
+            "初版(しょはん)",
             "first edition"
-        ],
-        "notation": "初版(しょはん)"
+        ]
     },
     {
         "name": "kifuku",
         "trans": [
+            "起伏(きふく)",
             "undulation"
-        ],
-        "notation": "起伏(きふく)"
+        ]
     },
     {
         "name": "yubisasu",
         "trans": [
+            "指(ゆび)差(さ)す",
             "to point at"
-        ],
-        "notation": "指(ゆび)差(さ)す"
+        ]
     },
     {
         "name": "juufuku",
         "trans": [
+            "重複(じゅうふく)",
             "duplication, repetition, overlapping, redundancy, restoration"
-        ],
-        "notation": "重複(じゅうふく)"
+        ]
     },
     {
         "name": "awase",
         "trans": [
+            "合(あ)わせ",
             "joint together, opposite, facing"
-        ],
-        "notation": "合(あ)わせ"
+        ]
     },
     {
         "name": "tane",
         "trans": [
+            "種(たね)",
             "kind, variety, species"
-        ],
-        "notation": "種(たね)"
+        ]
     },
     {
         "name": "taeru",
         "trans": [
+            "絶(た)える",
             "to die out, to peter out, to become extinct"
-        ],
-        "notation": "絶(た)える"
+        ]
     },
     {
         "name": "shikamo",
         "trans": [
+            "而(しか)も",
             "moreover, furthermore, nevertheless, and yet"
-        ],
-        "notation": "而(しか)も"
+        ]
     },
     {
         "name": "chinbotsu",
         "trans": [
+            "沈没(ちんぼつ)",
             "sinking, foundering"
-        ],
-        "notation": "沈没(ちんぼつ)"
+        ]
     },
     {
         "name": "machi",
         "trans": [
+            "街(まち)",
             "~street, ~quarters"
-        ],
-        "notation": "街(まち)"
+        ]
     },
     {
         "name": "idomu",
         "trans": [
+            "挑(いど)む",
             "to challenge, to contend for, to make love to"
-        ],
-        "notation": "挑(いど)む"
+        ]
     },
     {
         "name": "shinjin",
         "trans": [
+            "新人(しんじん)",
             "new face, newcomer"
-        ],
-        "notation": "新人(しんじん)"
+        ]
     },
     {
         "name": "gochisou",
         "trans": [
+            "ご馳走(ちそう)",
             "feast, treating (someone)"
-        ],
-        "notation": "ご馳走(ちそう)"
+        ]
     },
     {
         "name": "totemo",
         "trans": [
+            "迚(とて)も",
             "very, awfully, exceedingly"
-        ],
-        "notation": "迚(とて)も"
+        ]
     },
     {
         "name": "kokorozuyoi",
         "trans": [
+            "心強(こころづよ)い",
             "heartening, reassuring"
-        ],
-        "notation": "心強(こころづよ)い"
+        ]
     },
     {
         "name": "seeru",
         "trans": [
+            "セール",
             "sale"
-        ],
-        "notation": "セール"
+        ]
     },
     {
         "name": "kiraku",
         "trans": [
+            "気楽(きらく)",
             "at ease, comfortable"
-        ],
-        "notation": "気楽(きらく)"
+        ]
     },
     {
         "name": "hensai",
         "trans": [
+            "返済(へんさい)",
             "repayment"
-        ],
-        "notation": "返済(へんさい)"
+        ]
     },
     {
         "name": "seitei",
         "trans": [
+            "制定(せいてい)",
             "enactment, establishment, creation"
-        ],
-        "notation": "制定(せいてい)"
+        ]
     },
     {
         "name": "shohyou",
         "trans": [
+            "書評(しょひょう)",
             "book review"
-        ],
-        "notation": "書評(しょひょう)"
+        ]
     },
     {
         "name": "atokireru",
         "trans": [
+            "跡(あと)切(き)れる",
             "to pause, to be interrupted"
-        ],
-        "notation": "跡(あと)切(き)れる"
+        ]
     },
     {
         "name": "iraira",
         "trans": [
+            "苛々(イライラ)",
             "getting nervous, irritation"
-        ],
-        "notation": "苛々(イライラ)"
+        ]
     },
     {
         "name": "sukunakutomo",
         "trans": [
+            "少(すく)なくとも",
             "at least"
-        ],
-        "notation": "少(すく)なくとも"
+        ]
     },
     {
         "name": "yumi",
         "trans": [
+            "弓(ゆみ)",
             "bow (and arrow)"
-        ],
-        "notation": "弓(ゆみ)"
+        ]
     },
     {
         "name": "moshikashite",
         "trans": [
+            "若(も)しかして",
             "perhaps, possibly"
-        ],
-        "notation": "若(も)しかして"
+        ]
     },
     {
         "name": "hanahada",
         "trans": [
+            "甚(はなは)だ",
             "very, greatly, exceedingly"
-        ],
-        "notation": "甚(はなは)だ"
+        ]
     },
     {
         "name": "haeru",
         "trans": [
+            "映(は)える",
             "to shine, to look attractive, to look pretty"
-        ],
-        "notation": "映(は)える"
+        ]
     },
     {
         "name": "nichiya",
         "trans": [
+            "日夜(にちや)",
             "day and night, always"
-        ],
-        "notation": "日夜(にちや)"
+        ]
     },
     {
         "name": "kouzen",
         "trans": [
+            "公然(こうぜん)",
             "open (e.g. secret), public, official"
-        ],
-        "notation": "公然(こうぜん)"
+        ]
     },
     {
         "name": "yatou",
         "trans": [
+            "野党(やとう)",
             "opposition party"
-        ],
-        "notation": "野党(やとう)"
+        ]
     },
     {
         "name": "ayabumu",
         "trans": [
+            "危(あや)ぶむ",
             "to fear, to have misgivings, to be doubtful, to mistrust"
-        ],
-        "notation": "危(あや)ぶむ"
+        ]
     },
     {
         "name": "kinkyuu",
         "trans": [
+            "緊急(きんきゅう)",
             "urgent, pressing, emergency"
-        ],
-        "notation": "緊急(きんきゅう)"
+        ]
     },
     {
         "name": "ugoki",
         "trans": [
+            "動(うご)き",
             "movement, activity, trend, development, change"
-        ],
-        "notation": "動(うご)き"
+        ]
     },
     {
         "name": "hitasu",
         "trans": [
+            "浸(ひた)す",
             "to soak, to dip, to drench"
-        ],
-        "notation": "浸(ひた)す"
+        ]
     },
     {
         "name": "musen",
         "trans": [
+            "無線(むせん)",
             "wireless, radio"
-        ],
-        "notation": "無線(むせん)"
+        ]
     },
     {
         "name": "engawa",
         "trans": [
+            "縁側(えんがわ)",
             "veranda, porch, balcony, open corridor"
-        ],
-        "notation": "縁側(えんがわ)"
+        ]
     },
     {
         "name": "moroni",
         "trans": [
+            "もろに",
             "completely, all the way"
-        ],
-        "notation": "もろに"
+        ]
     },
     {
         "name": "shibui",
         "trans": [
+            "渋(しぶ)い",
             "1. tasteful (clothing), cool, an aura of refined masculinity, 2. astringent, sullen, bitter (taste), 3"
-        ],
-        "notation": "渋(しぶ)い"
+        ]
     },
     {
         "name": "hisshuu",
         "trans": [
+            "必修(ひっしゅう)",
             "required (subject)"
-        ],
-        "notation": "必修(ひっしゅう)"
+        ]
     },
     {
         "name": "ichidou",
         "trans": [
+            "一同(いちどう)",
             "all present, all concerned, all of us"
-        ],
-        "notation": "一同(いちどう)"
+        ]
     },
     {
         "name": "doko",
         "trans": [
+            "何処(どこ)",
             "where, what place"
-        ],
-        "notation": "何処(どこ)"
+        ]
     },
     {
         "name": "hashira",
         "trans": [
+            "柱(はしら)",
             "pillar, post"
-        ],
-        "notation": "柱(はしら)"
+        ]
     },
     {
         "name": "shin",
         "trans": [
+            "新(しん)",
             "new"
-        ],
-        "notation": "新(しん)"
+        ]
     },
     {
         "name": "toozakaru",
         "trans": [
+            "遠(とお)ざかる",
             "to go far off"
-        ],
-        "notation": "遠(とお)ざかる"
+        ]
     },
     {
         "name": "tanka",
         "trans": [
+            "担架(たんか)",
             "stretcher, litter"
-        ],
-        "notation": "担架(たんか)"
+        ]
     },
     {
         "name": "kanmuri",
         "trans": [
+            "冠(かんむり)",
             "crown, diadem, first, best, peerless, cap, naming, designating, initiating on coming of age, top character ra"
-        ],
-        "notation": "冠(かんむり)"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "図(はか)る",
             "to plot, to attempt, to plan, to take in, to deceive, to devise, to design, to refer A to B"
-        ],
-        "notation": "図(はか)る"
+        ]
     },
     {
         "name": "infure",
         "trans": [
+            "インフレ",
             "inflation"
-        ],
-        "notation": "インフレ"
+        ]
     },
     {
         "name": "fukaketsu",
         "trans": [
+            "不可欠(ふかけつ)",
             "indispensable, essential"
-        ],
-        "notation": "不可欠(ふかけつ)"
+        ]
     },
     {
         "name": "doukyo",
         "trans": [
+            "同居(どうきょ)",
             "living together"
-        ],
-        "notation": "同居(どうきょ)"
+        ]
     },
     {
         "name": "kotoniyoruto",
         "trans": [
+            "事(こと)によると",
             "depending on the circumstances"
-        ],
-        "notation": "事(こと)によると"
+        ]
     },
     {
         "name": "chenji",
         "trans": [
+            "チェンジ",
             "change"
-        ],
-        "notation": "チェンジ"
+        ]
     },
     {
         "name": "ohayou",
         "trans": [
+            "お早(はよ)う",
             "Good morning"
-        ],
-        "notation": "お早(はよ)う"
+        ]
     },
     {
         "name": "sotokata",
         "trans": [
+            "外(そと)方(かた)",
             "look (or turn) the other way"
-        ],
-        "notation": "外(そと)方(かた)"
+        ]
     },
     {
         "name": "jumoku",
         "trans": [
+            "樹木(じゅもく)",
             "trees and shrubs, arbour"
-        ],
-        "notation": "樹木(じゅもく)"
+        ]
     },
     {
         "name": "shounika",
         "trans": [
+            "小児科(しょうにか)",
             "pediatrics"
-        ],
-        "notation": "小児科(しょうにか)"
+        ]
     },
     {
         "name": "kouhai",
         "trans": [
+            "荒廃(こうはい)",
             "ruin"
-        ],
-        "notation": "荒廃(こうはい)"
+        ]
     },
     {
         "name": "zaiku",
         "trans": [
+            "細工(ざいく)",
             "work, craftsmanship, tactics, trick"
-        ],
-        "notation": "細工(ざいく)"
+        ]
     },
     {
         "name": "media",
         "trans": [
+            "メディア",
             "media"
-        ],
-        "notation": "メディア"
+        ]
     },
     {
         "name": "sakkaku",
         "trans": [
+            "錯覚(さっかく)",
             "optical illusion, hallucination"
-        ],
-        "notation": "錯覚(さっかく)"
+        ]
     },
     {
         "name": "ishou",
         "trans": [
+            "衣装(いしょう)",
             "clothing, costume, outfit, garment, dress"
-        ],
-        "notation": "衣装(いしょう)"
+        ]
     },
     {
         "name": "kyuuchi",
         "trans": [
+            "旧知(きゅうち)",
             "old friend, old friendship"
-        ],
-        "notation": "旧知(きゅうち)"
+        ]
     },
     {
         "name": "gasshou",
         "trans": [
+            "合唱(がっしょう)",
             "chorus, singing in a chorus"
-        ],
-        "notation": "合唱(がっしょう)"
+        ]
     },
     {
         "name": "nare",
         "trans": [
+            "慣(な)れ",
             "practice, experience"
-        ],
-        "notation": "慣(な)れ"
+        ]
     },
     {
         "name": "tonaeru",
         "trans": [
+            "唱(とな)える",
             "to recite, to chant, to call upon"
-        ],
-        "notation": "唱(とな)える"
+        ]
     },
     {
         "name": "gyoson",
         "trans": [
+            "漁村(ぎょそん)",
             "fishing village"
-        ],
-        "notation": "漁村(ぎょそん)"
+        ]
     },
     {
         "name": "ganka",
         "trans": [
+            "眼科(がんか)",
             "ophthalmology"
-        ],
-        "notation": "眼科(がんか)"
+        ]
     },
     {
         "name": "okosu",
         "trans": [
+            "起(お)こす",
             "to raise, to cause, to wake someone"
-        ],
-        "notation": "起(お)こす"
+        ]
     },
     {
         "name": "taiji",
         "trans": [
+            "退治(たいじ)",
             "extermination"
-        ],
-        "notation": "退治(たいじ)"
+        ]
     },
     {
         "name": "nyuu",
         "trans": [
+            "ニュー",
             "new"
-        ],
-        "notation": "ニュー"
+        ]
     },
     {
         "name": "pojishon",
         "trans": [
+            "ポジション",
             "position"
-        ],
-        "notation": "ポジション"
+        ]
     },
     {
         "name": "shibutsu",
         "trans": [
+            "私物(しぶつ)",
             "private property, personal effects"
-        ],
-        "notation": "私物(しぶつ)"
+        ]
     },
     {
         "name": "sei",
         "trans": [
+            "制(せい)",
             "system, organization, imperial command, laws, regulation, control, government, suppression, restraint, holdin"
-        ],
-        "notation": "制(せい)"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "思考(しこう)",
             "thought"
-        ],
-        "notation": "思考(しこう)"
+        ]
     },
     {
         "name": "engan",
         "trans": [
+            "沿岸(えんがん)",
             "coast, shore"
-        ],
-        "notation": "沿岸(えんがん)"
+        ]
     },
     {
         "name": "zenkai",
         "trans": [
+            "全快(ぜんかい)",
             "complete recovery of health"
-        ],
-        "notation": "全快(ぜんかい)"
+        ]
     },
     {
         "name": "nebari",
         "trans": [
+            "粘(ねば)り",
             "stickyness, viscosity"
-        ],
-        "notation": "粘(ねば)り"
+        ]
     },
     {
         "name": "koutou",
         "trans": [
+            "口頭(こうとう)",
             "oral"
-        ],
-        "notation": "口頭(こうとう)"
+        ]
     },
     {
         "name": "genchi",
         "trans": [
+            "現地(げんち)",
             "actual place, local"
-        ],
-        "notation": "現地(げんち)"
+        ]
     },
     {
         "name": "nasake",
         "trans": [
+            "情(なさ)け",
             "sympathy, compassion"
-        ],
-        "notation": "情(なさ)け"
+        ]
     },
     {
         "name": "nanino",
         "trans": [
+            "何(なに)の",
             "which, what"
-        ],
-        "notation": "何(なに)の"
+        ]
     },
     {
         "name": "michibiku",
         "trans": [
+            "導(みちび)く",
             "to be guided, to be shown"
-        ],
-        "notation": "導(みちび)く"
+        ]
     },
     {
         "name": "toshiyori",
         "trans": [
+            "年寄(としよ)り",
             "old people, the aged"
-        ],
-        "notation": "年寄(としよ)り"
+        ]
     },
     {
         "name": "kudari",
         "trans": [
+            "行(くだり)",
             "line, row, verse"
-        ],
-        "notation": "行(くだり)"
+        ]
     },
     {
         "name": "souzou",
         "trans": [
+            "創造(そうぞう)",
             "creation"
-        ],
-        "notation": "創造(そうぞう)"
+        ]
     },
     {
         "name": "joubu",
         "trans": [
+            "丈夫(じょうぶ)",
             "1. hero, gentleman, warrior, manly person, 2. good health, robustness, strong, solid, durable"
-        ],
-        "notation": "丈夫(じょうぶ)"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "症(しょう)",
             "illness"
-        ],
-        "notation": "症(しょう)"
+        ]
     },
     {
         "name": "inabikari",
         "trans": [
+            "稲光(いなびかり)",
             "(flash of) lightning"
-        ],
-        "notation": "稲光(いなびかり)"
+        ]
     },
     {
         "name": "ferii",
         "trans": [
+            "フェリー",
             "ferry"
-        ],
-        "notation": "フェリー"
+        ]
     },
     {
         "name": "hatasu",
         "trans": [
+            "果(は)たす",
             "to accomplish, to fulfill, to carry out, to achieve"
-        ],
-        "notation": "果(は)たす"
+        ]
     },
     {
         "name": "fumaeru",
         "trans": [
+            "踏(ふ)まえる",
             "to be based on, to have origin in"
-        ],
-        "notation": "踏(ふ)まえる"
+        ]
     },
     {
         "name": "kenji",
         "trans": [
+            "検事(けんじ)",
             "public prosecutor"
-        ],
-        "notation": "検事(けんじ)"
+        ]
     },
     {
         "name": "amachua",
         "trans": [
+            "アマチュア",
             "amateur"
-        ],
-        "notation": "アマチュア"
+        ]
     },
     {
         "name": "tsumuru",
         "trans": [
+            "瞑(つむ)る",
             "to close the eyes"
-        ],
-        "notation": "瞑(つむ)る"
+        ]
     },
     {
         "name": "kiryuu",
         "trans": [
+            "気流(きりゅう)",
             "atmospheric current"
-        ],
-        "notation": "気流(きりゅう)"
+        ]
     },
     {
         "name": "nemawashi",
         "trans": [
+            "根回(ねまわ)し",
             "making necessary arrangements"
-        ],
-        "notation": "根回(ねまわ)し"
+        ]
     },
     {
         "name": "kotae",
         "trans": [
+            "答(こた)え",
             "answer, response"
-        ],
-        "notation": "答(こた)え"
+        ]
     },
     {
         "name": "uwaru",
         "trans": [
+            "植(う)わる",
             "to be planted"
-        ],
-        "notation": "植(う)わる"
+        ]
     },
     {
         "name": "amaeru",
         "trans": [
+            "甘(あま)える",
             "to behave like a spoiled child, to fawn on"
-        ],
-        "notation": "甘(あま)える"
+        ]
     },
     {
         "name": "densen",
         "trans": [
+            "電線(でんせん)",
             "electric line"
-        ],
-        "notation": "電線(でんせん)"
+        ]
     },
     {
         "name": "houan",
         "trans": [
+            "法案(ほうあん)",
             "bill (law)"
-        ],
-        "notation": "法案(ほうあん)"
+        ]
     },
     {
         "name": "shio",
         "trans": [
+            "塩(しお)",
             "salt"
-        ],
-        "notation": "塩(しお)"
+        ]
     },
     {
         "name": "nanitozo",
         "trans": [
+            "何卒(なにとぞ)",
             "please"
-        ],
-        "notation": "何卒(なにとぞ)"
+        ]
     },
     {
         "name": "ogosoka",
         "trans": [
+            "厳(おごそ)か",
             "austere, majestic, dignified, stately, awful, impressive"
-        ],
-        "notation": "厳(おごそ)か"
+        ]
     },
     {
         "name": "kakushu",
         "trans": [
+            "各種(かくしゅ)",
             "every kind, all sorts"
-        ],
-        "notation": "各種(かくしゅ)"
+        ]
     },
     {
         "name": "tsukinami",
         "trans": [
+            "月並(つきな)み",
             "every month, common"
-        ],
-        "notation": "月並(つきな)み"
+        ]
     },
     {
         "name": "fukugou",
         "trans": [
+            "複合(ふくごう)",
             "composite, complex"
-        ],
-        "notation": "複合(ふくごう)"
+        ]
     },
     {
         "name": "kanyo",
         "trans": [
+            "関与(かんよ)",
             "participation, taking part in, participating in, being concerned in"
-        ],
-        "notation": "関与(かんよ)"
+        ]
     },
     {
         "name": "gachi",
         "trans": [
+            "雅致(がち)",
             "artistry, good taste, elegance, grace"
-        ],
-        "notation": "雅致(がち)"
+        ]
     },
     {
         "name": "tsutsu",
         "trans": [
+            "筒(つつ)",
             "pipe, tube"
-        ],
-        "notation": "筒(つつ)"
+        ]
     },
     {
         "name": "fuhyou",
         "trans": [
+            "不評(ふひょう)",
             "bad reputation, disgrace, unpopularity"
-        ],
-        "notation": "不評(ふひょう)"
+        ]
     },
     {
         "name": "sanpuku",
         "trans": [
+            "山腹(さんぷく)",
             "hillside, mountainside"
-        ],
-        "notation": "山腹(さんぷく)"
+        ]
     },
     {
         "name": "kasuru",
         "trans": [
+            "化(か)する",
             "to change into, to convert into, to transform, to be reduced, to influence, to improve (someone)"
-        ],
-        "notation": "化(か)する"
+        ]
     },
     {
         "name": "hikkaku",
         "trans": [
+            "引(ひ)っ掻(か)く",
             "to scratch"
-        ],
-        "notation": "引(ひ)っ掻(か)く"
+        ]
     },
     {
         "name": "shiiru",
         "trans": [
+            "強(し)いる",
             "to force, to compel, to coerce"
-        ],
-        "notation": "強(し)いる"
+        ]
     },
     {
         "name": "saisei",
         "trans": [
+            "再生(さいせい)",
             "playback, regeneration, resuscitation, return to life, rebirth, reincarnation, narrow escape, reclamation, r"
-        ],
-        "notation": "再生(さいせい)"
+        ]
     },
     {
         "name": "zen",
         "trans": [
+            "膳(ぜん)",
             "(small) table, tray, meal"
-        ],
-        "notation": "膳(ぜん)"
+        ]
     },
     {
         "name": "gyouseki",
         "trans": [
+            "業績(ぎょうせき)",
             "achievement, performance, results, work, contribution"
-        ],
-        "notation": "業績(ぎょうせき)"
+        ]
     },
     {
         "name": "jimoto",
         "trans": [
+            "地元(じもと)",
             "local"
-        ],
-        "notation": "地元(じもと)"
+        ]
     },
     {
         "name": "ijimeru",
         "trans": [
+            "苛(いじ)める",
             "to tease, to torment, to persecute, to chastise"
-        ],
-        "notation": "苛(いじ)める"
+        ]
     },
     {
         "name": "yogoreru",
         "trans": [
+            "汚(よご)れる",
             "to get dirty, to become dirty"
-        ],
-        "notation": "汚(よご)れる"
+        ]
     },
     {
         "name": "seiiku",
         "trans": [
+            "生育(せいいく)",
             "growth, development, breeding"
-        ],
-        "notation": "生育(せいいく)"
+        ]
     },
     {
         "name": "tokoroii",
         "trans": [
+            "所(ところ)謂(いい)",
             "the so-called, so to speak"
-        ],
-        "notation": "所(ところ)謂(いい)"
+        ]
     },
     {
         "name": "motareru",
         "trans": [
+            "凭(もた)れる",
             "to lean against, to lean on, to recline on, to lie heavy (on the stomach)"
-        ],
-        "notation": "凭(もた)れる"
+        ]
     },
     {
         "name": "meekaa",
         "trans": [
+            "メーカー",
             "maker"
-        ],
-        "notation": "メーカー"
+        ]
     },
     {
         "name": "seimitsu",
         "trans": [
+            "精密(せいみつ)",
             "precise, exact, detailed, minute, close"
-        ],
-        "notation": "精密(せいみつ)"
+        ]
     },
     {
         "name": "souou",
         "trans": [
+            "相応(そうおう)",
             "suitability, fitness"
-        ],
-        "notation": "相応(そうおう)"
+        ]
     },
     {
         "name": "ayamaru",
         "trans": [
+            "誤(あやま)る",
             "to make a mistake"
-        ],
-        "notation": "誤(あやま)る"
+        ]
     },
     {
         "name": "shirabe",
         "trans": [
+            "調(しら)べ",
             "preparation, investigation, inspection"
-        ],
-        "notation": "調(しら)べ"
+        ]
     },
     {
         "name": "kicchiri",
         "trans": [
+            "きっちり",
             "precisely, tightly"
-        ],
-        "notation": "きっちり"
+        ]
     },
     {
         "name": "tougi",
         "trans": [
+            "討議(とうぎ)",
             "debate, discussion"
-        ],
-        "notation": "討議(とうぎ)"
+        ]
     },
     {
         "name": "koisuru",
         "trans": [
+            "恋(こい)する",
             "to fall in love with, to love"
-        ],
-        "notation": "恋(こい)する"
+        ]
     },
     {
         "name": "gaitou",
         "trans": [
+            "該当(がいとう)",
             "corresponding, answering to, coming under"
-        ],
-        "notation": "該当(がいとう)"
+        ]
     },
     {
         "name": "sankyuu",
         "trans": [
+            "サンキュー",
             "thank you"
-        ],
-        "notation": "サンキュー"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "器官(きかん)",
             "organ (of body), instrument"
-        ],
-        "notation": "器官(きかん)"
+        ]
     },
     {
         "name": "shirusu",
         "trans": [
+            "記(しる)す",
             "to note, to write down"
-        ],
-        "notation": "記(しる)す"
+        ]
     },
     {
         "name": "ponpu",
         "trans": [
+            "ポンプ",
             "pump"
-        ],
-        "notation": "ポンプ"
+        ]
     },
     {
         "name": "uchitsukeru",
         "trans": [
+            "打付(うちつ)ける",
             "to knock, to run into, to nail on, to strike hard, to hit and attack"
-        ],
-        "notation": "打付(うちつ)ける"
+        ]
     },
     {
         "name": "hidarikiki",
         "trans": [
+            "左利(ひだりき)き",
             "left-handedness, sake drinker, left-hander"
-        ],
-        "notation": "左利(ひだりき)き"
+        ]
     },
     {
         "name": "yonaka",
         "trans": [
+            "夜中(よなか)",
             "all night, the whole night"
-        ],
-        "notation": "夜中(よなか)"
+        ]
     },
     {
         "name": "mucha",
         "trans": [
+            "無茶(むちゃ)",
             "absurd, unreasonable, excessive, rash, absurdity, nonsense"
-        ],
-        "notation": "無茶(むちゃ)"
+        ]
     },
     {
         "name": "nazenara",
         "trans": [
+            "何故(なぜ)なら",
             "because"
-        ],
-        "notation": "何故(なぜ)なら"
+        ]
     },
     {
         "name": "uridashi",
         "trans": [
+            "売(う)り出(だ)し",
             "(bargain) sale"
-        ],
-        "notation": "売(う)り出(だ)し"
+        ]
     },
     {
         "name": "kounaa",
         "trans": [
+            "コーナー",
             "corner"
-        ],
-        "notation": "コーナー"
+        ]
     },
     {
         "name": "houkai",
         "trans": [
+            "崩壊(ほうかい)",
             "collapse, decay (physics), crumbling, breaking down, caving in"
-        ],
-        "notation": "崩壊(ほうかい)"
+        ]
     },
     {
         "name": "masayoshi",
         "trans": [
+            "正義(まさよし)",
             "justice, right, righteousness, correct meaning"
-        ],
-        "notation": "正義(まさよし)"
+        ]
     },
     {
         "name": "yorikakaru",
         "trans": [
+            "寄(よ)り掛(か)かる",
             "to lean against, to recline on, to lean on, to rely on"
-        ],
-        "notation": "寄(よ)り掛(か)かる"
+        ]
     },
     {
         "name": "shuppin",
         "trans": [
+            "出品(しゅっぴん)",
             "exhibit, display"
-        ],
-        "notation": "出品(しゅっぴん)"
+        ]
     },
     {
         "name": "naizou",
         "trans": [
+            "内臓(ないぞう)",
             "internal organs, intestines, viscera"
-        ],
-        "notation": "内臓(ないぞう)"
+        ]
     },
     {
         "name": "dokoka",
         "trans": [
+            "何処(どこ)か",
             "somewhere, anywhere, in some respects"
-        ],
-        "notation": "何処(どこ)か"
+        ]
     },
     {
         "name": "tamotsu",
         "trans": [
+            "保(たも)つ",
             "to keep, to preserve, to hold, to retain, to maintain, to support, to sustain, to last, to endure, to keep we"
-        ],
-        "notation": "保(たも)つ"
+        ]
     },
     {
         "name": "karamu",
         "trans": [
+            "絡(から)む",
             "to entangle, to entwine"
-        ],
-        "notation": "絡(から)む"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "会(かい)",
             "understanding"
-        ],
-        "notation": "会(かい)"
+        ]
     },
     {
         "name": "kazaguruma",
         "trans": [
+            "風車(かざぐるま)",
             "1. windmill, 2. pinwheel"
-        ],
-        "notation": "風車(かざぐるま)"
+        ]
     },
     {
         "name": "juugyouin",
         "trans": [
+            "従業(じゅうぎょう)員(いん)",
             "employee, worker"
-        ],
-        "notation": "従業(じゅうぎょう)員(いん)"
+        ]
     },
     {
         "name": "monookiki",
         "trans": [
+            "物置(ものおき)き",
             "storeroom"
-        ],
-        "notation": "物置(ものおき)き"
+        ]
     },
     {
         "name": "han",
         "trans": [
+            "班(はん)",
             "group, party, section (mil)"
-        ],
-        "notation": "班(はん)"
+        ]
     },
     {
         "name": "toumin",
         "trans": [
+            "冬眠(とうみん)",
             "hibernation, winter sleep"
-        ],
-        "notation": "冬眠(とうみん)"
+        ]
     },
     {
         "name": "shinogu",
         "trans": [
+            "凌(しの)ぐ",
             "to outdo, to surpass, to endure, to keep out (rain), to stave off, to tide over, to pull through, to defy, t"
-        ],
-        "notation": "凌(しの)ぐ"
+        ]
     },
     {
         "name": "hakujaku",
         "trans": [
+            "薄弱(はくじゃく)",
             "feebleness, weakness, weak"
-        ],
-        "notation": "薄弱(はくじゃく)"
+        ]
     },
     {
         "name": "gutto",
         "trans": [
+            "ぐっと",
             "firmly, fast, much, more"
-        ],
-        "notation": "ぐっと"
+        ]
     },
     {
         "name": "iyayarashii",
         "trans": [
+            "厭(いや)やらしい",
             "detestable, disagreeable"
-        ],
-        "notation": "厭(いや)やらしい"
+        ]
     },
     {
         "name": "seisho",
         "trans": [
+            "聖書(せいしょ)",
             "Bible, scriptures"
-        ],
-        "notation": "聖書(せいしょ)"
+        ]
     },
     {
         "name": "inui",
         "trans": [
+            "乾(いぬい)",
             "heaven, emperor"
-        ],
-        "notation": "乾(いぬい)"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "総(そう)",
             "whole, all, general, gross"
-        ],
-        "notation": "総(そう)"
+        ]
     },
     {
         "name": "dekiru",
         "trans": [
+            "出切(でき)る",
             "to be out of, to have no more at hand"
-        ],
-        "notation": "出切(でき)る"
+        ]
     },
     {
         "name": "nomikomu",
         "trans": [
+            "飲(の)み込(こ)む",
             "to gulp down, to swallow deeply, to understand, to take in, to catch on to, to learn, to digest"
-        ],
-        "notation": "飲(の)み込(こ)む"
+        ]
     },
     {
         "name": "toutobu",
         "trans": [
+            "尊(とうと)ぶ",
             "to value, to prize, to esteem"
-        ],
-        "notation": "尊(とうと)ぶ"
+        ]
     },
     {
         "name": "shibireru",
         "trans": [
+            "痺(しび)れる",
             "to become numb, to go to sleep (i.e. a limb)"
-        ],
-        "notation": "痺(しび)れる"
+        ]
     },
     {
         "name": "shuushoku",
         "trans": [
+            "修飾(しゅうしょく)",
             "ornamentation, embellishment, decoration, adornment, polish up (writing), modification (gram)"
-        ],
-        "notation": "修飾(しゅうしょく)"
+        ]
     },
     {
         "name": "yuu",
         "trans": [
+            "雄(ゆう)",
             "male (animal)"
-        ],
-        "notation": "雄(ゆう)"
+        ]
     },
     {
         "name": "goban",
         "trans": [
+            "碁盤(ごばん)",
             "Go board"
-        ],
-        "notation": "碁盤(ごばん)"
+        ]
     },
     {
         "name": "kanshuu",
         "trans": [
+            "慣習(かんしゅう)",
             "usual (historical) custom"
-        ],
-        "notation": "慣習(かんしゅう)"
+        ]
     },
     {
         "name": "warizan",
         "trans": [
+            "割(わ)り算(ざん)",
             "division (math)"
-        ],
-        "notation": "割(わ)り算(ざん)"
+        ]
     },
     {
         "name": "jitai",
         "trans": [
+            "字体(じたい)",
             "type, font, lettering"
-        ],
-        "notation": "字体(じたい)"
+        ]
     },
     {
         "name": "arinomama",
         "trans": [
+            "有(あ)りのまま",
             "the truth, fact, as it is, frankly"
-        ],
-        "notation": "有(あ)りのまま"
+        ]
     },
     {
         "name": "kameraman",
         "trans": [
+            "カメラマン",
             "cameraman"
-        ],
-        "notation": "カメラマン"
+        ]
     },
     {
         "name": "dengon",
         "trans": [
+            "伝言(でんごん)",
             "verbal message, rumor, word"
-        ],
-        "notation": "伝言(でんごん)"
+        ]
     },
     {
         "name": "jounetsu",
         "trans": [
+            "情熱(じょうねつ)",
             "passion, enthusiasm, zeal"
-        ],
-        "notation": "情熱(じょうねつ)"
+        ]
     },
     {
         "name": "ringyou",
         "trans": [
+            "林業(りんぎょう)",
             "forestry"
-        ],
-        "notation": "林業(りんぎょう)"
+        ]
     },
     {
         "name": "yuuryoku",
         "trans": [
+            "有力(ゆうりょく)",
             "1. influence, prominence, 2. potent"
-        ],
-        "notation": "有力(ゆうりょく)"
+        ]
     },
     {
         "name": "kenzen",
         "trans": [
+            "健全(けんぜん)",
             "health, soundness, wholesome"
-        ],
-        "notation": "健全(けんぜん)"
+        ]
     },
     {
         "name": "shourei",
         "trans": [
+            "奨励(しょうれい)",
             "encouragement, promotion, message, address"
-        ],
-        "notation": "奨励(しょうれい)"
+        ]
     },
     {
         "name": "tounyuu",
         "trans": [
+            "投入(とうにゅう)",
             "throw, investment, making (an electrical circuit)"
-        ],
-        "notation": "投入(とうにゅう)"
+        ]
     },
     {
         "name": "tensai",
         "trans": [
+            "天災(てんさい)",
             "natural calamity, disaster"
-        ],
-        "notation": "天災(てんさい)"
+        ]
     },
     {
         "name": "danmen",
         "trans": [
+            "断面(だんめん)",
             "cross section"
-        ],
-        "notation": "断面(だんめん)"
+        ]
     },
     {
         "name": "yunifoumu",
         "trans": [
+            "ユニフォーム",
             "uniform"
-        ],
-        "notation": "ユニフォーム"
+        ]
     },
     {
         "name": "mahi",
         "trans": [
+            "麻痺(まひ)",
             "paralysis, palsy, numbness, stupor"
-        ],
-        "notation": "麻痺(まひ)"
+        ]
     },
     {
         "name": "kisen",
         "trans": [
+            "汽船(きせん)",
             "steamship"
-        ],
-        "notation": "汽船(きせん)"
+        ]
     },
     {
         "name": "kawasu",
         "trans": [
+            "交(か)わす",
             "to exchange (messages), to dodge, to parry, to avoid, to turn aside"
-        ],
-        "notation": "交(か)わす"
+        ]
     },
     {
         "name": "wariaini",
         "trans": [
+            "割合(わりあい)に",
             "comparatively"
-        ],
-        "notation": "割合(わりあい)に"
+        ]
     },
     {
         "name": "ko",
         "trans": [
+            "個(こ)",
             "article counter"
-        ],
-        "notation": "個(こ)"
+        ]
     },
     {
         "name": "torii",
         "trans": [
+            "鳥居(とりい)",
             "torii (Shinto shrine archway)"
-        ],
-        "notation": "鳥居(とりい)"
+        ]
     },
     {
         "name": "shuen",
         "trans": [
+            "主演(しゅえん)",
             "starring, playing the leading part"
-        ],
-        "notation": "主演(しゅえん)"
+        ]
     },
     {
         "name": "potto",
         "trans": [
+            "ポット",
             "pot"
-        ],
-        "notation": "ポット"
+        ]
     },
     {
         "name": "haiki",
         "trans": [
+            "廃棄(はいき)",
             "annullment, disposal, abandon, scrap, discarding, repeal"
-        ],
-        "notation": "廃棄(はいき)"
+        ]
     },
     {
         "name": "tsugime",
         "trans": [
+            "継(つ)ぎ目(め)",
             "a joint, joining point"
-        ],
-        "notation": "継(つ)ぎ目(め)"
+        ]
     },
     {
         "name": "kousaku",
         "trans": [
+            "工作(こうさく)",
             "work, construction, handicraft, maneuvering"
-        ],
-        "notation": "工作(こうさく)"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "ショー",
             "show"
-        ],
-        "notation": "ショー"
+        ]
     },
     {
         "name": "tekisei",
         "trans": [
+            "適性(てきせい)",
             "aptitude"
-        ],
-        "notation": "適性(てきせい)"
+        ]
     },
     {
         "name": "pekopeko",
         "trans": [
+            "ぺこぺこ",
             "fawn, be very hungry"
-        ],
-        "notation": "ぺこぺこ"
+        ]
     },
     {
         "name": "kaidan",
         "trans": [
+            "会談(かいだん)",
             "conversation, conference, discussion, interview"
-        ],
-        "notation": "会談(かいだん)"
+        ]
     },
     {
         "name": "soru",
         "trans": [
+            "剃(そ)る",
             "to shave"
-        ],
-        "notation": "剃(そ)る"
+        ]
     },
     {
         "name": "chouin",
         "trans": [
+            "調印(ちょういん)",
             "signature, sign, sealing"
-        ],
-        "notation": "調印(ちょういん)"
+        ]
     },
     {
         "name": "kikime",
         "trans": [
+            "効(き)き目(め)",
             "effect, virtue, efficacy, impression"
-        ],
-        "notation": "効(き)き目(め)"
+        ]
     },
     {
         "name": "kinjiru",
         "trans": [
+            "禁(きん)じる",
             "to prohibit"
-        ],
-        "notation": "禁(きん)じる"
+        ]
     },
     {
         "name": "kango",
         "trans": [
+            "漢語(かんご)",
             "Chinese word, Sino-Japanese word"
-        ],
-        "notation": "漢語(かんご)"
+        ]
     },
     {
         "name": "otozureru",
         "trans": [
+            "訪(おとず)れる",
             "to visit"
-        ],
-        "notation": "訪(おとず)れる"
+        ]
     },
     {
         "name": "jittai",
         "trans": [
+            "実態(じったい)",
             "truth, fact"
-        ],
-        "notation": "実態(じったい)"
+        ]
     },
     {
         "name": "komeru",
         "trans": [
+            "込(こ)める",
             "to include, to put into"
-        ],
-        "notation": "込(こ)める"
+        ]
     },
     {
         "name": "saikai",
         "trans": [
+            "再会(さいかい)",
             "another meeting, meeting again, reunion"
-        ],
-        "notation": "再会(さいかい)"
+        ]
     },
     {
         "name": "jissen",
         "trans": [
+            "実践(じっせん)",
             "practice, put into practice"
-        ],
-        "notation": "実践(じっせん)"
+        ]
     },
     {
         "name": "wa",
         "trans": [
+            "和(わ)",
             "sum, harmony, peace"
-        ],
-        "notation": "和(わ)"
+        ]
     },
     {
         "name": "kategorii",
         "trans": [
+            "カテゴリー",
             "category"
-        ],
-        "notation": "カテゴリー"
+        ]
     },
     {
         "name": "fuyou",
         "trans": [
+            "扶養(ふよう)",
             "support, maintenance"
-        ],
-        "notation": "扶養(ふよう)"
+        ]
     },
     {
         "name": "hobo",
         "trans": [
+            "保母(ほぼ)",
             "day care worker in a kindergarten nursery school etc."
-        ],
-        "notation": "保母(ほぼ)"
+        ]
     },
     {
         "name": "goui",
         "trans": [
+            "合意(ごうい)",
             "agreement, consent, mutual understanding"
-        ],
-        "notation": "合意(ごうい)"
+        ]
     },
     {
         "name": "zenmetsu",
         "trans": [
+            "全滅(ぜんめつ)",
             "annihilation"
-        ],
-        "notation": "全滅(ぜんめつ)"
+        ]
     },
     {
         "name": "kounin",
         "trans": [
+            "公認(こうにん)",
             "official recognition, authorization, licence, accreditation"
-        ],
-        "notation": "公認(こうにん)"
+        ]
     },
     {
         "name": "mitsudo",
         "trans": [
+            "密度(みつど)",
             "density"
-        ],
-        "notation": "密度(みつど)"
+        ]
     },
     {
         "name": "tabako",
         "trans": [
+            "煙草(たばこ)",
             "(pt:) (n) (uk) tobacco (pt: tabaco), cigarettes"
-        ],
-        "notation": "煙草(たばこ)"
+        ]
     },
     {
         "name": "wataridori",
         "trans": [
+            "渡(わた)り鳥(どり)",
             "migratory bird, bird of passage"
-        ],
-        "notation": "渡(わた)り鳥(どり)"
+        ]
     },
     {
         "name": "konpon",
         "trans": [
+            "根本(こんぽん)",
             "origin, source, foundation, root, base, principle"
-        ],
-        "notation": "根本(こんぽん)"
+        ]
     },
     {
         "name": "burabura",
         "trans": [
+            "ぶらぶら",
             "dangle heavily, swing, sway to and fro, aimlessly, idly, lazily, loiter, loaf, be idle, stroll idly"
-        ],
-        "notation": "ぶらぶら"
+        ]
     },
     {
         "name": "housaku",
         "trans": [
+            "方策(ほうさく)",
             "plan, policy"
-        ],
-        "notation": "方策(ほうさく)"
+        ]
     },
     {
         "name": "yoka",
         "trans": [
+            "余暇(よか)",
             "leisure, leisure time, spare time"
-        ],
-        "notation": "余暇(よか)"
+        ]
     },
     {
         "name": "futou",
         "trans": [
+            "不当(ふとう)",
             "injustice, impropriety, unreasonableness, undeservedness, unfair, invalid"
-        ],
-        "notation": "不当(ふとう)"
+        ]
     },
     {
         "name": "arisama",
         "trans": [
+            "有様(ありさま)",
             "state, condition, circumstances, the way things are or should be, truth"
-        ],
-        "notation": "有様(ありさま)"
+        ]
     },
     {
         "name": "ikani",
         "trans": [
+            "如何(いか)に",
             "how?, in what way?, how much?, however, whatever"
-        ],
-        "notation": "如何(いか)に"
+        ]
     },
     {
         "name": "oshie",
         "trans": [
+            "教(おし)え",
             "teachings, precept, lesson, doctrine"
-        ],
-        "notation": "教(おし)え"
+        ]
     },
     {
         "name": "toun",
         "trans": [
+            "トーン",
             "tone"
-        ],
-        "notation": "トーン"
+        ]
     },
     {
         "name": "choukan",
         "trans": [
+            "長官(ちょうかん)",
             "chief, (government) secretary"
-        ],
-        "notation": "長官(ちょうかん)"
+        ]
     },
     {
         "name": "shinja",
         "trans": [
+            "信者(しんじゃ)",
             "believer, adherent, devotee, Christian"
-        ],
-        "notation": "信者(しんじゃ)"
+        ]
     },
     {
         "name": "kenshou",
         "trans": [
+            "懸賞(けんしょう)",
             "offering prizes, winning, reward"
-        ],
-        "notation": "懸賞(けんしょう)"
+        ]
     },
     {
         "name": "taimingu",
         "trans": [
+            "タイミング",
             "timing"
-        ],
-        "notation": "タイミング"
+        ]
     },
     {
         "name": "sanshutsu",
         "trans": [
+            "産出(さんしゅつ)",
             "yield, produce"
-        ],
-        "notation": "産出(さんしゅつ)"
+        ]
     },
     {
         "name": "shiji",
         "trans": [
+            "支持(しじ)",
             "support, maintenance"
-        ],
-        "notation": "支持(しじ)"
+        ]
     },
     {
         "name": "megane",
         "trans": [
+            "眼鏡(めがね)",
             "spectacles, glasses"
-        ],
-        "notation": "眼鏡(めがね)"
+        ]
     },
     {
         "name": "kainyuu",
         "trans": [
+            "介入(かいにゅう)",
             "intervention"
-        ],
-        "notation": "介入(かいにゅう)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "銃(じゅう)",
             "gun"
-        ],
-        "notation": "銃(じゅう)"
+        ]
     },
     {
         "name": "ryuukou",
         "trans": [
+            "流行(りゅうこう)",
             "fashionable, fad, in vogue, prevailing"
-        ],
-        "notation": "流行(りゅうこう)"
+        ]
     },
     {
         "name": "yoi",
         "trans": [
+            "良(よ)い",
             "good"
-        ],
-        "notation": "良(よ)い"
+        ]
     },
     {
         "name": "moushibun",
         "trans": [
+            "申(もう)し分(ぶん)",
             "objection, shortcomings"
-        ],
-        "notation": "申(もう)し分(ぶん)"
+        ]
     },
     {
         "name": "ichinichi",
         "trans": [
+            "一(いち)日(にち)",
             "1. one day, 2. first of month"
-        ],
-        "notation": "一(いち)日(にち)"
+        ]
     },
     {
         "name": "honkan",
         "trans": [
+            "本館(ほんかん)",
             "main building"
-        ],
-        "notation": "本館(ほんかん)"
+        ]
     },
     {
         "name": "koui",
         "trans": [
+            "行為(こうい)",
             "act, deed, conduct"
-        ],
-        "notation": "行為(こうい)"
+        ]
     },
     {
         "name": "ichibetsu",
         "trans": [
+            "一(いち)別(べつ)",
             "parting"
-        ],
-        "notation": "一(いち)別(べつ)"
+        ]
     },
     {
         "name": "kadai",
         "trans": [
+            "課題(かだい)",
             "subject, theme, task"
-        ],
-        "notation": "課題(かだい)"
+        ]
     },
     {
         "name": "hotondo",
         "trans": [
+            "殆(ほとん)ど",
             "mostly, almost"
-        ],
-        "notation": "殆(ほとん)ど"
+        ]
     },
     {
         "name": "nagori",
         "trans": [
+            "名残(なごり)",
             "remains, traces, memory"
-        ],
-        "notation": "名残(なごり)"
+        ]
     },
     {
         "name": "mokaku",
         "trans": [
+            "藻(も)掻(か)く",
             "to struggle, to wriggle, to be impatient"
-        ],
-        "notation": "藻(も)掻(か)く"
+        ]
     },
     {
         "name": "shingi",
         "trans": [
+            "審議(しんぎ)",
             "deliberation"
-        ],
-        "notation": "審議(しんぎ)"
+        ]
     },
     {
         "name": "shiki",
         "trans": [
+            "指揮(しき)",
             "command, direction"
-        ],
-        "notation": "指揮(しき)"
+        ]
     },
     {
         "name": "niwakaka",
         "trans": [
+            "俄(にわか)か",
             "sudden, abrupt, unexpected, improvised, offhand"
-        ],
-        "notation": "俄(にわか)か"
+        ]
     },
     {
         "name": "kuru",
         "trans": [
+            "来(く)る",
             "to come, to arrive, to be due to, to be next, to be forthcoming"
-        ],
-        "notation": "来(く)る"
+        ]
     },
     {
         "name": "deau",
         "trans": [
+            "出合(であ)う",
             "to meet by chance, to come across, to happen to encounter, to hold a rendezvous, to have a date"
-        ],
-        "notation": "出合(であ)う"
+        ]
     },
     {
         "name": "keredo",
         "trans": [
+            "けれど",
             "but, however"
-        ],
-        "notation": "けれど"
+        ]
     },
     {
         "name": "bakuzen",
         "trans": [
+            "漠然(ばくぜん)",
             "obscure, vague, equivocal"
-        ],
-        "notation": "漠然(ばくぜん)"
+        ]
     },
     {
         "name": "kakari",
         "trans": [
+            "係(かか)り",
             "official, duty, person in charge"
-        ],
-        "notation": "係(かか)り"
+        ]
     },
     {
         "name": "kasanaru",
         "trans": [
+            "重(かさ)なる",
             "main, principal, important"
-        ],
-        "notation": "重(かさ)なる"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "園(えん)",
             "garden (esp. man-made)"
-        ],
-        "notation": "園(えん)"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "起源(きげん)",
             "origin, beginning, rise"
-        ],
-        "notation": "起源(きげん)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "解(と)く",
             "to unfasten"
-        ],
-        "notation": "解(と)く"
+        ]
     },
     {
         "name": "taimaa",
         "trans": [
+            "タイマー",
             "timer"
-        ],
-        "notation": "タイマー"
+        ]
     },
     {
         "name": "jikokuhyou",
         "trans": [
+            "時刻(じこく)表(ひょう)",
             "table, diagram, chart, timetable, schedule"
-        ],
-        "notation": "時刻(じこく)表(ひょう)"
+        ]
     },
     {
         "name": "teisei",
         "trans": [
+            "訂正(ていせい)",
             "correction, revision"
-        ],
-        "notation": "訂正(ていせい)"
+        ]
     },
     {
         "name": "ichiyou",
         "trans": [
+            "一様(いちよう)",
             "uniformity, evenness, similarity, equality, impartiality"
-        ],
-        "notation": "一様(いちよう)"
+        ]
     },
     {
         "name": "umaru",
         "trans": [
+            "埋(う)まる",
             "to be buried, to be surrounded, to overflow, to be filled"
-        ],
-        "notation": "埋(う)まる"
+        ]
     },
     {
         "name": "kansen",
         "trans": [
+            "感染(かんせん)",
             "infection, contagion"
-        ],
-        "notation": "感染(かんせん)"
+        ]
     },
     {
         "name": "shokun",
         "trans": [
+            "諸君(しょくん)",
             "Gentlemen!, Ladies!"
-        ],
-        "notation": "諸君(しょくん)"
+        ]
     },
     {
         "name": "genkei",
         "trans": [
+            "原形(げんけい)",
             "original form, base form"
-        ],
-        "notation": "原形(げんけい)"
+        ]
     },
     {
         "name": "otonashii",
         "trans": [
+            "大人(おとな)しい",
             "obedient, docile, quiet"
-        ],
-        "notation": "大人(おとな)しい"
+        ]
     },
     {
         "name": "ranpu",
         "trans": [
+            "ランプ",
             "lamp, ramp, headlight, light"
-        ],
-        "notation": "ランプ"
+        ]
     },
     {
         "name": "kakeashi",
         "trans": [
+            "駆(か)け足(あし)",
             "running fast, double time"
-        ],
-        "notation": "駆(か)け足(あし)"
+        ]
     },
     {
         "name": "yashin",
         "trans": [
+            "野心(やしん)",
             "ambition, aspiration, designs, treachery"
-        ],
-        "notation": "野心(やしん)"
+        ]
     },
     {
         "name": "kokkei",
         "trans": [
+            "滑稽(こっけい)",
             "funny, humorous, comical, laughable, ridiculous, joking"
-        ],
-        "notation": "滑稽(こっけい)"
+        ]
     },
     {
         "name": "taiman",
         "trans": [
+            "怠慢(たいまん)",
             "negligence, procrastination, carelessness"
-        ],
-        "notation": "怠慢(たいまん)"
+        ]
     },
     {
         "name": "sekushon",
         "trans": [
+            "セクション",
             "section"
-        ],
-        "notation": "セクション"
+        ]
     },
     {
         "name": "oogara",
         "trans": [
+            "大柄(おおがら)",
             "large build, large pattern"
-        ],
-        "notation": "大柄(おおがら)"
+        ]
     },
     {
         "name": "shusshou",
         "trans": [
+            "出生(しゅっしょう)",
             "birth"
-        ],
-        "notation": "出生(しゅっしょう)"
+        ]
     },
     {
         "name": "tenten",
         "trans": [
+            "転転(てんてん)",
             "rolling about, moving from place to place, being passed around repeatedly"
-        ],
-        "notation": "転転(てんてん)"
+        ]
     },
     {
         "name": "souba",
         "trans": [
+            "相場(そうば)",
             "market price, speculation, estimation"
-        ],
-        "notation": "相場(そうば)"
+        ]
     },
     {
         "name": "eiyuu",
         "trans": [
+            "英雄(えいゆう)",
             "hero, great man"
-        ],
-        "notation": "英雄(えいゆう)"
+        ]
     },
     {
         "name": "shinten",
         "trans": [
+            "進展(しんてん)",
             "progress, development"
-        ],
-        "notation": "進展(しんてん)"
+        ]
     },
     {
         "name": "ohachi",
         "trans": [
+            "お八(はち)",
             "1. (uk) between meal snack, afternoon refreshment, afternoon tea, 2. mid-day snack"
-        ],
-        "notation": "お八(はち)"
+        ]
     },
     {
         "name": "kehai",
         "trans": [
+            "気配(けはい)",
             "indication, market trend, worry"
-        ],
-        "notation": "気配(けはい)"
+        ]
     },
     {
         "name": "naninani",
         "trans": [
+            "何々(なになに)",
             "which (emphatic)"
-        ],
-        "notation": "何々(なになに)"
+        ]
     },
     {
         "name": "soboku",
         "trans": [
+            "素朴(そぼく)",
             "simplicity, artlessness, naivete"
-        ],
-        "notation": "素朴(そぼく)"
+        ]
     },
     {
         "name": "heisa",
         "trans": [
+            "閉鎖(へいさ)",
             "closing, closure, shutdown, lockout, unsociable"
-        ],
-        "notation": "閉鎖(へいさ)"
+        ]
     },
     {
         "name": "douzoyoroshiku",
         "trans": [
+            "どうぞ宜(よろ)しく",
             "pleased to meet you"
-        ],
-        "notation": "どうぞ宜(よろ)しく"
+        ]
     },
     {
         "name": "hannou",
         "trans": [
+            "反応(はんのう)",
             "reaction, response"
-        ],
-        "notation": "反応(はんのう)"
+        ]
     },
     {
         "name": "ho",
         "trans": [
+            "穂(ほ)",
             "ear (of plant), head (of plant)"
-        ],
-        "notation": "穂(ほ)"
+        ]
     },
     {
         "name": "hinan",
         "trans": [
+            "非難(ひなん)",
             "blame, attack, criticism"
-        ],
-        "notation": "非難(ひなん)"
+        ]
     },
     {
         "name": "unzari",
         "trans": [
+            "うんざり",
             "tedious, boring, being fed up with"
-        ],
-        "notation": "うんざり"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "沿(そ)う",
             "to run along, to follow"
-        ],
-        "notation": "沿(そ)う"
+        ]
     },
     {
         "name": "nebiki",
         "trans": [
+            "値引(ねび)き",
             "price reduction, discount"
-        ],
-        "notation": "値引(ねび)き"
+        ]
     },
     {
         "name": "okashii",
         "trans": [
+            "可笑(おか)しい",
             "strange, funny, amusing, ridiculous"
-        ],
-        "notation": "可笑(おか)しい"
+        ]
     },
     {
         "name": "kozeni",
         "trans": [
+            "小銭(こぜに)",
             "coins, small change"
-        ],
-        "notation": "小銭(こぜに)"
+        ]
     },
     {
         "name": "aimai",
         "trans": [
+            "曖昧(あいまい)",
             "vague, ambiguous"
-        ],
-        "notation": "曖昧(あいまい)"
+        ]
     },
     {
         "name": "chissoku",
         "trans": [
+            "窒息(ちっそく)",
             "suffocation"
-        ],
-        "notation": "窒息(ちっそく)"
+        ]
     },
     {
         "name": "shozoku",
         "trans": [
+            "所属(しょぞく)",
             "attached to, belong to"
-        ],
-        "notation": "所属(しょぞく)"
+        ]
     },
     {
         "name": "enjiru",
         "trans": [
+            "演(えん)じる",
             "to perform (a play), to play (a part), to act (a part), to commit (a blunder)"
-        ],
-        "notation": "演(えん)じる"
+        ]
     },
     {
         "name": "yousou",
         "trans": [
+            "様相(ようそう)",
             "aspect"
-        ],
-        "notation": "様相(ようそう)"
+        ]
     },
     {
         "name": "nanishiro",
         "trans": [
+            "何(なに)しろ",
             "at any rate, anyhow, anyway, in any case"
-        ],
-        "notation": "何(なに)しろ"
+        ]
     },
     {
         "name": "neuchi",
         "trans": [
+            "値打(ねう)ち",
             "value, worth, price, dignity"
-        ],
-        "notation": "値打(ねう)ち"
+        ]
     },
     {
         "name": "dekibutsu",
         "trans": [
+            "出来物(できぶつ)",
             "able man, tumour, growth, boil, ulcer, abcess, rash, pimple"
-        ],
-        "notation": "出来物(できぶつ)"
+        ]
     },
     {
         "name": "hikiukeru",
         "trans": [
+            "引(ひ)き受(う)ける",
             "to undertake, to take up, to take over, to be responsible for, to guarantee, to contract (disease)"
-        ],
-        "notation": "引(ひ)き受(う)ける"
+        ]
     },
     {
         "name": "kokoroyoi",
         "trans": [
+            "快(こころよ)い",
             "pleasant, agreeable"
-        ],
-        "notation": "快(こころよ)い"
+        ]
     },
     {
         "name": "kajougaki",
         "trans": [
+            "箇条(かじょう)書(が)き",
             "itemized form, itemization"
-        ],
-        "notation": "箇条(かじょう)書(が)き"
+        ]
     },
     {
         "name": "tenohira",
         "trans": [
+            "掌(てのひら)",
             "the palm"
-        ],
-        "notation": "掌(てのひら)"
+        ]
     },
     {
         "name": "kessei",
         "trans": [
+            "結成(けっせい)",
             "formation"
-        ],
-        "notation": "結成(けっせい)"
+        ]
     },
     {
         "name": "nejimawashi",
         "trans": [
+            "ねじ回(まわ)し",
             "screwdriver"
-        ],
-        "notation": "ねじ回(まわ)し"
+        ]
     },
     {
         "name": "kaerimiru",
         "trans": [
+            "省(かえり)みる",
             "to reflect"
-        ],
-        "notation": "省(かえり)みる"
+        ]
     },
     {
         "name": "juuji",
         "trans": [
+            "従事(じゅうじ)",
             "engaging, pursuing, following"
-        ],
-        "notation": "従事(じゅうじ)"
+        ]
     },
     {
         "name": "nadare",
         "trans": [
+            "雪崩(なだれ)",
             "avalanche"
-        ],
-        "notation": "雪崩(なだれ)"
+        ]
     },
     {
         "name": "sentou",
         "trans": [
+            "戦闘(せんとう)",
             "battle, fight, combat"
-        ],
-        "notation": "戦闘(せんとう)"
+        ]
     },
     {
         "name": "koudoku",
         "trans": [
+            "購読(こうどく)",
             "subscription (e.g. magazine)"
-        ],
-        "notation": "購読(こうどく)"
+        ]
     },
     {
         "name": "daiji",
         "trans": [
+            "大事(だいじ)",
             "important, valuable, serious matter"
-        ],
-        "notation": "大事(だいじ)"
+        ]
     },
     {
         "name": "kochou",
         "trans": [
+            "誇張(こちょう)",
             "exaggeration"
-        ],
-        "notation": "誇張(こちょう)"
+        ]
     },
     {
         "name": "ruiji",
         "trans": [
+            "類似(るいじ)",
             "analogous"
-        ],
-        "notation": "類似(るいじ)"
+        ]
     },
     {
         "name": "hossa",
         "trans": [
+            "発作(ほっさ)",
             "fit, spasm"
-        ],
-        "notation": "発作(ほっさ)"
+        ]
     },
     {
         "name": "konchuu",
         "trans": [
+            "昆虫(こんちゅう)",
             "insect, bug"
-        ],
-        "notation": "昆虫(こんちゅう)"
+        ]
     },
     {
         "name": "hirei",
         "trans": [
+            "比例(ひれい)",
             "proportion"
-        ],
-        "notation": "比例(ひれい)"
+        ]
     },
     {
         "name": "sekasu",
         "trans": [
+            "急(せ)かす",
             "to hurry, to urge on"
-        ],
-        "notation": "急(せ)かす"
+        ]
     },
     {
         "name": "youshi",
         "trans": [
+            "用紙(ようし)",
             "blank form"
-        ],
-        "notation": "用紙(ようし)"
+        ]
     },
     {
         "name": "hiromaru",
         "trans": [
+            "広(ひろ)まる",
             "to spread, to be propagated"
-        ],
-        "notation": "広(ひろ)まる"
+        ]
     },
     {
         "name": "shugyou",
         "trans": [
+            "修行(しゅぎょう)",
             "pursuit of knowledge, studying, learning, training, ascetic practice, discipline"
-        ],
-        "notation": "修行(しゅぎょう)"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "戸(と)",
             "counter for houses"
-        ],
-        "notation": "戸(と)"
+        ]
     },
     {
         "name": "gyosen",
         "trans": [
+            "漁船(ぎょせん)",
             "fishing boat"
-        ],
-        "notation": "漁船(ぎょせん)"
+        ]
     },
     {
         "name": "kyouwa",
         "trans": [
+            "共和(きょうわ)",
             "republicanism, cooperation"
-        ],
-        "notation": "共和(きょうわ)"
+        ]
     },
     {
         "name": "jouriku",
         "trans": [
+            "上陸(じょうりく)",
             "landing, disembarkation"
-        ],
-        "notation": "上陸(じょうりく)"
+        ]
     },
     {
         "name": "taiya",
         "trans": [
+            "タイヤ",
             "tire, tyre"
-        ],
-        "notation": "タイヤ"
+        ]
     },
     {
         "name": "haki",
         "trans": [
+            "破棄(はき)",
             "revocation, annulment, breaking (e.g. treaty)"
-        ],
-        "notation": "破棄(はき)"
+        ]
     },
     {
         "name": "doufuu",
         "trans": [
+            "同封(どうふう)",
             "enclosure (e.g. in a letter)"
-        ],
-        "notation": "同封(どうふう)"
+        ]
     },
     {
         "name": "uchiawase",
         "trans": [
+            "打(う)ち合(あ)わせ",
             "business meeting, previous arrangement, appointment"
-        ],
-        "notation": "打(う)ち合(あ)わせ"
+        ]
     },
     {
         "name": "tazusawaru",
         "trans": [
+            "携(たずさ)わる",
             "to participate, to take part"
-        ],
-        "notation": "携(たずさ)わる"
+        ]
     },
     {
         "name": "okure",
         "trans": [
+            "遅(おく)れ",
             "delay, lag"
-        ],
-        "notation": "遅(おく)れ"
+        ]
     },
     {
         "name": "sabi",
         "trans": [
+            "錆(さ)び",
             "rust (colour)"
-        ],
-        "notation": "錆(さ)び"
+        ]
     },
     {
         "name": "rekurieeshon",
         "trans": [
+            "レクリエーション",
             "recreation"
-        ],
-        "notation": "レクリエーション"
+        ]
     },
     {
         "name": "nikutai",
         "trans": [
+            "肉体(にくたい)",
             "the body, the flesh"
-        ],
-        "notation": "肉体(にくたい)"
+        ]
     },
     {
         "name": "setsuritsu",
         "trans": [
+            "設立(せつりつ)",
             "establishment, foundation, institution"
-        ],
-        "notation": "設立(せつりつ)"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "様(よう)",
             "Mr. or Mrs., manner, kind, appearance"
-        ],
-        "notation": "様(よう)"
+        ]
     },
     {
         "name": "hateru",
         "trans": [
+            "果(は)てる",
             "to end, to be finished, to be exhausted, to die, to perish"
-        ],
-        "notation": "果(は)てる"
+        ]
     },
     {
         "name": "hiruma",
         "trans": [
+            "昼間(ひるま)",
             "daytime, during the day"
-        ],
-        "notation": "昼間(ひるま)"
+        ]
     },
     {
         "name": "nenchou",
         "trans": [
+            "年長(ねんちょう)",
             "seniority"
-        ],
-        "notation": "年長(ねんちょう)"
+        ]
     },
     {
         "name": "sakizakishuu",
         "trans": [
+            "先先(さきざき)週(しゅう)",
             "week before last"
-        ],
-        "notation": "先先(さきざき)週(しゅう)"
+        ]
     },
     {
         "name": "tsunami",
         "trans": [
+            "津波(つなみ)",
             "tsunami, tidal wave"
-        ],
-        "notation": "津波(つなみ)"
+        ]
     },
     {
         "name": "narutake",
         "trans": [
+            "成(な)る丈(たけ)",
             "as much as possible, if possible"
-        ],
-        "notation": "成(な)る丈(たけ)"
+        ]
     },
     {
         "name": "torishimari",
         "trans": [
+            "取(と)り締(し)まり",
             "control, management, supervision"
-        ],
-        "notation": "取(と)り締(し)まり"
+        ]
     },
     {
         "name": "seji",
         "trans": [
+            "世辞(せじ)",
             "flattery, compliment"
-        ],
-        "notation": "世辞(せじ)"
+        ]
     },
     {
         "name": "chigaeru",
         "trans": [
+            "違(ちが)える",
             "to change"
-        ],
-        "notation": "違(ちが)える"
+        ]
     },
     {
         "name": "terekkusu",
         "trans": [
+            "テレックス",
             "telex, teletypewriter exchange"
-        ],
-        "notation": "テレックス"
+        ]
     },
     {
         "name": "tegaru",
         "trans": [
+            "手軽(てがる)",
             "easy, simple, informal, offhand, cheap"
-        ],
-        "notation": "手軽(てがる)"
+        ]
     },
     {
         "name": "junzuru",
         "trans": [
+            "準(じゅん)ずる",
             "to apply correspondingly, to correspond to, to be proportionate to, to conform to"
-        ],
-        "notation": "準(じゅん)ずる"
+        ]
     },
     {
         "name": "hijuu",
         "trans": [
+            "比重(ひじゅう)",
             "specific gravity"
-        ],
-        "notation": "比重(ひじゅう)"
+        ]
     },
     {
         "name": "tejika",
         "trans": [
+            "手近(てぢか)",
             "near, handy, familiar"
-        ],
-        "notation": "手近(てぢか)"
+        ]
     },
     {
         "name": "kyouhaku",
         "trans": [
+            "脅迫(きょうはく)",
             "threat, menace, coercion, terrorism"
-        ],
-        "notation": "脅迫(きょうはく)"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "了(りょう)",
             "finish, completion, understanding"
-        ],
-        "notation": "了(りょう)"
+        ]
     },
     {
         "name": "tareru",
         "trans": [
+            "垂(た)れる",
             "to hang, to droop, to drop, to lower, to pull down, to dangle, to sag, to drip, to ooze, to trickle, to leave"
-        ],
-        "notation": "垂(た)れる"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "於(お)",
             "at, in, on"
-        ],
-        "notation": "於(お)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "自信(じしん)",
             "self-confidence"
-        ],
-        "notation": "自信(じしん)"
+        ]
     },
     {
         "name": "ryoushin",
         "trans": [
+            "良心(りょうしん)",
             "conscience"
-        ],
-        "notation": "良心(りょうしん)"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "万(ばん)",
             "many, all"
-        ],
-        "notation": "万(ばん)"
+        ]
     },
     {
         "name": "souritsu",
         "trans": [
+            "創立(そうりつ)",
             "establishment, founding, organization"
-        ],
-        "notation": "創立(そうりつ)"
+        ]
     },
     {
         "name": "kikkake",
         "trans": [
+            "切(き)っ掛(か)け",
             "chance, start, cue, excuse, motive, impetus, occasion"
-        ],
-        "notation": "切(き)っ掛(か)け"
+        ]
     },
     {
         "name": "ikashitemo",
         "trans": [
+            "如何(いか)しても",
             "by all means, at any cost, no matter what, after all, in the long run, cravingly, at any rate, surely"
-        ],
-        "notation": "如何(いか)しても"
+        ]
     },
     {
         "name": "hokan",
         "trans": [
+            "保管(ほかん)",
             "charge, custody, safekeeping, deposit, storage"
-        ],
-        "notation": "保管(ほかん)"
+        ]
     },
     {
         "name": "kinrou",
         "trans": [
+            "勤労(きんろう)",
             "labor, exertion, diligent service"
-        ],
-        "notation": "勤労(きんろう)"
+        ]
     },
     {
         "name": "shamisen",
         "trans": [
+            "三味線(しゃみせん)",
             "three-stringed Japanese guitar, shamisen"
-        ],
-        "notation": "三味線(しゃみせん)"
+        ]
     },
     {
         "name": "kenchi",
         "trans": [
+            "見地(けんち)",
             "point of view"
-        ],
-        "notation": "見地(けんち)"
+        ]
     },
     {
         "name": "tomu",
         "trans": [
+            "富(と)む",
             "to be rich, to become rich"
-        ],
-        "notation": "富(と)む"
+        ]
     },
     {
         "name": "machiawase",
         "trans": [
+            "待(ま)ち合(あ)わせ",
             "appointment"
-        ],
-        "notation": "待(ま)ち合(あ)わせ"
+        ]
     },
     {
         "name": "unaru",
         "trans": [
+            "唸(うな)る",
             "to groan, to moan, to roar, to howl, to growl, to hum, to buzz, to sough"
-        ],
-        "notation": "唸(うな)る"
+        ]
     },
     {
         "name": "chuukoku",
         "trans": [
+            "忠告(ちゅうこく)",
             "advice, warning"
-        ],
-        "notation": "忠告(ちゅうこく)"
+        ]
     },
     {
         "name": "koretou",
         "trans": [
+            "此(こ)れ等(とう)",
             "these"
-        ],
-        "notation": "此(こ)れ等(とう)"
+        ]
     },
     {
         "name": "jisonshin",
         "trans": [
+            "自尊心(じそんしん)",
             "self-respect, conceit"
-        ],
-        "notation": "自尊心(じそんしん)"
+        ]
     },
     {
         "name": "kasumu",
         "trans": [
+            "霞(かす)む",
             "to grow hazy, to be misty"
-        ],
-        "notation": "霞(かす)む"
+        ]
     },
     {
         "name": "anji",
         "trans": [
+            "暗示(あんじ)",
             "hint, suggestion"
-        ],
-        "notation": "暗示(あんじ)"
+        ]
     },
     {
         "name": "houbi",
         "trans": [
+            "褒美(ほうび)",
             "reward, prize"
-        ],
-        "notation": "褒美(ほうび)"
+        ]
     },
     {
         "name": "dakyou",
         "trans": [
+            "妥協(だきょう)",
             "compromise, giving in"
-        ],
-        "notation": "妥協(だきょう)"
+        ]
     },
     {
         "name": "misesu",
         "trans": [
+            "ミセス",
             "Mrs."
-        ],
-        "notation": "ミセス"
+        ]
     },
     {
         "name": "hayasu",
         "trans": [
+            "生(は)やす",
             "to grow, to cultivate, to wear beard"
-        ],
-        "notation": "生(は)やす"
+        ]
     },
     {
         "name": "chihou",
         "trans": [
+            "地方(ちほう)",
             "area, locality, district, region, the coast"
-        ],
-        "notation": "地方(ちほう)"
+        ]
     },
     {
         "name": "usagimokaku",
         "trans": [
+            "兎(うさぎ)も角(かく)",
             "anyhow, anyway, somehow or other, generally speaking, in any case"
-        ],
-        "notation": "兎(うさぎ)も角(かく)"
+        ]
     },
     {
         "name": "jippi",
         "trans": [
+            "実費(じっぴ)",
             "actual expense, cost price"
-        ],
-        "notation": "実費(じっぴ)"
+        ]
     },
     {
         "name": "kondou",
         "trans": [
+            "混同(こんどう)",
             "confusion, mixing, merger"
-        ],
-        "notation": "混同(こんどう)"
+        ]
     },
     {
         "name": "kogara",
         "trans": [
+            "小柄(こがら)",
             "short (build)"
-        ],
-        "notation": "小柄(こがら)"
+        ]
     },
     {
         "name": "nakoudo",
         "trans": [
+            "仲人(なこうど)",
             "go-between, matchmaker"
-        ],
-        "notation": "仲人(なこうど)"
+        ]
     },
     {
         "name": "kikitori",
         "trans": [
+            "聞(き)き取(と)り",
             "listening comprehension"
-        ],
-        "notation": "聞(き)き取(と)り"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "御(お)",
             "go-, honourable"
-        ],
-        "notation": "御(お)"
+        ]
     },
     {
         "name": "kishitsu",
         "trans": [
+            "気質(きしつ)",
             "spirit, character, trait, temperament, disposition"
-        ],
-        "notation": "気質(きしつ)"
+        ]
     },
     {
         "name": "taihi",
         "trans": [
+            "対比(たいひ)",
             "contrast, comparison"
-        ],
-        "notation": "対比(たいひ)"
+        ]
     },
     {
         "name": "tayou",
         "trans": [
+            "多様(たよう)",
             "diversity, variety"
-        ],
-        "notation": "多様(たよう)"
+        ]
     },
     {
         "name": "kasuka",
         "trans": [
+            "微(かす)か",
             "faint, dim, weak, indistinct, hazy, poor, wretched"
-        ],
-        "notation": "微(かす)か"
+        ]
     },
     {
         "name": "kyoukou",
         "trans": [
+            "強硬(きょうこう)",
             "firm, vigorous, unbending, unyielding, strong, stubborn"
-        ],
-        "notation": "強硬(きょうこう)"
+        ]
     },
     {
         "name": "konbanha",
         "trans": [
+            "今晩(こんばん)は",
             "good evening"
-        ],
-        "notation": "今晩(こんばん)は"
+        ]
     },
     {
         "name": "hedataru",
         "trans": [
+            "隔(へだ)たる",
             "to be distant"
-        ],
-        "notation": "隔(へだ)たる"
+        ]
     },
     {
         "name": "shareru",
         "trans": [
+            "洒落(しゃれ)る",
             "to joke, to play on words, to dress stylishly"
-        ],
-        "notation": "洒落(しゃれ)る"
+        ]
     },
     {
         "name": "kyakuhon",
         "trans": [
+            "脚本(きゃくほん)",
             "scenario"
-        ],
-        "notation": "脚本(きゃくほん)"
+        ]
     },
     {
         "name": "kunshu",
         "trans": [
+            "君主(くんしゅ)",
             "ruler, monarch"
-        ],
-        "notation": "君主(くんしゅ)"
+        ]
     },
     {
         "name": "asa",
         "trans": [
+            "麻(あさ)",
             "flax, linen, hemp"
-        ],
-        "notation": "麻(あさ)"
+        ]
     },
     {
         "name": "domogyaku",
         "trans": [
+            "吃(ども)逆(ぎゃく)",
             "hiccough, hiccup"
-        ],
-        "notation": "吃(ども)逆(ぎゃく)"
+        ]
     },
     {
         "name": "konagona",
         "trans": [
+            "粉々(こなごな)",
             "in very small pieces"
-        ],
-        "notation": "粉々(こなごな)"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "同(どう)",
             "the same, the said, ibid."
-        ],
-        "notation": "同(どう)"
+        ]
     },
     {
         "name": "manmarui",
         "trans": [
+            "真(ま)ん丸(まる)い",
             "perfectly circular"
-        ],
-        "notation": "真(ま)ん丸(まる)い"
+        ]
     },
     {
         "name": "tennin",
         "trans": [
+            "転任(てんにん)",
             "change of post"
-        ],
-        "notation": "転任(てんにん)"
+        ]
     },
     {
         "name": "mamonaku",
         "trans": [
+            "間(ま)もなく",
             "soon, before long, in a short time"
-        ],
-        "notation": "間(ま)もなく"
+        ]
     },
     {
         "name": "yochi",
         "trans": [
+            "余地(よち)",
             "place, room, margin, scope"
-        ],
-        "notation": "余地(よち)"
+        ]
     },
     {
         "name": "kaapetto",
         "trans": [
+            "カーペット",
             "carpet"
-        ],
-        "notation": "カーペット"
+        ]
     },
     {
         "name": "kagai",
         "trans": [
+            "課外(かがい)",
             "extracurricular"
-        ],
-        "notation": "課外(かがい)"
+        ]
     },
     {
         "name": "tekigi",
         "trans": [
+            "適宜(てきぎ)",
             "suitability"
-        ],
-        "notation": "適宜(てきぎ)"
+        ]
     },
     {
         "name": "tanoshimu",
         "trans": [
+            "楽(たの)しむ",
             "to enjoy oneself"
-        ],
-        "notation": "楽(たの)しむ"
+        ]
     },
     {
         "name": "fushi",
         "trans": [
+            "節(ふし)",
             "node, section, occasion, time"
-        ],
-        "notation": "節(ふし)"
+        ]
     },
     {
         "name": "neiro",
         "trans": [
+            "音色(ねいろ)",
             "tone color, tone quality, timbre, synthesizer patch"
-        ],
-        "notation": "音色(ねいろ)"
+        ]
     },
     {
         "name": "-hi",
         "trans": [
+            "-非(ひ)",
             "faulty-, non"
-        ],
-        "notation": "-非(ひ)"
+        ]
     },
     {
         "name": "hitsuzen",
         "trans": [
+            "必然(ひつぜん)",
             "inevitable, necessary"
-        ],
-        "notation": "必然(ひつぜん)"
+        ]
     },
     {
         "name": "yosomi",
         "trans": [
+            "余所見(よそみ)",
             "looking away, looking aside"
-        ],
-        "notation": "余所見(よそみ)"
+        ]
     },
     {
         "name": "chiyahoya",
         "trans": [
+            "ちやほや",
             "pamper, make a fuss of, spoil"
-        ],
-        "notation": "ちやほや"
+        ]
     },
     {
         "name": "harigami",
         "trans": [
+            "張(は)り紙(がみ)",
             "paper patch, paper backing, poster"
-        ],
-        "notation": "張(は)り紙(がみ)"
+        ]
     },
     {
         "name": "koro",
         "trans": [
+            "頃(ころ)",
             "time, about, toward, approximately (time)"
-        ],
-        "notation": "頃(ころ)"
+        ]
     },
     {
         "name": "shuken",
         "trans": [
+            "主権(しゅけん)",
             "sovereignty, supremacy, dominion"
-        ],
-        "notation": "主権(しゅけん)"
+        ]
     },
     {
         "name": "rikutsu",
         "trans": [
+            "理屈(りくつ)",
             "theory, reason"
-        ],
-        "notation": "理屈(りくつ)"
+        ]
     },
     {
         "name": "kari",
         "trans": [
+            "借(か)り",
             "borrowing, debt, loan"
-        ],
-        "notation": "借(か)り"
+        ]
     },
     {
         "name": "houshuu",
         "trans": [
+            "報酬(ほうしゅう)",
             "remuneration, recompense, reward, toll"
-        ],
-        "notation": "報酬(ほうしゅう)"
+        ]
     },
     {
         "name": "hikiwake",
         "trans": [
+            "引(ひ)き分(わ)け",
             "a draw (in competition), tie game"
-        ],
-        "notation": "引(ひ)き分(わ)け"
+        ]
     },
     {
         "name": "rishi",
         "trans": [
+            "利子(りし)",
             "interest (bank)"
-        ],
-        "notation": "利子(りし)"
+        ]
     },
     {
         "name": "keni",
         "trans": [
+            "権威(けんい)",
             "authority, power, influence"
-        ],
-        "notation": "権威(けんい)"
+        ]
     },
     {
         "name": "onoono",
         "trans": [
+            "各々(おのおの)",
             "each, every, either, respectively, severally"
-        ],
-        "notation": "各々(おのおの)"
+        ]
     },
     {
         "name": "yanushi",
         "trans": [
+            "家主(やぬし)",
             "landlord"
-        ],
-        "notation": "家主(やぬし)"
+        ]
     },
     {
         "name": "sha",
         "trans": [
+            "社(しゃ)",
             "Shinto shrine"
-        ],
-        "notation": "社(しゃ)"
+        ]
     },
     {
         "name": "tamawaru",
         "trans": [
+            "賜(たまわ)る",
             "to grant, to bestow"
-        ],
-        "notation": "賜(たまわ)る"
+        ]
     },
     {
         "name": "tekkou",
         "trans": [
+            "鉄鋼(てっこう)",
             "iron and steel"
-        ],
-        "notation": "鉄鋼(てっこう)"
+        ]
     },
     {
         "name": "etsuran",
         "trans": [
+            "閲覧(えつらん)",
             "inspection, reading"
-        ],
-        "notation": "閲覧(えつらん)"
+        ]
     },
     {
         "name": "sashikakaru",
         "trans": [
+            "差(さ)し掛(か)かる",
             "to come near to, to approach"
-        ],
-        "notation": "差(さ)し掛(か)かる"
+        ]
     },
     {
         "name": "moppara",
         "trans": [
+            "専(もっぱ)ら",
             "wholly, solely, entirely"
-        ],
-        "notation": "専(もっぱ)ら"
+        ]
     },
     {
         "name": "enzuru",
         "trans": [
+            "演(えん)ずる",
             "to perform, to play"
-        ],
-        "notation": "演(えん)ずる"
+        ]
     },
     {
         "name": "hinjaku",
         "trans": [
+            "貧弱(ひんじゃく)",
             "poor, meagre, insubstantial"
-        ],
-        "notation": "貧弱(ひんじゃく)"
+        ]
     },
     {
         "name": "shinpi",
         "trans": [
+            "神秘(しんぴ)",
             "mystery"
-        ],
-        "notation": "神秘(しんぴ)"
+        ]
     },
     {
         "name": "fukushi",
         "trans": [
+            "福祉(ふくし)",
             "welfare, well-being"
-        ],
-        "notation": "福祉(ふくし)"
+        ]
     },
     {
         "name": "nebaru",
         "trans": [
+            "粘(ねば)る",
             "to be sticky, to be adhesive, to persevere, to persist, to stick to"
-        ],
-        "notation": "粘(ねば)る"
+        ]
     },
     {
         "name": "shishi",
         "trans": [
+            "獣(しし)",
             "beast, brute"
-        ],
-        "notation": "獣(しし)"
+        ]
     },
     {
         "name": "asanebou",
         "trans": [
+            "朝寝坊(あさねぼう)",
             "oversleeping, late riser"
-        ],
-        "notation": "朝寝坊(あさねぼう)"
+        ]
     },
     {
         "name": "yomiageru",
         "trans": [
+            "読(よ)み上(あ)げる",
             "to read out loud (and clearly), to call a roll"
-        ],
-        "notation": "読(よ)み上(あ)げる"
+        ]
     },
     {
         "name": "kugiri",
         "trans": [
+            "区切(くぎ)り",
             "an end, a stop, punctuation"
-        ],
-        "notation": "区切(くぎ)り"
+        ]
     },
     {
         "name": "yuueki",
         "trans": [
+            "有益(ゆうえき)",
             "beneficial, profitable"
-        ],
-        "notation": "有益(ゆうえき)"
+        ]
     },
     {
         "name": "houridasu",
         "trans": [
+            "放(ほう)り出(だ)す",
             "to throw out, to fire, to expel, to give up, to abandon, to neglect"
-        ],
-        "notation": "放(ほう)り出(だ)す"
+        ]
     },
     {
         "name": "aete",
         "trans": [
+            "敢(あ)えて",
             "dare (to do), challenge (to do)"
-        ],
-        "notation": "敢(あ)えて"
+        ]
     },
     {
         "name": "dainashi",
         "trans": [
+            "台無(だいな)し",
             "mess, spoiled, (come to) nothing"
-        ],
-        "notation": "台無(だいな)し"
+        ]
     },
     {
         "name": "moushiireru",
         "trans": [
+            "申(もう)し入(い)れる",
             "to propose, to suggest"
-        ],
-        "notation": "申(もう)し入(い)れる"
+        ]
     },
     {
         "name": "ichigaini",
         "trans": [
+            "一概(いちがい)に",
             "unconditionally, as a rule"
-        ],
-        "notation": "一概(いちがい)に"
+        ]
     },
     {
         "name": "kango",
         "trans": [
+            "看護(かんご)",
             "nursing, (army) nurse"
-        ],
-        "notation": "看護(かんご)"
+        ]
     },
     {
         "name": "nameraka",
         "trans": [
+            "滑(なめ)らか",
             "smoothness, glassiness"
-        ],
-        "notation": "滑(なめ)らか"
+        ]
     },
     {
         "name": "oozora",
         "trans": [
+            "大空(おおぞら)",
             "heaven, firmament, the sky"
-        ],
-        "notation": "大空(おおぞら)"
+        ]
     },
     {
         "name": "karada",
         "trans": [
+            "体(からだ)",
             "appearance, air, condition, state, form"
-        ],
-        "notation": "体(からだ)"
+        ]
     },
     {
         "name": "oshikomu",
         "trans": [
+            "押(お)し込(こ)む",
             "to push into, to crowd into"
-        ],
-        "notation": "押(お)し込(こ)む"
+        ]
     },
     {
         "name": "tsubomi",
         "trans": [
+            "蕾(つぼみ)",
             "bud, flower bud"
-        ],
-        "notation": "蕾(つぼみ)"
+        ]
     },
     {
         "name": "oozappa",
         "trans": [
+            "大(おお)ざっぱ",
             "rough (as in not precise), broad, sketchy"
-        ],
-        "notation": "大(おお)ざっぱ"
+        ]
     },
     {
         "name": "nameru",
         "trans": [
+            "嘗(な)める",
             "to lick, to taste, to experience, to make fun of, to make light of, to put down, to treat with contempt"
-        ],
-        "notation": "嘗(な)める"
+        ]
     },
     {
         "name": "hyou",
         "trans": [
+            "票(ひょう)",
             "label, ballot, ticket, sign"
-        ],
-        "notation": "票(ひょう)"
+        ]
     },
     {
         "name": "gacchi",
         "trans": [
+            "合致(がっち)",
             "agreement, concurrence, conforming to"
-        ],
-        "notation": "合致(がっち)"
+        ]
     },
     {
         "name": "osamaru",
         "trans": [
+            "収(おさ)まる",
             "to be obtained, to end, to settle into, to fit into, to be settled, to be paid, to be delivered"
-        ],
-        "notation": "収(おさ)まる"
+        ]
     },
     {
         "name": "shimatta",
         "trans": [
+            "しまった",
             "Damn it!"
-        ],
-        "notation": "しまった"
+        ]
     },
     {
         "name": "eri",
         "trans": [
+            "襟(えり)",
             "neck, collar, lapel, neckband"
-        ],
-        "notation": "襟(えり)"
+        ]
     },
     {
         "name": "soutai",
         "trans": [
+            "相対(そうたい)",
             "confrontation, facing, between ourselves, no third party, tete-a-tete"
-        ],
-        "notation": "相対(そうたい)"
+        ]
     },
     {
         "name": "unnun",
         "trans": [
+            "云々(うんぬん)",
             "and so on, and so forth, comment"
-        ],
-        "notation": "云々(うんぬん)"
+        ]
     },
     {
         "name": "genbun",
         "trans": [
+            "原文(げんぶん)",
             "the text, original"
-        ],
-        "notation": "原文(げんぶん)"
+        ]
     },
     {
         "name": "shushi",
         "trans": [
+            "趣旨(しゅし)",
             "object, meaning"
-        ],
-        "notation": "趣旨(しゅし)"
+        ]
     },
     {
         "name": "komaasharu",
         "trans": [
+            "コマーシャル",
             "a commercial"
-        ],
-        "notation": "コマーシャル"
+        ]
     },
     {
         "name": "sashidasu",
         "trans": [
+            "差(さ)し出(だ)す",
             "to present, to submit, to tender, to hold out"
-        ],
-        "notation": "差(さ)し出(だ)す"
+        ]
     },
     {
         "name": "muke",
         "trans": [
+            "向(む)け",
             "for ~, oriented towards ~"
-        ],
-        "notation": "向(む)け"
+        ]
     },
     {
         "name": "aizou",
         "trans": [
+            "愛憎(あいぞう)",
             "likes and dislikes"
-        ],
-        "notation": "愛憎(あいぞう)"
+        ]
     },
     {
         "name": "janpu",
         "trans": [
+            "ジャンプ",
             "jump"
-        ],
-        "notation": "ジャンプ"
+        ]
     },
     {
         "name": "hashigo",
         "trans": [
+            "梯子(はしご)",
             "ladder, stairs"
-        ],
-        "notation": "梯子(はしご)"
+        ]
     },
     {
         "name": "jintai",
         "trans": [
+            "人体(じんたい)",
             "human body"
-        ],
-        "notation": "人体(じんたい)"
+        ]
     },
     {
         "name": "hogo",
         "trans": [
+            "保護(ほご)",
             "care, protection, shelter, guardianship, favor, patronage"
-        ],
-        "notation": "保護(ほご)"
+        ]
     },
     {
         "name": "hisan",
         "trans": [
+            "悲惨(ひさん)",
             "misery"
-        ],
-        "notation": "悲惨(ひさん)"
+        ]
     },
     {
         "name": "rijun",
         "trans": [
+            "利潤(りじゅん)",
             "profit, returns"
-        ],
-        "notation": "利潤(りじゅん)"
+        ]
     },
     {
         "name": "taitou",
         "trans": [
+            "対等(たいとう)",
             "equivalent"
-        ],
-        "notation": "対等(たいとう)"
+        ]
     },
     {
         "name": "keisei",
         "trans": [
+            "形勢(けいせい)",
             "condition, situation, prospects"
-        ],
-        "notation": "形勢(けいせい)"
+        ]
     },
     {
         "name": "taidan",
         "trans": [
+            "対談(たいだん)",
             "talk, dialogue, conversation"
-        ],
-        "notation": "対談(たいだん)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "駆(か)ける",
             "to run (race esp. horse), to gallop, to canter"
-        ],
-        "notation": "駆(か)ける"
+        ]
     },
     {
         "name": "tainou",
         "trans": [
+            "滞納(たいのう)",
             "non-payment, default"
-        ],
-        "notation": "滞納(たいのう)"
+        ]
     },
     {
         "name": "massaaji",
         "trans": [
+            "マッサージ",
             "massage"
-        ],
-        "notation": "マッサージ"
+        ]
     },
     {
         "name": "machigau",
         "trans": [
+            "間違(まちが)う",
             "to make a mistake, to be incorrect, to be mistaken"
-        ],
-        "notation": "間違(まちが)う"
+        ]
     },
     {
         "name": "seou",
         "trans": [
+            "背負(せお)う",
             "to be burdened with, to carry on back or shoulder"
-        ],
-        "notation": "背負(せお)う"
+        ]
     },
     {
         "name": "sankyuu",
         "trans": [
+            "産休(さんきゅう)",
             "maternity leave"
-        ],
-        "notation": "産休(さんきゅう)"
+        ]
     },
     {
         "name": "usaginikaku",
         "trans": [
+            "兎(うさぎ)に角(かく)",
             "anyhow, at any rate, anyway, somehow or other, generally speaking, in any case"
-        ],
-        "notation": "兎(うさぎ)に角(かく)"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "粋(いき)",
             "chic, style, purity, essence"
-        ],
-        "notation": "粋(いき)"
+        ]
     },
     {
         "name": "yuuboku",
         "trans": [
+            "遊牧(ゆうぼく)",
             "nomadism"
-        ],
-        "notation": "遊牧(ゆうぼく)"
+        ]
     },
     {
         "name": "yakamashii",
         "trans": [
+            "喧(やかま)しい",
             "noisy, strict, fussy"
-        ],
-        "notation": "喧(やかま)しい"
+        ]
     },
     {
         "name": "secchi",
         "trans": [
+            "設置(せっち)",
             "establishment, institution"
-        ],
-        "notation": "設置(せっち)"
+        ]
     },
     {
         "name": "toutoi",
         "trans": [
+            "尊(とうと)い",
             "precious, valuable, priceless, noble, exalted, sacred"
-        ],
-        "notation": "尊(とうと)い"
+        ]
     },
     {
         "name": "men",
         "trans": [
+            "面(めん)",
             "face"
-        ],
-        "notation": "面(めん)"
+        ]
     },
     {
         "name": "taimurii",
         "trans": [
+            "タイムリー",
             "timely, run-batted-in (baseball), RBI"
-        ],
-        "notation": "タイムリー"
+        ]
     },
     {
         "name": "shikirini",
         "trans": [
+            "頻(しき)りに",
             "frequently, repeatedly, incessantly, eagerly"
-        ],
-        "notation": "頻(しき)りに"
+        ]
     },
     {
         "name": "hoiku",
         "trans": [
+            "保育(ほいく)",
             "nursing, nurturing, rearing, lactation, suckling"
-        ],
-        "notation": "保育(ほいく)"
+        ]
     },
     {
         "name": "tairyoku",
         "trans": [
+            "体力(たいりょく)",
             "physical strength"
-        ],
-        "notation": "体力(たいりょく)"
+        ]
     },
     {
         "name": "shinni",
         "trans": [
+            "真(しん)に",
             "truly, actually, really"
-        ],
-        "notation": "真(しん)に"
+        ]
     },
     {
         "name": "sukui",
         "trans": [
+            "救(すく)い",
             "help, aid, relief"
-        ],
-        "notation": "救(すく)い"
+        ]
     },
     {
         "name": "ii",
         "trans": [
+            "伊井(いい)",
             "that one, Italy"
-        ],
-        "notation": "伊井(いい)"
+        ]
     },
     {
         "name": "jogen",
         "trans": [
+            "助言(じょげん)",
             "advice, suggestion"
-        ],
-        "notation": "助言(じょげん)"
+        ]
     },
     {
         "name": "aruru",
         "trans": [
+            "或(ある)る",
             "a certain..., some..."
-        ],
-        "notation": "或(ある)る"
+        ]
     },
     {
         "name": "chigiru",
         "trans": [
+            "契(ちぎ)る",
             "to pledge, to promise, to swear"
-        ],
-        "notation": "契(ちぎ)る"
+        ]
     },
     {
         "name": "wagamama",
         "trans": [
+            "我(わ)がまま",
             "selfishness, egoism, wilfulness, disobedience, whim"
-        ],
-        "notation": "我(わ)がまま"
+        ]
     },
     {
         "name": "shinkon",
         "trans": [
+            "新婚(しんこん)",
             "newly-wed"
-        ],
-        "notation": "新婚(しんこん)"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "織(お)",
             "weave, weaving, woven item"
-        ],
-        "notation": "織(お)"
+        ]
     },
     {
         "name": "kukkiri",
         "trans": [
+            "くっきり",
             "distinctly, clearly, boldly"
-        ],
-        "notation": "くっきり"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "突(つ)く",
             "1. to thrust, to strike, to attack, 2. to poke, to nudge, to pick at"
-        ],
-        "notation": "突(つ)く"
+        ]
     },
     {
         "name": "omonjiru",
         "trans": [
+            "重(おも)んじる",
             "to respect, to honor, to esteem, to prize"
-        ],
-        "notation": "重(おも)んじる"
+        ]
     },
     {
         "name": "saihatsu",
         "trans": [
+            "再発(さいはつ)",
             "return, relapse, reoccurrence"
-        ],
-        "notation": "再発(さいはつ)"
+        ]
     },
     {
         "name": "akudoi",
         "trans": [
+            "あくどい",
             "1. gaudy, showy, excessive, 2. vicious"
-        ],
-        "notation": "あくどい"
+        ]
     },
     {
         "name": "seiri",
         "trans": [
+            "生理(せいり)",
             "physiology, menses"
-        ],
-        "notation": "生理(せいり)"
+        ]
     },
     {
         "name": "botsuraku",
         "trans": [
+            "没落(ぼつらく)",
             "ruin, fall, collapse"
-        ],
-        "notation": "没落(ぼつらく)"
+        ]
     },
     {
         "name": "jisshitsu",
         "trans": [
+            "実質(じっしつ)",
             "substance, essence"
-        ],
-        "notation": "実質(じっしつ)"
+        ]
     },
     {
         "name": "hinomaru",
         "trans": [
+            "日(ひ)の丸(まる)",
             "the Japanese flag"
-        ],
-        "notation": "日(ひ)の丸(まる)"
+        ]
     },
     {
         "name": "chakuseki",
         "trans": [
+            "着席(ちゃくせき)",
             "sit down, seat"
-        ],
-        "notation": "着席(ちゃくせき)"
+        ]
     },
     {
         "name": "zento",
         "trans": [
+            "前途(ぜんと)",
             "future prospects, outlook, the journey ahead"
-        ],
-        "notation": "前途(ぜんと)"
+        ]
     },
     {
         "name": "yuuzuu",
         "trans": [
+            "融通(ゆうずう)",
             "lending (money), accommodation, adaptability, versatility, finance"
-        ],
-        "notation": "融通(ゆうずう)"
+        ]
     },
     {
         "name": "kesshou",
         "trans": [
+            "決勝(けっしょう)",
             "decision of a contest, finals (in sports)"
-        ],
-        "notation": "決勝(けっしょう)"
+        ]
     },
     {
         "name": "soudou",
         "trans": [
+            "騒動(そうどう)",
             "strife, riot, rebellion"
-        ],
-        "notation": "騒動(そうどう)"
+        ]
     },
     {
         "name": "torimaku",
         "trans": [
+            "取(と)り巻(ま)く",
             "to surround, to circle, to enclose"
-        ],
-        "notation": "取(と)り巻(ま)く"
+        ]
     },
     {
         "name": "inori",
         "trans": [
+            "祈(いの)り",
             "prayer, supplication"
-        ],
-        "notation": "祈(いの)り"
+        ]
     },
     {
         "name": "pachinko",
         "trans": [
+            "パチンコ",
             "pachinko (Japanese pinball)"
-        ],
-        "notation": "パチンコ"
+        ]
     },
     {
         "name": "amakuchi",
         "trans": [
+            "甘口(あまくち)",
             "sweet flavour, mildness, flattery, stupidity"
-        ],
-        "notation": "甘口(あまくち)"
+        ]
     },
     {
         "name": "chichihaha",
         "trans": [
+            "父母(ちちはは)",
             "father and mother, parents"
-        ],
-        "notation": "父母(ちちはは)"
+        ]
     },
     {
         "name": "tsuikyuu",
         "trans": [
+            "追及(ついきゅう)",
             "gaining on, carrying out, solving (crime)"
-        ],
-        "notation": "追及(ついきゅう)"
+        ]
     },
     {
         "name": "oukyuu",
         "trans": [
+            "応急(おうきゅう)",
             "emergency"
-        ],
-        "notation": "応急(おうきゅう)"
+        ]
     },
     {
         "name": "taishite",
         "trans": [
+            "対(たい)して",
             "for, in regard to, per"
-        ],
-        "notation": "対(たい)して"
+        ]
     },
     {
         "name": "migurushii",
         "trans": [
+            "見苦(みぐる)しい",
             "unsightly, ugly"
-        ],
-        "notation": "見苦(みぐる)しい"
+        ]
     },
     {
         "name": "kyoumei",
         "trans": [
+            "共鳴(きょうめい)",
             "resonance, sympathy"
-        ],
-        "notation": "共鳴(きょうめい)"
+        ]
     },
     {
         "name": "shimatsu",
         "trans": [
+            "始末(しまつ)",
             "management, dealing, settlement, cleaning up afterwards"
-        ],
-        "notation": "始末(しまつ)"
+        ]
     },
     {
         "name": "gorannasai",
         "trans": [
+            "御覧(ごらん)なさい",
             "(please) look, (please) try to do"
-        ],
-        "notation": "御覧(ごらん)なさい"
+        ]
     },
     {
         "name": "gyakunoboru",
         "trans": [
+            "逆(ぎゃく)上(のぼ)る",
             "to go back, to go upstream, to make retroactive"
-        ],
-        "notation": "逆(ぎゃく)上(のぼ)る"
+        ]
     },
     {
         "name": "joui",
         "trans": [
+            "上位(じょうい)",
             "superior (rank not class), higher order (e.g. byte), host computer (of connected device)"
-        ],
-        "notation": "上位(じょうい)"
+        ]
     },
     {
         "name": "gesuto",
         "trans": [
+            "ゲスト",
             "guest"
-        ],
-        "notation": "ゲスト"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "選考(せんこう)",
             "selection, screening"
-        ],
-        "notation": "選考(せんこう)"
+        ]
     },
     {
         "name": "ito",
         "trans": [
+            "意図(いと)",
             "intention, aim, design"
-        ],
-        "notation": "意図(いと)"
+        ]
     },
     {
         "name": "nyuushu",
         "trans": [
+            "入手(にゅうしゅ)",
             "obtaining, coming to hand"
-        ],
-        "notation": "入手(にゅうしゅ)"
+        ]
     },
     {
         "name": "bocchan",
         "trans": [
+            "坊(ぼっ)ちゃん",
             "son (of others)"
-        ],
-        "notation": "坊(ぼっ)ちゃん"
+        ]
     },
     {
         "name": "urusai",
         "trans": [
+            "五月蝿(うるさ)い",
             "noisy, loud, fussy"
-        ],
-        "notation": "五月蝿(うるさ)い"
+        ]
     },
     {
         "name": "imuhisoka",
         "trans": [
+            "厳(いむ)密(ひそか)",
             "strict, close"
-        ],
-        "notation": "厳(いむ)密(ひそか)"
+        ]
     },
     {
         "name": "fukeiki",
         "trans": [
+            "不景気(ふけいき)",
             "business recession, hard times, depression, gloom, sullenness, cheerlessness"
-        ],
-        "notation": "不景気(ふけいき)"
+        ]
     },
     {
         "name": "chou",
         "trans": [
+            "蝶(ちょう)",
             "butterfly"
-        ],
-        "notation": "蝶(ちょう)"
+        ]
     },
     {
         "name": "masukomi",
         "trans": [
+            "マスコミ",
             "mass communication"
-        ],
-        "notation": "マスコミ"
+        ]
     },
     {
         "name": "najiranai",
         "trans": [
+            "詰(なじ)らない",
             "insignificant, boring, trifling"
-        ],
-        "notation": "詰(なじ)らない"
+        ]
     },
     {
         "name": "kanata",
         "trans": [
+            "彼方(かなた)",
             "1. there, yonder, that"
-        ],
-        "notation": "彼方(かなた)"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "視覚(しかく)",
             "sense of sight, vision"
-        ],
-        "notation": "視覚(しかく)"
+        ]
     },
     {
         "name": "minamoto",
         "trans": [
+            "源(みなもと)",
             "source, origin"
-        ],
-        "notation": "源(みなもと)"
+        ]
     },
     {
         "name": "bouchou",
         "trans": [
+            "膨脹(ぼうちょう)",
             "expansion, swelling, increase, growth"
-        ],
-        "notation": "膨脹(ぼうちょう)"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "階層(かいそう)",
             "class, level, stratum, hierarchy"
-        ],
-        "notation": "階層(かいそう)"
+        ]
     },
     {
         "name": "riron",
         "trans": [
+            "理論(りろん)",
             "theory"
-        ],
-        "notation": "理論(りろん)"
+        ]
     },
     {
         "name": "kougo",
         "trans": [
+            "交互(こうご)",
             "mutual, reciprocal, alternate"
-        ],
-        "notation": "交互(こうご)"
+        ]
     },
     {
         "name": "kasamu",
         "trans": [
+            "嵩(かさ)む",
             "to pile up, to increase"
-        ],
-        "notation": "嵩(かさ)む"
+        ]
     },
     {
         "name": "gekirei",
         "trans": [
+            "激励(げきれい)",
             "encouragement"
-        ],
-        "notation": "激励(げきれい)"
+        ]
     },
     {
         "name": "soro",
         "trans": [
+            "ソロ",
             "solo"
-        ],
-        "notation": "ソロ"
+        ]
     },
     {
         "name": "itsumo",
         "trans": [
+            "何時(いつ)も",
             "always, usually, every time, never (with neg. verb)"
-        ],
-        "notation": "何時(いつ)も"
+        ]
     },
     {
         "name": "watashi",
         "trans": [
+            "私(わたし)",
             "I (fem)"
-        ],
-        "notation": "私(わたし)"
+        ]
     },
     {
         "name": "fuuzoku",
         "trans": [
+            "風俗(ふうぞく)",
             "1. manners, customs, 2. sex service, sex industry"
-        ],
-        "notation": "風俗(ふうぞく)"
+        ]
     },
     {
         "name": "doushi",
         "trans": [
+            "同士(どうし)",
             "fellow, companion, comrade"
-        ],
-        "notation": "同士(どうし)"
+        ]
     },
     {
         "name": "ibiki",
         "trans": [
+            "鼾(いびき)",
             "snoring"
-        ],
-        "notation": "鼾(いびき)"
+        ]
     },
     {
         "name": "makoto",
         "trans": [
+            "誠(まこと)",
             "truth, faith, fidelity, sincerity, trust, confidence, reliance, devotion"
-        ],
-        "notation": "誠(まこと)"
+        ]
     },
     {
         "name": "sakugo",
         "trans": [
+            "錯誤(さくご)",
             "mistake"
-        ],
-        "notation": "錯誤(さくご)"
+        ]
     },
     {
         "name": "kizashi",
         "trans": [
+            "兆(きざ)し",
             "signs, omen, symptoms"
-        ],
-        "notation": "兆(きざ)し"
+        ]
     },
     {
         "name": "kotoni",
         "trans": [
+            "殊(こと)に",
             "especially, above all"
-        ],
-        "notation": "殊(こと)に"
+        ]
     },
     {
         "name": "kokochi",
         "trans": [
+            "心地(ここち)",
             "feeling, sensation, mood"
-        ],
-        "notation": "心地(ここち)"
+        ]
     },
     {
         "name": "shitagokoro",
         "trans": [
+            "下心(したごころ)",
             "secret intention, motive"
-        ],
-        "notation": "下心(したごころ)"
+        ]
     },
     {
         "name": "totte",
         "trans": [
+            "取(と)っ手(て)",
             "handle, grip, knob"
-        ],
-        "notation": "取(と)っ手(て)"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "倣(ほう)",
             "imitate, follow, emulate"
-        ],
-        "notation": "倣(ほう)"
+        ]
     },
     {
         "name": "sakisengetsu",
         "trans": [
+            "先(さき)先月(せんげつ)",
             "month before last"
-        ],
-        "notation": "先(さき)先月(せんげつ)"
+        ]
     },
     {
         "name": "taigai",
         "trans": [
+            "大概(たいがい)",
             "in general, mainly"
-        ],
-        "notation": "大概(たいがい)"
+        ]
     },
     {
         "name": "reesu",
         "trans": [
+            "レース",
             "race, lace"
-        ],
-        "notation": "レース"
+        ]
     },
     {
         "name": "kizuku",
         "trans": [
+            "築(きず)く",
             "to build, to pile up, to amass"
-        ],
-        "notation": "築(きず)く"
+        ]
     },
     {
         "name": "nukedasu",
         "trans": [
+            "抜(ぬ)け出(だ)す",
             "to slip out, to sneak away, to excel"
-        ],
-        "notation": "抜(ぬ)け出(だ)す"
+        ]
     },
     {
         "name": "taika",
         "trans": [
+            "退化(たいか)",
             "degeneration, retrogression"
-        ],
-        "notation": "退化(たいか)"
+        ]
     },
     {
         "name": "ryouchi",
         "trans": [
+            "領地(りょうち)",
             "territory, dominion"
-        ],
-        "notation": "領地(りょうち)"
+        ]
     },
     {
         "name": "mijin",
         "trans": [
+            "微塵(みじん)",
             "particle, atom"
-        ],
-        "notation": "微塵(みじん)"
+        ]
     },
     {
         "name": "jouho",
         "trans": [
+            "譲歩(じょうほ)",
             "concession, conciliation, compromise"
-        ],
-        "notation": "譲歩(じょうほ)"
+        ]
     },
     {
         "name": "haizara",
         "trans": [
+            "灰皿(はいざら)",
             "ashtray"
-        ],
-        "notation": "灰皿(はいざら)"
+        ]
     },
     {
         "name": "wakashi",
         "trans": [
+            "若(わか)し",
             "if, in case, supposing"
-        ],
-        "notation": "若(わか)し"
+        ]
     },
     {
         "name": "sensu",
         "trans": [
+            "センス",
             "good sense (for music style tact etc.)"
-        ],
-        "notation": "センス"
+        ]
     },
     {
         "name": "nikibi",
         "trans": [
+            "面皰(にきび)",
             "pimple, acne"
-        ],
-        "notation": "面皰(にきび)"
+        ]
     },
     {
         "name": "fukkatsu",
         "trans": [
+            "復活(ふっかつ)",
             "revival (e.g. musical), restoration"
-        ],
-        "notation": "復活(ふっかつ)"
+        ]
     },
     {
         "name": "jinkaku",
         "trans": [
+            "人格(じんかく)",
             "personality, character, individuality"
-        ],
-        "notation": "人格(じんかく)"
+        ]
     },
     {
         "name": "naga",
         "trans": [
+            "長(なが)",
             "chief, head"
-        ],
-        "notation": "長(なが)"
+        ]
     },
     {
         "name": "teishoku",
         "trans": [
+            "定食(ていしょく)",
             "set meal, special (of the day)"
-        ],
-        "notation": "定食(ていしょく)"
+        ]
     },
     {
         "name": "nandaka",
         "trans": [
+            "何(なん)だか",
             "a little, somewhat, somehow"
-        ],
-        "notation": "何(なん)だか"
+        ]
     },
     {
         "name": "tomokasegi",
         "trans": [
+            "共稼(ともかせ)ぎ",
             "working together, (husband and wife) earning a living together"
-        ],
-        "notation": "共稼(ともかせ)ぎ"
+        ]
     },
     {
         "name": "kiri",
         "trans": [
+            "切(き)り",
             "limits, end, bounds, period, place to leave off, closing sentence, all there is, only, since"
-        ],
-        "notation": "切(き)り"
+        ]
     },
     {
         "name": "saezuru",
         "trans": [
+            "囀(さえず)る",
             "to sing, to chirp, to twitter"
-        ],
-        "notation": "囀(さえず)る"
+        ]
     },
     {
         "name": "mama",
         "trans": [
+            "間々(まま)",
             "occasionally, frequently"
-        ],
-        "notation": "間々(まま)"
+        ]
     },
     {
         "name": "sakumotsu",
         "trans": [
+            "作物(さくもつ)",
             "literary work"
-        ],
-        "notation": "作物(さくもつ)"
+        ]
     },
     {
         "name": "omiya",
         "trans": [
+            "お宮(みや)",
             "Shinto shrine"
-        ],
-        "notation": "お宮(みや)"
+        ]
     },
     {
         "name": "jizoku",
         "trans": [
+            "持続(じぞく)",
             "continuation"
-        ],
-        "notation": "持続(じぞく)"
+        ]
     },
     {
         "name": "furi",
         "trans": [
+            "振(ふ)り",
             "pretence, show, appearance"
-        ],
-        "notation": "振(ふ)り"
+        ]
     },
     {
         "name": "ikkatsu",
         "trans": [
+            "一括(いっかつ)",
             "all together, batch, one lump, one bundle, summing up"
-        ],
-        "notation": "一括(いっかつ)"
+        ]
     },
     {
         "name": "funtou",
         "trans": [
+            "奮闘(ふんとう)",
             "hard struggle, strenuous effort"
-        ],
-        "notation": "奮闘(ふんとう)"
+        ]
     },
     {
         "name": "gakushi",
         "trans": [
+            "学士(がくし)",
             "university graduate"
-        ],
-        "notation": "学士(がくし)"
+        ]
     },
     {
         "name": "seisou",
         "trans": [
+            "盛装(せいそう)",
             "be dressed up, wear rich clothes"
-        ],
-        "notation": "盛装(せいそう)"
+        ]
     },
     {
         "name": "fukkyuu",
         "trans": [
+            "復旧(ふっきゅう)",
             "restoration, restitution, rehabilitation"
-        ],
-        "notation": "復旧(ふっきゅう)"
+        ]
     },
     {
         "name": "tonosama",
         "trans": [
+            "殿様(とのさま)",
             "feudal lord"
-        ],
-        "notation": "殿様(とのさま)"
+        ]
     },
     {
         "name": "miotosu",
         "trans": [
+            "見落(みお)とす",
             "to overlook, to fail to notice"
-        ],
-        "notation": "見落(みお)とす"
+        ]
     },
     {
         "name": "houzuru",
         "trans": [
+            "報(ほう)ずる",
             "to inform, to report"
-        ],
-        "notation": "報(ほう)ずる"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "版(ばん)",
             "edition"
-        ],
-        "notation": "版(ばん)"
+        ]
     },
     {
         "name": "kanatakonokata",
         "trans": [
+            "彼方(かなた)此(この)方(かた)",
             "here and there"
-        ],
-        "notation": "彼方(かなた)此(この)方(かた)"
+        ]
     },
     {
         "name": "bengo",
         "trans": [
+            "弁護(べんご)",
             "defense, pleading, advocacy"
-        ],
-        "notation": "弁護(べんご)"
+        ]
     },
     {
         "name": "kireme",
         "trans": [
+            "切(き)れ目(め)",
             "break, pause, gap, end, rift, interruption, cut, section, notch, incision, end (of a task)"
-        ],
-        "notation": "切(き)れ目(め)"
+        ]
     },
     {
         "name": "soukai",
         "trans": [
+            "総会(そうかい)",
             "general meeting"
-        ],
-        "notation": "総会(そうかい)"
+        ]
     },
     {
         "name": "koudoku",
         "trans": [
+            "講読(こうどく)",
             "reading, translation"
-        ],
-        "notation": "講読(こうどく)"
+        ]
     },
     {
         "name": "houshiki",
         "trans": [
+            "方式(ほうしき)",
             "form, method, system"
-        ],
-        "notation": "方式(ほうしき)"
+        ]
     },
     {
         "name": "hayakkuni",
         "trans": [
+            "疾(はや)っくに",
             "long ago, already, a long time ago"
-        ],
-        "notation": "疾(はや)っくに"
+        ]
     },
     {
         "name": "hinata",
         "trans": [
+            "日向(ひなた)",
             "sunny place, in the sun"
-        ],
-        "notation": "日向(ひなた)"
+        ]
     },
     {
         "name": "tatoe",
         "trans": [
+            "仮令(たとえ)",
             "example, even if, if, though, although"
-        ],
-        "notation": "仮令(たとえ)"
+        ]
     },
     {
         "name": "ruisui",
         "trans": [
+            "類推(るいすい)",
             "analogy"
-        ],
-        "notation": "類推(るいすい)"
+        ]
     },
     {
         "name": "shouri",
         "trans": [
+            "勝利(しょうり)",
             "victory, triumph, conquest, success, win"
-        ],
-        "notation": "勝利(しょうり)"
+        ]
     },
     {
         "name": "gaitou",
         "trans": [
+            "街頭(がいとう)",
             "in the street"
-        ],
-        "notation": "街頭(がいとう)"
+        ]
     },
     {
         "name": "tenraku",
         "trans": [
+            "転落(てんらく)",
             "fall, degradation, slump"
-        ],
-        "notation": "転落(てんらく)"
+        ]
     },
     {
         "name": "shitau",
         "trans": [
+            "慕(した)う",
             "to yearn for, to miss, to adore, to love dearly"
-        ],
-        "notation": "慕(した)う"
+        ]
     },
     {
         "name": "minami",
         "trans": [
+            "南(みなみ)",
             "south"
-        ],
-        "notation": "南(みなみ)"
+        ]
     },
     {
         "name": "ranyou",
         "trans": [
+            "濫用(らんよう)",
             "abuse, misuse, misappropriation, using to excess"
-        ],
-        "notation": "濫用(らんよう)"
+        ]
     },
     {
         "name": "sonomama",
         "trans": [
+            "其(そ)の儘(まま)",
             "without change, as it is (i.e. now)"
-        ],
-        "notation": "其(そ)の儘(まま)"
+        ]
     },
     {
         "name": "genba",
         "trans": [
+            "現場(げんば)",
             "actual spot, scene, scene of the crime"
-        ],
-        "notation": "現場(げんば)"
+        ]
     },
     {
         "name": "joshi",
         "trans": [
+            "女子(じょし)",
             "woman, girl"
-        ],
-        "notation": "女子(じょし)"
+        ]
     },
     {
         "name": "seikai",
         "trans": [
+            "正解(せいかい)",
             "correct, right, correct interpretation (answer solution)"
-        ],
-        "notation": "正解(せいかい)"
+        ]
     },
     {
         "name": "hiyakasu",
         "trans": [
+            "冷(ひ)やかす",
             "to banter, to make fun of, to jeer at, to cool, to refrigerate"
-        ],
-        "notation": "冷(ひ)やかす"
+        ]
     },
     {
         "name": "atehamaru",
         "trans": [
+            "当(あ)てはまる",
             "to apply (a rule)"
-        ],
-        "notation": "当(あ)てはまる"
+        ]
     },
     {
         "name": "kukaku",
         "trans": [
+            "区画(くかく)",
             "division, section, compartment, boundary, area, block"
-        ],
-        "notation": "区画(くかく)"
+        ]
     },
     {
         "name": "ketsubou",
         "trans": [
+            "欠乏(けつぼう)",
             "want, shortage, famine"
-        ],
-        "notation": "欠乏(けつぼう)"
+        ]
     },
     {
         "name": "ruuzu",
         "trans": [
+            "ルーズ",
             "loose"
-        ],
-        "notation": "ルーズ"
+        ]
     },
     {
         "name": "zenryou",
         "trans": [
+            "善良(ぜんりょう)",
             "goodness, excellence, virtue"
-        ],
-        "notation": "善良(ぜんりょう)"
+        ]
     },
     {
         "name": "kareru",
         "trans": [
+            "涸(か)れる",
             "to dry up, to run out"
-        ],
-        "notation": "涸(か)れる"
+        ]
     },
     {
         "name": "hajimemashite",
         "trans": [
+            "始(はじ)めまして",
             "How do you do?, I am glad to meet you"
-        ],
-        "notation": "始(はじ)めまして"
+        ]
     },
     {
         "name": "soi",
         "trans": [
+            "沿(そ)い",
             "along"
-        ],
-        "notation": "沿(そ)い"
+        ]
     },
     {
         "name": "hakugai",
         "trans": [
+            "迫害(はくがい)",
             "persecution"
-        ],
-        "notation": "迫害(はくがい)"
+        ]
     },
     {
         "name": "waruguchi",
         "trans": [
+            "悪口(わるぐち)",
             "abuse, insult, slander, evil speaking"
-        ],
-        "notation": "悪口(わるぐち)"
+        ]
     },
     {
         "name": "ichinindeni",
         "trans": [
+            "一(いち)人(にん)でに",
             "by itself, automatically, naturally"
-        ],
-        "notation": "一(いち)人(にん)でに"
+        ]
     },
     {
         "name": "yagate",
         "trans": [
+            "軈(やが)て",
             "before long, soon, at length"
-        ],
-        "notation": "軈(やが)て"
+        ]
     },
     {
         "name": "kyouzai",
         "trans": [
+            "教材(きょうざい)",
             "teaching materials"
-        ],
-        "notation": "教材(きょうざい)"
+        ]
     },
     {
         "name": "moshikuha",
         "trans": [
+            "若(も)しくは",
             "or, otherwise"
-        ],
-        "notation": "若(も)しくは"
+        ]
     },
     {
         "name": "tayasui",
         "trans": [
+            "容易(たやす)い",
             "easy, simple, light"
-        ],
-        "notation": "容易(たやす)い"
+        ]
     },
     {
         "name": "unsou",
         "trans": [
+            "運送(うんそう)",
             "shipping, marine transportation"
-        ],
-        "notation": "運送(うんそう)"
+        ]
     },
     {
         "name": "chokumen",
         "trans": [
+            "直面(ちょくめん)",
             "confrontation"
-        ],
-        "notation": "直面(ちょくめん)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "肺(はい)",
             "lung"
-        ],
-        "notation": "肺(はい)"
+        ]
     },
     {
         "name": "senyou",
         "trans": [
+            "専用(せんよう)",
             "exclusive use, personal use"
-        ],
-        "notation": "専用(せんよう)"
+        ]
     },
     {
         "name": "kegasu",
         "trans": [
+            "汚(けが)す",
             "to disgrace, to dishonour"
-        ],
-        "notation": "汚(けが)す"
+        ]
     },
     {
         "name": "kontakuto",
         "trans": [
+            "コンタクト",
             "contact, contact lens"
-        ],
-        "notation": "コンタクト"
+        ]
     },
     {
         "name": "hendou",
         "trans": [
+            "変動(へんどう)",
             "change, fluctuation"
-        ],
-        "notation": "変動(へんどう)"
+        ]
     },
     {
         "name": "tengoku",
         "trans": [
+            "天国(てんごく)",
             "paradise, heaven, Kingdom of Heaven"
-        ],
-        "notation": "天国(てんごく)"
+        ]
     },
     {
         "name": "shuujitsu",
         "trans": [
+            "終日(しゅうじつ)",
             "all day"
-        ],
-        "notation": "終日(しゅうじつ)"
+        ]
     },
     {
         "name": "chuudoku",
         "trans": [
+            "中毒(ちゅうどく)",
             "poisoning"
-        ],
-        "notation": "中毒(ちゅうどく)"
+        ]
     },
     {
         "name": "chinretsu",
         "trans": [
+            "陳列(ちんれつ)",
             "exhibition, display, show"
-        ],
-        "notation": "陳列(ちんれつ)"
+        ]
     },
     {
         "name": "obieru",
         "trans": [
+            "怯(おび)える",
             "to become frightened, to have a nightmare"
-        ],
-        "notation": "怯(おび)える"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "保障(ほしょう)",
             "guarantee, security, assurance, pledge, warranty"
-        ],
-        "notation": "保障(ほしょう)"
+        ]
     },
     {
         "name": "keisha",
         "trans": [
+            "傾斜(けいしゃ)",
             "inclination, slant, slope, bevel, list, dip"
-        ],
-        "notation": "傾斜(けいしゃ)"
+        ]
     },
     {
         "name": "henkaku",
         "trans": [
+            "変革(へんかく)",
             "change, reform, revolution, upheaval, (the) Reformation"
-        ],
-        "notation": "変革(へんかく)"
+        ]
     },
     {
         "name": "otoroeru",
         "trans": [
+            "衰(おとろ)える",
             "to become weak, to decline, to wear, to abate, to decay, to wither, to waste away"
-        ],
-        "notation": "衰(おとろ)える"
+        ]
     },
     {
         "name": "roku",
         "trans": [
+            "六(ろく)",
             "(num) six"
-        ],
-        "notation": "六(ろく)"
+        ]
     },
     {
         "name": "wara",
         "trans": [
+            "藁(わら)",
             "straw"
-        ],
-        "notation": "藁(わら)"
+        ]
     },
     {
         "name": "ikki",
         "trans": [
+            "一気(いっき)",
             "drink!(said repeatedly as a party cheer)"
-        ],
-        "notation": "一気(いっき)"
+        ]
     },
     {
         "name": "marumaru",
         "trans": [
+            "丸々(まるまる)",
             "completely"
-        ],
-        "notation": "丸々(まるまる)"
+        ]
     },
     {
         "name": "sattomo",
         "trans": [
+            "些(さ)っとも",
             "not at all (neg. verb)"
-        ],
-        "notation": "些(さ)っとも"
+        ]
     },
     {
         "name": "miawaseru",
         "trans": [
+            "見合(みあ)わせる",
             "to exchange glances, to postpone, to suspend operations, to refrain from performing an action"
-        ],
-        "notation": "見合(みあ)わせる"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "派(は)",
             "clique, faction, school"
-        ],
-        "notation": "派(は)"
+        ]
     },
     {
         "name": "ayatsuru",
         "trans": [
+            "操(あやつ)る",
             "to manipulate, to operate, to pull strings"
-        ],
-        "notation": "操(あやつ)る"
+        ]
     },
     {
         "name": "tsuusetsu",
         "trans": [
+            "痛切(つうせつ)",
             "keen, acute"
-        ],
-        "notation": "痛切(つうせつ)"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "費(ひ)",
             "cost, expense"
-        ],
-        "notation": "費(ひ)"
+        ]
     },
     {
         "name": "sekkai",
         "trans": [
+            "切開(せっかい)",
             "clearing (land), opening up, cutting through"
-        ],
-        "notation": "切開(せっかい)"
+        ]
     },
     {
         "name": "zentei",
         "trans": [
+            "前提(ぜんてい)",
             "preamble, premise, reason, prerequisite"
-        ],
-        "notation": "前提(ぜんてい)"
+        ]
     },
     {
         "name": "minshu",
         "trans": [
+            "民主(みんしゅ)",
             "democratic, the head of the nation"
-        ],
-        "notation": "民主(みんしゅ)"
+        ]
     },
     {
         "name": "koukai",
         "trans": [
+            "公開(こうかい)",
             "presenting to the public"
-        ],
-        "notation": "公開(こうかい)"
+        ]
     },
     {
         "name": "sureru",
         "trans": [
+            "擦(す)れる",
             "to rub, to chafe, to wear, to become sophisticated"
-        ],
-        "notation": "擦(す)れる"
+        ]
     },
     {
         "name": "meiryou",
         "trans": [
+            "明瞭(めいりょう)",
             "clarity"
-        ],
-        "notation": "明瞭(めいりょう)"
+        ]
     },
     {
         "name": "moru",
         "trans": [
+            "盛(も)る",
             "to prosper, to flourish, to copulate (animals)"
-        ],
-        "notation": "盛(も)る"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "刃(は)",
             "edge (of a sword)"
-        ],
-        "notation": "刃(は)"
+        ]
     },
     {
         "name": "hinshitsu",
         "trans": [
+            "品質(ひんしつ)",
             "quality"
-        ],
-        "notation": "品質(ひんしつ)"
+        ]
     },
     {
         "name": "doraikuriiningu",
         "trans": [
+            "ドライクリーニング",
             "dry cleaning"
-        ],
-        "notation": "ドライクリーニング"
+        ]
     },
     {
         "name": "kasen",
         "trans": [
+            "化繊(かせん)",
             "synthetic fibres"
-        ],
-        "notation": "化繊(かせん)"
+        ]
     },
     {
         "name": "settoku",
         "trans": [
+            "説得(せっとく)",
             "persuasion"
-        ],
-        "notation": "説得(せっとく)"
+        ]
     },
     {
         "name": "gaika",
         "trans": [
+            "外貨(がいか)",
             "imported goods, foreign money"
-        ],
-        "notation": "外貨(がいか)"
+        ]
     },
     {
         "name": "mayu",
         "trans": [
+            "眉(まゆ)",
             "eyebrow"
-        ],
-        "notation": "眉(まゆ)"
+        ]
     },
     {
         "name": "sazo",
         "trans": [
+            "嘸(さぞ)",
             "I am sure, certainly, no doubt"
-        ],
-        "notation": "嘸(さぞ)"
+        ]
     },
     {
         "name": "hensen",
         "trans": [
+            "変遷(へんせん)",
             "change, transition, vicissitudes"
-        ],
-        "notation": "変遷(へんせん)"
+        ]
     },
     {
         "name": "keigu",
         "trans": [
+            "敬具(けいぐ)",
             "Sincerely yours"
-        ],
-        "notation": "敬具(けいぐ)"
+        ]
     },
     {
         "name": "kyoutei",
         "trans": [
+            "協定(きょうてい)",
             "arrangement, pact, agreement"
-        ],
-        "notation": "協定(きょうてい)"
+        ]
     },
     {
         "name": "bouka",
         "trans": [
+            "防火(ぼうか)",
             "fire prevention, fire fighting, fire proof"
-        ],
-        "notation": "防火(ぼうか)"
+        ]
     },
     {
         "name": "orikaesu",
         "trans": [
+            "折(お)り返(かえ)す",
             "to turn up, to fold back"
-        ],
-        "notation": "折(お)り返(かえ)す"
+        ]
     },
     {
         "name": "keiki",
         "trans": [
+            "契機(けいき)",
             "opportunity, chance"
-        ],
-        "notation": "契機(けいき)"
+        ]
     },
     {
         "name": "roudoku",
         "trans": [
+            "朗読(ろうどく)",
             "reading aloud, recitation"
-        ],
-        "notation": "朗読(ろうどく)"
+        ]
     },
     {
         "name": "chikazuku",
         "trans": [
+            "近付(ちかづ)く",
             "to approach, to get near, to get acquainted with, to get closer"
-        ],
-        "notation": "近付(ちかづ)く"
+        ]
     },
     {
         "name": "ichiritsu",
         "trans": [
+            "一律(いちりつ)",
             "evenness, uniformity, monotony, equality"
-        ],
-        "notation": "一律(いちりつ)"
+        ]
     },
     {
         "name": "yo",
         "trans": [
+            "世(よ)",
             "world, society, age, generation"
-        ],
-        "notation": "世(よ)"
+        ]
     },
     {
         "name": "onegaishimasu",
         "trans": [
+            "お願(ねが)いします",
             "please"
-        ],
-        "notation": "お願(ねが)いします"
+        ]
     },
     {
         "name": "guchi",
         "trans": [
+            "愚痴(ぐち)",
             "idle complaint, grumble"
-        ],
-        "notation": "愚痴(ぐち)"
+        ]
     },
     {
         "name": "itsumademo",
         "trans": [
+            "何時(いつ)までも",
             "forever, for good, eternally, as long as one likes, indefinitely"
-        ],
-        "notation": "何時(いつ)までも"
+        ]
     },
     {
         "name": "doushi",
         "trans": [
+            "同志(どうし)",
             "same mind, comrade, kindred soul"
-        ],
-        "notation": "同志(どうし)"
+        ]
     },
     {
         "name": "teki",
         "trans": [
+            "的(てき)",
             "mark, target"
-        ],
-        "notation": "的(てき)"
+        ]
     },
     {
         "name": "bouryoku",
         "trans": [
+            "暴力(ぼうりょく)",
             "violence"
-        ],
-        "notation": "暴力(ぼうりょく)"
+        ]
     },
     {
         "name": "oobu",
         "trans": [
+            "大部(おおぶ)",
             "most (e.g. most part), greater, fairly, a good deal, much"
-        ],
-        "notation": "大部(おおぶ)"
+        ]
     },
     {
         "name": "ougon",
         "trans": [
+            "黄金(おうごん)",
             "gold"
-        ],
-        "notation": "黄金(おうごん)"
+        ]
     },
     {
         "name": "hara",
         "trans": [
+            "原(はら)",
             "original, primitive, primary, fundamental, raw"
-        ],
-        "notation": "原(はら)"
+        ]
     },
     {
         "name": "iku",
         "trans": [
+            "いく",
             "to come, to orgasm"
-        ],
-        "notation": "いく"
+        ]
     },
     {
         "name": "appaku",
         "trans": [
+            "圧迫(あっぱく)",
             "pressure, coercion, oppression"
-        ],
-        "notation": "圧迫(あっぱく)"
+        ]
     },
     {
         "name": "arukari",
         "trans": [
+            "アルカリ",
             "alkali"
-        ],
-        "notation": "アルカリ"
+        ]
     },
     {
         "name": "nantomo",
         "trans": [
+            "何(なん)とも",
             "nothing (with neg. verb), quite, not a bit"
-        ],
-        "notation": "何(なん)とも"
+        ]
     },
     {
         "name": "chuujitsu",
         "trans": [
+            "忠実(ちゅうじつ)",
             "fidelity, faithfulness"
-        ],
-        "notation": "忠実(ちゅうじつ)"
+        ]
     },
     {
         "name": "kyoushoku",
         "trans": [
+            "教職(きょうしょく)",
             "teaching certificate, the teaching profession"
-        ],
-        "notation": "教職(きょうしょく)"
+        ]
     },
     {
         "name": "kuki",
         "trans": [
+            "茎(くき)",
             "stalk"
-        ],
-        "notation": "茎(くき)"
+        ]
     },
     {
         "name": "chian",
         "trans": [
+            "治安(ちあん)",
             "public order"
-        ],
-        "notation": "治安(ちあん)"
+        ]
     },
     {
         "name": "unubore",
         "trans": [
+            "自惚(うぬぼ)れ",
             "pretension, conceit, hubris"
-        ],
-        "notation": "自惚(うぬぼ)れ"
+        ]
     },
     {
         "name": "teki",
         "trans": [
+            "敵(てき)",
             "enemy, rival"
-        ],
-        "notation": "敵(てき)"
+        ]
     },
     {
         "name": "tsurusu",
         "trans": [
+            "吊(つ)るす",
             "to hang"
-        ],
-        "notation": "吊(つ)るす"
+        ]
     },
     {
         "name": "tokugi",
         "trans": [
+            "特技(とくぎ)",
             "special skill"
-        ],
-        "notation": "特技(とくぎ)"
+        ]
     },
     {
         "name": "makanau",
         "trans": [
+            "賄(まかな)う",
             "to give board to, to provide meals, to pay"
-        ],
-        "notation": "賄(まかな)う"
+        ]
     },
     {
         "name": "tsutomete",
         "trans": [
+            "努(つと)めて",
             "make an effort!, work hard!"
-        ],
-        "notation": "努(つと)めて"
+        ]
     },
     {
         "name": "kenasu",
         "trans": [
+            "貶(けな)す",
             "to speak ill of"
-        ],
-        "notation": "貶(けな)す"
+        ]
     },
     {
         "name": "gunkan",
         "trans": [
+            "軍艦(ぐんかん)",
             "warship, battleship"
-        ],
-        "notation": "軍艦(ぐんかん)"
+        ]
     },
     {
         "name": "idaku",
         "trans": [
+            "懐(いだ)く",
             "to become emotionally attached"
-        ],
-        "notation": "懐(いだ)く"
+        ]
     },
     {
         "name": "nimokakawarazu",
         "trans": [
+            "にも拘(かかわ)らず",
             "in spite of, nevertheless"
-        ],
-        "notation": "にも拘(かかわ)らず"
+        ]
     },
     {
         "name": "shikisai",
         "trans": [
+            "色彩(しきさい)",
             "colour, hue, tints"
-        ],
-        "notation": "色彩(しきさい)"
+        ]
     },
     {
         "name": "tsuiraku",
         "trans": [
+            "墜落(ついらく)",
             "falling, crashing"
-        ],
-        "notation": "墜落(ついらく)"
+        ]
     },
     {
         "name": "dokusou",
         "trans": [
+            "独創(どくそう)",
             "originality"
-        ],
-        "notation": "独創(どくそう)"
+        ]
     },
     {
         "name": "suisoku",
         "trans": [
+            "推測(すいそく)",
             "guess, conjecture"
-        ],
-        "notation": "推測(すいそく)"
+        ]
     },
     {
         "name": "kyoyou",
         "trans": [
+            "許容(きょよう)",
             "permission, pardon"
-        ],
-        "notation": "許容(きょよう)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "新興(しんこう)",
             "rising, developing, emergent"
-        ],
-        "notation": "新興(しんこう)"
+        ]
     },
     {
         "name": "doutou",
         "trans": [
+            "同等(どうとう)",
             "equality, equal, same rights, same rank"
-        ],
-        "notation": "同等(どうとう)"
+        ]
     },
     {
         "name": "itonamu",
         "trans": [
+            "営(いとな)む",
             "to carry on (e.g. in ceremony), to run a business"
-        ],
-        "notation": "営(いとな)む"
+        ]
     },
     {
         "name": "osoreiru",
         "trans": [
+            "恐(おそ)れ入(い)る",
             "to be filled with awe, to feel small, to be amazed, to be surprised, to be disconcerted, to be sorry, to b"
-        ],
-        "notation": "恐(おそ)れ入(い)る"
+        ]
     },
     {
         "name": "sate",
         "trans": [
+            "偖(さて)",
             "well, now, then"
-        ],
-        "notation": "偖(さて)"
+        ]
     },
     {
         "name": "muudo",
         "trans": [
+            "ムード",
             "mood"
-        ],
-        "notation": "ムード"
+        ]
     },
     {
         "name": "yurumeru",
         "trans": [
+            "緩(ゆる)める",
             "to loosen, to slow down"
-        ],
-        "notation": "緩(ゆる)める"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "閉口(へいこう)",
             "shut mouth"
-        ],
-        "notation": "閉口(へいこう)"
+        ]
     },
     {
         "name": "honshitsu",
         "trans": [
+            "本質(ほんしつ)",
             "essence, true nature, reality"
-        ],
-        "notation": "本質(ほんしつ)"
+        ]
     },
     {
         "name": "hansuru",
         "trans": [
+            "反(はん)する",
             "to be inconsistent with, to oppose, to contradict, to transgress, to rebel"
-        ],
-        "notation": "反(はん)する"
+        ]
     },
     {
         "name": "supoutsukaa",
         "trans": [
+            "スポーツカー",
             "sports car"
-        ],
-        "notation": "スポーツカー"
+        ]
     },
     {
         "name": "ittai",
         "trans": [
+            "一帯(いったい)",
             "a region, a zone, the whole place"
-        ],
-        "notation": "一帯(いったい)"
+        ]
     },
     {
         "name": "unei",
         "trans": [
+            "運営(うんえい)",
             "management, administration, operation"
-        ],
-        "notation": "運営(うんえい)"
+        ]
     },
     {
         "name": "sashihiku",
         "trans": [
+            "差(さ)し引(ひ)く",
             "to deduct"
-        ],
-        "notation": "差(さ)し引(ひ)く"
+        ]
     },
     {
         "name": "seni",
         "trans": [
+            "繊維(せんい)",
             "fibre, fiber, textile"
-        ],
-        "notation": "繊維(せんい)"
+        ]
     },
     {
         "name": "yuugure",
         "trans": [
+            "夕暮(ゆうぐ)れ",
             "evening, (evening) twilight"
-        ],
-        "notation": "夕暮(ゆうぐ)れ"
+        ]
     },
     {
         "name": "chou",
         "trans": [
+            "腸(ちょう)",
             "guts, bowels, intestines"
-        ],
-        "notation": "腸(ちょう)"
+        ]
     },
     {
         "name": "magireru",
         "trans": [
+            "紛(まぎ)れる",
             "to be diverted, to slip into"
-        ],
-        "notation": "紛(まぎ)れる"
+        ]
     },
     {
         "name": "hashiwatashi",
         "trans": [
+            "橋渡(はしわた)し",
             "bridge building, mediation"
-        ],
-        "notation": "橋渡(はしわた)し"
+        ]
     },
     {
         "name": "sonotame",
         "trans": [
+            "その為(ため)",
             "hence, for that reason"
-        ],
-        "notation": "その為(ため)"
+        ]
     },
     {
         "name": "shussan",
         "trans": [
+            "出産(しゅっさん)",
             "(child)birth, delivery, production (of goods)"
-        ],
-        "notation": "出産(しゅっさん)"
+        ]
     },
     {
         "name": "tatta",
         "trans": [
+            "たった",
             "only, merely, but, no more than"
-        ],
-        "notation": "たった"
+        ]
     },
     {
         "name": "kumiawase",
         "trans": [
+            "組(く)み合(あ)わせ",
             "combination"
-        ],
-        "notation": "組(く)み合(あ)わせ"
+        ]
     },
     {
         "name": "iyoiyo",
         "trans": [
+            "愈々(いよいよ)",
             "more and more, all the more, increasingly, at last, beyond doubt"
-        ],
-        "notation": "愈々(いよいよ)"
+        ]
     },
     {
         "name": "tomonau",
         "trans": [
+            "伴(ともな)う",
             "to accompany, to bring with, to be accompanied by, to be involved in"
-        ],
-        "notation": "伴(ともな)う"
+        ]
     },
     {
         "name": "kawairashii",
         "trans": [
+            "可愛(かわい)らしい",
             "lovely, sweet"
-        ],
-        "notation": "可愛(かわい)らしい"
+        ]
     },
     {
         "name": "hosoku",
         "trans": [
+            "補足(ほそく)",
             "supplement, complement"
-        ],
-        "notation": "補足(ほそく)"
+        ]
     },
     {
         "name": "akasu",
         "trans": [
+            "明(あ)かす",
             "to pass, spend, to reveal, to divulge"
-        ],
-        "notation": "明(あ)かす"
+        ]
     },
     {
         "name": "sanmyaku",
         "trans": [
+            "山脈(さんみゃく)",
             "mountain range"
-        ],
-        "notation": "山脈(さんみゃく)"
+        ]
     },
     {
         "name": "bukabuka",
         "trans": [
+            "ぶかぶか",
             "too big, baggy"
-        ],
-        "notation": "ぶかぶか"
+        ]
     },
     {
         "name": "kizu",
         "trans": [
+            "傷(きず)",
             "wound, injury, hurt, cut, gash, bruise, scratch, scar, weak point"
-        ],
-        "notation": "傷(きず)"
+        ]
     },
     {
         "name": "shisoku",
         "trans": [
+            "子息(しそく)",
             "son"
-        ],
-        "notation": "子息(しそく)"
+        ]
     },
     {
         "name": "zensei",
         "trans": [
+            "全盛(ぜんせい)",
             "height of prosperity"
-        ],
-        "notation": "全盛(ぜんせい)"
+        ]
     },
     {
         "name": "yotte",
         "trans": [
+            "依(よ)って",
             "therefore, consequently, accordingly, because of"
-        ],
-        "notation": "依(よ)って"
+        ]
     },
     {
         "name": "oyobu",
         "trans": [
+            "及(およ)ぶ",
             "to reach, to come up to, to amount to, to befall, to happen to, to extend, to match, to equal"
-        ],
-        "notation": "及(およ)ぶ"
+        ]
     },
     {
         "name": "dattai",
         "trans": [
+            "脱退(だったい)",
             "secession"
-        ],
-        "notation": "脱退(だったい)"
+        ]
     },
     {
         "name": "kyoujiru",
         "trans": [
+            "興(きょう)じる",
             "to amuse oneself, to make merry"
-        ],
-        "notation": "興(きょう)じる"
+        ]
     },
     {
         "name": "kaidou",
         "trans": [
+            "街道(かいどう)",
             "highway"
-        ],
-        "notation": "街道(かいどう)"
+        ]
     },
     {
         "name": "genten",
         "trans": [
+            "原典(げんてん)",
             "original (text)"
-        ],
-        "notation": "原典(げんてん)"
+        ]
     },
     {
         "name": "houchi",
         "trans": [
+            "放置(ほうち)",
             "leave as is, leave to chance, leave alone, neglect"
-        ],
-        "notation": "放置(ほうち)"
+        ]
     },
     {
         "name": "shougen",
         "trans": [
+            "証言(しょうげん)",
             "evidence, testimony"
-        ],
-        "notation": "証言(しょうげん)"
+        ]
     },
     {
         "name": "hiyake",
         "trans": [
+            "日焼(ひや)け",
             "sunburn"
-        ],
-        "notation": "日焼(ひや)け"
+        ]
     },
     {
         "name": "tokaku",
         "trans": [
+            "兎角(とかく)",
             "anyhow, anyway, somehow or other, generally speaking, in any case, this and that, many, be apt to"
-        ],
-        "notation": "兎角(とかく)"
+        ]
     },
     {
         "name": "zatsudan",
         "trans": [
+            "雑談(ざつだん)",
             "chatting, idle talk"
-        ],
-        "notation": "雑談(ざつだん)"
+        ]
     },
     {
         "name": "samuke",
         "trans": [
+            "寒気(さむけ)",
             "cold, frost, chill"
-        ],
-        "notation": "寒気(さむけ)"
+        ]
     },
     {
         "name": "shinden",
         "trans": [
+            "神殿(しんでん)",
             "temple, sacred place"
-        ],
-        "notation": "神殿(しんでん)"
+        ]
     },
     {
         "name": "ooi",
         "trans": [
+            "おおい",
             "hey!"
-        ],
-        "notation": "おおい"
+        ]
     },
     {
         "name": "kashikomarimashita",
         "trans": [
+            "畏(かしこ)まりました",
             "certainly!"
-        ],
-        "notation": "畏(かしこ)まりました"
+        ]
     },
     {
         "name": "genbaku",
         "trans": [
+            "原爆(げんばく)",
             "atomic bomb"
-        ],
-        "notation": "原爆(げんばく)"
+        ]
     },
     {
         "name": "koritsu",
         "trans": [
+            "孤立(こりつ)",
             "isolation, helplessness"
-        ],
-        "notation": "孤立(こりつ)"
+        ]
     },
     {
         "name": "dai",
         "trans": [
+            "代(だい)",
             "price, materials, substitution"
-        ],
-        "notation": "代(だい)"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "氏(し)",
             "family name"
-        ],
-        "notation": "氏(し)"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "堪(こた)える",
             "to bear, to stand, to endure, to put up with, to support, to withstand, to resist, to brave, to be fit for, t"
-        ],
-        "notation": "堪(こた)える"
+        ]
     },
     {
         "name": "kotogotoku",
         "trans": [
+            "悉(ことごと)く",
             "altogether, entirely"
-        ],
-        "notation": "悉(ことごと)く"
+        ]
     },
     {
         "name": "jiipan",
         "trans": [
+            "ジーパン",
             "jeans (lit: jeans pants), dungarees"
-        ],
-        "notation": "ジーパン"
+        ]
     },
     {
         "name": "oshiyoseru",
         "trans": [
+            "押(お)し寄(よ)せる",
             "to push aside, to advance on"
-        ],
-        "notation": "押(お)し寄(よ)せる"
+        ]
     },
     {
         "name": "zehitomo",
         "trans": [
+            "是非(ぜひ)とも",
             "by all means (with sense of not taking no for an answer)"
-        ],
-        "notation": "是非(ぜひ)とも"
+        ]
     },
     {
         "name": "kyakushoku",
         "trans": [
+            "脚色(きゃくしょく)",
             "dramatization (e.g. film)"
-        ],
-        "notation": "脚色(きゃくしょく)"
+        ]
     },
     {
         "name": "shousoku",
         "trans": [
+            "消息(しょうそく)",
             "news, letter, circumstances"
-        ],
-        "notation": "消息(しょうそく)"
+        ]
     },
     {
         "name": "sonosoto",
         "trans": [
+            "その外(そと)",
             "besides, in addition, the rest"
-        ],
-        "notation": "その外(そと)"
+        ]
     },
     {
         "name": "ressun",
         "trans": [
+            "レッスン",
             "lesson"
-        ],
-        "notation": "レッスン"
+        ]
     },
     {
         "name": "bateru",
         "trans": [
+            "ばてる",
             "to be exhausted, to be worn out"
-        ],
-        "notation": "ばてる"
+        ]
     },
     {
         "name": "ansatsu",
         "trans": [
+            "暗殺(あんさつ)",
             "assassination"
-        ],
-        "notation": "暗殺(あんさつ)"
+        ]
     },
     {
         "name": "suushi",
         "trans": [
+            "数詞(すうし)",
             "numeral"
-        ],
-        "notation": "数詞(すうし)"
+        ]
     },
     {
         "name": "masui",
         "trans": [
+            "麻酔(ますい)",
             "anaesthesia"
-        ],
-        "notation": "麻酔(ますい)"
+        ]
     },
     {
         "name": "reikoku",
         "trans": [
+            "冷酷(れいこく)",
             "cruelty, coldheartedness, relentless, ruthless"
-        ],
-        "notation": "冷酷(れいこく)"
+        ]
     },
     {
         "name": "keiro",
         "trans": [
+            "経路(けいろ)",
             "course, route, channel"
-        ],
-        "notation": "経路(けいろ)"
+        ]
     },
     {
         "name": "zubari",
         "trans": [
+            "ずばり",
             "decisively, decidedly, once and for all, unreservedly, frankly"
-        ],
-        "notation": "ずばり"
+        ]
     },
     {
         "name": "kouzan",
         "trans": [
+            "鉱山(こうざん)",
             "mine (ore)"
-        ],
-        "notation": "鉱山(こうざん)"
+        ]
     },
     {
         "name": "tsugu",
         "trans": [
+            "継(つ)ぐ",
             "to succeed"
-        ],
-        "notation": "継(つ)ぐ"
+        ]
     },
     {
         "name": "keiku",
         "trans": [
+            "佳(けい)句(く)",
             "beautiful passage of literature"
-        ],
-        "notation": "佳(けい)句(く)"
+        ]
     },
     {
         "name": "koufun",
         "trans": [
+            "興奮(こうふん)",
             "excitement, stimulation, agitation, arousal"
-        ],
-        "notation": "興奮(こうふん)"
+        ]
     },
     {
         "name": "togameru",
         "trans": [
+            "咎(とが)める",
             "to blame, to find fault, to take someone to task, to aggravate (an injury)"
-        ],
-        "notation": "咎(とが)める"
+        ]
     },
     {
         "name": "yotou",
         "trans": [
+            "与党(よとう)",
             "government party, (ruling) party in power, government"
-        ],
-        "notation": "与党(よとう)"
+        ]
     },
     {
         "name": "sakugen",
         "trans": [
+            "削減(さくげん)",
             "cut, reduction, curtailment"
-        ],
-        "notation": "削減(さくげん)"
+        ]
     },
     {
         "name": "obaasan",
         "trans": [
+            "お祖母(ばあ)さん",
             "grandmother, female senior-citizen"
-        ],
-        "notation": "お祖母(ばあ)さん"
+        ]
     },
     {
         "name": "shisso",
         "trans": [
+            "質素(しっそ)",
             "simplicity, modesty, frugality"
-        ],
-        "notation": "質素(しっそ)"
+        ]
     },
     {
         "name": "tisshupeepaa",
         "trans": [
+            "ティッシュペーパー",
             "tissue paper"
-        ],
-        "notation": "ティッシュペーパー"
+        ]
     },
     {
         "name": "tennou",
         "trans": [
+            "天皇(てんのう)",
             "Emperor of Japan"
-        ],
-        "notation": "天皇(てんのう)"
+        ]
     },
     {
         "name": "taiou",
         "trans": [
+            "対応(たいおう)",
             "interaction, correspondence, coping with, dealing with"
-        ],
-        "notation": "対応(たいおう)"
+        ]
     },
     {
         "name": "tai",
         "trans": [
+            "他意(たい)",
             "ill will, malice, another intention, secret purpose, ulterior motive, fickleness, double-mindedness"
-        ],
-        "notation": "他意(たい)"
+        ]
     },
     {
         "name": "ryouiki",
         "trans": [
+            "領域(りょういき)",
             "area, domain, territory, field, region, regime"
-        ],
-        "notation": "領域(りょういき)"
+        ]
     },
     {
         "name": "kuichigau",
         "trans": [
+            "食(く)い違(ちが)う",
             "to cross each other, to run counter to, to differ, to clash, to go awry"
-        ],
-        "notation": "食(く)い違(ちが)う"
+        ]
     },
     {
         "name": "rokotsu",
         "trans": [
+            "露骨(ろこつ)",
             "1. frank, blunt, plain, outspoken, 2. conspicuous, open, 3. broad, suggestive"
-        ],
-        "notation": "露骨(ろこつ)"
+        ]
     },
     {
         "name": "soreni",
         "trans": [
+            "其(そ)れに",
             "besides, moreover"
-        ],
-        "notation": "其(そ)れに"
+        ]
     },
     {
         "name": "kissa",
         "trans": [
+            "喫茶(きっさ)",
             "tea drinking, tea house"
-        ],
-        "notation": "喫茶(きっさ)"
+        ]
     },
     {
         "name": "dabudabu",
         "trans": [
+            "だぶだぶ",
             "loose, baggy"
-        ],
-        "notation": "だぶだぶ"
+        ]
     },
     {
         "name": "seifuku",
         "trans": [
+            "征服(せいふく)",
             "conquest, subjugation, overcoming"
-        ],
-        "notation": "征服(せいふく)"
+        ]
     },
     {
         "name": "shiji",
         "trans": [
+            "指示(しじ)",
             "indication, instruction, directions"
-        ],
-        "notation": "指示(しじ)"
+        ]
     },
     {
         "name": "futa",
         "trans": [
+            "蓋(ふた)",
             "cover, lid, cap"
-        ],
-        "notation": "蓋(ふた)"
+        ]
     },
     {
         "name": "ichinin",
         "trans": [
+            "一(いち)人(にん)",
             "one person"
-        ],
-        "notation": "一(いち)人(にん)"
+        ]
     },
     {
         "name": "somaru",
         "trans": [
+            "染(そ)まる",
             "to dye"
-        ],
-        "notation": "染(そ)まる"
+        ]
     },
     {
         "name": "matome",
         "trans": [
+            "纏(まと)め",
             "settlement, conclusion"
-        ],
-        "notation": "纏(まと)め"
+        ]
     },
     {
         "name": "jouen",
         "trans": [
+            "上演(じょうえん)",
             "performance (e.g. music)"
-        ],
-        "notation": "上演(じょうえん)"
+        ]
     },
     {
         "name": "kinkou",
         "trans": [
+            "近郊(きんこう)",
             "suburbs, outskirts"
-        ],
-        "notation": "近郊(きんこう)"
+        ]
     },
     {
         "name": "dokuji",
         "trans": [
+            "独自(どくじ)",
             "original, peculiar, characteristic"
-        ],
-        "notation": "独自(どくじ)"
+        ]
     },
     {
         "name": "jibika",
         "trans": [
+            "耳鼻(じび)科(か)",
             "otolaryngology"
-        ],
-        "notation": "耳鼻(じび)科(か)"
+        ]
     },
     {
         "name": "renpou",
         "trans": [
+            "連邦(れんぽう)",
             "commonwealth, federation of states"
-        ],
-        "notation": "連邦(れんぽう)"
+        ]
     },
     {
         "name": "miyage",
         "trans": [
+            "土産(みやげ)",
             "product of the land"
-        ],
-        "notation": "土産(みやげ)"
+        ]
     },
     {
         "name": "naitaa",
         "trans": [
+            "ナイター",
             "game under lights (e.g. baseball) (lit: nighter), night game"
-        ],
-        "notation": "ナイター"
+        ]
     },
     {
         "name": "arigatou",
         "trans": [
+            "有難(ありがと)う",
             "Thank you"
-        ],
-        "notation": "有難(ありがと)う"
+        ]
     },
     {
         "name": "toushi",
         "trans": [
+            "投資(とうし)",
             "investment"
-        ],
-        "notation": "投資(とうし)"
+        ]
     },
     {
         "name": "shirei",
         "trans": [
+            "指令(しれい)",
             "orders, instructions, directive"
-        ],
-        "notation": "指令(しれい)"
+        ]
     },
     {
         "name": "sendatte",
         "trans": [
+            "先(せん)だって",
             "recently, the other day"
-        ],
-        "notation": "先(せん)だって"
+        ]
     },
     {
         "name": "faito",
         "trans": [
+            "ファイト",
             "fight"
-        ],
-        "notation": "ファイト"
+        ]
     },
     {
         "name": "mekata",
         "trans": [
+            "目方(めかた)",
             "weight"
-        ],
-        "notation": "目方(めかた)"
+        ]
     },
     {
         "name": "zenrei",
         "trans": [
+            "前例(ぜんれい)",
             "precedent"
-        ],
-        "notation": "前例(ぜんれい)"
+        ]
     },
     {
         "name": "mikaku",
         "trans": [
+            "味覚(みかく)",
             "taste, palate, sense of taste"
-        ],
-        "notation": "味覚(みかく)"
+        ]
     },
     {
         "name": "soretomo",
         "trans": [
+            "其(そ)れ共(とも)",
             "or, or else"
-        ],
-        "notation": "其(そ)れ共(とも)"
+        ]
     },
     {
         "name": "shutsudai",
         "trans": [
+            "出題(しゅつだい)",
             "proposing a question"
-        ],
-        "notation": "出題(しゅつだい)"
+        ]
     },
     {
         "name": "furidashi",
         "trans": [
+            "振(ふ)り出(だ)し",
             "outset, starting point, drawing or issuing (draft)"
-        ],
-        "notation": "振(ふ)り出(だ)し"
+        ]
     },
     {
         "name": "taitoru",
         "trans": [
+            "タイトル",
             "title"
-        ],
-        "notation": "タイトル"
+        ]
     },
     {
         "name": "warui",
         "trans": [
+            "悪(わる)い",
             "hateful, abominable, poor-looking"
-        ],
-        "notation": "悪(わる)い"
+        ]
     },
     {
         "name": "koutaku",
         "trans": [
+            "光沢(こうたく)",
             "brilliance, polish, lustre, glossy finish (of photographs)"
-        ],
-        "notation": "光沢(こうたく)"
+        ]
     },
     {
         "name": "oite",
         "trans": [
+            "於(お)いて",
             "at, in, on"
-        ],
-        "notation": "於(お)いて"
+        ]
     },
     {
         "name": "sayou",
         "trans": [
+            "作用(さよう)",
             "action, operation, effect, function"
-        ],
-        "notation": "作用(さよう)"
+        ]
     },
     {
         "name": "hanabira",
         "trans": [
+            "花(はな)びら",
             "(flower) petal"
-        ],
-        "notation": "花(はな)びら"
+        ]
     },
     {
         "name": "ooyake",
         "trans": [
+            "公(おおやけ)",
             "official, public, formal, open, governmental"
-        ],
-        "notation": "公(おおやけ)"
+        ]
     },
     {
         "name": "fan",
         "trans": [
+            "ファン",
             "fan, fun"
-        ],
-        "notation": "ファン"
+        ]
     },
     {
         "name": "haikei",
         "trans": [
+            "背景(はいけい)",
             "background, scenery, setting, circumstance"
-        ],
-        "notation": "背景(はいけい)"
+        ]
     },
     {
         "name": "kuufuku",
         "trans": [
+            "空腹(くうふく)",
             "hunger"
-        ],
-        "notation": "空腹(くうふく)"
+        ]
     },
     {
         "name": "meirou",
         "trans": [
+            "明朗(めいろう)",
             "bright, clear, cheerful"
-        ],
-        "notation": "明朗(めいろう)"
+        ]
     },
     {
         "name": "nonoshiru",
         "trans": [
+            "罵(ののし)る",
             "to speak ill of, to abuse"
-        ],
-        "notation": "罵(ののし)る"
+        ]
     },
     {
         "name": "eiji",
         "trans": [
+            "英字(えいじ)",
             "English letter (character)"
-        ],
-        "notation": "英字(えいじ)"
+        ]
     },
     {
         "name": "chikajika",
         "trans": [
+            "近々(ちかぢか)",
             "nearness, before long"
-        ],
-        "notation": "近々(ちかぢか)"
+        ]
     },
     {
         "name": "haradachi",
         "trans": [
+            "腹立(はらだ)ち",
             "anger"
-        ],
-        "notation": "腹立(はらだ)ち"
+        ]
     },
     {
         "name": "tessuru",
         "trans": [
+            "徹(てっ)する",
             "to sink in, to penetrate, to devote oneself, to believe in, to go through, to do intently and exclusively"
-        ],
-        "notation": "徹(てっ)する"
+        ]
     },
     {
         "name": "keisai",
         "trans": [
+            "掲載(けいさい)",
             "appearance (e.g. article in paper)"
-        ],
-        "notation": "掲載(けいさい)"
+        ]
     },
     {
         "name": "toritsugu",
         "trans": [
+            "取(と)り次(つ)ぐ",
             "to act as an agent for, to announce (someone), to convey (a message)"
-        ],
-        "notation": "取(と)り次(つ)ぐ"
+        ]
     },
     {
         "name": "shikijou",
         "trans": [
+            "式場(しきじょう)",
             "ceremonial hall, place of ceremony (e.g. marriage)"
-        ],
-        "notation": "式場(しきじょう)"
+        ]
     }
 ]

--- a/assets/dicts/JapVocabList.N2.json
+++ b/assets/dicts/JapVocabList.N2.json
@@ -2,12839 +2,12839 @@
     {
         "name": "kazuhide",
         "trans": [
+            "和英(かずひで)",
             "Japanese-English"
-        ],
-        "notation": "和英(かずひで)"
+        ]
     },
     {
         "name": "teire",
         "trans": [
+            "手入(てい)れ",
             "repairs,maintenance"
-        ],
-        "notation": "手入(てい)れ"
+        ]
     },
     {
         "name": "temae",
         "trans": [
+            "手前(てまえ)",
             "before,this side,we,you"
-        ],
-        "notation": "手前(てまえ)"
+        ]
     },
     {
         "name": "nigasu",
         "trans": [
+            "逃(に)がす",
             "to let loose,to set free,to let escape"
-        ],
-        "notation": "逃(に)がす"
+        ]
     },
     {
         "name": "matomeru",
         "trans": [
+            "纏(まと)める",
             "to put in order,to collect,to bring to a conclusion"
-        ],
-        "notation": "纏(まと)める"
+        ]
     },
     {
         "name": "zunou",
         "trans": [
+            "頭脳(ずのう)",
             "head,brains,intellect"
-        ],
-        "notation": "頭脳(ずのう)"
+        ]
     },
     {
         "name": "teishi",
         "trans": [
+            "停止(ていし)",
             "suspension,interruption,stoppage,ban"
-        ],
-        "notation": "停止(ていし)"
+        ]
     },
     {
         "name": "oodoori",
         "trans": [
+            "大通(おおどお)り",
             "main street"
-        ],
-        "notation": "大通(おおどお)り"
+        ]
     },
     {
         "name": "outomeeshon",
         "trans": [
+            "オートメーション",
             "automation"
-        ],
-        "notation": "オートメーション"
+        ]
     },
     {
         "name": "gouryuu",
         "trans": [
+            "合流(ごうりゅう)",
             "confluence,union,linking up,merge"
-        ],
-        "notation": "合流(ごうりゅう)"
+        ]
     },
     {
         "name": "shouyu",
         "trans": [
+            "醤油(しょうゆ)",
             "soy sauce"
-        ],
-        "notation": "醤油(しょうゆ)"
+        ]
     },
     {
         "name": "kakine",
         "trans": [
+            "垣根(かきね)",
             "hedge"
-        ],
-        "notation": "垣根(かきね)"
+        ]
     },
     {
         "name": "konsento",
         "trans": [
+            "コンセント",
             "(1) consent,(2) concentric"
-        ],
-        "notation": "コンセント"
+        ]
     },
     {
         "name": "taki",
         "trans": [
+            "滝(たき)",
             "waterfall"
-        ],
-        "notation": "滝(たき)"
+        ]
     },
     {
         "name": "youryou",
         "trans": [
+            "要領(ようりょう)",
             "point,gist,essentials,outline"
-        ],
-        "notation": "要領(ようりょう)"
+        ]
     },
     {
         "name": "mafuraa",
         "trans": [
+            "マフラー",
             "muffler,scarf"
-        ],
-        "notation": "マフラー"
+        ]
     },
     {
         "name": "tenisukouto",
         "trans": [
+            "テニスコート",
             "tennis court"
-        ],
-        "notation": "テニスコート"
+        ]
     },
     {
         "name": "pikapika",
         "trans": [
+            "ぴかぴか",
             "glitter,sparkle"
-        ],
-        "notation": "ぴかぴか"
+        ]
     },
     {
         "name": "bon",
         "trans": [
+            "盆(ぼん)",
             "Lantern Festival,Festival of the Dead,tray"
-        ],
-        "notation": "盆(ぼん)"
+        ]
     },
     {
         "name": "moukeru",
         "trans": [
+            "儲(もう)ける",
             "to get,to earn,to gain,to have (bear, beget) a child"
-        ],
-        "notation": "儲(もう)ける"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "浸(つ)ける",
             "to dip in,to soak"
-        ],
-        "notation": "浸(つ)ける"
+        ]
     },
     {
         "name": "sakasa",
         "trans": [
+            "逆(さか)さ",
             "reverse,inversion,upside down"
-        ],
-        "notation": "逆(さか)さ"
+        ]
     },
     {
         "name": "kouyou",
         "trans": [
+            "紅葉(こうよう)",
             "(1) (Japanese) maple"
-        ],
-        "notation": "紅葉(こうよう)"
+        ]
     },
     {
         "name": "kyakuseki",
         "trans": [
+            "客席(きゃくせき)",
             "guest seating"
-        ],
-        "notation": "客席(きゃくせき)"
+        ]
     },
     {
         "name": "kazei",
         "trans": [
+            "課税(かぜい)",
             "taxation"
-        ],
-        "notation": "課税(かぜい)"
+        ]
     },
     {
         "name": "zuutto",
         "trans": [
+            "ずうっと",
             ""
-        ],
-        "notation": "ずうっと"
+        ]
     },
     {
         "name": "toriireru",
         "trans": [
+            "取(と)り入(い)れる",
             "to harvest,to take in,to adopt"
-        ],
-        "notation": "取(と)り入(い)れる"
+        ]
     },
     {
         "name": "gisshiri",
         "trans": [
+            "ぎっしり",
             "tightly,fully"
-        ],
-        "notation": "ぎっしり"
+        ]
     },
     {
         "name": "uyamau",
         "trans": [
+            "敬(うやま)う",
             "to show respect,to honour"
-        ],
-        "notation": "敬(うやま)う"
+        ]
     },
     {
         "name": "mabuta",
         "trans": [
+            "まぶた",
             "eyelids"
-        ],
-        "notation": "まぶた"
+        ]
     },
     {
         "name": "youji",
         "trans": [
+            "幼児(ようじ)",
             "infant,baby,child"
-        ],
-        "notation": "幼児(ようじ)"
+        ]
     },
     {
         "name": "reitou",
         "trans": [
+            "冷凍(れいとう)",
             "freezing,cold storage,refrigeration"
-        ],
-        "notation": "冷凍(れいとう)"
+        ]
     },
     {
         "name": "nyuusha",
         "trans": [
+            "入社(にゅうしゃ)",
             "entry to a company"
-        ],
-        "notation": "入社(にゅうしゃ)"
+        ]
     },
     {
         "name": "shishagonyuu",
         "trans": [
+            "四捨五入(ししゃごにゅう)",
             "rounding up (fractions)"
-        ],
-        "notation": "四捨五入(ししゃごにゅう)"
+        ]
     },
     {
         "name": "hibiku",
         "trans": [
+            "響(ひび)く",
             "to resound"
-        ],
-        "notation": "響(ひび)く"
+        ]
     },
     {
         "name": "jumyou",
         "trans": [
+            "寿命(じゅみょう)",
             "life span"
-        ],
-        "notation": "寿命(じゅみょう)"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "固(かた)い",
             "stubborn,firm (not viscous or easily moved)"
-        ],
-        "notation": "固(かた)い"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "討(う)つ",
             "to attack,to avenge"
-        ],
-        "notation": "討(う)つ"
+        ]
     },
     {
         "name": "tansho",
         "trans": [
+            "短所(たんしょ)",
             "(1) defect,demerit,weak point,(2) disadvantage"
-        ],
-        "notation": "短所(たんしょ)"
+        ]
     },
     {
         "name": "ousetsu",
         "trans": [
+            "応接(おうせつ)",
             "reception"
-        ],
-        "notation": "応接(おうせつ)"
+        ]
     },
     {
         "name": "tomokaku",
         "trans": [
+            "ともかく",
             "anyhow,anyway,somehow or other,generally speaking,in any case"
-        ],
-        "notation": "ともかく"
+        ]
     },
     {
         "name": "kegasu",
         "trans": [
+            "汚(けが)す",
             "(1) to disgrace,to dishonour,(2) to pollute,to contaminate,to soil,to make dirty,to stain"
-        ],
-        "notation": "汚(けが)す"
+        ]
     },
     {
         "name": "shippo",
         "trans": [
+            "しっぽ",
             "tail (animal)"
-        ],
-        "notation": "しっぽ"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "向(むこ)う",
             "(v5u) to face,to go towards"
-        ],
-        "notation": "向(むこ)う"
+        ]
     },
     {
         "name": "minoru",
         "trans": [
+            "実(みの)る",
             "to bear fruit,to ripen"
-        ],
-        "notation": "実(みの)る"
+        ]
     },
     {
         "name": "shoumou",
         "trans": [
+            "消耗(しょうもう)",
             "exhaustion,consumption"
-        ],
-        "notation": "消耗(しょうもう)"
+        ]
     },
     {
         "name": "enshuu",
         "trans": [
+            "円周(えんしゅう)",
             "circumference"
-        ],
-        "notation": "円周(えんしゅう)"
+        ]
     },
     {
         "name": "aojiroi",
         "trans": [
+            "青白(あおじろ)い",
             "pale,pallid"
-        ],
-        "notation": "青白(あおじろ)い"
+        ]
     },
     {
         "name": "yawarakai",
         "trans": [
+            "軟(やわ)らかい",
             "soft,tender,limp"
-        ],
-        "notation": "軟(やわ)らかい"
+        ]
     },
     {
         "name": "kenshuu",
         "trans": [
+            "研修(けんしゅう)",
             "training"
-        ],
-        "notation": "研修(けんしゅう)"
+        ]
     },
     {
         "name": "tenpo",
         "trans": [
+            "テンポ",
             "tempo"
-        ],
-        "notation": "テンポ"
+        ]
     },
     {
         "name": "mihon",
         "trans": [
+            "見本(みほん)",
             "sample"
-        ],
-        "notation": "見本(みほん)"
+        ]
     },
     {
         "name": "bouenkyou",
         "trans": [
+            "望遠鏡(ぼうえんきょう)",
             "telescope"
-        ],
-        "notation": "望遠鏡(ぼうえんきょう)"
+        ]
     },
     {
         "name": "tsuika",
         "trans": [
+            "追加(ついか)",
             "addition,supplement,appendix"
-        ],
-        "notation": "追加(ついか)"
+        ]
     },
     {
         "name": "shoutousan",
         "trans": [
+            "小(しょう)父(とう)さん",
             "middle-aged gentleman,uncle"
-        ],
-        "notation": "小(しょう)父(とう)さん"
+        ]
     },
     {
         "name": "tadashi",
         "trans": [
+            "但(ただ)し",
             "but,however,provided that"
-        ],
-        "notation": "但(ただ)し"
+        ]
     },
     {
         "name": "kokoroeru",
         "trans": [
+            "心得(こころえ)る",
             "to be informed,to have thorough knowledge"
-        ],
-        "notation": "心得(こころえ)る"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "量(はか)る",
             "to measure,to weigh,to survey"
-        ],
-        "notation": "量(はか)る"
+        ]
     },
     {
         "name": "shinnyuu",
         "trans": [
+            "侵入(しんにゅう)",
             "penetration,invasion,raid,aggression,trespass"
-        ],
-        "notation": "侵入(しんにゅう)"
+        ]
     },
     {
         "name": "tokuchou",
         "trans": [
+            "特長(とくちょう)",
             "forte,merit"
-        ],
-        "notation": "特長(とくちょう)"
+        ]
     },
     {
         "name": "nozoku",
         "trans": [
+            "覗(のぞ)く",
             "to peep in,to look in,to peek in,to stick out"
-        ],
-        "notation": "覗(のぞ)く"
+        ]
     },
     {
         "name": "gesui",
         "trans": [
+            "下水(げすい)",
             "drainage,sewage,ditch,gutter,sewerage"
-        ],
-        "notation": "下水(げすい)"
+        ]
     },
     {
         "name": "chuushou",
         "trans": [
+            "抽象(ちゅうしょう)",
             "abstract"
-        ],
-        "notation": "抽象(ちゅうしょう)"
+        ]
     },
     {
         "name": "osaeru",
         "trans": [
+            "押(おさ)える",
             "to stop,to restrain,to seize,to repress,to suppress,to press down"
-        ],
-        "notation": "押(おさ)える"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "写(うつ)る",
             "to be photographed,to be projected"
-        ],
-        "notation": "写(うつ)る"
+        ]
     },
     {
         "name": "kaneru",
         "trans": [
+            "兼(か)ねる",
             "to hold (position),to serve,to be unable"
-        ],
-        "notation": "兼(か)ねる"
+        ]
     },
     {
         "name": "kajiru",
         "trans": [
+            "かじる",
             "to chew,to bite (at),to gnaw,to nibble"
-        ],
-        "notation": "かじる"
+        ]
     },
     {
         "name": "kisu",
         "trans": [
+            "帰(き)す",
             "to send back"
-        ],
-        "notation": "帰(き)す"
+        ]
     },
     {
         "name": "suiso",
         "trans": [
+            "水素(すいそ)",
             "hydrogen"
-        ],
-        "notation": "水素(すいそ)"
+        ]
     },
     {
         "name": "okawari",
         "trans": [
+            "お代(か)わり",
             "second helping,another cup"
-        ],
-        "notation": "お代(か)わり"
+        ]
     },
     {
         "name": "nokorazu",
         "trans": [
+            "残(のこ)らず",
             "all,entirely,completely,without exception"
-        ],
-        "notation": "残(のこ)らず"
+        ]
     },
     {
         "name": "dansui",
         "trans": [
+            "断水(だんすい)",
             "water outage"
-        ],
-        "notation": "断水(だんすい)"
+        ]
     },
     {
         "name": "chokusen",
         "trans": [
+            "直線(ちょくせん)",
             "straight line"
-        ],
-        "notation": "直線(ちょくせん)"
+        ]
     },
     {
         "name": "handoru",
         "trans": [
+            "ハンドル",
             "handle,steering wheel"
-        ],
-        "notation": "ハンドル"
+        ]
     },
     {
         "name": "chouten",
         "trans": [
+            "頂点(ちょうてん)",
             "top,summit"
-        ],
-        "notation": "頂点(ちょうてん)"
+        ]
     },
     {
         "name": "shokuen",
         "trans": [
+            "食塩(しょくえん)",
             "table salt"
-        ],
-        "notation": "食塩(しょくえん)"
+        ]
     },
     {
         "name": "jitsuyou",
         "trans": [
+            "実用(じつよう)",
             "practical use,utility"
-        ],
-        "notation": "実用(じつよう)"
+        ]
     },
     {
         "name": "tsukuru/tsukuru",
         "trans": [
+            "作(つく)る/造(つく)る",
             "to make,to create"
-        ],
-        "notation": "作(つく)る/造(つく)る"
+        ]
     },
     {
         "name": "kutouten",
         "trans": [
+            "句読点(くとうてん)",
             "punctuation marks"
-        ],
-        "notation": "句読点(くとうてん)"
+        ]
     },
     {
         "name": "doukaku",
         "trans": [
+            "同格(どうかく)",
             "the same rank,equality,apposition"
-        ],
-        "notation": "同格(どうかく)"
+        ]
     },
     {
         "name": "wariaini",
         "trans": [
+            "わりあいに",
             "comparatively"
-        ],
-        "notation": "わりあいに"
+        ]
     },
     {
         "name": "shuukin",
         "trans": [
+            "集金(しゅうきん)",
             "money collection"
-        ],
-        "notation": "集金(しゅうきん)"
+        ]
     },
     {
         "name": "heitai",
         "trans": [
+            "兵隊(へいたい)",
             "soldier,sailor"
-        ],
-        "notation": "兵隊(へいたい)"
+        ]
     },
     {
         "name": "chishitsu",
         "trans": [
+            "地質(ちしつ)",
             "geological features"
-        ],
-        "notation": "地質(ちしつ)"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "仮定(かてい)",
             "assumption,supposition,hypothesis"
-        ],
-        "notation": "仮定(かてい)"
+        ]
     },
     {
         "name": "ekitai",
         "trans": [
+            "液体(えきたい)",
             "liquid,fluid"
-        ],
-        "notation": "液体(えきたい)"
+        ]
     },
     {
         "name": "katamari",
         "trans": [
+            "塊(かたまり)",
             "lump,mass,clod,cluster"
-        ],
-        "notation": "塊(かたまり)"
+        ]
     },
     {
         "name": "heiki",
         "trans": [
+            "平気(へいき)",
             "coolness,calmness,composure,unconcern"
-        ],
-        "notation": "平気(へいき)"
+        ]
     },
     {
         "name": "oubei",
         "trans": [
+            "欧米(おうべい)",
             "Europe and America,the West"
-        ],
-        "notation": "欧米(おうべい)"
+        ]
     },
     {
         "name": "sakujo",
         "trans": [
+            "削除(さくじょ)",
             "elimination,cancellation,deletion,erasure"
-        ],
-        "notation": "削除(さくじょ)"
+        ]
     },
     {
         "name": "daen",
         "trans": [
+            "楕円(だえん)",
             "ellipse"
-        ],
-        "notation": "楕円(だえん)"
+        ]
     },
     {
         "name": "reiten",
         "trans": [
+            "零(れい)点(てん)",
             "zero,no marks"
-        ],
-        "notation": "零(れい)点(てん)"
+        ]
     },
     {
         "name": "hayakuchi",
         "trans": [
+            "早口(はやくち)",
             "fast-talking"
-        ],
-        "notation": "早口(はやくち)"
+        ]
     },
     {
         "name": "soubetsu",
         "trans": [
+            "送別(そうべつ)",
             "farewell,send-off"
-        ],
-        "notation": "送別(そうべつ)"
+        ]
     },
     {
         "name": "moshikasuruto",
         "trans": [
+            "もしかすると",
             "perhaps,maybe,by some chance"
-        ],
-        "notation": "もしかすると"
+        ]
     },
     {
         "name": "miri",
         "trans": [
+            "ミリ",
             "milli-,10^-3"
-        ],
-        "notation": "ミリ"
+        ]
     },
     {
         "name": "kabuseru",
         "trans": [
+            "被(かぶ)せる",
             "to cover (with something)"
-        ],
-        "notation": "被(かぶ)せる"
+        ]
     },
     {
         "name": "kuttsuku",
         "trans": [
+            "くっつく",
             "to adhere to,to keep close to"
-        ],
-        "notation": "くっつく"
+        ]
     },
     {
         "name": "taikei",
         "trans": [
+            "体系(たいけい)",
             "system,organization"
-        ],
-        "notation": "体系(たいけい)"
+        ]
     },
     {
         "name": "osameru",
         "trans": [
+            "治(おさ)める",
             "(1) to govern,to manage,(2) to subdue"
-        ],
-        "notation": "治(おさ)める"
+        ]
     },
     {
         "name": "shuuzen",
         "trans": [
+            "修繕(しゅうぜん)",
             "repair,mending"
-        ],
-        "notation": "修繕(しゅうぜん)"
+        ]
     },
     {
         "name": "hitosashiyubi",
         "trans": [
+            "人差指(ひとさしゆび)",
             "index finger"
-        ],
-        "notation": "人差指(ひとさしゆび)"
+        ]
     },
     {
         "name": "usugurai",
         "trans": [
+            "薄暗(うすぐら)い",
             "dim,gloomy"
-        ],
-        "notation": "薄暗(うすぐら)い"
+        ]
     },
     {
         "name": "tameru",
         "trans": [
+            "溜(た)める",
             "to amass,to accumulate"
-        ],
-        "notation": "溜(た)める"
+        ]
     },
     {
         "name": "shinkuu",
         "trans": [
+            "真空(しんくう)",
             "vacuum,hollow,empty"
-        ],
-        "notation": "真空(しんくう)"
+        ]
     },
     {
         "name": "ouzuru",
         "trans": [
+            "応(おう)ずる",
             "to answer,to respond,to meet,to satisfy,to accept"
-        ],
-        "notation": "応(おう)ずる"
+        ]
     },
     {
         "name": "sumi",
         "trans": [
+            "墨(すみ)",
             "ink"
-        ],
-        "notation": "墨(すみ)"
+        ]
     },
     {
         "name": "hikyou",
         "trans": [
+            "卑怯(ひきょう)",
             "cowardice,meanness,unfairness"
-        ],
-        "notation": "卑怯(ひきょう)"
+        ]
     },
     {
         "name": "tansuu",
         "trans": [
+            "単数(たんすう)",
             "singular (number)"
-        ],
-        "notation": "単数(たんすう)"
+        ]
     },
     {
         "name": "rekurieeshon",
         "trans": [
+            "レクリェーション",
             "recreation"
-        ],
-        "notation": "レクリェーション"
+        ]
     },
     {
         "name": "sukkiri",
         "trans": [
+            "すっきり",
             "shapely,clear,neat"
-        ],
-        "notation": "すっきり"
+        ]
     },
     {
         "name": "kanchou",
         "trans": [
+            "官庁(かんちょう)",
             "government office,authorities"
-        ],
-        "notation": "官庁(かんちょう)"
+        ]
     },
     {
         "name": "uketamawaru",
         "trans": [
+            "承(うけたまわ)る",
             "(hum) to hear,to be told,to know"
-        ],
-        "notation": "承(うけたまわ)る"
+        ]
     },
     {
         "name": "kanwa",
         "trans": [
+            "漢和(かんわ)",
             "Chinese Character-Japanese (e.g. dictionary)"
-        ],
-        "notation": "漢和(かんわ)"
+        ]
     },
     {
         "name": "chousho",
         "trans": [
+            "長所(ちょうしょ)",
             "(1) strong point,merit,(2) advantage"
-        ],
-        "notation": "長所(ちょうしょ)"
+        ]
     },
     {
         "name": "namiki",
         "trans": [
+            "並木(なみき)",
             "roadside tree,row of trees"
-        ],
-        "notation": "並木(なみき)"
+        ]
     },
     {
         "name": "wanpiisu",
         "trans": [
+            "ワンピース",
             "one-piece dress"
-        ],
-        "notation": "ワンピース"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "課程(かてい)",
             "course,curriculum"
-        ],
-        "notation": "課程(かてい)"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "点(つ)く",
             "to catch fire,(electricity) comes on"
-        ],
-        "notation": "点(つ)く"
+        ]
     },
     {
         "name": "shokyuu",
         "trans": [
+            "初級(しょきゅう)",
             "elementary level"
-        ],
-        "notation": "初級(しょきゅう)"
+        ]
     },
     {
         "name": "hikkomu",
         "trans": [
+            "引(ひ)っ込(こ)む",
             "to draw back,to sink,to cave in"
-        ],
-        "notation": "引(ひ)っ込(こ)む"
+        ]
     },
     {
         "name": "take",
         "trans": [
+            "竹(たけ)",
             "bamboo,middle (of a three-tier ranking system)"
-        ],
-        "notation": "竹(たけ)"
+        ]
     },
     {
         "name": "makkura",
         "trans": [
+            "真(ま)っ暗(くら)",
             "total darkness,shortsightedness,pitch dark"
-        ],
-        "notation": "真(ま)っ暗(くら)"
+        ]
     },
     {
         "name": "meibutsu",
         "trans": [
+            "名物(めいぶつ)",
             "famous product,special product,speciality"
-        ],
-        "notation": "名物(めいぶつ)"
+        ]
     },
     {
         "name": "fuyasu",
         "trans": [
+            "殖(ふ)やす",
             "to increase,to add to,to augment"
-        ],
-        "notation": "殖(ふ)やす"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "拭(ふ)く",
             "to wipe,to dry"
-        ],
-        "notation": "拭(ふ)く"
+        ]
     },
     {
         "name": "kawara",
         "trans": [
+            "瓦(かわら)",
             "roof tile"
-        ],
-        "notation": "瓦(かわら)"
+        ]
     },
     {
         "name": "gekkyuu",
         "trans": [
+            "月給(げっきゅう)",
             "monthly salary"
-        ],
-        "notation": "月給(げっきゅう)"
+        ]
     },
     {
         "name": "kanzume",
         "trans": [
+            "缶詰(かんづめ)",
             "packing (in cans),canning,canned goods,tin can"
-        ],
-        "notation": "缶詰(かんづめ)"
+        ]
     },
     {
         "name": "sukima",
         "trans": [
+            "隙間(すきま)",
             "crevice,crack,gap,opening"
-        ],
-        "notation": "隙間(すきま)"
+        ]
     },
     {
         "name": "tsuuka",
         "trans": [
+            "通貨(つうか)",
             "currency"
-        ],
-        "notation": "通貨(つうか)"
+        ]
     },
     {
         "name": "aratameru",
         "trans": [
+            "改(あらた)める",
             "to change,to alter,to reform,to revise"
-        ],
-        "notation": "改(あらた)める"
+        ]
     },
     {
         "name": "oginau",
         "trans": [
+            "補(おぎな)う",
             "to compensate for"
-        ],
-        "notation": "補(おぎな)う"
+        ]
     },
     {
         "name": "gyouji",
         "trans": [
+            "行事(ぎょうじ)",
             "event,function"
-        ],
-        "notation": "行事(ぎょうじ)"
+        ]
     },
     {
         "name": "yakusu",
         "trans": [
+            "訳(やく)す",
             "to translate"
-        ],
-        "notation": "訳(やく)す"
+        ]
     },
     {
         "name": "shoukin",
         "trans": [
+            "賞金(しょうきん)",
             "prize,monetary award"
-        ],
-        "notation": "賞金(しょうきん)"
+        ]
     },
     {
         "name": "daigakuin",
         "trans": [
+            "大学院(だいがくいん)",
             "graduate school"
-        ],
-        "notation": "大学院(だいがくいん)"
+        ]
     },
     {
         "name": "tekubi",
         "trans": [
+            "手首(てくび)",
             "wrist"
-        ],
-        "notation": "手首(てくび)"
+        ]
     },
     {
         "name": "minikui",
         "trans": [
+            "醜(みにく)い",
             "ugly"
-        ],
-        "notation": "醜(みにく)い"
+        ]
     },
     {
         "name": "koeru",
         "trans": [
+            "超(こ)える",
             "to exceed,to cross over,to cross"
-        ],
-        "notation": "超(こ)える"
+        ]
     },
     {
         "name": "shima",
         "trans": [
+            "縞(しま)",
             "stripe"
-        ],
-        "notation": "縞(しま)"
+        ]
     },
     {
         "name": "yuuenchi",
         "trans": [
+            "遊園(ゆうえん)地(ち)",
             "amusement park"
-        ],
-        "notation": "遊園(ゆうえん)地(ち)"
+        ]
     },
     {
         "name": "zenshin",
         "trans": [
+            "全身(ぜんしん)",
             "the whole body,full-length (portrait)"
-        ],
-        "notation": "全身(ぜんしん)"
+        ]
     },
     {
         "name": "yakusha",
         "trans": [
+            "役者(やくしゃ)",
             "actor,actress"
-        ],
-        "notation": "役者(やくしゃ)"
+        ]
     },
     {
         "name": "donburi",
         "trans": [
+            "丼(どんぶり)",
             "porcelain bowl,bowl of rice with food on top"
-        ],
-        "notation": "丼(どんぶり)"
+        ]
     },
     {
         "name": "kikin",
         "trans": [
+            "飢饉(ききん)",
             "famine"
-        ],
-        "notation": "飢饉(ききん)"
+        ]
     },
     {
         "name": "kasen",
         "trans": [
+            "下線(かせん)",
             "underline,underscore"
-        ],
-        "notation": "下線(かせん)"
+        ]
     },
     {
         "name": "koukou",
         "trans": [
+            "孝行(こうこう)",
             "filial piety"
-        ],
-        "notation": "孝行(こうこう)"
+        ]
     },
     {
         "name": "ani",
         "trans": [
+            "安易(あんい)",
             "easy-going"
-        ],
-        "notation": "安易(あんい)"
+        ]
     },
     {
         "name": "hitodoori",
         "trans": [
+            "人通(ひとどお)り",
             "pedestrian traffic"
-        ],
-        "notation": "人通(ひとどお)り"
+        ]
     },
     {
         "name": "shougakusei",
         "trans": [
+            "小学生(しょうがくせい)",
             "grade school student"
-        ],
-        "notation": "小学生(しょうがくせい)"
+        ]
     },
     {
         "name": "yakuhin",
         "trans": [
+            "薬品(やくひん)",
             "medicine(s),chemical(s)"
-        ],
-        "notation": "薬品(やくひん)"
+        ]
     },
     {
         "name": "genjuu",
         "trans": [
+            "厳重(げんじゅう)",
             "strict,rigour,severe,firm"
-        ],
-        "notation": "厳重(げんじゅう)"
+        ]
     },
     {
         "name": "kushin",
         "trans": [
+            "苦心(くしん)",
             "pain,trouble"
-        ],
-        "notation": "苦心(くしん)"
+        ]
     },
     {
         "name": "junjou",
         "trans": [
+            "純情(じゅんじょう)",
             "pure heart,naivete,self-sacrificing devotion"
-        ],
-        "notation": "純情(じゅんじょう)"
+        ]
     },
     {
         "name": "yorokobi",
         "trans": [
+            "慶(よろこ)び",
             "(n) (a) joy,(a) delight,rapture,pleasure,gratification,rejoicing,congratulations,felicitations"
-        ],
-        "notation": "慶(よろこ)び"
+        ]
     },
     {
         "name": "sunpou",
         "trans": [
+            "寸法(すんぽう)",
             "measurement,size,dimension"
-        ],
-        "notation": "寸法(すんぽう)"
+        ]
     },
     {
         "name": "gesha",
         "trans": [
+            "下車(げしゃ)",
             "alighting,getting off"
-        ],
-        "notation": "下車(げしゃ)"
+        ]
     },
     {
         "name": "sujiru",
         "trans": [
+            "捩(すじ)る",
             "to twist"
-        ],
-        "notation": "捩(すじ)る"
+        ]
     },
     {
         "name": "mochi",
         "trans": [
+            "餅(もち)",
             "sticky rice cake"
-        ],
-        "notation": "餅(もち)"
+        ]
     },
     {
         "name": "kakou",
         "trans": [
+            "火口(かこう)",
             "a burner,origin of a fire"
-        ],
-        "notation": "火口(かこう)"
+        ]
     },
     {
         "name": "suppai",
         "trans": [
+            "すっぱい",
             "sour,acid"
-        ],
-        "notation": "すっぱい"
+        ]
     },
     {
         "name": "niji",
         "trans": [
+            "虹(にじ)",
             "rainbow"
-        ],
-        "notation": "虹(にじ)"
+        ]
     },
     {
         "name": "kakuu",
         "trans": [
+            "架空(かくう)",
             "aerial,overhead,fiction,fanciful"
-        ],
-        "notation": "架空(かくう)"
+        ]
     },
     {
         "name": "fuun",
         "trans": [
+            "不運(ふうん)",
             "unlucky,misfortune,bad luck,fate"
-        ],
-        "notation": "不運(ふうん)"
+        ]
     },
     {
         "name": "modan",
         "trans": [
+            "モダン",
             "modern"
-        ],
-        "notation": "モダン"
+        ]
     },
     {
         "name": "houru",
         "trans": [
+            "放(ほう)る",
             "to let go"
-        ],
-        "notation": "放(ほう)る"
+        ]
     },
     {
         "name": "sabiru",
         "trans": [
+            "錆(さ)びる",
             "to rust,to become rusty"
-        ],
-        "notation": "錆(さ)びる"
+        ]
     },
     {
         "name": "suitou",
         "trans": [
+            "水筒(すいとう)",
             "canteen,flask,water bottle"
-        ],
-        "notation": "水筒(すいとう)"
+        ]
     },
     {
         "name": "uragaesu",
         "trans": [
+            "裏返(うらがえ)す",
             "to turn inside out,to turn (something) over"
-        ],
-        "notation": "裏返(うらがえ)す"
+        ]
     },
     {
         "name": "urayamashii",
         "trans": [
+            "羨(うらや)ましい",
             "envious,enviable"
-        ],
-        "notation": "羨(うらや)ましい"
+        ]
     },
     {
         "name": "sontoku",
         "trans": [
+            "損得(そんとく)",
             "loss and gain,advantage and disadvantage"
-        ],
-        "notation": "損得(そんとく)"
+        ]
     },
     {
         "name": "go",
         "trans": [
+            "碁(ご)",
             "Go (board game of capturing territory)"
-        ],
-        "notation": "碁(ご)"
+        ]
     },
     {
         "name": "meyasu",
         "trans": [
+            "目安(めやす)",
             "criterion,aim"
-        ],
-        "notation": "目安(めやす)"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "過程(かてい)",
             "process"
-        ],
-        "notation": "過程(かてい)"
+        ]
     },
     {
         "name": "housou",
         "trans": [
+            "包装(ほうそう)",
             "packing,wrapping"
-        ],
-        "notation": "包装(ほうそう)"
+        ]
     },
     {
         "name": "heijitsu",
         "trans": [
+            "平日(へいじつ)",
             "weekday,ordinary days"
-        ],
-        "notation": "平日(へいじつ)"
+        ]
     },
     {
         "name": "odorokasu",
         "trans": [
+            "驚(おどろ)かす",
             "to surprise,to frighten,to create a stir"
-        ],
-        "notation": "驚(おどろ)かす"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "鳴(な)らす",
             "to ring,to sound,to chime,to beat,to snort (nose)"
-        ],
-        "notation": "鳴(な)らす"
+        ]
     },
     {
         "name": "hasamu",
         "trans": [
+            "挟(はさ)む",
             "to interpose,to hold between,to insert"
-        ],
-        "notation": "挟(はさ)む"
+        ]
     },
     {
         "name": "kingyo",
         "trans": [
+            "金魚(きんぎょ)",
             "goldfish"
-        ],
-        "notation": "金魚(きんぎょ)"
+        ]
     },
     {
         "name": "toshin",
         "trans": [
+            "都心(としん)",
             "heart (of city)"
-        ],
-        "notation": "都心(としん)"
+        ]
     },
     {
         "name": "madoguchi",
         "trans": [
+            "窓口(まどぐち)",
             "ticket window"
-        ],
-        "notation": "窓口(まどぐち)"
+        ]
     },
     {
         "name": "chiten",
         "trans": [
+            "地点(ちてん)",
             "site,point on a map"
-        ],
-        "notation": "地点(ちてん)"
+        ]
     },
     {
         "name": "shitei",
         "trans": [
+            "指定(してい)",
             "designation,specification,assignment,pointing at"
-        ],
-        "notation": "指定(してい)"
+        ]
     },
     {
         "name": "michijun",
         "trans": [
+            "道順(みちじゅん)",
             "itinerary,route"
-        ],
-        "notation": "道順(みちじゅん)"
+        ]
     },
     {
         "name": "wakawakashii",
         "trans": [
+            "若々しい(わかわかしい)",
             "youthful,young"
-        ],
-        "notation": "若々しい(わかわかしい)"
+        ]
     },
     {
         "name": "kouin",
         "trans": [
+            "工員(こういん)",
             "factory worker"
-        ],
-        "notation": "工員(こういん)"
+        ]
     },
     {
         "name": "hirogeru",
         "trans": [
+            "広(ひろ)げる",
             "to spread,to extend,to expand,to enlarge"
-        ],
-        "notation": "広(ひろ)げる"
+        ]
     },
     {
         "name": "koushi",
         "trans": [
+            "講師(こうし)",
             "lecturer"
-        ],
-        "notation": "講師(こうし)"
+        ]
     },
     {
         "name": "niru",
         "trans": [
+            "煮(に)る",
             "to boil,to cook"
-        ],
-        "notation": "煮(に)る"
+        ]
     },
     {
         "name": "monooki",
         "trans": [
+            "物置(ものおき)",
             "storage room"
-        ],
-        "notation": "物置(ものおき)"
+        ]
     },
     {
         "name": "tounan",
         "trans": [
+            "盗難(とうなん)",
             "theft,robbery"
-        ],
-        "notation": "盗難(とうなん)"
+        ]
     },
     {
         "name": "zouri",
         "trans": [
+            "草履(ぞうり)",
             "zoori (Japanese footwear),sandals"
-        ],
-        "notation": "草履(ぞうり)"
+        ]
     },
     {
         "name": "mure",
         "trans": [
+            "群(む)れ",
             "group,crowd,flock,herd"
-        ],
-        "notation": "群(む)れ"
+        ]
     },
     {
         "name": "kuyashii",
         "trans": [
+            "悔(くや)しい",
             "regrettable,mortifying,vexing"
-        ],
-        "notation": "悔(くや)しい"
+        ]
     },
     {
         "name": "toujou",
         "trans": [
+            "登場(とうじょう)",
             "entry (on stage)"
-        ],
-        "notation": "登場(とうじょう)"
+        ]
     },
     {
         "name": "mainasu",
         "trans": [
+            "マイナス",
             "minus"
-        ],
-        "notation": "マイナス"
+        ]
     },
     {
         "name": "kakezan",
         "trans": [
+            "掛(か)け算(ざん)",
             "multiplication"
-        ],
-        "notation": "掛(か)け算(ざん)"
+        ]
     },
     {
         "name": "sutaato",
         "trans": [
+            "スタート",
             "start"
-        ],
-        "notation": "スタート"
+        ]
     },
     {
         "name": "shitagaki",
         "trans": [
+            "下書(したが)き",
             "rough copy,draft"
-        ],
-        "notation": "下書(したが)き"
+        ]
     },
     {
         "name": "souieba",
         "trans": [
+            "そういえば",
             "which reminds me .."
-        ],
-        "notation": "そういえば"
+        ]
     },
     {
         "name": "tokoya",
         "trans": [
+            "床屋(とこや)",
             "barber"
-        ],
-        "notation": "床屋(とこや)"
+        ]
     },
     {
         "name": "onkei",
         "trans": [
+            "恩恵(おんけい)",
             "grace,favor,blessing,benefit"
-        ],
-        "notation": "恩恵(おんけい)"
+        ]
     },
     {
         "name": "hitomi",
         "trans": [
+            "瞳(ひとみ)",
             "pupil (of eye)"
-        ],
-        "notation": "瞳(ひとみ)"
+        ]
     },
     {
         "name": "hori",
         "trans": [
+            "堀(ほり)",
             "moat,canal"
-        ],
-        "notation": "堀(ほり)"
+        ]
     },
     {
         "name": "ryoushi",
         "trans": [
+            "漁師(りょうし)",
             "fisherman"
-        ],
-        "notation": "漁師(りょうし)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "掻(か)く",
             "to scratch,to perspire"
-        ],
-        "notation": "掻(か)く"
+        ]
     },
     {
         "name": "buhin",
         "trans": [
+            "部品(ぶひん)",
             "parts,accessories"
-        ],
-        "notation": "部品(ぶひん)"
+        ]
     },
     {
         "name": "kakitome",
         "trans": [
+            "書留(かきとめ)",
             "writing down,putting on record,recording,making a note of,registration (of mail)"
-        ],
-        "notation": "書留(かきとめ)"
+        ]
     },
     {
         "name": "koutsuukikan",
         "trans": [
+            "交通(こうつう)機関(きかん)",
             "transportation facilities"
-        ],
-        "notation": "交通(こうつう)機関(きかん)"
+        ]
     },
     {
         "name": "kaisei",
         "trans": [
+            "改正(かいせい)",
             "revision,amendment,alteration"
-        ],
-        "notation": "改正(かいせい)"
+        ]
     },
     {
         "name": "akusento",
         "trans": [
+            "アクセント",
             "accent"
-        ],
-        "notation": "アクセント"
+        ]
     },
     {
         "name": "yakunin",
         "trans": [
+            "役人(やくにん)",
             "government official"
-        ],
-        "notation": "役人(やくにん)"
+        ]
     },
     {
         "name": "karorii",
         "trans": [
+            "カロリー",
             "calorie"
-        ],
-        "notation": "カロリー"
+        ]
     },
     {
         "name": "otetsudaisan",
         "trans": [
+            "お手伝(てつだ)いさん",
             "maid"
-        ],
-        "notation": "お手伝(てつだ)いさん"
+        ]
     },
     {
         "name": "jitsurei",
         "trans": [
+            "実例(じつれい)",
             "example,illustration"
-        ],
-        "notation": "実例(じつれい)"
+        ]
     },
     {
         "name": "kaisetsu",
         "trans": [
+            "解説(かいせつ)",
             "explanation,commentary"
-        ],
-        "notation": "解説(かいせつ)"
+        ]
     },
     {
         "name": "chijireru",
         "trans": [
+            "縮(ちぢ)れる",
             "to be wavy,to be curled"
-        ],
-        "notation": "縮(ちぢ)れる"
+        ]
     },
     {
         "name": "kakudo",
         "trans": [
+            "角度(かくど)",
             "angle"
-        ],
-        "notation": "角度(かくど)"
+        ]
     },
     {
         "name": "shougi",
         "trans": [
+            "将棋(しょうぎ)",
             "Japanese chess"
-        ],
-        "notation": "将棋(しょうぎ)"
+        ]
     },
     {
         "name": "betsubetsu",
         "trans": [
+            "別々(べつべつ)",
             "separately,individually"
-        ],
-        "notation": "別々(べつべつ)"
+        ]
     },
     {
         "name": "kousa",
         "trans": [
+            "交差(こうさ)",
             "cross"
-        ],
-        "notation": "交差(こうさ)"
+        ]
     },
     {
         "name": "chikazukeru",
         "trans": [
+            "近付(ちかづ)ける",
             "to bring near,to put close,to let come near,to associate with"
-        ],
-        "notation": "近付(ちかづ)ける"
+        ]
     },
     {
         "name": "narau",
         "trans": [
+            "倣(なら)う",
             "to imitate,to follow,to emulate"
-        ],
-        "notation": "倣(なら)う"
+        ]
     },
     {
         "name": "oiru",
         "trans": [
+            "オイル",
             "oil,engine oil,kerosene"
-        ],
-        "notation": "オイル"
+        ]
     },
     {
         "name": "tsunagari",
         "trans": [
+            "繋(つな)がり",
             "connection,link,relationship"
-        ],
-        "notation": "繋(つな)がり"
+        ]
     },
     {
         "name": "hiatari",
         "trans": [
+            "日当(ひあ)たり",
             "exposure to the sun,sunny place"
-        ],
-        "notation": "日当(ひあ)たり"
+        ]
     },
     {
         "name": "kamisori",
         "trans": [
+            "剃刀(かみそり)",
             "razor"
-        ],
-        "notation": "剃刀(かみそり)"
+        ]
     },
     {
         "name": "chitai",
         "trans": [
+            "地帯(ちたい)",
             "area,zone"
-        ],
-        "notation": "地帯(ちたい)"
+        ]
     },
     {
         "name": "kamisama",
         "trans": [
+            "神様(かみさま)",
             "god"
-        ],
-        "notation": "神様(かみさま)"
+        ]
     },
     {
         "name": "zougen",
         "trans": [
+            "増減(ぞうげん)",
             "increase and decrease,fluctuation"
-        ],
-        "notation": "増減(ぞうげん)"
+        ]
     },
     {
         "name": "chakuchaku",
         "trans": [
+            "着々(ちゃくちゃく)",
             "steadily"
-        ],
-        "notation": "着々(ちゃくちゃく)"
+        ]
     },
     {
         "name": "katsuji",
         "trans": [
+            "活字(かつじ)",
             "printing type"
-        ],
-        "notation": "活字(かつじ)"
+        ]
     },
     {
         "name": "kessaku",
         "trans": [
+            "傑作(けっさく)",
             "masterpiece,best work,boner,blunder"
-        ],
-        "notation": "傑作(けっさく)"
+        ]
     },
     {
         "name": "aimai",
         "trans": [
+            "あいまい",
             "vague,ambiguous"
-        ],
-        "notation": "あいまい"
+        ]
     },
     {
         "name": "kehai",
         "trans": [
+            "気配(けはい)",
             "indication,market trend,worry"
-        ],
-        "notation": "気配(けはい)"
+        ]
     },
     {
         "name": "tsukiau",
         "trans": [
+            "付合(つきあ)う",
             "to associate with,to keep company with,to get on with"
-        ],
-        "notation": "付合(つきあ)う"
+        ]
     },
     {
         "name": "teiin",
         "trans": [
+            "定員(ていいん)",
             "fixed number of regular personnel,capacity (of boat, etc.)"
-        ],
-        "notation": "定員(ていいん)"
+        ]
     },
     {
         "name": "nakanaori",
         "trans": [
+            "仲直(なかなお)り",
             "reconciliation,make peace with"
-        ],
-        "notation": "仲直(なかなお)り"
+        ]
     },
     {
         "name": "zashiki",
         "trans": [
+            "座敷(ざしき)",
             "tatami room"
-        ],
-        "notation": "座敷(ざしき)"
+        ]
     },
     {
         "name": "zaigaku",
         "trans": [
+            "在学(ざいがく)",
             "(enrolled) in school"
-        ],
-        "notation": "在学(ざいがく)"
+        ]
     },
     {
         "name": "moguru",
         "trans": [
+            "潜(もぐ)る",
             "(1) to drive,to pass through,(2) to evade,to hide,(3) to dive (into or under water),to go undergroun"
-        ],
-        "notation": "潜(もぐ)る"
+        ]
     },
     {
         "name": "kikansha",
         "trans": [
+            "機関(きかん)車(しゃ)",
             "locomotive,engine"
-        ],
-        "notation": "機関(きかん)車(しゃ)"
+        ]
     },
     {
         "name": "ogenkide",
         "trans": [
+            "おげんきで",
             ""
-        ],
-        "notation": "おげんきで"
+        ]
     },
     {
         "name": "tokeru",
         "trans": [
+            "溶(と)ける",
             "to melt,to thaw,to fuse,to dissolve"
-        ],
-        "notation": "溶(と)ける"
+        ]
     },
     {
         "name": "osakini",
         "trans": [
+            "おさきに",
             "before,ahead,previously"
-        ],
-        "notation": "おさきに"
+        ]
     },
     {
         "name": "jukugo",
         "trans": [
+            "熟語(じゅくご)",
             "idiom,idiomatic phrase,kanji compound"
-        ],
-        "notation": "熟語(じゅくご)"
+        ]
     },
     {
         "name": "shinzuru",
         "trans": [
+            "信(しん)ずる",
             "to believe,to believe in,to place trust in"
-        ],
-        "notation": "信(しん)ずる"
+        ]
     },
     {
         "name": "menseki",
         "trans": [
+            "面積(めんせき)",
             "area"
-        ],
-        "notation": "面積(めんせき)"
+        ]
     },
     {
         "name": "koudo",
         "trans": [
+            "高度(こうど)",
             "altitude,height,advanced"
-        ],
-        "notation": "高度(こうど)"
+        ]
     },
     {
         "name": "kansai",
         "trans": [
+            "関西(かんさい)",
             ""
-        ],
-        "notation": "関西(かんさい)"
+        ]
     },
     {
         "name": "zenshuu",
         "trans": [
+            "全集(ぜんしゅう)",
             "complete works"
-        ],
-        "notation": "全集(ぜんしゅう)"
+        ]
     },
     {
         "name": "suiteki",
         "trans": [
+            "水滴(すいてき)",
             "drop of water"
-        ],
-        "notation": "水滴(すいてき)"
+        ]
     },
     {
         "name": "kasetto",
         "trans": [
+            "カセット",
             "cassette (tape)"
-        ],
-        "notation": "カセット"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "酌(く)む",
             "to serve sake"
-        ],
-        "notation": "酌(く)む"
+        ]
     },
     {
         "name": "zukan",
         "trans": [
+            "図鑑(ずかん)",
             "picture book"
-        ],
-        "notation": "図鑑(ずかん)"
+        ]
     },
     {
         "name": "awateru",
         "trans": [
+            "あわてる",
             "to become confused"
-        ],
-        "notation": "あわてる"
+        ]
     },
     {
         "name": "nouson",
         "trans": [
+            "農村(のうそん)",
             "agricultural community,farm village,rural"
-        ],
-        "notation": "農村(のうそん)"
+        ]
     },
     {
         "name": "koshikake",
         "trans": [
+            "腰掛(こしか)け",
             "seat,bench"
-        ],
-        "notation": "腰掛(こしか)け"
+        ]
     },
     {
         "name": "keiko",
         "trans": [
+            "稽古(けいこ)",
             "practice,training,study"
-        ],
-        "notation": "稽古(けいこ)"
+        ]
     },
     {
         "name": "sashimi",
         "trans": [
+            "刺身(さしみ)",
             "sliced raw fish"
-        ],
-        "notation": "刺身(さしみ)"
+        ]
     },
     {
         "name": "kouseki",
         "trans": [
+            "功績(こうせき)",
             "achievements,merit,meritorious service,meritorious deed"
-        ],
-        "notation": "功績(こうせき)"
+        ]
     },
     {
         "name": "suzu",
         "trans": [
+            "鈴(すず)",
             "bell"
-        ],
-        "notation": "鈴(すず)"
+        ]
     },
     {
         "name": "horu",
         "trans": [
+            "掘(ほ)る",
             "to dig,to excavate"
-        ],
-        "notation": "掘(ほ)る"
+        ]
     },
     {
         "name": "chiru",
         "trans": [
+            "散(ち)る",
             "to fall,to scatter (e.g. blossoms)"
-        ],
-        "notation": "散(ち)る"
+        ]
     },
     {
         "name": "mitarashi",
         "trans": [
+            "御手洗(みたらし)",
             "font of purifying water placed at entrance of shrine"
-        ],
-        "notation": "御手洗(みたらし)"
+        ]
     },
     {
         "name": "juuyaku",
         "trans": [
+            "重役(じゅうやく)",
             "director,high executive"
-        ],
-        "notation": "重役(じゅうやく)"
+        ]
     },
     {
         "name": "kawaku",
         "trans": [
+            "渇(かわ)く",
             "to be thirsty"
-        ],
-        "notation": "渇(かわ)く"
+        ]
     },
     {
         "name": "pen",
         "trans": [
+            "ぺん",
             "pen"
-        ],
-        "notation": "ぺん"
+        ]
     },
     {
         "name": "kakou",
         "trans": [
+            "下降(かこう)",
             "downward,descent,fall,drop,subsidence"
-        ],
-        "notation": "下降(かこう)"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "汲(く)む",
             "(1) to draw (water),to dip,to scoop,to pump"
-        ],
-        "notation": "汲(く)む"
+        ]
     },
     {
         "name": "sei",
         "trans": [
+            "姓(せい)",
             "surname,family name"
-        ],
-        "notation": "姓(せい)"
+        ]
     },
     {
         "name": "fukushi",
         "trans": [
+            "副詞(ふくし)",
             "adverb"
-        ],
-        "notation": "副詞(ふくし)"
+        ]
     },
     {
         "name": "funsui",
         "trans": [
+            "噴水(ふんすい)",
             "water fountain"
-        ],
-        "notation": "噴水(ふんすい)"
+        ]
     },
     {
         "name": "enchou",
         "trans": [
+            "延長(えんちょう)",
             "extension,elongation,prolongation,lengthening"
-        ],
-        "notation": "延長(えんちょう)"
+        ]
     },
     {
         "name": "moyooshi",
         "trans": [
+            "催(もよお)し",
             "event,festivities,function"
-        ],
-        "notation": "催(もよお)し"
+        ]
     },
     {
         "name": "hanayome",
         "trans": [
+            "花嫁(はなよめ)",
             "bride"
-        ],
-        "notation": "花嫁(はなよめ)"
+        ]
     },
     {
         "name": "tenkai",
         "trans": [
+            "展開(てんかい)",
             "develop,expansion (opposite of compression)"
-        ],
-        "notation": "展開(てんかい)"
+        ]
     },
     {
         "name": "kashou",
         "trans": [
+            "火傷(かしょう)",
             "burn,scald"
-        ],
-        "notation": "火傷(かしょう)"
+        ]
     },
     {
         "name": "kagu",
         "trans": [
+            "嗅(か)ぐ",
             "to sniff,to smell"
-        ],
-        "notation": "嗅(か)ぐ"
+        ]
     },
     {
         "name": "hanji",
         "trans": [
+            "判事(はんじ)",
             "judge,judiciary"
-        ],
-        "notation": "判事(はんじ)"
+        ]
     },
     {
         "name": "chikau",
         "trans": [
+            "誓(ちか)う",
             "to swear,to vow,to take an oath,to pledge"
-        ],
-        "notation": "誓(ちか)う"
+        ]
     },
     {
         "name": "housoku",
         "trans": [
+            "法則(ほうそく)",
             "law,rule"
-        ],
-        "notation": "法則(ほうそく)"
+        ]
     },
     {
         "name": "zokusuru",
         "trans": [
+            "属(ぞく)する",
             "to belong to,to come under,to be affiliated with,to be subject to"
-        ],
-        "notation": "属(ぞく)する"
+        ]
     },
     {
         "name": "seisho",
         "trans": [
+            "清書(せいしょ)",
             "clean copy"
-        ],
-        "notation": "清書(せいしょ)"
+        ]
     },
     {
         "name": "chigiru",
         "trans": [
+            "ちぎる",
             "to cut up fine,to pick (fruit)"
-        ],
-        "notation": "ちぎる"
+        ]
     },
     {
         "name": "touitsu",
         "trans": [
+            "統一(とういつ)",
             "unity,consolidation,uniformity"
-        ],
-        "notation": "統一(とういつ)"
+        ]
     },
     {
         "name": "suri",
         "trans": [
+            "掏摸(すり)",
             "pickpocket"
-        ],
-        "notation": "掏摸(すり)"
+        ]
     },
     {
         "name": "robii",
         "trans": [
+            "ロビー",
             "lobby"
-        ],
-        "notation": "ロビー"
+        ]
     },
     {
         "name": "daiku",
         "trans": [
+            "大工(だいく)",
             "carpenter"
-        ],
-        "notation": "大工(だいく)"
+        ]
     },
     {
         "name": "shikke",
         "trans": [
+            "湿気(しっけ)",
             "moisture,humidity,dampness"
-        ],
-        "notation": "湿気(しっけ)"
+        ]
     },
     {
         "name": "taishite",
         "trans": [
+            "大(たい)して",
             "(not so) much,(not) very"
-        ],
-        "notation": "大(たい)して"
+        ]
     },
     {
         "name": "tansu",
         "trans": [
+            "たんす",
             "chest of drawers"
-        ],
-        "notation": "たんす"
+        ]
     },
     {
         "name": "sainan",
         "trans": [
+            "災難(さいなん)",
             "calamity,misfortune"
-        ],
-        "notation": "災難(さいなん)"
+        ]
     },
     {
         "name": "bakarashii",
         "trans": [
+            "ばからしい",
             "absurd"
-        ],
-        "notation": "ばからしい"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "澄(す)む",
             "to clear (e.g. weather),to become transparent"
-        ],
-        "notation": "澄(す)む"
+        ]
     },
     {
         "name": "kantou",
         "trans": [
+            "関東(かんとう)",
             "eastern half of Japan, including Tokyo"
-        ],
-        "notation": "関東(かんとう)"
+        ]
     },
     {
         "name": "seisuu",
         "trans": [
+            "整数(せいすう)",
             "integer"
-        ],
-        "notation": "整数(せいすう)"
+        ]
     },
     {
         "name": "-kajou",
         "trans": [
+            "-過剰(かじょう)",
             "excess,over"
-        ],
-        "notation": "-過剰(かじょう)"
+        ]
     },
     {
         "name": "kiseru",
         "trans": [
+            "着(き)せる",
             "to put on clothes"
-        ],
-        "notation": "着(き)せる"
+        ]
     },
     {
         "name": "kabaa",
         "trans": [
+            "カバー",
             "cover (ex. book)"
-        ],
-        "notation": "カバー"
+        ]
     },
     {
         "name": "sakizakitsuki",
         "trans": [
+            "先々(さきざき)月(つき)",
             "month before last"
-        ],
-        "notation": "先々(さきざき)月(つき)"
+        ]
     },
     {
         "name": "shakkuri",
         "trans": [
+            "しゃっくり",
             "hiccough,hiccup"
-        ],
-        "notation": "しゃっくり"
+        ]
     },
     {
         "name": "nousanbutsu",
         "trans": [
+            "農産物(のうさんぶつ)",
             "agricultural produce"
-        ],
-        "notation": "農産物(のうさんぶつ)"
+        ]
     },
     {
         "name": "jikkan",
         "trans": [
+            "実感(じっかん)",
             "feelings (actual, true)"
-        ],
-        "notation": "実感(じっかん)"
+        ]
     },
     {
         "name": "atehamaru",
         "trans": [
+            "あてはまる",
             "to be applicable,to come under (a category),to fulfill"
-        ],
-        "notation": "あてはまる"
+        ]
     },
     {
         "name": "sukunakutomo",
         "trans": [
+            "すくなくとも",
             "at least"
-        ],
-        "notation": "すくなくとも"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "挿(さ)す",
             "to insert,to put in,to graft,to wear in belt"
-        ],
-        "notation": "挿(さ)す"
+        ]
     },
     {
         "name": "uchikesu",
         "trans": [
+            "打(う)ち消(け)す",
             "to deny,to negate,to contradict"
-        ],
-        "notation": "打(う)ち消(け)す"
+        ]
     },
     {
         "name": "zoukin",
         "trans": [
+            "雑巾(ぞうきん)",
             "house-cloth,dust cloth"
-        ],
-        "notation": "雑巾(ぞうきん)"
+        ]
     },
     {
         "name": "kaisei",
         "trans": [
+            "快晴(かいせい)",
             "good weather"
-        ],
-        "notation": "快晴(かいせい)"
+        ]
     },
     {
         "name": "nichiji",
         "trans": [
+            "日時(にちじ)",
             "date and time"
-        ],
-        "notation": "日時(にちじ)"
+        ]
     },
     {
         "name": "machiaishitsu",
         "trans": [
+            "待合室(まちあいしつ)",
             "waiting room"
-        ],
-        "notation": "待合室(まちあいしつ)"
+        ]
     },
     {
         "name": "jisshuu",
         "trans": [
+            "実習(じっしゅう)",
             "practice,training"
-        ],
-        "notation": "実習(じっしゅう)"
+        ]
     },
     {
         "name": "kossori",
         "trans": [
+            "こっそり",
             "stealthily,secretly"
-        ],
-        "notation": "こっそり"
+        ]
     },
     {
         "name": "kuusou",
         "trans": [
+            "空想(くうそう)",
             "daydream,fantasy,fancy,vision"
-        ],
-        "notation": "空想(くうそう)"
+        ]
     },
     {
         "name": "kouzou",
         "trans": [
+            "構造(こうぞう)",
             "structure,construction"
-        ],
-        "notation": "構造(こうぞう)"
+        ]
     },
     {
         "name": "engei",
         "trans": [
+            "園芸(えんげい)",
             "horticulture,gardening"
-        ],
-        "notation": "園芸(えんげい)"
+        ]
     },
     {
         "name": "takameru",
         "trans": [
+            "高(たか)める",
             "to raise,to lift,to boost"
-        ],
-        "notation": "高(たか)める"
+        ]
     },
     {
         "name": "futa",
         "trans": [
+            "蓋(ふた)",
             "cover,lid,cap"
-        ],
-        "notation": "蓋(ふた)"
+        ]
     },
     {
         "name": "tameiki",
         "trans": [
+            "溜息(ためいき)",
             "a sigh"
-        ],
-        "notation": "溜息(ためいき)"
+        ]
     },
     {
         "name": "shakaikagaku",
         "trans": [
+            "社会(しゃかい)科学(かがく)",
             "social science"
-        ],
-        "notation": "社会(しゃかい)科学(かがく)"
+        ]
     },
     {
         "name": "kawakasu",
         "trans": [
+            "乾(かわ)かす",
             "to dry (clothes, etc.),to desiccate"
-        ],
-        "notation": "乾(かわ)かす"
+        ]
     },
     {
         "name": "rinji",
         "trans": [
+            "臨時(りんじ)",
             "temporary,special,extraordinary"
-        ],
-        "notation": "臨時(りんじ)"
+        ]
     },
     {
         "name": "arigatai",
         "trans": [
+            "有難(ありがた)い",
             "grateful,thankful,welcome,appreciated,evoking gratitude"
-        ],
-        "notation": "有難(ありがた)い"
+        ]
     },
     {
         "name": "kengaku",
         "trans": [
+            "見学(けんがく)",
             "inspection,study by observation,field trip"
-        ],
-        "notation": "見学(けんがく)"
+        ]
     },
     {
         "name": "harigane",
         "trans": [
+            "針金(はりがね)",
             "wire"
-        ],
-        "notation": "針金(はりがね)"
+        ]
     },
     {
         "name": "kuriiningu",
         "trans": [
+            "クリーニング",
             "cleaning,dry cleaning,laundry service"
-        ],
-        "notation": "クリーニング"
+        ]
     },
     {
         "name": "meishin",
         "trans": [
+            "迷信(めいしん)",
             "superstition"
-        ],
-        "notation": "迷信(めいしん)"
+        ]
     },
     {
         "name": "sharin",
         "trans": [
+            "車輪(しゃりん)",
             "(car) wheel"
-        ],
-        "notation": "車輪(しゃりん)"
+        ]
     },
     {
         "name": "rasshuawaa",
         "trans": [
+            "ラッシュアワー",
             "rush hour"
-        ],
-        "notation": "ラッシュアワー"
+        ]
     },
     {
         "name": "onegaishimasu",
         "trans": [
+            "おねがいします",
             "please"
-        ],
-        "notation": "おねがいします"
+        ]
     },
     {
         "name": "shibireru",
         "trans": [
+            "しびれる",
             "to become numb,to go to sleep (i.e., a limb)"
-        ],
-        "notation": "しびれる"
+        ]
     },
     {
         "name": "kyoushuku",
         "trans": [
+            "恐縮(きょうしゅく)",
             "shame,very kind of you,sorry to trouble"
-        ],
-        "notation": "恐縮(きょうしゅく)"
+        ]
     },
     {
         "name": "noseru",
         "trans": [
+            "載(の)せる",
             "to place on (something),to take on board,to give a ride"
-        ],
-        "notation": "載(の)せる"
+        ]
     },
     {
         "name": "shiriai",
         "trans": [
+            "知合(しりあ)い",
             "acquaintance"
-        ],
-        "notation": "知合(しりあ)い"
+        ]
     },
     {
         "name": "nyoubou",
         "trans": [
+            "女房(にょうぼう)",
             "wife"
-        ],
-        "notation": "女房(にょうぼう)"
+        ]
     },
     {
         "name": "bunrui",
         "trans": [
+            "分類(ぶんるい)",
             "classification"
-        ],
-        "notation": "分類(ぶんるい)"
+        ]
     },
     {
         "name": "hiragana",
         "trans": [
+            "平仮名(ひらがな)",
             "hiragana,47 syllables,the cursive syllabary"
-        ],
-        "notation": "平仮名(ひらがな)"
+        ]
     },
     {
         "name": "furii",
         "trans": [
+            "フリー",
             "free"
-        ],
-        "notation": "フリー"
+        ]
     },
     {
         "name": "sokuryou",
         "trans": [
+            "測量(そくりょう)",
             "measurement,surveying"
-        ],
-        "notation": "測量(そくりょう)"
+        ]
     },
     {
         "name": "sonaeru",
         "trans": [
+            "具(そな)える",
             "to be furnished with"
-        ],
-        "notation": "具(そな)える"
+        ]
     },
     {
         "name": "kureguremo",
         "trans": [
+            "くれぐれも",
             "repeatedly,sincerely,earnestly"
-        ],
-        "notation": "くれぐれも"
+        ]
     },
     {
         "name": "yappari",
         "trans": [
+            "やっぱり",
             "also,as I thought,still,in spite of,absolutely,of course"
-        ],
-        "notation": "やっぱり"
+        ]
     },
     {
         "name": "kokku",
         "trans": [
+            "コック",
             "(1) cook (nl:),(2) tap,spigot,faucet,cock"
-        ],
-        "notation": "コック"
+        ]
     },
     {
         "name": "kazari",
         "trans": [
+            "飾(かざ)り",
             "decoration"
-        ],
-        "notation": "飾(かざ)り"
+        ]
     },
     {
         "name": "kaisuiyoku",
         "trans": [
+            "海水浴(かいすいよく)",
             "sea bathing,seawater bath"
-        ],
-        "notation": "海水浴(かいすいよく)"
+        ]
     },
     {
         "name": "ohayou",
         "trans": [
+            "おはよう",
             "(abbr) Good morning"
-        ],
-        "notation": "おはよう"
+        ]
     },
     {
         "name": "yomigaeru",
         "trans": [
+            "蘇(よみがえ)る",
             "to be resurrected,to be revived,to be resuscitated,to be rehabilitated"
-        ],
-        "notation": "蘇(よみがえ)る"
+        ]
     },
     {
         "name": "amado",
         "trans": [
+            "雨戸(あまど)",
             "sliding storm door"
-        ],
-        "notation": "雨戸(あまど)"
+        ]
     },
     {
         "name": "nobiru",
         "trans": [
+            "延(の)びる",
             "to be prolonged"
-        ],
-        "notation": "延(の)びる"
+        ]
     },
     {
         "name": "ojamashimasu",
         "trans": [
+            "おじゃまします",
             "Excuse me for disturbing you"
-        ],
-        "notation": "おじゃまします"
+        ]
     },
     {
         "name": "shouji",
         "trans": [
+            "障子(しょうじ)",
             "paper sliding door"
-        ],
-        "notation": "障子(しょうじ)"
+        ]
     },
     {
         "name": "ketsueki",
         "trans": [
+            "血液(けつえき)",
             "blood"
-        ],
-        "notation": "血液(けつえき)"
+        ]
     },
     {
         "name": "ageru (=yaru)",
         "trans": [
+            "あげる (=やる)",
             "to do for"
-        ],
-        "notation": "あげる (=やる)"
+        ]
     },
     {
         "name": "hiyakkajiten",
         "trans": [
+            "ひゃっかじてん",
             "encyclopedia"
-        ],
-        "notation": "ひゃっかじてん"
+        ]
     },
     {
         "name": "meguru",
         "trans": [
+            "巡(めぐ)る",
             "to go around"
-        ],
-        "notation": "巡(めぐ)る"
+        ]
     },
     {
         "name": "yoseru",
         "trans": [
+            "寄(よ)せる",
             "to collect,to gather,to add,to put aside"
-        ],
-        "notation": "寄(よ)せる"
+        ]
     },
     {
         "name": "baketsu",
         "trans": [
+            "バケツ",
             "bucket,pail"
-        ],
-        "notation": "バケツ"
+        ]
     },
     {
         "name": "hyouhon",
         "trans": [
+            "標本(ひょうほん)",
             "example,specimen"
-        ],
-        "notation": "標本(ひょうほん)"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "揚(あ)げる",
             "to lift,to fry"
-        ],
-        "notation": "揚(あ)げる"
+        ]
     },
     {
         "name": "tetsuzuki",
         "trans": [
+            "手続(てつづ)き",
             "procedure,(legal) process,formalities"
-        ],
-        "notation": "手続(てつづ)き"
+        ]
     },
     {
         "name": "junsui",
         "trans": [
+            "純粋(じゅんすい)",
             "pure,true,genuine,unmixed"
-        ],
-        "notation": "純粋(じゅんすい)"
+        ]
     },
     {
         "name": "monosashi",
         "trans": [
+            "物差(ものさ)し",
             "ruler,measure"
-        ],
-        "notation": "物差(ものさ)し"
+        ]
     },
     {
         "name": "kousou",
         "trans": [
+            "高層(こうそう)",
             "upper"
-        ],
-        "notation": "高層(こうそう)"
+        ]
     },
     {
         "name": "shousuu",
         "trans": [
+            "小数(しょうすう)",
             "fraction (part of),decimal"
-        ],
-        "notation": "小数(しょうすう)"
+        ]
     },
     {
         "name": "dokidoki",
         "trans": [
+            "どきどき",
             "throb,beat (fast)"
-        ],
-        "notation": "どきどき"
+        ]
     },
     {
         "name": "senro",
         "trans": [
+            "線路(せんろ)",
             "line,track,roadbed"
-        ],
-        "notation": "線路(せんろ)"
+        ]
     },
     {
         "name": "shodou",
         "trans": [
+            "書道(しょどう)",
             "calligraphy"
-        ],
-        "notation": "書道(しょどう)"
+        ]
     },
     {
         "name": "soru",
         "trans": [
+            "反(そ)る",
             "to warp,to be warped,to curve"
-        ],
-        "notation": "反(そ)る"
+        ]
     },
     {
         "name": "shouhai",
         "trans": [
+            "勝敗(しょうはい)",
             "victory or defeat,issue (of battle)"
-        ],
-        "notation": "勝敗(しょうはい)"
+        ]
     },
     {
         "name": "achirakochira",
         "trans": [
+            "あちらこちら",
             "here and there"
-        ],
-        "notation": "あちらこちら"
+        ]
     },
     {
         "name": "soroban",
         "trans": [
+            "算盤(そろばん)",
             "abacus"
-        ],
-        "notation": "算盤(そろばん)"
+        ]
     },
     {
         "name": "hanei",
         "trans": [
+            "反映(はんえい)",
             "reflection,influence"
-        ],
-        "notation": "反映(はんえい)"
+        ]
     },
     {
         "name": "hiromeru",
         "trans": [
+            "広(ひろ)める",
             "to broaden,to propagate"
-        ],
-        "notation": "広(ひろ)める"
+        ]
     },
     {
         "name": "binzume",
         "trans": [
+            "瓶詰(びんづめ)",
             "bottling,bottled"
-        ],
-        "notation": "瓶詰(びんづめ)"
+        ]
     },
     {
         "name": "kugiru",
         "trans": [
+            "区切(くぎ)る",
             "to punctuate,to cut off,to mark off,to stop,to put an end to"
-        ],
-        "notation": "区切(くぎ)る"
+        ]
     },
     {
         "name": "ronzuru",
         "trans": [
+            "論(ろん)ずる",
             "to argue,to discuss,to debate"
-        ],
-        "notation": "論(ろん)ずる"
+        ]
     },
     {
         "name": "moushiwakenai",
         "trans": [
+            "申(もう)し訳(わけ)ない",
             "inexcusable"
-        ],
-        "notation": "申(もう)し訳(わけ)ない"
+        ]
     },
     {
         "name": "erai",
         "trans": [
+            "偉(えら)い",
             "great,celebrated,eminent,terrible,awful,famous,remarkable,excellent"
-        ],
-        "notation": "偉(えら)い"
+        ]
     },
     {
         "name": "natsukashii",
         "trans": [
+            "懐(なつ)かしい",
             "dear,desired,missed"
-        ],
-        "notation": "懐(なつ)かしい"
+        ]
     },
     {
         "name": "henshuu",
         "trans": [
+            "編集(へんしゅう)",
             "editing,compilation,editorial (e.g. committee)"
-        ],
-        "notation": "編集(へんしゅう)"
+        ]
     },
     {
         "name": "shuyaku",
         "trans": [
+            "主役(しゅやく)",
             "leading part,leading actor (actress)"
-        ],
-        "notation": "主役(しゅやく)"
+        ]
     },
     {
         "name": "urami",
         "trans": [
+            "恨(うら)み",
             "resentment"
-        ],
-        "notation": "恨(うら)み"
+        ]
     },
     {
         "name": "gojigi",
         "trans": [
+            "御(ご)辞儀(じぎ)",
             "bow"
-        ],
-        "notation": "御(ご)辞儀(じぎ)"
+        ]
     },
     {
         "name": "kakitori",
         "trans": [
+            "書取(かきとり)",
             "dictation"
-        ],
-        "notation": "書取(かきとり)"
+        ]
     },
     {
         "name": "chuuto",
         "trans": [
+            "中途(ちゅうと)",
             "in the middle,half-way"
-        ],
-        "notation": "中途(ちゅうと)"
+        ]
     },
     {
         "name": "hiji",
         "trans": [
+            "肘(ひじ)",
             "elbow"
-        ],
-        "notation": "肘(ひじ)"
+        ]
     },
     {
         "name": "ueru",
         "trans": [
+            "飢(う)える",
             "to starve"
-        ],
-        "notation": "飢(う)える"
+        ]
     },
     {
         "name": "machikado",
         "trans": [
+            "街角(まちかど)",
             "street corner"
-        ],
-        "notation": "街角(まちかど)"
+        ]
     },
     {
         "name": "atatameru",
         "trans": [
+            "暖(あたた)める",
             "to warm,to heat"
-        ],
-        "notation": "暖(あたた)める"
+        ]
     },
     {
         "name": "higaeri",
         "trans": [
+            "日帰(ひがえ)り",
             "day trip"
-        ],
-        "notation": "日帰(ひがえ)り"
+        ]
     },
     {
         "name": "shikakui",
         "trans": [
+            "四角(しかく)い",
             "square"
-        ],
-        "notation": "四角(しかく)い"
+        ]
     },
     {
         "name": "orugan",
         "trans": [
+            "オルガン",
             "organ"
-        ],
-        "notation": "オルガン"
+        ]
     },
     {
         "name": "onshitsu",
         "trans": [
+            "温室(おんしつ)",
             "greenhouse"
-        ],
-        "notation": "温室(おんしつ)"
+        ]
     },
     {
         "name": "hibiki",
         "trans": [
+            "響(ひび)き",
             "echo,sound,reverberation,noise"
-        ],
-        "notation": "響(ひび)き"
+        ]
     },
     {
         "name": "yuderu",
         "trans": [
+            "ゆでる",
             "to boil"
-        ],
-        "notation": "ゆでる"
+        ]
     },
     {
         "name": "hikidasu",
         "trans": [
+            "引出(ひきだ)す",
             "to pull out,to take out,to draw out,to withdraw"
-        ],
-        "notation": "引出(ひきだ)す"
+        ]
     },
     {
         "name": "shiasatte",
         "trans": [
+            "しあさって",
             "two days after tomorrow"
-        ],
-        "notation": "しあさって"
+        ]
     },
     {
         "name": "taku",
         "trans": [
+            "焚(た)く",
             "to burn,to kindle,to build a fire"
-        ],
-        "notation": "焚(た)く"
+        ]
     },
     {
         "name": "kaisuu",
         "trans": [
+            "回数(かいすう)",
             "number of times,frequency"
-        ],
-        "notation": "回数(かいすう)"
+        ]
     },
     {
         "name": "gishiki",
         "trans": [
+            "儀式(ぎしき)",
             "ceremony,rite,ritual,service"
-        ],
-        "notation": "儀式(ぎしき)"
+        ]
     },
     {
         "name": "kaizou",
         "trans": [
+            "改造(かいぞう)",
             "(1) remodeling,(2) modding (comp)"
-        ],
-        "notation": "改造(かいぞう)"
+        ]
     },
     {
         "name": "banchi",
         "trans": [
+            "番地(ばんち)",
             "house number,address"
-        ],
-        "notation": "番地(ばんち)"
+        ]
     },
     {
         "name": "asshuku",
         "trans": [
+            "圧縮(あっしゅく)",
             "compression,condensation,pressure"
-        ],
-        "notation": "圧縮(あっしゅく)"
+        ]
     },
     {
         "name": "shinrin",
         "trans": [
+            "森林(しんりん)",
             "forest,woods"
-        ],
-        "notation": "森林(しんりん)"
+        ]
     },
     {
         "name": "daiyaguramu",
         "trans": [
+            "ダイヤグラム",
             "diagram"
-        ],
-        "notation": "ダイヤグラム"
+        ]
     },
     {
         "name": "senchi",
         "trans": [
+            "センチ",
             "centimeter,centi-,10^-2"
-        ],
-        "notation": "センチ"
+        ]
     },
     {
         "name": "yokubari",
         "trans": [
+            "欲張(よくば)り",
             "avarice,covetousness,greed"
-        ],
-        "notation": "欲張(よくば)り"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "代(か)える",
             "to exchange,to interchange,to substitute,to replace"
-        ],
-        "notation": "代(か)える"
+        ]
     },
     {
         "name": "kajitsu",
         "trans": [
+            "果実(かじつ)",
             "fruit,nut,berry."
-        ],
-        "notation": "果実(かじつ)"
+        ]
     },
     {
         "name": "jishuu",
         "trans": [
+            "自習(じしゅう)",
             "self-study"
-        ],
-        "notation": "自習(じしゅう)"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "因(よ)る",
             "to come from"
-        ],
-        "notation": "因(よ)る"
+        ]
     },
     {
         "name": "epuron",
         "trans": [
+            "エプロン",
             "apron"
-        ],
-        "notation": "エプロン"
+        ]
     },
     {
         "name": "saguru",
         "trans": [
+            "探(さぐ)る",
             "to search,to look for,to sound out"
-        ],
-        "notation": "探(さぐ)る"
+        ]
     },
     {
         "name": "chouku",
         "trans": [
+            "チョーク",
             "chock,chalk"
-        ],
-        "notation": "チョーク"
+        ]
     },
     {
         "name": "jaanarisuto",
         "trans": [
+            "ジャーナリスト",
             "journalist"
-        ],
-        "notation": "ジャーナリスト"
+        ]
     },
     {
         "name": "onoono",
         "trans": [
+            "各々(おのおの)",
             "each,every,either,respectively,severally"
-        ],
-        "notation": "各々(おのおの)"
+        ]
     },
     {
         "name": "sakanoboru",
         "trans": [
+            "遡(さかのぼ)る",
             "to go back,to go upstream,to make retroactive"
-        ],
-        "notation": "遡(さかのぼ)る"
+        ]
     },
     {
         "name": "obasan",
         "trans": [
+            "叔母(おば)さん",
             "(1) aunt,(2) middle-aged lady"
-        ],
-        "notation": "叔母(おば)さん"
+        ]
     },
     {
         "name": "douse",
         "trans": [
+            "どうせ",
             "anyhow,in any case,at any rate"
-        ],
-        "notation": "どうせ"
+        ]
     },
     {
         "name": "kyokusen",
         "trans": [
+            "曲線(きょくせん)",
             "curve"
-        ],
-        "notation": "曲線(きょくせん)"
+        ]
     },
     {
         "name": "hikkoshi",
         "trans": [
+            "引越(ひっこ)し",
             "moving (dwelling etc.),changing residence"
-        ],
-        "notation": "引越(ひっこ)し"
+        ]
     },
     {
         "name": "nanbaa",
         "trans": [
+            "ナンバー",
             "number"
-        ],
-        "notation": "ナンバー"
+        ]
     },
     {
         "name": "suteeji",
         "trans": [
+            "ステージ",
             "(1) stage,(2) performance"
-        ],
-        "notation": "ステージ"
+        ]
     },
     {
         "name": "guusuu",
         "trans": [
+            "偶数(ぐうすう)",
             "even number"
-        ],
-        "notation": "偶数(ぐうすう)"
+        ]
     },
     {
         "name": "shinya",
         "trans": [
+            "深夜(しんや)",
             "late at night"
-        ],
-        "notation": "深夜(しんや)"
+        ]
     },
     {
         "name": "suibun",
         "trans": [
+            "水分(すいぶん)",
             "moisture"
-        ],
-        "notation": "水分(すいぶん)"
+        ]
     },
     {
         "name": "omairi",
         "trans": [
+            "お参(まい)り",
             "worship,shrine visit"
-        ],
-        "notation": "お参(まい)り"
+        ]
     },
     {
         "name": "ittei",
         "trans": [
+            "一定(いってい)",
             "fixed,settled,definite"
-        ],
-        "notation": "一定(いってい)"
+        ]
     },
     {
         "name": "touyu",
         "trans": [
+            "灯油(とうゆ)",
             "lamp oil,kerosene"
-        ],
-        "notation": "灯油(とうゆ)"
+        ]
     },
     {
         "name": "dekiagaru",
         "trans": [
+            "出来上(できあ)がる",
             "(1) to be finished,to be ready,by definition,(2) to be very drunk"
-        ],
-        "notation": "出来上(できあ)がる"
+        ]
     },
     {
         "name": "tekkyou",
         "trans": [
+            "鉄橋(てっきょう)",
             "railway bridge,iron bridge"
-        ],
-        "notation": "鉄橋(てっきょう)"
+        ]
     },
     {
         "name": "omoikomu",
         "trans": [
+            "思(おも)い込(こ)む",
             "to be under impression that,to be convinced that"
-        ],
-        "notation": "思(おも)い込(こ)む"
+        ]
     },
     {
         "name": "urikire",
         "trans": [
+            "売(う)り切(き)れ",
             "sold-out"
-        ],
-        "notation": "売(う)り切(き)れ"
+        ]
     },
     {
         "name": "ikinari",
         "trans": [
+            "いきなり",
             "(uk) abruptly,suddenly,all of a sudden,without warning"
-        ],
-        "notation": "いきなり"
+        ]
     },
     {
         "name": "yokei",
         "trans": [
+            "余計(よけい)",
             "too much,unnecessary,abundance,surplus,excess,superfluity"
-        ],
-        "notation": "余計(よけい)"
+        ]
     },
     {
         "name": "bunmyaku",
         "trans": [
+            "文脈(ぶんみゃく)",
             "context"
-        ],
-        "notation": "文脈(ぶんみゃく)"
+        ]
     },
     {
         "name": "manshon",
         "trans": [
+            "マンション",
             "large apartment,apartment house"
-        ],
-        "notation": "マンション"
+        ]
     },
     {
         "name": "kaoku",
         "trans": [
+            "家屋(かおく)",
             "house,building"
-        ],
-        "notation": "家屋(かおく)"
+        ]
     },
     {
         "name": "nareru",
         "trans": [
+            "馴(な)れる",
             "to become domesticated,to become tame"
-        ],
-        "notation": "馴(な)れる"
+        ]
     },
     {
         "name": "yobidasu",
         "trans": [
+            "呼(よ)び出(だ)す",
             "to summon,to call (e.g. phone)"
-        ],
-        "notation": "呼(よ)び出(だ)す"
+        ]
     },
     {
         "name": "soroeru",
         "trans": [
+            "揃(そろ)える",
             "to put things in order,to arrange,to make uniform,to get something ready"
-        ],
-        "notation": "揃(そろ)える"
+        ]
     },
     {
         "name": "gomenkudasai",
         "trans": [
+            "ごめんください",
             "May I come in?"
-        ],
-        "notation": "ごめんください"
+        ]
     },
     {
         "name": "chokuryuu",
         "trans": [
+            "直流(ちょくりゅう)",
             "direct current"
-        ],
-        "notation": "直流(ちょくりゅう)"
+        ]
     },
     {
         "name": "taiin",
         "trans": [
+            "退院(たいいん)",
             "leaving hospital"
-        ],
-        "notation": "退院(たいいん)"
+        ]
     },
     {
         "name": "mezamashi",
         "trans": [
+            "目覚(めざま)し",
             "(abbr) alarm-clock"
-        ],
-        "notation": "目覚(めざま)し"
+        ]
     },
     {
         "name": "sawayaka",
         "trans": [
+            "さわやか",
             "fresh,refreshing,invigorating"
-        ],
-        "notation": "さわやか"
+        ]
     },
     {
         "name": "sousaku",
         "trans": [
+            "創作(そうさく)",
             "production,literary creation,work"
-        ],
-        "notation": "創作(そうさく)"
+        ]
     },
     {
         "name": "rakuchakuku",
         "trans": [
+            "落着(らくちゃく)く",
             "to calm down,to settle down"
-        ],
-        "notation": "落着(らくちゃく)く"
+        ]
     },
     {
         "name": "koushiki",
         "trans": [
+            "公式(こうしき)",
             "formula,formality,official"
-        ],
-        "notation": "公式(こうしき)"
+        ]
     },
     {
         "name": "douwa",
         "trans": [
+            "童話(どうわ)",
             "fairy tale"
-        ],
-        "notation": "童話(どうわ)"
+        ]
     },
     {
         "name": "yunomi",
         "trans": [
+            "湯飲(ゆの)み",
             "teacup"
-        ],
-        "notation": "湯飲(ゆの)み"
+        ]
     },
     {
         "name": "soshitsu",
         "trans": [
+            "素質(そしつ)",
             "character,qualities,genius"
-        ],
-        "notation": "素質(そしつ)"
+        ]
     },
     {
         "name": "harikiru",
         "trans": [
+            "張(は)り切(き)る",
             "to be in high spirits,to be full of vigor"
-        ],
-        "notation": "張(は)り切(き)る"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "射(さ)す",
             "to shine,to strike"
-        ],
-        "notation": "射(さ)す"
+        ]
     },
     {
         "name": "koraeru",
         "trans": [
+            "こらえる",
             "to bear,to stand,to endure,to put up with"
-        ],
-        "notation": "こらえる"
+        ]
     },
     {
         "name": "katazuku",
         "trans": [
+            "片付(かたづ)く",
             "to put in order,to dispose of,to solve"
-        ],
-        "notation": "片付(かたづ)く"
+        ]
     },
     {
         "name": "goraku",
         "trans": [
+            "娯楽(ごらく)",
             "pleasure,amusement"
-        ],
-        "notation": "娯楽(ごらく)"
+        ]
     },
     {
         "name": "hanareru",
         "trans": [
+            "放(はな)れる",
             "to leave,to get free,to cut oneself off"
-        ],
-        "notation": "放(はな)れる"
+        ]
     },
     {
         "name": "shitai",
         "trans": [
+            "死体(したい)",
             "corpse"
-        ],
-        "notation": "死体(したい)"
+        ]
     },
     {
         "name": "bando",
         "trans": [
+            "バンド",
             "band"
-        ],
-        "notation": "バンド"
+        ]
     },
     {
         "name": "reigai",
         "trans": [
+            "例外(れいがい)",
             "exception"
-        ],
-        "notation": "例外(れいがい)"
+        ]
     },
     {
         "name": "akaki",
         "trans": [
+            "明(あか)き",
             "room,time to spare,emptiness"
-        ],
-        "notation": "明(あか)き"
+        ]
     },
     {
         "name": "nairon",
         "trans": [
+            "ナイロン",
             "nylon"
-        ],
-        "notation": "ナイロン"
+        ]
     },
     {
         "name": "ogamu",
         "trans": [
+            "拝(おが)む",
             "to worship,to beg,to make a supplication"
-        ],
-        "notation": "拝(おが)む"
+        ]
     },
     {
         "name": "jisoku",
         "trans": [
+            "時速(じそく)",
             "speed (per hour)"
-        ],
-        "notation": "時速(じそく)"
+        ]
     },
     {
         "name": "shibomu",
         "trans": [
+            "しぼむ",
             "to wither,to fade (away),to shrivel,to wilt"
-        ],
-        "notation": "しぼむ"
+        ]
     },
     {
         "name": "yotsukado",
         "trans": [
+            "四(よ)つ角(かど)",
             "four corners,crossroads"
-        ],
-        "notation": "四(よ)つ角(かど)"
+        ]
     },
     {
         "name": "seireki",
         "trans": [
+            "西暦(せいれき)",
             "Christian Era,anno domini (A.D.)"
-        ],
-        "notation": "西暦(せいれき)"
+        ]
     },
     {
         "name": "samatageru",
         "trans": [
+            "妨(さまた)げる",
             "to disturb,to prevent"
-        ],
-        "notation": "妨(さまた)げる"
+        ]
     },
     {
         "name": "massao",
         "trans": [
+            "真(ま)っ青(さお)",
             "deep blue,ghastly pale"
-        ],
-        "notation": "真(ま)っ青(さお)"
+        ]
     },
     {
         "name": "toukei",
         "trans": [
+            "統計(とうけい)",
             "scattering,a scatter,dispersion"
-        ],
-        "notation": "統計(とうけい)"
+        ]
     },
     {
         "name": "bouhan",
         "trans": [
+            "防犯(ぼうはん)",
             "prevention of crime"
-        ],
-        "notation": "防犯(ぼうはん)"
+        ]
     },
     {
         "name": "koutei",
         "trans": [
+            "校庭(こうてい)",
             "campus"
-        ],
-        "notation": "校庭(こうてい)"
+        ]
     },
     {
         "name": "kuwaeru",
         "trans": [
+            "咥(くわ)える",
             ""
-        ],
-        "notation": "咥(くわ)える"
+        ]
     },
     {
         "name": "shokunin",
         "trans": [
+            "職人(しょくにん)",
             "worker,mechanic,artisan,craftsman"
-        ],
-        "notation": "職人(しょくにん)"
+        ]
     },
     {
         "name": "tsuuzuru",
         "trans": [
+            "通(つう)ずる",
             ""
-        ],
-        "notation": "通(つう)ずる"
+        ]
     },
     {
         "name": "yudan",
         "trans": [
+            "油断(ゆだん)",
             "negligence,unpreparedness"
-        ],
-        "notation": "油断(ゆだん)"
+        ]
     },
     {
         "name": "shindan",
         "trans": [
+            "診断(しんだん)",
             "diagnosis"
-        ],
-        "notation": "診断(しんだん)"
+        ]
     },
     {
         "name": "youseki",
         "trans": [
+            "容積(ようせき)",
             "capacity,volume"
-        ],
-        "notation": "容積(ようせき)"
+        ]
     },
     {
         "name": "juuryou",
         "trans": [
+            "重量(じゅうりょう)",
             "(1) weight,(2) heavyweight boxer"
-        ],
-        "notation": "重量(じゅうりょう)"
+        ]
     },
     {
         "name": "miman",
         "trans": [
+            "未満(みまん)",
             "less than,insufficient"
-        ],
-        "notation": "未満(みまん)"
+        ]
     },
     {
         "name": "honrai",
         "trans": [
+            "本来(ほんらい)",
             "essentially,naturally,by nature"
-        ],
-        "notation": "本来(ほんらい)"
+        ]
     },
     {
         "name": "jishaku",
         "trans": [
+            "磁石(じしゃく)",
             "magnet"
-        ],
-        "notation": "磁石(じしゃく)"
+        ]
     },
     {
         "name": "semeru",
         "trans": [
+            "攻(せ)める",
             "to attack,to assault"
-        ],
-        "notation": "攻(せ)める"
+        ]
     },
     {
         "name": "shougyou",
         "trans": [
+            "商業(しょうぎょう)",
             "commerce,trade,business"
-        ],
-        "notation": "商業(しょうぎょう)"
+        ]
     },
     {
         "name": "issakunen",
         "trans": [
+            "一昨年(いっさくねん)",
             "year before last"
-        ],
-        "notation": "一昨年(いっさくねん)"
+        ]
     },
     {
         "name": "kakuritsu",
         "trans": [
+            "確率(かくりつ)",
             "probability"
-        ],
-        "notation": "確率(かくりつ)"
+        ]
     },
     {
         "name": "arekore",
         "trans": [
+            "あれこれ",
             "one thing or another,this and that,this or that"
-        ],
-        "notation": "あれこれ"
+        ]
     },
     {
         "name": "kanpai",
         "trans": [
+            "乾杯(かんぱい)",
             "toast (drink)"
-        ],
-        "notation": "乾杯(かんぱい)"
+        ]
     },
     {
         "name": "ukabu",
         "trans": [
+            "浮(うか)ぶ",
             "to float,to rise to surface,to come to mind"
-        ],
-        "notation": "浮(うか)ぶ"
+        ]
     },
     {
         "name": "hikkakaru",
         "trans": [
+            "引(ひ)っ掛(か)かる",
             "to be caught in,to be stuck in,to be cheated"
-        ],
-        "notation": "引(ひ)っ掛(か)かる"
+        ]
     },
     {
         "name": "seinou",
         "trans": [
+            "性能(せいのう)",
             "ability,efficiency"
-        ],
-        "notation": "性能(せいのう)"
+        ]
     },
     {
         "name": "mimau",
         "trans": [
+            "見舞(みま)う",
             "to ask after (health),to visit"
-        ],
-        "notation": "見舞(みま)う"
+        ]
     },
     {
         "name": "sanpuru",
         "trans": [
+            "サンプル",
             "sample"
-        ],
-        "notation": "サンプル"
+        ]
     },
     {
         "name": "penchi",
         "trans": [
+            "ペンチ",
             "(abbr) pliers (lit: pinchers)"
-        ],
-        "notation": "ペンチ"
+        ]
     },
     {
         "name": "reinkouto",
         "trans": [
+            "レインコート",
             "raincoat"
-        ],
-        "notation": "レインコート"
+        ]
     },
     {
         "name": "burouchi",
         "trans": [
+            "ブローチ",
             "brooch"
-        ],
-        "notation": "ブローチ"
+        ]
     },
     {
         "name": "teru",
         "trans": [
+            "照(て)る",
             "to shine"
-        ],
-        "notation": "照(て)る"
+        ]
     },
     {
         "name": "shin",
         "trans": [
+            "芯(しん)",
             "core,heart,wick,marrow"
-        ],
-        "notation": "芯(しん)"
+        ]
     },
     {
         "name": "kichi",
         "trans": [
+            "基地(きち)",
             "base"
-        ],
-        "notation": "基地(きち)"
+        ]
     },
     {
         "name": "oyayubi",
         "trans": [
+            "親指(おやゆび)",
             "thumb"
-        ],
-        "notation": "親指(おやゆび)"
+        ]
     },
     {
         "name": "hodoku",
         "trans": [
+            "ほどく",
             "to unfasten"
-        ],
-        "notation": "ほどく"
+        ]
     },
     {
         "name": "kareru",
         "trans": [
+            "枯(か)れる",
             "to wither,to die (plant),to be blasted (plant)"
-        ],
-        "notation": "枯(か)れる"
+        ]
     },
     {
         "name": "jitsuryoku",
         "trans": [
+            "実力(じつりょく)",
             "merit,efficiency,arms,force"
-        ],
-        "notation": "実力(じつりょく)"
+        ]
     },
     {
         "name": "nouyaku",
         "trans": [
+            "農薬(のうやく)",
             "agricultural chemicals"
-        ],
-        "notation": "農薬(のうやく)"
+        ]
     },
     {
         "name": "medatsu",
         "trans": [
+            "目立(めだ)つ",
             "to be conspicuous,to stand out"
-        ],
-        "notation": "目立(めだ)つ"
+        ]
     },
     {
         "name": "kashima",
         "trans": [
+            "貸間(かしま)",
             "room to let"
-        ],
-        "notation": "貸間(かしま)"
+        ]
     },
     {
         "name": "taue",
         "trans": [
+            "田植(たう)え",
             "rice planting"
-        ],
-        "notation": "田植(たう)え"
+        ]
     },
     {
         "name": "soushiki",
         "trans": [
+            "葬式(そうしき)",
             "funeral"
-        ],
-        "notation": "葬式(そうしき)"
+        ]
     },
     {
         "name": "zokuzoku",
         "trans": [
+            "続々(ぞくぞく)",
             "successively,one after another"
-        ],
-        "notation": "続々(ぞくぞく)"
+        ]
     },
     {
         "name": "kara",
         "trans": [
+            "殻(から)",
             "shell,husk,hull,chaff"
-        ],
-        "notation": "殻(から)"
+        ]
     },
     {
         "name": "suru",
         "trans": [
+            "刷(す)る",
             "to print"
-        ],
-        "notation": "刷(す)る"
+        ]
     },
     {
         "name": "dassen",
         "trans": [
+            "脱線(だっせん)",
             "derailment,digression"
-        ],
-        "notation": "脱線(だっせん)"
+        ]
     },
     {
         "name": "biyou",
         "trans": [
+            "美容(びよう)",
             "beauty of figure or form"
-        ],
-        "notation": "美容(びよう)"
+        ]
     },
     {
         "name": "dantei",
         "trans": [
+            "断定(だんてい)",
             "conclusion,decision"
-        ],
-        "notation": "断定(だんてい)"
+        ]
     },
     {
         "name": "sokuryoku",
         "trans": [
+            "速力(そくりょく)",
             "speed"
-        ],
-        "notation": "速力(そくりょく)"
+        ]
     },
     {
         "name": "kouji",
         "trans": [
+            "工事(こうじ)",
             "construction work"
-        ],
-        "notation": "工事(こうじ)"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "撒(ま)く",
             "to scatter,to sprinkle,to sow"
-        ],
-        "notation": "撒(ま)く"
+        ]
     },
     {
         "name": "onnanohito",
         "trans": [
+            "女(おんな)の人(ひと)",
             "woman"
-        ],
-        "notation": "女(おんな)の人(ひと)"
+        ]
     },
     {
         "name": "choujo",
         "trans": [
+            "長女(ちょうじょ)",
             "eldest daughter"
-        ],
-        "notation": "長女(ちょうじょ)"
+        ]
     },
     {
         "name": "sokutei",
         "trans": [
+            "測定(そくてい)",
             "measurement"
-        ],
-        "notation": "測定(そくてい)"
+        ]
     },
     {
         "name": "yukata",
         "trans": [
+            "浴衣(ゆかた)",
             "bathrobe,informal summer kimono,yukata"
-        ],
-        "notation": "浴衣(ゆかた)"
+        ]
     },
     {
         "name": "sunao",
         "trans": [
+            "素直(すなお)",
             "obedient,meek,docile,unaffected"
-        ],
-        "notation": "素直(すなお)"
+        ]
     },
     {
         "name": "medetai",
         "trans": [
+            "めでたい",
             "happy,simple soul,propitious,joyous"
-        ],
-        "notation": "めでたい"
+        ]
     },
     {
         "name": "mugen",
         "trans": [
+            "無限(むげん)",
             "infinite"
-        ],
-        "notation": "無限(むげん)"
+        ]
     },
     {
         "name": "ran",
         "trans": [
+            "欄(らん)",
             "column of text (e.g. as in a newspaper)"
-        ],
-        "notation": "欄(らん)"
+        ]
     },
     {
         "name": "rejaa",
         "trans": [
+            "レジャー",
             "leisure"
-        ],
-        "notation": "レジャー"
+        ]
     },
     {
         "name": "odokasu",
         "trans": [
+            "おどかす",
             "to threaten,to coerce"
-        ],
-        "notation": "おどかす"
+        ]
     },
     {
         "name": "sekkaku",
         "trans": [
+            "折角(せっかく)",
             "with trouble,at great pains,long-awaited"
-        ],
-        "notation": "折角(せっかく)"
+        ]
     },
     {
         "name": "muku",
         "trans": [
+            "剥(む)く",
             "to peel,to skin,to pare,to hull"
-        ],
-        "notation": "剥(む)く"
+        ]
     },
     {
         "name": "kiatsu",
         "trans": [
+            "気圧(きあつ)",
             "atmospheric pressure"
-        ],
-        "notation": "気圧(きあつ)"
+        ]
     },
     {
         "name": "souko",
         "trans": [
+            "倉庫(そうこ)",
             "storehouse,warehouse,godown"
-        ],
-        "notation": "倉庫(そうこ)"
+        ]
     },
     {
         "name": "supiikaa",
         "trans": [
+            "スピーカー",
             "speaker"
-        ],
-        "notation": "スピーカー"
+        ]
     },
     {
         "name": "massaki",
         "trans": [
+            "真(ま)っ先(さき)",
             "the head,the foremost,beginning"
-        ],
-        "notation": "真(ま)っ先(さき)"
+        ]
     },
     {
         "name": "iidasu",
         "trans": [
+            "言(い)い出(だ)す",
             "to start talking,to speak,to tell,to propose,to suggest,to break the ice"
-        ],
-        "notation": "言(い)い出(だ)す"
+        ]
     },
     {
         "name": "ueetoresu",
         "trans": [
+            "ウエートレス",
             "waitress"
-        ],
-        "notation": "ウエートレス"
+        ]
     },
     {
         "name": "okinodokuni",
         "trans": [
+            "おきのどくに",
             ""
-        ],
-        "notation": "おきのどくに"
+        ]
     },
     {
         "name": "seou",
         "trans": [
+            "背負(せお)う",
             "to be burdened with,to carry on back or shoulder"
-        ],
-        "notation": "背負(せお)う"
+        ]
     },
     {
         "name": "sougo",
         "trans": [
+            "相互(そうご)",
             "mutual,reciprocal"
-        ],
-        "notation": "相互(そうご)"
+        ]
     },
     {
         "name": "shouten",
         "trans": [
+            "商店(しょうてん)",
             "shop,business firm"
-        ],
-        "notation": "商店(しょうてん)"
+        ]
     },
     {
         "name": "meetaa",
         "trans": [
+            "メーター",
             "meter (clock)"
-        ],
-        "notation": "メーター"
+        ]
     },
     {
         "name": "shugo",
         "trans": [
+            "主語(しゅご)",
             "(gram) subject"
-        ],
-        "notation": "主語(しゅご)"
+        ]
     },
     {
         "name": "chousetsu",
         "trans": [
+            "調節(ちょうせつ)",
             "regulation,adjustment,control"
-        ],
-        "notation": "調節(ちょうせつ)"
+        ]
     },
     {
         "name": "shibaru",
         "trans": [
+            "縛(しば)る",
             "to tie,to bind"
-        ],
-        "notation": "縛(しば)る"
+        ]
     },
     {
         "name": "tensuu",
         "trans": [
+            "点数(てんすう)",
             "marks,points,score,runs"
-        ],
-        "notation": "点数(てんすう)"
+        ]
     },
     {
         "name": "kudaranai",
         "trans": [
+            "くだらない",
             "good-for-nothing,stupid,trivial,worthless"
-        ],
-        "notation": "くだらない"
+        ]
     },
     {
         "name": "tearai",
         "trans": [
+            "手洗(てあら)い",
             "restroom,lavatory,hand-washing"
-        ],
-        "notation": "手洗(てあら)い"
+        ]
     },
     {
         "name": "kawaru",
         "trans": [
+            "代(かわ)る",
             "(v5r,vi) to take the place of,to relieve,to be substituted for"
-        ],
-        "notation": "代(かわ)る"
+        ]
     },
     {
         "name": "hayaru",
         "trans": [
+            "流行(はや)る",
             "to flourish,to thrive,to be popular,to come into fashion"
-        ],
-        "notation": "流行(はや)る"
+        ]
     },
     {
         "name": "korogaru",
         "trans": [
+            "転(ころ)がる",
             "to roll,to tumble"
-        ],
-        "notation": "転(ころ)がる"
+        ]
     },
     {
         "name": "senden",
         "trans": [
+            "宣伝(せんでん)",
             "propaganda,publicity"
-        ],
-        "notation": "宣伝(せんでん)"
+        ]
     },
     {
         "name": "gun",
         "trans": [
+            "郡(ぐん)",
             "country,district"
-        ],
-        "notation": "郡(ぐん)"
+        ]
     },
     {
         "name": "chijimu",
         "trans": [
+            "縮(ちぢ)む",
             "to shrink,to be contracted"
-        ],
-        "notation": "縮(ちぢ)む"
+        ]
     },
     {
         "name": "hirobiro",
         "trans": [
+            "広々(ひろびろ)",
             "extensive,spacious"
-        ],
-        "notation": "広々(ひろびろ)"
+        ]
     },
     {
         "name": "bessou",
         "trans": [
+            "別荘(べっそう)",
             "holiday house,villa"
-        ],
-        "notation": "別荘(べっそう)"
+        ]
     },
     {
         "name": "zuuzuushii",
         "trans": [
+            "ずうずうしい",
             "impudent,shameless"
-        ],
-        "notation": "ずうずうしい"
+        ]
     },
     {
         "name": "hitomazu",
         "trans": [
+            "ひとまず",
             "for the present,once,in outline"
-        ],
-        "notation": "ひとまず"
+        ]
     },
     {
         "name": "bungei",
         "trans": [
+            "文芸(ぶんげい)",
             "literature,art and literature,belles-lettres"
-        ],
-        "notation": "文芸(ぶんげい)"
+        ]
     },
     {
         "name": "sutoppu",
         "trans": [
+            "ストップ",
             "stop"
-        ],
-        "notation": "ストップ"
+        ]
     },
     {
         "name": "bonchi",
         "trans": [
+            "盆地(ぼんち)",
             "basin (e.g. between mountains)"
-        ],
-        "notation": "盆地(ぼんち)"
+        ]
     },
     {
         "name": "fusagu",
         "trans": [
+            "塞(ふさ)ぐ",
             "to stop up,to close up,to block (up)"
-        ],
-        "notation": "塞(ふさ)ぐ"
+        ]
     },
     {
         "name": "momu",
         "trans": [
+            "揉(も)む",
             "to rub,to crumple (up),to wrinkle"
-        ],
-        "notation": "揉(も)む"
+        ]
     },
     {
         "name": "yakan",
         "trans": [
+            "夜間(やかん)",
             "at night,nighttime"
-        ],
-        "notation": "夜間(やかん)"
+        ]
     },
     {
         "name": "katamichi",
         "trans": [
+            "片道(かたみち)",
             "one-way (trip)"
-        ],
-        "notation": "片道(かたみち)"
+        ]
     },
     {
         "name": "bushi",
         "trans": [
+            "武士(ぶし)",
             "warrior,samurai"
-        ],
-        "notation": "武士(ぶし)"
+        ]
     },
     {
         "name": "tsuru",
         "trans": [
+            "吊(つ)る",
             "to hang"
-        ],
-        "notation": "吊(つ)る"
+        ]
     },
     {
         "name": "hasamaru",
         "trans": [
+            "挟(はさ)まる",
             "to get between,to be caught in"
-        ],
-        "notation": "挟(はさ)まる"
+        ]
     },
     {
         "name": "nemaki",
         "trans": [
+            "寝間着(ねまき)",
             "sleep-wear,nightclothes,pyjamas,nightgown,nightdress"
-        ],
-        "notation": "寝間着(ねまき)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "留(と)まる",
             "(1) to be fixed,(2) to abide,to stay (in the one place)"
-        ],
-        "notation": "留(と)まる"
+        ]
     },
     {
         "name": "ketsuatsu",
         "trans": [
+            "血圧(けつあつ)",
             "blood pressure"
-        ],
-        "notation": "血圧(けつあつ)"
+        ]
     },
     {
         "name": "youshi",
         "trans": [
+            "要旨(ようし)",
             "gist,essentials,summary,fundamentals"
-        ],
-        "notation": "要旨(ようし)"
+        ]
     },
     {
         "name": "taisaku",
         "trans": [
+            "対策(たいさく)",
             "counter-plan,counter-measure"
-        ],
-        "notation": "対策(たいさく)"
+        ]
     },
     {
         "name": "hikkurikaesu",
         "trans": [
+            "引(ひ)っ繰(く)り返(かえ)す",
             "to turn over,to overturn,to knock over,to upset,to turn inside out"
-        ],
-        "notation": "引(ひ)っ繰(く)り返(かえ)す"
+        ]
     },
     {
         "name": "daimei",
         "trans": [
+            "題名(だいめい)",
             "title"
-        ],
-        "notation": "題名(だいめい)"
+        ]
     },
     {
         "name": "shizumaru",
         "trans": [
+            "静(しず)まる",
             "to quieten down,to calm down,to subside"
-        ],
-        "notation": "静(しず)まる"
+        ]
     },
     {
         "name": "juuten",
         "trans": [
+            "重点(じゅうてん)",
             "important point,lay stress on,colon,emphasis"
-        ],
-        "notation": "重点(じゅうてん)"
+        ]
     },
     {
         "name": "shiboru",
         "trans": [
+            "絞(しぼ)る",
             "to press,to wring,to squeeze"
-        ],
-        "notation": "絞(しぼ)る"
+        ]
     },
     {
         "name": "tsubusu",
         "trans": [
+            "潰(つぶ)す",
             "to smash,to waste"
-        ],
-        "notation": "潰(つぶ)す"
+        ]
     },
     {
         "name": "tsubureru",
         "trans": [
+            "潰(つぶ)れる",
             "to be smashed,to go bankrupt"
-        ],
-        "notation": "潰(つぶ)れる"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "発(た)つ",
             "to depart (on a plane, train, etc.)"
-        ],
-        "notation": "発(た)つ"
+        ]
     },
     {
         "name": "fusagaru",
         "trans": [
+            "塞(ふさ)がる",
             "to be plugged up,to be shut up"
-        ],
-        "notation": "塞(ふさ)がる"
+        ]
     },
     {
         "name": "koishii",
         "trans": [
+            "恋(こい)しい",
             "(1) dear,beloved,darling,(2) yearned for"
-        ],
-        "notation": "恋(こい)しい"
+        ]
     },
     {
         "name": "yobi",
         "trans": [
+            "予備(よび)",
             "preparation,preliminaries,reserve,spare"
-        ],
-        "notation": "予備(よび)"
+        ]
     },
     {
         "name": "gakunen",
         "trans": [
+            "学年(がくねん)",
             "year in school,grade in school"
-        ],
-        "notation": "学年(がくねん)"
+        ]
     },
     {
         "name": "tsuukin",
         "trans": [
+            "通勤(つうきん)",
             "commuting to work"
-        ],
-        "notation": "通勤(つうきん)"
+        ]
     },
     {
         "name": "akegata",
         "trans": [
+            "明(あ)け方(がた)",
             "dawn"
-        ],
-        "notation": "明(あ)け方(がた)"
+        ]
     },
     {
         "name": "chirakasu",
         "trans": [
+            "散(ち)らかす",
             "to scatter around,to leave untidy"
-        ],
-        "notation": "散(ち)らかす"
+        ]
     },
     {
         "name": "kakuchi",
         "trans": [
+            "各地(かくち)",
             "every place,various places"
-        ],
-        "notation": "各地(かくち)"
+        ]
     },
     {
         "name": "mezasu",
         "trans": [
+            "目指(めざ)す",
             "to aim at,to have an eye on"
-        ],
-        "notation": "目指(めざ)す"
+        ]
     },
     {
         "name": "teema",
         "trans": [
+            "テーマ",
             "(n) theme,project,topic (de: Thema)"
-        ],
-        "notation": "テーマ"
+        ]
     },
     {
         "name": "burausu",
         "trans": [
+            "ブラウス",
             "blouse"
-        ],
-        "notation": "ブラウス"
+        ]
     },
     {
         "name": "seinengappi",
         "trans": [
+            "生年月日(せいねんがっぴ)",
             "birth date"
-        ],
-        "notation": "生年月日(せいねんがっぴ)"
+        ]
     },
     {
         "name": "karaa",
         "trans": [
+            "カラー",
             "collar,color,colour"
-        ],
-        "notation": "カラー"
+        ]
     },
     {
         "name": "nokogiri",
         "trans": [
+            "のこぎり",
             "saw"
-        ],
-        "notation": "のこぎり"
+        ]
     },
     {
         "name": "kusuriyubi",
         "trans": [
+            "薬指(くすりゆび)",
             "ring finger"
-        ],
-        "notation": "薬指(くすりゆび)"
+        ]
     },
     {
         "name": "kokoroatari",
         "trans": [
+            "心当(こころあ)たり",
             "having some knowledge of,happening to know"
-        ],
-        "notation": "心当(こころあ)たり"
+        ]
     },
     {
         "name": "monoreeru",
         "trans": [
+            "モノレール",
             "monorail"
-        ],
-        "notation": "モノレール"
+        ]
     },
     {
         "name": "ouen",
         "trans": [
+            "応援(おうえん)",
             "aid,assistance,help,reinforcement"
-        ],
-        "notation": "応援(おうえん)"
+        ]
     },
     {
         "name": "katamuku",
         "trans": [
+            "傾(かたむ)く",
             "to incline toward,to slant,to lurch"
-        ],
-        "notation": "傾(かたむ)く"
+        ]
     },
     {
         "name": "hansei",
         "trans": [
+            "反省(はんせい)",
             "reflection,reconsideration,introspection,meditation,contemplation"
-        ],
-        "notation": "反省(はんせい)"
+        ]
     },
     {
         "name": "shuunin",
         "trans": [
+            "就任(しゅうにん)",
             "inauguration,assumption of office"
-        ],
-        "notation": "就任(しゅうにん)"
+        ]
     },
     {
         "name": "houchou",
         "trans": [
+            "庖丁(ほうちょう)",
             "kitchen knife,carving knife"
-        ],
-        "notation": "庖丁(ほうちょう)"
+        ]
     },
     {
         "name": "koukyou",
         "trans": [
+            "公共(こうきょう)",
             "public,community,public service,society,communal"
-        ],
-        "notation": "公共(こうきょう)"
+        ]
     },
     {
         "name": "kane",
         "trans": [
+            "鐘(かね)",
             "bell,chime"
-        ],
-        "notation": "鐘(かね)"
+        ]
     },
     {
         "name": "toridasu",
         "trans": [
+            "取(と)り出(だ)す",
             "to take out,to produce,to pick out"
-        ],
-        "notation": "取(と)り出(だ)す"
+        ]
     },
     {
         "name": "nendo",
         "trans": [
+            "年度(ねんど)",
             "year,fiscal year,school year,term"
-        ],
-        "notation": "年度(ねんど)"
+        ]
     },
     {
         "name": "nikoniko",
         "trans": [
+            "にこにこ",
             ""
-        ],
-        "notation": "にこにこ"
+        ]
     },
     {
         "name": "katsuyaku",
         "trans": [
+            "活躍(かつやく)",
             "activity"
-        ],
-        "notation": "活躍(かつやく)"
+        ]
     },
     {
         "name": "deai",
         "trans": [
+            "出合(であ)い",
             "an encounter"
-        ],
-        "notation": "出合(であ)い"
+        ]
     },
     {
         "name": "sukejuuru",
         "trans": [
+            "スケジュール",
             "schedule"
-        ],
-        "notation": "スケジュール"
+        ]
     },
     {
         "name": "yamuwoenai",
         "trans": [
+            "やむをえない",
             "cannot be helped,unavoidable"
-        ],
-        "notation": "やむをえない"
+        ]
     },
     {
         "name": "buntai",
         "trans": [
+            "文体(ぶんたい)",
             "literary style"
-        ],
-        "notation": "文体(ぶんたい)"
+        ]
     },
     {
         "name": "yakume",
         "trans": [
+            "役目(やくめ)",
             "duty,business"
-        ],
-        "notation": "役目(やくめ)"
+        ]
     },
     {
         "name": "zenpan",
         "trans": [
+            "全般(ぜんぱん)",
             "(the) whole,universal,wholly,general"
-        ],
-        "notation": "全般(ぜんぱん)"
+        ]
     },
     {
         "name": "hokkyoku",
         "trans": [
+            "北極(ほっきょく)",
             "North Pole"
-        ],
-        "notation": "北極(ほっきょく)"
+        ]
     },
     {
         "name": "pinku",
         "trans": [
+            "ピンク",
             "pink"
-        ],
-        "notation": "ピンク"
+        ]
     },
     {
         "name": "taisou",
         "trans": [
+            "体操(たいそう)",
             "gymnastics,physical exercises,calisthenics"
-        ],
-        "notation": "体操(たいそう)"
+        ]
     },
     {
         "name": "joujun",
         "trans": [
+            "上旬(じょうじゅん)",
             "first 10 days of month"
-        ],
-        "notation": "上旬(じょうじゅん)"
+        ]
     },
     {
         "name": "renzu",
         "trans": [
+            "レンズ",
             "lens"
-        ],
-        "notation": "レンズ"
+        ]
     },
     {
         "name": "rengou",
         "trans": [
+            "連合(れんごう)",
             "union,alliance"
-        ],
-        "notation": "連合(れんごう)"
+        ]
     },
     {
         "name": "ikuji",
         "trans": [
+            "育児(いくじ)",
             "childcare,nursing,upbringing"
-        ],
-        "notation": "育児(いくじ)"
+        ]
     },
     {
         "name": "geta",
         "trans": [
+            "下駄(げた)",
             "geta (Japanese footwear),wooden clogs"
-        ],
-        "notation": "下駄(げた)"
+        ]
     },
     {
         "name": "sentan",
         "trans": [
+            "先端(せんたん)",
             "pointed end,tip,fine point"
-        ],
-        "notation": "先端(せんたん)"
+        ]
     },
     {
         "name": "kyouyou",
         "trans": [
+            "教養(きょうよう)",
             "culture,education,refinement,cultivation"
-        ],
-        "notation": "教養(きょうよう)"
+        ]
     },
     {
         "name": "mare",
         "trans": [
+            "稀(まれ)",
             "rare,seldom"
-        ],
-        "notation": "稀(まれ)"
+        ]
     },
     {
         "name": "sassoku",
         "trans": [
+            "早速(さっそく)",
             "at once,immediately,without delay,promptly"
-        ],
-        "notation": "早速(さっそく)"
+        ]
     },
     {
         "name": "ripouto",
         "trans": [
+            "リポート",
             "report,paper"
-        ],
-        "notation": "リポート"
+        ]
     },
     {
         "name": "burashi",
         "trans": [
+            "ブラシ",
             "brushy,brush"
-        ],
-        "notation": "ブラシ"
+        ]
     },
     {
         "name": "kyuuyou",
         "trans": [
+            "休養(きゅうよう)",
             "rest,break,recreation"
-        ],
-        "notation": "休養(きゅうよう)"
+        ]
     },
     {
         "name": "fukumeru",
         "trans": [
+            "含(ふく)める",
             "to include,to instruct,to make one understand"
-        ],
-        "notation": "含(ふく)める"
+        ]
     },
     {
         "name": "ahira",
         "trans": [
+            "あひら",
             ""
-        ],
-        "notation": "あひら"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "巻(ま)く",
             "to wind,to coil,to roll"
-        ],
-        "notation": "巻(ま)く"
+        ]
     },
     {
         "name": "youchien",
         "trans": [
+            "幼稚園(ようちえん)",
             "kindergarten"
-        ],
-        "notation": "幼稚園(ようちえん)"
+        ]
     },
     {
         "name": "kougei",
         "trans": [
+            "工芸(こうげい)",
             "industrial arts"
-        ],
-        "notation": "工芸(こうげい)"
+        ]
     },
     {
         "name": "iitsukeru",
         "trans": [
+            "言(い)い付(つ)ける",
             "to tell,to tell on (someone),to order"
-        ],
-        "notation": "言(い)い付(つ)ける"
+        ]
     },
     {
         "name": "nieru",
         "trans": [
+            "煮(に)える",
             "to boil,to cook,to be cooked"
-        ],
-        "notation": "煮(に)える"
+        ]
     },
     {
         "name": "oikakeru",
         "trans": [
+            "追(お)い掛(か)ける",
             "to chase or run after someone,to run down,to pursue"
-        ],
-        "notation": "追(お)い掛(か)ける"
+        ]
     },
     {
         "name": "kyuusoku",
         "trans": [
+            "休息(きゅうそく)",
             "rest,relief,relaxation"
-        ],
-        "notation": "休息(きゅうそく)"
+        ]
     },
     {
         "name": "chokkaku",
         "trans": [
+            "直角(ちょっかく)",
             "right angle"
-        ],
-        "notation": "直角(ちょっかく)"
+        ]
     },
     {
         "name": "ka",
         "trans": [
+            "蚊(か)",
             "mosquito"
-        ],
-        "notation": "蚊(か)"
+        ]
     },
     {
         "name": "mushiatsui",
         "trans": [
+            "蒸(む)し暑(あつ)い",
             "humid,sultry"
-        ],
-        "notation": "蒸(む)し暑(あつ)い"
+        ]
     },
     {
         "name": "keiyoushi",
         "trans": [
+            "形容詞(けいようし)",
             "true adjective"
-        ],
-        "notation": "形容詞(けいようし)"
+        ]
     },
     {
         "name": "tatamu",
         "trans": [
+            "畳(たた)む",
             "to fold (clothes)"
-        ],
-        "notation": "畳(たた)む"
+        ]
     },
     {
         "name": "angai",
         "trans": [
+            "案外(あんがい)",
             "unexpectedly"
-        ],
-        "notation": "案外(あんがい)"
+        ]
     },
     {
         "name": "youto",
         "trans": [
+            "用途(ようと)",
             "use,usefulness"
-        ],
-        "notation": "用途(ようと)"
+        ]
     },
     {
         "name": "hougen",
         "trans": [
+            "方言(ほうげん)",
             "dialect"
-        ],
-        "notation": "方言(ほうげん)"
+        ]
     },
     {
         "name": "ouyou",
         "trans": [
+            "応用(おうよう)",
             "application,put to practical use"
-        ],
-        "notation": "応用(おうよう)"
+        ]
     },
     {
         "name": "jinmei",
         "trans": [
+            "人命(じんめい)",
             "(human) life"
-        ],
-        "notation": "人命(じんめい)"
+        ]
     },
     {
         "name": "bane",
         "trans": [
+            "ばね",
             "spring (e.g. coil, leaf)"
-        ],
-        "notation": "ばね"
+        ]
     },
     {
         "name": "ribon",
         "trans": [
+            "リボン",
             "ribbon"
-        ],
-        "notation": "リボン"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "寮(りょう)",
             "hostel,dormitory"
-        ],
-        "notation": "寮(りょう)"
+        ]
     },
     {
         "name": "tansui",
         "trans": [
+            "淡水(たんすい)",
             "fresh water"
-        ],
-        "notation": "淡水(たんすい)"
+        ]
     },
     {
         "name": "jakuten",
         "trans": [
+            "弱点(じゃくてん)",
             "weak point,weakness"
-        ],
-        "notation": "弱点(じゃくてん)"
+        ]
     },
     {
         "name": "ayashii",
         "trans": [
+            "怪(あや)しい",
             "suspicious,dubious,doubtful"
-        ],
-        "notation": "怪(あや)しい"
+        ]
     },
     {
         "name": "itteirasshai",
         "trans": [
+            "いっていらっしゃい",
             ""
-        ],
-        "notation": "いっていらっしゃい"
+        ]
     },
     {
         "name": "keizoku",
         "trans": [
+            "継続(けいぞく)",
             "continuation"
-        ],
-        "notation": "継続(けいぞく)"
+        ]
     },
     {
         "name": "ryakusu",
         "trans": [
+            "略(りゃく)す",
             "to abbreviate"
-        ],
-        "notation": "略(りゃく)す"
+        ]
     },
     {
         "name": "shukkin",
         "trans": [
+            "出勤(しゅっきん)",
             "going to work,at work"
-        ],
-        "notation": "出勤(しゅっきん)"
+        ]
     },
     {
         "name": "keigo",
         "trans": [
+            "敬語(けいご)",
             "honorific,term of respect"
-        ],
-        "notation": "敬語(けいご)"
+        ]
     },
     {
         "name": "tsume",
         "trans": [
+            "爪(つめ)",
             "fingernail or toenail,claw,talon,hoof"
-        ],
-        "notation": "爪(つめ)"
+        ]
     },
     {
         "name": "denryoku",
         "trans": [
+            "電力(でんりょく)",
             "electric power"
-        ],
-        "notation": "電力(でんりょく)"
+        ]
     },
     {
         "name": "kasaneru",
         "trans": [
+            "重(かさ)ねる",
             "to pile up,to put something on another,to heap up,to add,to repeat"
-        ],
-        "notation": "重(かさ)ねる"
+        ]
     },
     {
         "name": "taiko",
         "trans": [
+            "太鼓(たいこ)",
             "drum,tambourine"
-        ],
-        "notation": "太鼓(たいこ)"
+        ]
     },
     {
         "name": "uramu",
         "trans": [
+            "恨(うら)む",
             "to curse,to feel bitter"
-        ],
-        "notation": "恨(うら)む"
+        ]
     },
     {
         "name": "zuihitsu",
         "trans": [
+            "随筆(ずいひつ)",
             "essays,miscellaneous writings"
-        ],
-        "notation": "随筆(ずいひつ)"
+        ]
     },
     {
         "name": "chuunen",
         "trans": [
+            "中年(ちゅうねん)",
             "middle-aged"
-        ],
-        "notation": "中年(ちゅうねん)"
+        ]
     },
     {
         "name": "amaru",
         "trans": [
+            "余(あま)る",
             "to remain,to be left over,to be in excess,to be too many"
-        ],
-        "notation": "余(あま)る"
+        ]
     },
     {
         "name": "tsukiatari",
         "trans": [
+            "突(つ)き当(あ)たり",
             "end (e.g. of street)"
-        ],
-        "notation": "突(つ)き当(あ)たり"
+        ]
     },
     {
         "name": "senpuuki",
         "trans": [
+            "扇風機(せんぷうき)",
             "electric fan"
-        ],
-        "notation": "扇風機(せんぷうき)"
+        ]
     },
     {
         "name": "seishitsu",
         "trans": [
+            "性質(せいしつ)",
             "nature,property,disposition"
-        ],
-        "notation": "性質(せいしつ)"
+        ]
     },
     {
         "name": "iyagaru",
         "trans": [
+            "嫌(いや)がる",
             "to hate,to dislike"
-        ],
-        "notation": "嫌(いや)がる"
+        ]
     },
     {
         "name": "nanboku",
         "trans": [
+            "南北(なんぼく)",
             "south and north"
-        ],
-        "notation": "南北(なんぼく)"
+        ]
     },
     {
         "name": "tsuna",
         "trans": [
+            "綱(つな)",
             "rope"
-        ],
-        "notation": "綱(つな)"
+        ]
     },
     {
         "name": "kushami",
         "trans": [
+            "くしゃみ",
             "sneeze"
-        ],
-        "notation": "くしゃみ"
+        ]
     },
     {
         "name": "wabiru",
         "trans": [
+            "詫(わ)びる",
             "to apologize"
-        ],
-        "notation": "詫(わ)びる"
+        ]
     },
     {
         "name": "kugi",
         "trans": [
+            "釘(くぎ)",
             "nail"
-        ],
-        "notation": "釘(くぎ)"
+        ]
     },
     {
         "name": "jidou",
         "trans": [
+            "児童(じどう)",
             "children,juvenile"
-        ],
-        "notation": "児童(じどう)"
+        ]
     },
     {
         "name": "juukyo",
         "trans": [
+            "住居(じゅうきょ)",
             "dwelling,house,residence,address"
-        ],
-        "notation": "住居(じゅうきょ)"
+        ]
     },
     {
         "name": "saijitsu",
         "trans": [
+            "祭日(さいじつ)",
             "national holiday,festival day"
-        ],
-        "notation": "祭日(さいじつ)"
+        ]
     },
     {
         "name": "geinou",
         "trans": [
+            "芸能(げいのう)",
             "public entertainment,accomplishments,attainments"
-        ],
-        "notation": "芸能(げいのう)"
+        ]
     },
     {
         "name": "shizenkagaku",
         "trans": [
+            "自然(しぜん)科学(かがく)",
             "natural science"
-        ],
-        "notation": "自然(しぜん)科学(かがく)"
+        ]
     },
     {
         "name": "hadagi",
         "trans": [
+            "肌着(はだぎ)",
             "underwear"
-        ],
-        "notation": "肌着(はだぎ)"
+        ]
     },
     {
         "name": "sawagashii",
         "trans": [
+            "騒(さわ)がしい",
             "noisy"
-        ],
-        "notation": "騒(さわ)がしい"
+        ]
     },
     {
         "name": "akubi",
         "trans": [
+            "あくび",
             "yawn"
-        ],
-        "notation": "あくび"
+        ]
     },
     {
         "name": "kouchi",
         "trans": [
+            "耕地(こうち)",
             "arable land"
-        ],
-        "notation": "耕地(こうち)"
+        ]
     },
     {
         "name": "kansou",
         "trans": [
+            "感想(かんそう)",
             "impressions,thoughts"
-        ],
-        "notation": "感想(かんそう)"
+        ]
     },
     {
         "name": "iru",
         "trans": [
+            "煎(い)る",
             "to parch,to fry"
-        ],
-        "notation": "煎(い)る"
+        ]
     },
     {
         "name": "hitorideni",
         "trans": [
+            "ひとりでに",
             "by itself,automatically,naturally"
-        ],
-        "notation": "ひとりでに"
+        ]
     },
     {
         "name": "bunryou",
         "trans": [
+            "分量(ぶんりょう)",
             "amount,quantity"
-        ],
-        "notation": "分量(ぶんりょう)"
+        ]
     },
     {
         "name": "kondate",
         "trans": [
+            "献立(こんだて)",
             "menu,program,schedule"
-        ],
-        "notation": "献立(こんだて)"
+        ]
     },
     {
         "name": "ichiou",
         "trans": [
+            "一応(いちおう)",
             "once,tentatively,in outline,for the time being"
-        ],
-        "notation": "一応(いちおう)"
+        ]
     },
     {
         "name": "tagayasu",
         "trans": [
+            "耕(たがや)す",
             "to till,to plow,to cultivate"
-        ],
-        "notation": "耕(たがや)す"
+        ]
     },
     {
         "name": "saji",
         "trans": [
+            "匙(さじ)",
             "spoon"
-        ],
-        "notation": "匙(さじ)"
+        ]
     },
     {
         "name": "oikosu",
         "trans": [
+            "追(お)い越(こ)す",
             "to pass (e.g. car),to outdistance,to outstrip"
-        ],
-        "notation": "追(お)い越(こ)す"
+        ]
     },
     {
         "name": "hifu",
         "trans": [
+            "皮膚(ひふ)",
             "skin"
-        ],
-        "notation": "皮膚(ひふ)"
+        ]
     },
     {
         "name": "shitsuren",
         "trans": [
+            "失恋(しつれん)",
             "disappointed love,broken heart,unrequited love,be lovelorn"
-        ],
-        "notation": "失恋(しつれん)"
+        ]
     },
     {
         "name": "intabyuu",
         "trans": [
+            "インタビュー",
             "interview"
-        ],
-        "notation": "インタビュー"
+        ]
     },
     {
         "name": "kotobazukai",
         "trans": [
+            "言葉(ことば)遣(づか)い",
             "speech,expression,wording"
-        ],
-        "notation": "言葉(ことば)遣(づか)い"
+        ]
     },
     {
         "name": "kasoku",
         "trans": [
+            "加速(かそく)",
             "acceleration"
-        ],
-        "notation": "加速(かそく)"
+        ]
     },
     {
         "name": "densen",
         "trans": [
+            "伝染(でんせん)",
             "contagion"
-        ],
-        "notation": "伝染(でんせん)"
+        ]
     },
     {
         "name": "kannen",
         "trans": [
+            "観念(かんねん)",
             "(1) idea,notion,conception,(2) sense (e.g. of duty)"
-        ],
-        "notation": "観念(かんねん)"
+        ]
     },
     {
         "name": "sumaato",
         "trans": [
+            "スマート",
             "smart,stylish,slim"
-        ],
-        "notation": "スマート"
+        ]
     },
     {
         "name": "suzumu",
         "trans": [
+            "涼(すず)む",
             "to cool oneself,to cool off,to enjoy evening cool"
-        ],
-        "notation": "涼(すず)む"
+        ]
     },
     {
         "name": "burasageru",
         "trans": [
+            "ぶらさげる",
             "to hang,to suspend,to dangle,to swing"
-        ],
-        "notation": "ぶらさげる"
+        ]
     },
     {
         "name": "kuuchuu",
         "trans": [
+            "空中(くうちゅう)",
             "sky,air"
-        ],
-        "notation": "空中(くうちゅう)"
+        ]
     },
     {
         "name": "urikireru",
         "trans": [
+            "売(う)り切(き)れる",
             "to be sold out"
-        ],
-        "notation": "売(う)り切(き)れる"
+        ]
     },
     {
         "name": "kanki",
         "trans": [
+            "換気(かんき)",
             "ventilation"
-        ],
-        "notation": "換気(かんき)"
+        ]
     },
     {
         "name": "hibi",
         "trans": [
+            "日日(ひび)",
             "every day,daily,day after day"
-        ],
-        "notation": "日日(ひび)"
+        ]
     },
     {
         "name": "hikakuteki",
         "trans": [
+            "比較的(ひかくてき)",
             "comparatively,relatively"
-        ],
-        "notation": "比較的(ひかくてき)"
+        ]
     },
     {
         "name": "surechigau",
         "trans": [
+            "すれちがう",
             "to pass by one another,to disagree"
-        ],
-        "notation": "すれちがう"
+        ]
     },
     {
         "name": "sukuuru",
         "trans": [
+            "スクール",
             "school"
-        ],
-        "notation": "スクール"
+        ]
     },
     {
         "name": "hiniku",
         "trans": [
+            "皮肉(ひにく)",
             "cynicism,sarcasm"
-        ],
-        "notation": "皮肉(ひにく)"
+        ]
     },
     {
         "name": "semete",
         "trans": [
+            "せめて",
             "offense,method of attack"
-        ],
-        "notation": "せめて"
+        ]
     },
     {
         "name": "arasuji",
         "trans": [
+            "あらすじ",
             "outline,summary"
-        ],
-        "notation": "あらすじ"
+        ]
     },
     {
         "name": "shuukai",
         "trans": [
+            "集会(しゅうかい)",
             "meeting,assembly"
-        ],
-        "notation": "集会(しゅうかい)"
+        ]
     },
     {
         "name": "atena",
         "trans": [
+            "宛名(あてな)",
             "address,direction"
-        ],
-        "notation": "宛名(あてな)"
+        ]
     },
     {
         "name": "atarimae",
         "trans": [
+            "あたりまえ",
             "usual,common,ordinary"
-        ],
-        "notation": "あたりまえ"
+        ]
     },
     {
         "name": "takuwaeru",
         "trans": [
+            "蓄(たくわ)える",
             "to store,to lay in stock"
-        ],
-        "notation": "蓄(たくわ)える"
+        ]
     },
     {
         "name": "chouka",
         "trans": [
+            "超過(ちょうか)",
             "excess,being more than"
-        ],
-        "notation": "超過(ちょうか)"
+        ]
     },
     {
         "name": "kuzureru",
         "trans": [
+            "崩(くず)れる",
             "to collapse,to crumble"
-        ],
-        "notation": "崩(くず)れる"
+        ]
     },
     {
         "name": "engeki",
         "trans": [
+            "演劇(えんげき)",
             "play (theatrical)"
-        ],
-        "notation": "演劇(えんげき)"
+        ]
     },
     {
         "name": "kantai",
         "trans": [
+            "寒帯(かんたい)",
             "frigid zone"
-        ],
-        "notation": "寒帯(かんたい)"
+        ]
     },
     {
         "name": "motomoto",
         "trans": [
+            "元々(もともと)",
             "originally,by nature,from the start"
-        ],
-        "notation": "元々(もともと)"
+        ]
     },
     {
         "name": "sakusha",
         "trans": [
+            "作者(さくしゃ)",
             "author,authoress"
-        ],
-        "notation": "作者(さくしゃ)"
+        ]
     },
     {
         "name": "senzo",
         "trans": [
+            "先祖(せんぞ)",
             "ancestor"
-        ],
-        "notation": "先祖(せんぞ)"
+        ]
     },
     {
         "name": "gozonjidesuka",
         "trans": [
+            "ごぞんじですか",
             ""
-        ],
-        "notation": "ごぞんじですか"
+        ]
     },
     {
         "name": "tokkuni",
         "trans": [
+            "とっくに",
             "long ago,already,a long time ago"
-        ],
-        "notation": "とっくに"
+        ]
     },
     {
         "name": "sasaru",
         "trans": [
+            "刺(さ)さる",
             "to stick,to be stuck"
-        ],
-        "notation": "刺(さ)さる"
+        ]
     },
     {
         "name": "sairen",
         "trans": [
+            "サイレン",
             "siren"
-        ],
-        "notation": "サイレン"
+        ]
     },
     {
         "name": "tsukkomu",
         "trans": [
+            "突(つ)っ込(こ)む",
             "to plunge into,to go into deeply"
-        ],
-        "notation": "突(つ)っ込(こ)む"
+        ]
     },
     {
         "name": "shukushou",
         "trans": [
+            "縮小(しゅくしょう)",
             "reduction,curtailment"
-        ],
-        "notation": "縮小(しゅくしょう)"
+        ]
     },
     {
         "name": "yuukou",
         "trans": [
+            "友好(ゆうこう)",
             "friendship"
-        ],
-        "notation": "友好(ゆうこう)"
+        ]
     },
     {
         "name": "joukyuu",
         "trans": [
+            "上級(じょうきゅう)",
             "advanced level,high grade,senior"
-        ],
-        "notation": "上級(じょうきゅう)"
+        ]
     },
     {
         "name": "chichihaha",
         "trans": [
+            "父母(ちちはは)",
             "father and mother,parents"
-        ],
-        "notation": "父母(ちちはは)"
+        ]
     },
     {
         "name": "kakawaru",
         "trans": [
+            "係(かか)わる",
             "to concern oneself in,to have to do with,to affect,to influence,to stick to (opinions)"
-        ],
-        "notation": "係(かか)わる"
+        ]
     },
     {
         "name": "sokutatsu",
         "trans": [
+            "速達(そくたつ)",
             "express,special delivery"
-        ],
-        "notation": "速達(そくたつ)"
+        ]
     },
     {
         "name": "koutou",
         "trans": [
+            "高等(こうとう)",
             "high class,high grade"
-        ],
-        "notation": "高等(こうとう)"
+        ]
     },
     {
         "name": "nantonaku",
         "trans": [
+            "なんとなく",
             "somehow or other,for some reason or another"
-        ],
-        "notation": "なんとなく"
+        ]
     },
     {
         "name": "entotsu",
         "trans": [
+            "煙突(えんとつ)",
             "chimney"
-        ],
-        "notation": "煙突(えんとつ)"
+        ]
     },
     {
         "name": "zatsuon",
         "trans": [
+            "雑音(ざつおん)",
             "noise (jarring, grating)"
-        ],
-        "notation": "雑音(ざつおん)"
+        ]
     },
     {
         "name": "sagasu",
         "trans": [
+            "捜(さが)す",
             "to search,to seek,to look for"
-        ],
-        "notation": "捜(さが)す"
+        ]
     },
     {
         "name": "umu",
         "trans": [
+            "有無(うむ)",
             "yes or no,existence,flag indicator (comp),presence or absence marker"
-        ],
-        "notation": "有無(うむ)"
+        ]
     },
     {
         "name": "pantsu",
         "trans": [
+            "パンツ",
             "underpants"
-        ],
-        "notation": "パンツ"
+        ]
     },
     {
         "name": "shucchou",
         "trans": [
+            "出張(しゅっちょう)",
             "official tour,business trip"
-        ],
-        "notation": "出張(しゅっちょう)"
+        ]
     },
     {
         "name": "shinwa",
         "trans": [
+            "神話(しんわ)",
             "myth,legend"
-        ],
-        "notation": "神話(しんわ)"
+        ]
     },
     {
         "name": "demukae",
         "trans": [
+            "出迎(でむか)え",
             "meeting,reception"
-        ],
-        "notation": "出迎(でむか)え"
+        ]
     },
     {
         "name": "seizon",
         "trans": [
+            "生存(せいぞん)",
             "existence,being,survival"
-        ],
-        "notation": "生存(せいぞん)"
+        ]
     },
     {
         "name": "fusuma",
         "trans": [
+            "襖(ふすま)",
             "sliding screen"
-        ],
-        "notation": "襖(ふすま)"
+        ]
     },
     {
         "name": "getsumatsu",
         "trans": [
+            "月末(げつまつ)",
             "end of the month"
-        ],
-        "notation": "月末(げつまつ)"
+        ]
     },
     {
         "name": "fukuramasu",
         "trans": [
+            "膨(ふく)らます",
             "to swell,to expand,to inflate,to bulge"
-        ],
-        "notation": "膨(ふく)らます"
+        ]
     },
     {
         "name": "shinro",
         "trans": [
+            "針路(しんろ)",
             "course,direction,compass bearing"
-        ],
-        "notation": "針路(しんろ)"
+        ]
     },
     {
         "name": "okazu",
         "trans": [
+            "おかず",
             "side dish,accompaniment for rice dishes"
-        ],
-        "notation": "おかず"
+        ]
     },
     {
         "name": "masshiro",
         "trans": [
+            "真(ま)っ白(しろ)",
             "pure white"
-        ],
-        "notation": "真(ま)っ白(しろ)"
+        ]
     },
     {
         "name": "sekken",
         "trans": [
+            "石鹸(せっけん)",
             "soap"
-        ],
-        "notation": "石鹸(せっけん)"
+        ]
     },
     {
         "name": "bitamin",
         "trans": [
+            "ビタミン",
             "vitamin"
-        ],
-        "notation": "ビタミン"
+        ]
     },
     {
         "name": "konkuriito",
         "trans": [
+            "コンクリート",
             "concrete"
-        ],
-        "notation": "コンクリート"
+        ]
     },
     {
         "name": "jisseki",
         "trans": [
+            "実績(じっせき)",
             "achievements,actual results"
-        ],
-        "notation": "実績(じっせき)"
+        ]
     },
     {
         "name": "souryou",
         "trans": [
+            "送料(そうりょう)",
             "postage,carriage"
-        ],
-        "notation": "送料(そうりょう)"
+        ]
     },
     {
         "name": "gyogyou",
         "trans": [
+            "漁業(ぎょぎょう)",
             "fishing (industry)"
-        ],
-        "notation": "漁業(ぎょぎょう)"
+        ]
     },
     {
         "name": "gomen",
         "trans": [
+            "御免(ごめん)",
             "your pardon,declining (something),dismissal,permission"
-        ],
-        "notation": "御免(ごめん)"
+        ]
     },
     {
         "name": "shiku",
         "trans": [
+            "敷(し)く",
             "to spread out,to lay out"
-        ],
-        "notation": "敷(し)く"
+        ]
     },
     {
         "name": "kou",
         "trans": [
+            "請(こ)う",
             "to ask,to request"
-        ],
-        "notation": "請(こ)う"
+        ]
     },
     {
         "name": "denki",
         "trans": [
+            "伝記(でんき)",
             "biography,life story"
-        ],
-        "notation": "伝記(でんき)"
+        ]
     },
     {
         "name": "fumikiri",
         "trans": [
+            "踏切(ふみきり)",
             "railway crossing,level crossing,starting line,scratch,crossover"
-        ],
-        "notation": "踏切(ふみきり)"
+        ]
     },
     {
         "name": "kawase",
         "trans": [
+            "為替(かわせ)",
             "money order,exchange"
-        ],
-        "notation": "為替(かわせ)"
+        ]
     },
     {
         "name": "itsu",
         "trans": [
+            "佚(いつ)",
             "be lost,peace,hide,mistake,beautiful,in turn"
-        ],
-        "notation": "佚(いつ)"
+        ]
     },
     {
         "name": "roumaji",
         "trans": [
+            "ローマじ",
             "romanization,Roman letters"
-        ],
-        "notation": "ローマじ"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "映(うつ)る",
             "to be reflected,to harmonize with,to come out (photo)"
-        ],
-        "notation": "映(うつ)る"
+        ]
     },
     {
         "name": "ikou",
         "trans": [
+            "以降(いこう)",
             "on and after,hereafter,thereafter"
-        ],
-        "notation": "以降(いこう)"
+        ]
     },
     {
         "name": "ojisan",
         "trans": [
+            "伯父(おじ)さん",
             "middle-aged gentleman,uncle"
-        ],
-        "notation": "伯父(おじ)さん"
+        ]
     },
     {
         "name": "kazan",
         "trans": [
+            "火山(かざん)",
             "volcano"
-        ],
-        "notation": "火山(かざん)"
+        ]
     },
     {
         "name": "tada",
         "trans": [
+            "只(ただ)",
             "free of charge,mere,sole,only,usual,common"
-        ],
-        "notation": "只(ただ)"
+        ]
     },
     {
         "name": "gakkai",
         "trans": [
+            "学会(がっかい)",
             "scientific society,academic meeting"
-        ],
-        "notation": "学会(がっかい)"
+        ]
     },
     {
         "name": "tenkeru",
         "trans": [
+            "点(てん)ける",
             "to turn on,to switch on,to light up"
-        ],
-        "notation": "点(てん)ける"
+        ]
     },
     {
         "name": "tsurusu",
         "trans": [
+            "吊(つる)す",
             "to hang"
-        ],
-        "notation": "吊(つる)す"
+        ]
     },
     {
         "name": "wan",
         "trans": [
+            "碗(わん)",
             "bowl"
-        ],
-        "notation": "碗(わん)"
+        ]
     },
     {
         "name": "chikasui",
         "trans": [
+            "地下(ちか)水(すい)",
             "underground water"
-        ],
-        "notation": "地下(ちか)水(すい)"
+        ]
     },
     {
         "name": "kashidashi",
         "trans": [
+            "貸(か)し出(だ)し",
             "lending,loaning"
-        ],
-        "notation": "貸(か)し出(だ)し"
+        ]
     },
     {
         "name": "onsen",
         "trans": [
+            "温泉(おんせん)",
             "spa,hot spring,onsen"
-        ],
-        "notation": "温泉(おんせん)"
+        ]
     },
     {
         "name": "shisei",
         "trans": [
+            "姿勢(しせい)",
             "attitude,posture"
-        ],
-        "notation": "姿勢(しせい)"
+        ]
     },
     {
         "name": "keta",
         "trans": [
+            "桁(けた)",
             "column,beam,digit"
-        ],
-        "notation": "桁(けた)"
+        ]
     },
     {
         "name": "nikurashii",
         "trans": [
+            "憎(にく)らしい",
             "odious,hateful"
-        ],
-        "notation": "憎(にく)らしい"
+        ]
     },
     {
         "name": "keredo/keredomo",
         "trans": [
+            "けれど/けれども",
             "but,however"
-        ],
-        "notation": "けれど/けれども"
+        ]
     },
     {
         "name": "katsugu",
         "trans": [
+            "担(かつ)ぐ",
             "to shoulder,to carry on shoulder"
-        ],
-        "notation": "担(かつ)ぐ"
+        ]
     },
     {
         "name": "genri",
         "trans": [
+            "原理(げんり)",
             "principle,theory,fundamental truth"
-        ],
-        "notation": "原理(げんり)"
+        ]
     },
     {
         "name": "taisei",
         "trans": [
+            "体制(たいせい)",
             "order,system,structure,set-up,organization"
-        ],
-        "notation": "体制(たいせい)"
+        ]
     },
     {
         "name": "kokuou",
         "trans": [
+            "国王(こくおう)",
             "king"
-        ],
-        "notation": "国王(こくおう)"
+        ]
     },
     {
         "name": "okusan",
         "trans": [
+            "おくさん",
             "(hon) wife,your wife,madam"
-        ],
-        "notation": "おくさん"
+        ]
     },
     {
         "name": "denpa",
         "trans": [
+            "電波(でんぱ)",
             "electro-magnetic wave"
-        ],
-        "notation": "電波(でんぱ)"
+        ]
     },
     {
         "name": "shiagaru",
         "trans": [
+            "仕上(しあ)がる",
             "to be finished"
-        ],
-        "notation": "仕上(しあ)がる"
+        ]
     },
     {
         "name": "dekiagari",
         "trans": [
+            "出来上(できあ)がり",
             "be finished,ready,made for,cut out"
-        ],
-        "notation": "出来上(できあ)がり"
+        ]
     },
     {
         "name": "heru",
         "trans": [
+            "へる",
             "to decrease (in size or number),to diminish,to abate"
-        ],
-        "notation": "へる"
+        ]
     },
     {
         "name": "suijouki",
         "trans": [
+            "水蒸気(すいじょうき)",
             "water vapour,steam"
-        ],
-        "notation": "水蒸気(すいじょうき)"
+        ]
     },
     {
         "name": "shiitsu",
         "trans": [
+            "シーツ",
             "sheet"
-        ],
-        "notation": "シーツ"
+        ]
     },
     {
         "name": "jousha",
         "trans": [
+            "乗車(じょうしゃ)",
             "taking a train,entraining"
-        ],
-        "notation": "乗車(じょうしゃ)"
+        ]
     },
     {
         "name": "hanashichuu",
         "trans": [
+            "話(はなし)中(ちゅう)",
             "while talking,the line is busy"
-        ],
-        "notation": "話(はなし)中(ちゅう)"
+        ]
     },
     {
         "name": "kansetsu",
         "trans": [
+            "間接(かんせつ)",
             "indirection,indirectness"
-        ],
-        "notation": "間接(かんせつ)"
+        ]
     },
     {
         "name": "keru",
         "trans": [
+            "蹴(け)る",
             "to kick"
-        ],
-        "notation": "蹴(け)る"
+        ]
     },
     {
         "name": "chirakaru",
         "trans": [
+            "散(ち)らかる",
             "to be in disorder,to lie scattered around"
-        ],
-        "notation": "散(ち)らかる"
+        ]
     },
     {
         "name": "meimei",
         "trans": [
+            "銘々(めいめい)",
             "each,individual"
-        ],
-        "notation": "銘々(めいめい)"
+        ]
     },
     {
         "name": "unto",
         "trans": [
+            "うんと",
             "a great deal,very much"
-        ],
-        "notation": "うんと"
+        ]
     },
     {
         "name": "gaibu",
         "trans": [
+            "外部(がいぶ)",
             "the outside,external"
-        ],
-        "notation": "外部(がいぶ)"
+        ]
     },
     {
         "name": "uranau",
         "trans": [
+            "占(うらな)う",
             "to forecast,to predict"
-        ],
-        "notation": "占(うらな)う"
+        ]
     },
     {
         "name": "touzai",
         "trans": [
+            "東西(とうざい)",
             "East and West,whole country"
-        ],
-        "notation": "東西(とうざい)"
+        ]
     },
     {
         "name": "kaikai",
         "trans": [
+            "開会(かいかい)",
             "opening of a meeting"
-        ],
-        "notation": "開会(かいかい)"
+        ]
     },
     {
         "name": "genryou",
         "trans": [
+            "原料(げんりょう)",
             "raw materials"
-        ],
-        "notation": "原料(げんりょう)"
+        ]
     },
     {
         "name": "chounan",
         "trans": [
+            "長男(ちょうなん)",
             "eldest son"
-        ],
-        "notation": "長男(ちょうなん)"
+        ]
     },
     {
         "name": "menzei",
         "trans": [
+            "免税(めんぜい)",
             "tax exemption,duty exemption"
-        ],
-        "notation": "免税(めんぜい)"
+        ]
     },
     {
         "name": "juutai",
         "trans": [
+            "重体(じゅうたい)",
             "seriously ill,serious condition,critical state"
-        ],
-        "notation": "重体(じゅうたい)"
+        ]
     },
     {
         "name": "fuyasu",
         "trans": [
+            "増(ふ)やす",
             "to increase,to add to,to augment"
-        ],
-        "notation": "増(ふ)やす"
+        ]
     },
     {
         "name": "soba",
         "trans": [
+            "蕎麦(そば)",
             "soba (buckwheat noodles)"
-        ],
-        "notation": "蕎麦(そば)"
+        ]
     },
     {
         "name": "ryuuiki",
         "trans": [
+            "流域(りゅういき)",
             "(river) basin"
-        ],
-        "notation": "流域(りゅういき)"
+        ]
     },
     {
         "name": "jitsubutsu",
         "trans": [
+            "実物(じつぶつ)",
             "real thing,original"
-        ],
-        "notation": "実物(じつぶつ)"
+        ]
     },
     {
         "name": "shitsukoi",
         "trans": [
+            "しつこい",
             "insistent,obstinate"
-        ],
-        "notation": "しつこい"
+        ]
     },
     {
         "name": "oyatsu",
         "trans": [
+            "おやつ",
             "(1) between meal snack,afternoon refreshment"
-        ],
-        "notation": "おやつ"
+        ]
     },
     {
         "name": "jisan",
         "trans": [
+            "持参(じさん)",
             "bringing,taking,carrying"
-        ],
-        "notation": "持参(じさん)"
+        ]
     },
     {
         "name": "hanashikakeru",
         "trans": [
+            "話(はな)し掛(か)ける",
             "to accost a person,to talk (to someone)"
-        ],
-        "notation": "話(はな)し掛(か)ける"
+        ]
     },
     {
         "name": "shitetsu",
         "trans": [
+            "私鉄(してつ)",
             "private railway"
-        ],
-        "notation": "私鉄(してつ)"
+        ]
     },
     {
         "name": "jikanwari",
         "trans": [
+            "時間割(じかんわり)",
             "timetable,schedule"
-        ],
-        "notation": "時間割(じかんわり)"
+        ]
     },
     {
         "name": "atsukamashii",
         "trans": [
+            "厚(あつ)かましい",
             "impudent,shameless,brazen"
-        ],
-        "notation": "厚(あつ)かましい"
+        ]
     },
     {
         "name": "rittoru",
         "trans": [
+            "リットル",
             "litre"
-        ],
-        "notation": "リットル"
+        ]
     },
     {
         "name": "hyoushi",
         "trans": [
+            "表紙(ひょうし)",
             "front cover,binding"
-        ],
-        "notation": "表紙(ひょうし)"
+        ]
     },
     {
         "name": "aogu",
         "trans": [
+            "扇(あお)ぐ",
             "to fan,to flap"
-        ],
-        "notation": "扇(あお)ぐ"
+        ]
     },
     {
         "name": "sakaba",
         "trans": [
+            "酒場(さかば)",
             "bar,bar-room"
-        ],
-        "notation": "酒場(さかば)"
+        ]
     },
     {
         "name": "oufuku",
         "trans": [
+            "往復(おうふく)",
             "(col) round trip,coming and going,return ticket"
-        ],
-        "notation": "往復(おうふく)"
+        ]
     },
     {
         "name": "heikai",
         "trans": [
+            "閉会(へいかい)",
             "closure"
-        ],
-        "notation": "閉会(へいかい)"
+        ]
     },
     {
         "name": "hikiwakeke",
         "trans": [
+            "引分(ひきわけ)け",
             "a draw (in competition),tie game"
-        ],
-        "notation": "引分(ひきわけ)け"
+        ]
     },
     {
         "name": "kogoeru",
         "trans": [
+            "凍(こご)える",
             "to freeze,to be chilled,to be frozen"
-        ],
-        "notation": "凍(こご)える"
+        ]
     },
     {
         "name": "moshikashitara",
         "trans": [
+            "もしかしたら",
             "perhaps,maybe,by some chance"
-        ],
-        "notation": "もしかしたら"
+        ]
     },
     {
         "name": "kitai",
         "trans": [
+            "気体(きたい)",
             "vapour,gas"
-        ],
-        "notation": "気体(きたい)"
+        ]
     },
     {
         "name": "eibun",
         "trans": [
+            "英文(えいぶん)",
             "sentence in English"
-        ],
-        "notation": "英文(えいぶん)"
+        ]
     },
     {
         "name": "kijun",
         "trans": [
+            "基準(きじゅん)",
             "standard,basis,criteria,norm"
-        ],
-        "notation": "基準(きじゅん)"
+        ]
     },
     {
         "name": "tobikomu",
         "trans": [
+            "飛(と)び込(こ)む",
             "to jump in,to leap in,to plunge into,to dive"
-        ],
-        "notation": "飛(と)び込(こ)む"
+        ]
     },
     {
         "name": "gekizou",
         "trans": [
+            "激増(げきぞう)",
             "sudden increase"
-        ],
-        "notation": "激増(げきぞう)"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "並行(へいこう)",
             "(going) side by side,concurrent,abreast,at the same time"
-        ],
-        "notation": "並行(へいこう)"
+        ]
     },
     {
         "name": "seisaku",
         "trans": [
+            "製作(せいさく)",
             "manufacture,production"
-        ],
-        "notation": "製作(せいさく)"
+        ]
     },
     {
         "name": "akogareru",
         "trans": [
+            "憧(あこが)れる",
             "to long for,to yearn after,to admire"
-        ],
-        "notation": "憧(あこが)れる"
+        ]
     },
     {
         "name": "kouryuu",
         "trans": [
+            "交流(こうりゅう)",
             "alternating current,intercourse,(cultural) exchange,intermingling"
-        ],
-        "notation": "交流(こうりゅう)"
+        ]
     },
     {
         "name": "tsutawaru",
         "trans": [
+            "伝(つた)わる",
             "to be handed down,to be introduced,to be transmitted"
-        ],
-        "notation": "伝(つた)わる"
+        ]
     },
     {
         "name": "oujo",
         "trans": [
+            "王女(おうじょ)",
             "princess"
-        ],
-        "notation": "王女(おうじょ)"
+        ]
     },
     {
         "name": "kanshou",
         "trans": [
+            "鑑賞(かんしょう)",
             "appreciation"
-        ],
-        "notation": "鑑賞(かんしょう)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "努(つと)める",
             "(1) to serve,to fill a post,to serve under,to work (for)"
-        ],
-        "notation": "努(つと)める"
+        ]
     },
     {
         "name": "fuusen",
         "trans": [
+            "風船(ふうせん)",
             "balloon"
-        ],
-        "notation": "風船(ふうせん)"
+        ]
     },
     {
         "name": "chozou",
         "trans": [
+            "貯蔵(ちょぞう)",
             "storage,preservation"
-        ],
-        "notation": "貯蔵(ちょぞう)"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "蒔(ま)く",
             "to sow (seeds)"
-        ],
-        "notation": "蒔(ま)く"
+        ]
     },
     {
         "name": "shukujitsu",
         "trans": [
+            "祝日(しゅくじつ)",
             "national holiday"
-        ],
-        "notation": "祝日(しゅくじつ)"
+        ]
     },
     {
         "name": "maneru",
         "trans": [
+            "真似(まね)る",
             "to mimic,to imitate"
-        ],
-        "notation": "真似(まね)る"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "更(ふ)ける",
             "to get late,to advance,to wear on"
-        ],
-        "notation": "更(ふ)ける"
+        ]
     },
     {
         "name": "koshiraeru",
         "trans": [
+            "こしらえる",
             "to make,to manufacture"
-        ],
-        "notation": "こしらえる"
+        ]
     },
     {
         "name": "togaru",
         "trans": [
+            "尖(とが)る",
             "to taper to a point,to become sharp,to be sour,to look displeased"
-        ],
-        "notation": "尖(とが)る"
+        ]
     },
     {
         "name": "tsunagaru",
         "trans": [
+            "繋(つな)がる",
             "to be tied together,to be connected to,to be related to"
-        ],
-        "notation": "繋(つな)がる"
+        ]
     },
     {
         "name": "kandenchi",
         "trans": [
+            "乾電池(かんでんち)",
             "dry cell,battery"
-        ],
-        "notation": "乾電池(かんでんち)"
+        ]
     },
     {
         "name": "wareru",
         "trans": [
+            "破(わ)れる",
             "to get torn,to wear out"
-        ],
-        "notation": "破(わ)れる"
+        ]
     },
     {
         "name": "zurasu",
         "trans": [
+            "ずらす",
             "to put off,to delay"
-        ],
-        "notation": "ずらす"
+        ]
     },
     {
         "name": "shiriizu",
         "trans": [
+            "シリーズ",
             "series"
-        ],
-        "notation": "シリーズ"
+        ]
     },
     {
         "name": "kyuugyou",
         "trans": [
+            "休業(きゅうぎょう)",
             "closed (e.g. store),business suspended,shutdown,holiday"
-        ],
-        "notation": "休業(きゅうぎょう)"
+        ]
     },
     {
         "name": "yuuhi",
         "trans": [
+            "夕日(ゆうひ)",
             "(in) the evening sun,setting sun"
-        ],
-        "notation": "夕日(ゆうひ)"
+        ]
     },
     {
         "name": "orosu",
         "trans": [
+            "卸(おろ)す",
             "to sell wholesale,grated (vegetables)"
-        ],
-        "notation": "卸(おろ)す"
+        ]
     },
     {
         "name": "houteishiki",
         "trans": [
+            "方程式(ほうていしき)",
             "equation"
-        ],
-        "notation": "方程式(ほうていしき)"
+        ]
     },
     {
         "name": "damasu",
         "trans": [
+            "だます",
             "to trick,to cheat,to deceive"
-        ],
-        "notation": "だます"
+        ]
     },
     {
         "name": "ryouji",
         "trans": [
+            "領事(りょうじ)",
             "consul"
-        ],
-        "notation": "領事(りょうじ)"
+        ]
     },
     {
         "name": "haguruma",
         "trans": [
+            "歯車(はぐるま)",
             "gear,cog-wheel"
-        ],
-        "notation": "歯車(はぐるま)"
+        ]
     },
     {
         "name": "kanzuru",
         "trans": [
+            "感(かん)ずる",
             "to feel,to sense"
-        ],
-        "notation": "感(かん)ずる"
+        ]
     },
     {
         "name": "meizuru",
         "trans": [
+            "命(めい)ずる",
             "to command,to appoint"
-        ],
-        "notation": "命(めい)ずる"
+        ]
     },
     {
         "name": "tsumu",
         "trans": [
+            "積(つ)む",
             "to pile up,to stack"
-        ],
-        "notation": "積(つ)む"
+        ]
     },
     {
         "name": "tennou",
         "trans": [
+            "天皇(てんのう)",
             "Emperor of Japan"
-        ],
-        "notation": "天皇(てんのう)"
+        ]
     },
     {
         "name": "suekko",
         "trans": [
+            "末(すえ)っ子(こ)",
             "youngest child"
-        ],
-        "notation": "末(すえ)っ子(こ)"
+        ]
     },
     {
         "name": "kakko",
         "trans": [
+            "括弧(かっこ)",
             "parenthesis,brackets"
-        ],
-        "notation": "括弧(かっこ)"
+        ]
     },
     {
         "name": "youhinten",
         "trans": [
+            "洋品(ようひん)店(てん)",
             "shop which handles Western-style apparel and accessories"
-        ],
-        "notation": "洋品(ようひん)店(てん)"
+        ]
     },
     {
         "name": "tsuriau",
         "trans": [
+            "釣(つ)り合(あ)う",
             "to balance,to be in harmony,to suit"
-        ],
-        "notation": "釣(つ)り合(あ)う"
+        ]
     },
     {
         "name": "ototoi",
         "trans": [
+            "おととい",
             "day before yesterday"
-        ],
-        "notation": "おととい"
+        ]
     },
     {
         "name": "daishou",
         "trans": [
+            "大小(だいしょう)",
             "size"
-        ],
-        "notation": "大小(だいしょう)"
+        ]
     },
     {
         "name": "tenten",
         "trans": [
+            "転々(てんてん)",
             ""
-        ],
-        "notation": "転々(てんてん)"
+        ]
     },
     {
         "name": "hougaku",
         "trans": [
+            "方角(ほうがく)",
             "direction,way,compass point"
-        ],
-        "notation": "方角(ほうがく)"
+        ]
     },
     {
         "name": "nori",
         "trans": [
+            "糊(のり)",
             "paste,starch"
-        ],
-        "notation": "糊(のり)"
+        ]
     },
     {
         "name": "omoitsuku",
         "trans": [
+            "思(おも)い付(つ)く",
             "to think of,to hit upon"
-        ],
-        "notation": "思(おも)い付(つ)く"
+        ]
     },
     {
         "name": "teika",
         "trans": [
+            "定価(ていか)",
             "established price"
-        ],
-        "notation": "定価(ていか)"
+        ]
     },
     {
         "name": "kewashii",
         "trans": [
+            "険(けわ)しい",
             "inaccessible place,sharp eyes"
-        ],
-        "notation": "険(けわ)しい"
+        ]
     },
     {
         "name": "sasuga",
         "trans": [
+            "流石(さすが)",
             "clever,adept,good,expectations,as one would expect"
-        ],
-        "notation": "流石(さすが)"
+        ]
     },
     {
         "name": "fumoto",
         "trans": [
+            "麓(ふもと)",
             "the foot,the bottom,the base (of a mountain)"
-        ],
-        "notation": "麓(ふもと)"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "解答(かいとう)",
             "answer,solution"
-        ],
-        "notation": "解答(かいとう)"
+        ]
     },
     {
         "name": "shoudoku",
         "trans": [
+            "消毒(しょうどく)",
             "disinfection,sterilization"
-        ],
-        "notation": "消毒(しょうどく)"
+        ]
     },
     {
         "name": "sakizakishuu",
         "trans": [
+            "先々(さきざき)週(しゅう)",
             ""
-        ],
-        "notation": "先々(さきざき)週(しゅう)"
+        ]
     },
     {
         "name": "toubun",
         "trans": [
+            "等分(とうぶん)",
             "division into equal parts"
-        ],
-        "notation": "等分(とうぶん)"
+        ]
     },
     {
         "name": "tsubu",
         "trans": [
+            "粒(つぶ)",
             "grain"
-        ],
-        "notation": "粒(つぶ)"
+        ]
     },
     {
         "name": "saisoku",
         "trans": [
+            "催促(さいそく)",
             "request,demand,claim,urge (action),press for"
-        ],
-        "notation": "催促(さいそく)"
+        ]
     },
     {
         "name": "shoseki",
         "trans": [
+            "書籍(しょせき)",
             "book,publication"
-        ],
-        "notation": "書籍(しょせき)"
+        ]
     },
     {
         "name": "taku",
         "trans": [
+            "炊(た)く",
             "to boil,to cook"
-        ],
-        "notation": "炊(た)く"
+        ]
     },
     {
         "name": "hakuhatsu",
         "trans": [
+            "白髪(はくはつ)",
             "white or grey hair,trendy hair bleaching"
-        ],
-        "notation": "白髪(はくはつ)"
+        ]
     },
     {
         "name": "dotto",
         "trans": [
+            "どっと",
             "suddenly"
-        ],
-        "notation": "どっと"
+        ]
     },
     {
         "name": "setomono",
         "trans": [
+            "瀬戸物(せともの)",
             "earthenware,crockery,china"
-        ],
-        "notation": "瀬戸物(せともの)"
+        ]
     },
     {
         "name": "totonou",
         "trans": [
+            "整(ととの)う",
             "to be prepared,to be in order,to be put in order,to be arranged"
-        ],
-        "notation": "整(ととの)う"
+        ]
     },
     {
         "name": "tachidomaru",
         "trans": [
+            "立(た)ち止(ど)まる",
             "to stop,to halt,to stand still"
-        ],
-        "notation": "立(た)ち止(ど)まる"
+        ]
     },
     {
         "name": "horu",
         "trans": [
+            "彫(ほ)る",
             "to carve,to engrave,to sculpture,to chisel"
-        ],
-        "notation": "彫(ほ)る"
+        ]
     },
     {
         "name": "keikoutou",
         "trans": [
+            "蛍光(けいこう)灯(とう)",
             "fluorescent lamp,person who is slow to react"
-        ],
-        "notation": "蛍光(けいこう)灯(とう)"
+        ]
     },
     {
         "name": "yokosu",
         "trans": [
+            "よこす",
             "(1) to send,to forward,(2) to hand over (e.g. money)"
-        ],
-        "notation": "よこす"
+        ]
     },
     {
         "name": "nakayoshi",
         "trans": [
+            "仲良(なかよ)し",
             "intimate friend,bosom buddy,chum"
-        ],
-        "notation": "仲良(なかよ)し"
+        ]
     },
     {
         "name": "kuchibiru",
         "trans": [
+            "唇(くちびる)",
             "lips"
-        ],
-        "notation": "唇(くちびる)"
+        ]
     },
     {
         "name": "sakuin",
         "trans": [
+            "索引(さくいん)",
             "index,indices"
-        ],
-        "notation": "索引(さくいん)"
+        ]
     },
     {
         "name": "toorikakaru",
         "trans": [
+            "通(とお)り掛(か)かる",
             "to happen to pass by"
-        ],
-        "notation": "通(とお)り掛(か)かる"
+        ]
     },
     {
         "name": "makkuro",
         "trans": [
+            "真(ま)っ黒(くろ)",
             "pitch black"
-        ],
-        "notation": "真(ま)っ黒(くろ)"
+        ]
     },
     {
         "name": "sakasama",
         "trans": [
+            "逆様(さかさま)",
             "inversion,upside down"
-        ],
-        "notation": "逆様(さかさま)"
+        ]
     },
     {
         "name": "zuhyou",
         "trans": [
+            "図表(ずひょう)",
             "chart,diagram,graph"
-        ],
-        "notation": "図表(ずひょう)"
+        ]
     },
     {
         "name": "yorokobu",
         "trans": [
+            "慶(よろこ)ぶ",
             ""
-        ],
-        "notation": "慶(よろこ)ぶ"
+        ]
     },
     {
         "name": "chijimeru",
         "trans": [
+            "縮(ちぢ)める",
             "to shorten,to reduce,to boil down,to shrink"
-        ],
-        "notation": "縮(ちぢ)める"
+        ]
     },
     {
         "name": "ranbou",
         "trans": [
+            "乱暴(らんぼう)",
             "rude,violent,rough,lawless,unreasonable,reckless"
-        ],
-        "notation": "乱暴(らんぼう)"
+        ]
     },
     {
         "name": "oubaakouto",
         "trans": [
+            "オーバーコート",
             ""
-        ],
-        "notation": "オーバーコート"
+        ]
     },
     {
         "name": "tsuuyou",
         "trans": [
+            "通用(つうよう)",
             "popular use,circulation"
-        ],
-        "notation": "通用(つうよう)"
+        ]
     },
     {
         "name": "mokka",
         "trans": [
+            "目下(もっか)",
             "at present,now"
-        ],
-        "notation": "目下(もっか)"
+        ]
     },
     {
         "name": "tenten",
         "trans": [
+            "点々(てんてん)",
             "here and there,little by little"
-        ],
-        "notation": "点々(てんてん)"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "捕(と)る",
             "to take,to catch (fish),to capture"
-        ],
-        "notation": "捕(と)る"
+        ]
     },
     {
         "name": "naninani",
         "trans": [
+            "何々(なになに)",
             "such and such,What?"
-        ],
-        "notation": "何々(なになに)"
+        ]
     },
     {
         "name": "shousha",
         "trans": [
+            "商社(しょうしゃ)",
             "trading company,firm"
-        ],
-        "notation": "商社(しょうしゃ)"
+        ]
     },
     {
         "name": "rusuban",
         "trans": [
+            "留守番(るすばん)",
             "care-taking,caretaker,house-watching"
-        ],
-        "notation": "留守番(るすばん)"
+        ]
     },
     {
         "name": "kubun",
         "trans": [
+            "区分(くぶん)",
             "division,section,classification"
-        ],
-        "notation": "区分(くぶん)"
+        ]
     },
     {
         "name": "ashiato",
         "trans": [
+            "足跡(あしあと)",
             "footprints"
-        ],
-        "notation": "足跡(あしあと)"
+        ]
     },
     {
         "name": "hirune",
         "trans": [
+            "昼寝(ひるね)",
             "nap (at home),siesta"
-        ],
-        "notation": "昼寝(ひるね)"
+        ]
     },
     {
         "name": "kouhai",
         "trans": [
+            "後輩(こうはい)",
             "junior (at work or school)"
-        ],
-        "notation": "後輩(こうはい)"
+        ]
     },
     {
         "name": "warito",
         "trans": [
+            "割(わり)と",
             "relatively, comparitively"
-        ],
-        "notation": "割(わり)と"
+        ]
     },
     {
         "name": "chokuzen",
         "trans": [
+            "直前(ちょくぜん)",
             "just before"
-        ],
-        "notation": "直前(ちょくぜん)"
+        ]
     },
     {
         "name": "teikyuubi",
         "trans": [
+            "定休(ていきゅう)日(び)",
             "regular holiday"
-        ],
-        "notation": "定休(ていきゅう)日(び)"
+        ]
     },
     {
         "name": "yoso",
         "trans": [
+            "余所(よそ)",
             "another place,somewhere else,strange parts"
-        ],
-        "notation": "余所(よそ)"
+        ]
     },
     {
         "name": "moukaru",
         "trans": [
+            "儲(もう)かる",
             "to be profitable,to yield a profit"
-        ],
-        "notation": "儲(もう)かる"
+        ]
     },
     {
         "name": "shasetsu",
         "trans": [
+            "社説(しゃせつ)",
             "editorial,leading article"
-        ],
-        "notation": "社説(しゃせつ)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "留(と)まる",
             "(1) to be fixed,(2) to abide,to stay (in the one place)"
-        ],
-        "notation": "留(と)まる"
+        ]
     },
     {
         "name": "niwaka",
         "trans": [
+            "俄(にわか)",
             "sudden,abrupt,unexpected,improvised,offhand"
-        ],
-        "notation": "俄(にわか)"
+        ]
     },
     {
         "name": "tabi",
         "trans": [
+            "足袋(たび)",
             "tabi,Japanese socks (with split toe)"
-        ],
-        "notation": "足袋(たび)"
+        ]
     },
     {
         "name": "fukusuu",
         "trans": [
+            "複数(ふくすう)",
             "plural,multiple"
-        ],
-        "notation": "複数(ふくすう)"
+        ]
     },
     {
         "name": "nakayubi",
         "trans": [
+            "中指(なかゆび)",
             "middle finger"
-        ],
-        "notation": "中指(なかゆび)"
+        ]
     },
     {
         "name": "gouri",
         "trans": [
+            "合理(ごうり)",
             "rational"
-        ],
-        "notation": "合理(ごうり)"
+        ]
     },
     {
         "name": "sorou",
         "trans": [
+            "揃(そろ)う",
             "to become complete,to be equal,to be all present,to gather"
-        ],
-        "notation": "揃(そろ)う"
+        ]
     },
     {
         "name": "rousoku",
         "trans": [
+            "蝋燭(ろうそく)",
             "candle"
-        ],
-        "notation": "蝋燭(ろうそく)"
+        ]
     },
     {
         "name": "sessuru",
         "trans": [
+            "接(せっ)する",
             "to come in contact with,to connect,to attend,to receive"
-        ],
-        "notation": "接(せっ)する"
+        ]
     },
     {
         "name": "soui",
         "trans": [
+            "相違(そうい)",
             "difference,discrepancy,variation"
-        ],
-        "notation": "相違(そうい)"
+        ]
     },
     {
         "name": "nikumu",
         "trans": [
+            "憎(にく)む",
             "to hate,to detest"
-        ],
-        "notation": "憎(にく)む"
+        ]
     },
     {
         "name": "mottainai",
         "trans": [
+            "もったいない",
             "too good,more than one deserves,wasteful,sacrilegious,unworthy of"
-        ],
-        "notation": "もったいない"
+        ]
     },
     {
         "name": "issei",
         "trans": [
+            "一斉(いっせい)",
             "simultaneous,all at once"
-        ],
-        "notation": "一斉(いっせい)"
+        ]
     },
     {
         "name": "rainichi",
         "trans": [
+            "来日(らいにち)",
             "arrival in Japan,coming to Japan,visit to Japan"
-        ],
-        "notation": "来日(らいにち)"
+        ]
     },
     {
         "name": "gakuryoku",
         "trans": [
+            "学力(がくりょく)",
             "scholarship,knowledge,literary ability"
-        ],
-        "notation": "学力(がくりょく)"
+        ]
     },
     {
         "name": "uku",
         "trans": [
+            "浮(う)く",
             "to float,to become merry,to become loose"
-        ],
-        "notation": "浮(う)く"
+        ]
     },
     {
         "name": "kigou",
         "trans": [
+            "記号(きごう)",
             "symbol,code"
-        ],
-        "notation": "記号(きごう)"
+        ]
     },
     {
         "name": "matsuru",
         "trans": [
+            "祭(まつ)る",
             "to deify,to enshrine"
-        ],
-        "notation": "祭(まつ)る"
+        ]
     },
     {
         "name": "kakubetsu",
         "trans": [
+            "格別(かくべつ)",
             "exceptional"
-        ],
-        "notation": "格別(かくべつ)"
+        ]
     },
     {
         "name": "hatsuden",
         "trans": [
+            "発電(はつでん)",
             "generation (e.g. power)"
-        ],
-        "notation": "発電(はつでん)"
+        ]
     },
     {
         "name": "meisaku",
         "trans": [
+            "名作(めいさく)",
             "masterpiece"
-        ],
-        "notation": "名作(めいさく)"
+        ]
     },
     {
         "name": "genkou",
         "trans": [
+            "原稿(げんこう)",
             "manuscript,copy"
-        ],
-        "notation": "原稿(げんこう)"
+        ]
     },
     {
         "name": "hyoushiki",
         "trans": [
+            "標識(ひょうしき)",
             "sign,mark"
-        ],
-        "notation": "標識(ひょうしき)"
+        ]
     },
     {
         "name": "nichiyouhin",
         "trans": [
+            "日(にち)用品(ようひん)",
             "daily necessities"
-        ],
-        "notation": "日(にち)用品(ようひん)"
+        ]
     },
     {
         "name": "demukaeru",
         "trans": [
+            "出迎(でむか)える",
             "to meet,to greet"
-        ],
-        "notation": "出迎(でむか)える"
+        ]
     },
     {
         "name": "shirizoku",
         "trans": [
+            "退(しりぞ)く",
             "(1) to retreat,to recede,to withdraw"
-        ],
-        "notation": "退(しりぞ)く"
+        ]
     },
     {
         "name": "kokuseki",
         "trans": [
+            "国籍(こくせき)",
             "nationality"
-        ],
-        "notation": "国籍(こくせき)"
+        ]
     },
     {
         "name": "jouka",
         "trans": [
+            "上下(じょうか)",
             "high and low,up and down,unloading and loading,praising and blaming"
-        ],
-        "notation": "上下(じょうか)"
+        ]
     },
     {
         "name": "iyoiyo",
         "trans": [
+            "いよいよ",
             "more and more,all the more,increasingly,at last,beyond doubt"
-        ],
-        "notation": "いよいよ"
+        ]
     },
     {
         "name": "kurumu",
         "trans": [
+            "くるむ",
             "to be engulfed in,to be enveloped by,to wrap up"
-        ],
-        "notation": "くるむ"
+        ]
     },
     {
         "name": "machiawaseru",
         "trans": [
+            "待(ま)ち合(あ)わせる",
             "to rendezvous,to meet at a prearranged place and time"
-        ],
-        "notation": "待(ま)ち合(あ)わせる"
+        ]
     },
     {
         "name": "toraeru",
         "trans": [
+            "捕(とら)える",
             "to seize,to grasp,to capture,to arrest"
-        ],
-        "notation": "捕(とら)える"
+        ]
     },
     {
         "name": "kenkyo",
         "trans": [
+            "謙虚(けんきょ)",
             "modesty,humility"
-        ],
-        "notation": "謙虚(けんきょ)"
+        ]
     },
     {
         "name": "shikichi",
         "trans": [
+            "敷地(しきち)",
             "site"
-        ],
-        "notation": "敷地(しきち)"
+        ]
     },
     {
         "name": "yougan",
         "trans": [
+            "溶岩(ようがん)",
             "lava"
-        ],
-        "notation": "溶岩(ようがん)"
+        ]
     },
     {
         "name": "daiichi",
         "trans": [
+            "だいいち",
             "first,foremost,# 1"
-        ],
-        "notation": "だいいち"
+        ]
     },
     {
         "name": "ishokujuu",
         "trans": [
+            "衣食住(いしょくじゅう)",
             "necessities of life (food, clothing, etc.)"
-        ],
-        "notation": "衣食住(いしょくじゅう)"
+        ]
     },
     {
         "name": "fukuramu",
         "trans": [
+            "膨(ふく)らむ",
             "to expand,to swell (out),to get big,to become inflated"
-        ],
-        "notation": "膨(ふく)らむ"
+        ]
     },
     {
         "name": "shattaa",
         "trans": [
+            "シャッター",
             "shutter"
-        ],
-        "notation": "シャッター"
+        ]
     },
     {
         "name": "sumanai",
         "trans": [
+            "すまない",
             "sorry (phrase)"
-        ],
-        "notation": "すまない"
+        ]
     },
     {
         "name": "meishi",
         "trans": [
+            "名刺(めいし)",
             "business card"
-        ],
-        "notation": "名刺(めいし)"
+        ]
     },
     {
         "name": "sekkin",
         "trans": [
+            "接近(せっきん)",
             "getting closer,drawing nearer,approaching"
-        ],
-        "notation": "接近(せっきん)"
+        ]
     },
     {
         "name": "kigae",
         "trans": [
+            "着替(きが)え",
             "changing clothes,change of clothes"
-        ],
-        "notation": "着替(きが)え"
+        ]
     },
     {
         "name": "yanushi",
         "trans": [
+            "家主(やぬし)",
             "landlord"
-        ],
-        "notation": "家主(やぬし)"
+        ]
     },
     {
         "name": "shigeru",
         "trans": [
+            "茂(しげ)る",
             "to grow thick,to luxuriate,to be luxurious"
-        ],
-        "notation": "茂(しげ)る"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "器械(きかい)",
             "instrument"
-        ],
-        "notation": "器械(きかい)"
+        ]
     },
     {
         "name": "teikiken",
         "trans": [
+            "定期(ていき)券(けん)",
             "commuter pass,season ticket"
-        ],
-        "notation": "定期(ていき)券(けん)"
+        ]
     },
     {
         "name": "soushite",
         "trans": [
+            "そうして",
             "and,like that"
-        ],
-        "notation": "そうして"
+        ]
     },
     {
         "name": "magomago",
         "trans": [
+            "まごまご",
             "confused"
-        ],
-        "notation": "まごまご"
+        ]
     },
     {
         "name": "fubuki",
         "trans": [
+            "吹雪(ふぶき)",
             "snow storm"
-        ],
-        "notation": "吹雪(ふぶき)"
+        ]
     },
     {
         "name": "hosu",
         "trans": [
+            "干(ほ)す",
             "to air,to dry,to desiccate,to drain (off),to drink up"
-        ],
-        "notation": "干(ほ)す"
+        ]
     },
     {
         "name": "karakau",
         "trans": [
+            "からかう",
             "to ridicule,to tease,to banter with,to make fun of"
-        ],
-        "notation": "からかう"
+        ]
     },
     {
         "name": "chokkei",
         "trans": [
+            "直径(ちょっけい)",
             "diameter"
-        ],
-        "notation": "直径(ちょっけい)"
+        ]
     },
     {
         "name": "kuuraa",
         "trans": [
+            "クーラー",
             "cooler,air conditioner"
-        ],
-        "notation": "クーラー"
+        ]
     },
     {
         "name": "sekidou",
         "trans": [
+            "赤道(せきどう)",
             "equator"
-        ],
-        "notation": "赤道(せきどう)"
+        ]
     },
     {
         "name": "mondou",
         "trans": [
+            "問答(もんどう)",
             "questions and answers,dialogue"
-        ],
-        "notation": "問答(もんどう)"
+        ]
     },
     {
         "name": "hashigo",
         "trans": [
+            "梯子(はしご)",
             "ladder,stairs"
-        ],
-        "notation": "梯子(はしご)"
+        ]
     },
     {
         "name": "tsuyoki",
         "trans": [
+            "強気(つよき)",
             "firm,strong"
-        ],
-        "notation": "強気(つよき)"
+        ]
     },
     {
         "name": "hankei",
         "trans": [
+            "半径(はんけい)",
             "radius"
-        ],
-        "notation": "半径(はんけい)"
+        ]
     },
     {
         "name": "deiri",
         "trans": [
+            "出入(でい)り",
             "in and out,coming and going,free association,income and expenditure,debits and credit"
-        ],
-        "notation": "出入(でい)り"
+        ]
     },
     {
         "name": "kuttsukeru",
         "trans": [
+            "くっつける",
             "to attach"
-        ],
-        "notation": "くっつける"
+        ]
     },
     {
         "name": "gakka",
         "trans": [
+            "学科(がっか)",
             "study subject,course of study"
-        ],
-        "notation": "学科(がっか)"
+        ]
     },
     {
         "name": "baiten",
         "trans": [
+            "売店(ばいてん)",
             "shop,stand"
-        ],
-        "notation": "売店(ばいてん)"
+        ]
     },
     {
         "name": "hantou",
         "trans": [
+            "半島(はんとう)",
             "peninsula"
-        ],
-        "notation": "半島(はんとう)"
+        ]
     },
     {
         "name": "maamaa",
         "trans": [
+            "まあまあ",
             "so-so"
-        ],
-        "notation": "まあまあ"
+        ]
     },
     {
         "name": "myouji",
         "trans": [
+            "名字(みょうじ)",
             "surname,family name"
-        ],
-        "notation": "名字(みょうじ)"
+        ]
     },
     {
         "name": "kutabireru",
         "trans": [
+            "くたびれる",
             "to get tired,to wear out"
-        ],
-        "notation": "くたびれる"
+        ]
     },
     {
         "name": "moutaa",
         "trans": [
+            "モーター",
             "motor"
-        ],
-        "notation": "モーター"
+        ]
     },
     {
         "name": "ranningu",
         "trans": [
+            "ランニング",
             "(1) running,(2) tank top"
-        ],
-        "notation": "ランニング"
+        ]
     },
     {
         "name": "jougi",
         "trans": [
+            "定規(じょうぎ)",
             "(measuring) ruler"
-        ],
-        "notation": "定規(じょうぎ)"
+        ]
     },
     {
         "name": "semento",
         "trans": [
+            "セメント",
             "cement"
-        ],
-        "notation": "セメント"
+        ]
     },
     {
         "name": "niou",
         "trans": [
+            "匂(にお)う",
             "to be fragrant,to smell,to stink"
-        ],
-        "notation": "匂(にお)う"
+        ]
     },
     {
         "name": "kizamu",
         "trans": [
+            "刻(きざ)む",
             "to mince,to carve,to engrave"
-        ],
-        "notation": "刻(きざ)む"
+        ]
     },
     {
         "name": "hyoujun",
         "trans": [
+            "標準(ひょうじゅん)",
             "standard,level"
-        ],
-        "notation": "標準(ひょうじゅん)"
+        ]
     },
     {
         "name": "udon",
         "trans": [
+            "うどん",
             "noodles (Japanese)"
-        ],
-        "notation": "うどん"
+        ]
     },
     {
         "name": "damu",
         "trans": [
+            "ダム",
             "dumb"
-        ],
-        "notation": "ダム"
+        ]
     },
     {
         "name": "omachikudasai",
         "trans": [
+            "おまちください",
             "Please wait a moment"
-        ],
-        "notation": "おまちください"
+        ]
     },
     {
         "name": "sakusei",
         "trans": [
+            "作製(さくせい)",
             "manufacture"
-        ],
-        "notation": "作製(さくせい)"
+        ]
     },
     {
         "name": "arasou",
         "trans": [
+            "争(あらそ)う",
             "to dispute,to argue,to be at variance,to compete"
-        ],
-        "notation": "争(あらそ)う"
+        ]
     },
     {
         "name": "sabi",
         "trans": [
+            "錆(さび)",
             "rust (colour)"
-        ],
-        "notation": "錆(さび)"
+        ]
     },
     {
         "name": "azukaru",
         "trans": [
+            "預(あず)かる",
             "to keep in custody,to receive on deposit,to take charge of"
-        ],
-        "notation": "預(あず)かる"
+        ]
     },
     {
         "name": "gochisou",
         "trans": [
+            "御馳走(ごちそう)",
             "feast,treating (someone)"
-        ],
-        "notation": "御馳走(ごちそう)"
+        ]
     },
     {
         "name": "memai",
         "trans": [
+            "めまい",
             "dizziness,giddiness"
-        ],
-        "notation": "めまい"
+        ]
     },
     {
         "name": "danchi",
         "trans": [
+            "団地(だんち)",
             "multi-unit apartments"
-        ],
-        "notation": "団地(だんち)"
+        ]
     },
     {
         "name": "kousui",
         "trans": [
+            "香水(こうすい)",
             "perfume"
-        ],
-        "notation": "香水(こうすい)"
+        ]
     },
     {
         "name": "bunken",
         "trans": [
+            "文献(ぶんけん)",
             "literature,books (reference)"
-        ],
-        "notation": "文献(ぶんけん)"
+        ]
     },
     {
         "name": "nekkuresu",
         "trans": [
+            "ネックレス",
             "necklace"
-        ],
-        "notation": "ネックレス"
+        ]
     },
     {
         "name": "koushite",
         "trans": [
+            "こうして",
             "thus"
-        ],
-        "notation": "こうして"
+        ]
     },
     {
         "name": "ontai",
         "trans": [
+            "温帯(おんたい)",
             "temperate zone"
-        ],
-        "notation": "温帯(おんたい)"
+        ]
     },
     {
         "name": "seiritsu",
         "trans": [
+            "成立(せいりつ)",
             "coming into existence,arrangements,establishment,completion"
-        ],
-        "notation": "成立(せいりつ)"
+        ]
     },
     {
         "name": "nanibun",
         "trans": [
+            "何分(なにぶん)",
             "what minute?,how many minutes?"
-        ],
-        "notation": "何分(なにぶん)"
+        ]
     },
     {
         "name": "hanabi",
         "trans": [
+            "花火(はなび)",
             "fireworks"
-        ],
-        "notation": "花火(はなび)"
+        ]
     },
     {
         "name": "sasayaku",
         "trans": [
+            "囁(ささや)く",
             "to whisper,to murmur"
-        ],
-        "notation": "囁(ささや)く"
+        ]
     },
     {
         "name": "saisan",
         "trans": [
+            "再三(さいさん)",
             "again and again,repeatedly"
-        ],
-        "notation": "再三(さいさん)"
+        ]
     },
     {
         "name": "hikizan",
         "trans": [
+            "引算(ひきざん)",
             "subtraction"
-        ],
-        "notation": "引算(ひきざん)"
+        ]
     },
     {
         "name": "shiizun",
         "trans": [
+            "シーズン",
             "season (sporting)"
-        ],
-        "notation": "シーズン"
+        ]
     },
     {
         "name": "aikawarazu",
         "trans": [
+            "あいかわらず",
             "as ever,as usual,the same"
-        ],
-        "notation": "あいかわらず"
+        ]
     },
     {
         "name": "haiken",
         "trans": [
+            "拝見(はいけん)",
             "(hum) (pol) seeing,look at"
-        ],
-        "notation": "拝見(はいけん)"
+        ]
     },
     {
         "name": "shuuryou",
         "trans": [
+            "終了(しゅうりょう)",
             "end,close,termination"
-        ],
-        "notation": "終了(しゅうりょう)"
+        ]
     },
     {
         "name": "inryoku",
         "trans": [
+            "引力(いんりょく)",
             "gravity"
-        ],
-        "notation": "引力(いんりょく)"
+        ]
     },
     {
         "name": "mensetsu",
         "trans": [
+            "面接(めんせつ)",
             "interview"
-        ],
-        "notation": "面接(めんせつ)"
+        ]
     },
     {
         "name": "mishin",
         "trans": [
+            "ミシン",
             "sewing machine"
-        ],
-        "notation": "ミシン"
+        ]
     },
     {
         "name": "kamei",
         "trans": [
+            "仮名(かめい)",
             "(n) alias,pseudonym,pen name"
-        ],
-        "notation": "仮名(かめい)"
+        ]
     },
     {
         "name": "gyouretsu",
         "trans": [
+            "行列(ぎょうれつ)",
             "(1) line,procession,(2) matrix (math)"
-        ],
-        "notation": "行列(ぎょうれつ)"
+        ]
     },
     {
         "name": "sashihiki",
         "trans": [
+            "差(さ)し引(ひ)き",
             "deduction,subtraction,balance,ebb and flow,rise and fall"
-        ],
-        "notation": "差(さ)し引(ひ)き"
+        ]
     },
     {
         "name": "denchuu",
         "trans": [
+            "電柱(でんちゅう)",
             "telephone pole,telegraph pole,lightpole"
-        ],
-        "notation": "電柱(でんちゅう)"
+        ]
     },
     {
         "name": "shiki",
         "trans": [
+            "四季(しき)",
             "four seasons"
-        ],
-        "notation": "四季(しき)"
+        ]
     },
     {
         "name": "kiso",
         "trans": [
+            "基礎(きそ)",
             "foundation,basis"
-        ],
-        "notation": "基礎(きそ)"
+        ]
     },
     {
         "name": "oyasumi",
         "trans": [
+            "おやすみ",
             "(1) holiday,absence,rest,(2) (exp) Good night"
-        ],
-        "notation": "おやすみ"
+        ]
     },
     {
         "name": "katayoru",
         "trans": [
+            "片寄(かたよ)る",
             "to be one-sided,to incline,to be partial"
-        ],
-        "notation": "片寄(かたよ)る"
+        ]
     },
     {
         "name": "hirosa",
         "trans": [
+            "広(ひろ)さ",
             "extent"
-        ],
-        "notation": "広(ひろ)さ"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "裂(さ)く",
             "to tear,to split"
-        ],
-        "notation": "裂(さ)く"
+        ]
     },
     {
         "name": "houmen",
         "trans": [
+            "方面(ほうめん)",
             "direction,district,field (e.g., of study)"
-        ],
-        "notation": "方面(ほうめん)"
+        ]
     },
     {
         "name": "ranchi",
         "trans": [
+            "ランチ",
             "launch,lunch"
-        ],
-        "notation": "ランチ"
+        ]
     },
     {
         "name": "okaeri",
         "trans": [
+            "お帰(かえ)り",
             "return,welcome"
-        ],
-        "notation": "お帰(かえ)り"
+        ]
     },
     {
         "name": "shison",
         "trans": [
+            "子孫(しそん)",
             "descendants,posterity,offspring"
-        ],
-        "notation": "子孫(しそん)"
+        ]
     },
     {
         "name": "shouten",
         "trans": [
+            "焦点(しょうてん)",
             "focus,point"
-        ],
-        "notation": "焦点(しょうてん)"
+        ]
     },
     {
         "name": "tankou",
         "trans": [
+            "炭鉱(たんこう)",
             "coal mine,coal pit"
-        ],
-        "notation": "炭鉱(たんこう)"
+        ]
     },
     {
         "name": "mitsukeru",
         "trans": [
+            "見付(みつ)ける",
             "to be familiar,to discover,to detect"
-        ],
-        "notation": "見付(みつ)ける"
+        ]
     },
     {
         "name": "korogasu",
         "trans": [
+            "転(ころ)がす",
             "to roll"
-        ],
-        "notation": "転(ころ)がす"
+        ]
     },
     {
         "name": "yakan",
         "trans": [
+            "薬缶(やかん)",
             "kettle"
-        ],
-        "notation": "薬缶(やかん)"
+        ]
     },
     {
         "name": "boudai",
         "trans": [
+            "膨大(ぼうだい)",
             "huge,bulky,enormous,extensive,swelling,expansion"
-        ],
-        "notation": "膨大(ぼうだい)"
+        ]
     },
     {
         "name": "chokugo",
         "trans": [
+            "直後(ちょくご)",
             "immediately following"
-        ],
-        "notation": "直後(ちょくご)"
+        ]
     },
     {
         "name": "kenson",
         "trans": [
+            "謙遜(けんそん)",
             "humble,humility,modesty"
-        ],
-        "notation": "謙遜(けんそん)"
+        ]
     },
     {
         "name": "koumoku",
         "trans": [
+            "項目(こうもく)",
             "item"
-        ],
-        "notation": "項目(こうもく)"
+        ]
     },
     {
         "name": "kamikuzu",
         "trans": [
+            "紙屑(かみくず)",
             "wastepaper"
-        ],
-        "notation": "紙屑(かみくず)"
+        ]
     },
     {
         "name": "umeru",
         "trans": [
+            "埋(う)める",
             "to bury,to fill up,to fill (a seat, a vacant position)"
-        ],
-        "notation": "埋(う)める"
+        ]
     },
     {
         "name": "sugi",
         "trans": [
+            "杉(すぎ)",
             "Japanese cedar"
-        ],
-        "notation": "杉(すぎ)"
+        ]
     },
     {
         "name": "ototoshi",
         "trans": [
+            "おととし",
             "year before last"
-        ],
-        "notation": "おととし"
+        ]
     },
     {
         "name": "taezu",
         "trans": [
+            "絶(た)えず",
             "constantly"
-        ],
-        "notation": "絶(た)えず"
+        ]
     },
     {
         "name": "seitou",
         "trans": [
+            "政党(せいとう)",
             "(member of) political party"
-        ],
-        "notation": "政党(せいとう)"
+        ]
     },
     {
         "name": "chikayoru",
         "trans": [
+            "近寄(ちかよ)る",
             "to approach,to draw near"
-        ],
-        "notation": "近寄(ちかよ)る"
+        ]
     },
     {
         "name": "touban",
         "trans": [
+            "当番(とうばん)",
             "being on duty"
-        ],
-        "notation": "当番(とうばん)"
+        ]
     },
     {
         "name": "waribiki",
         "trans": [
+            "割引(わりびき)",
             "discount,reduction,rebate"
-        ],
-        "notation": "割引(わりびき)"
+        ]
     },
     {
         "name": "wakareru",
         "trans": [
+            "分(わ)かれる",
             "to branch off,to diverge from,to fork,to split,to dispense,to scatter,to divide into"
-        ],
-        "notation": "分(わ)かれる"
+        ]
     },
     {
         "name": "suteru",
         "trans": [
+            "棄(す)てる",
             ""
-        ],
-        "notation": "棄(す)てる"
+        ]
     },
     {
         "name": "kaette",
         "trans": [
+            "却(かえ)って",
             "on the contrary,rather,all the more,instead"
-        ],
-        "notation": "却(かえ)って"
+        ]
     },
     {
         "name": "inki",
         "trans": [
+            "インキ",
             "ink"
-        ],
-        "notation": "インキ"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "期限(きげん)",
             "term,period"
-        ],
-        "notation": "期限(きげん)"
+        ]
     },
     {
         "name": "hitotoori",
         "trans": [
+            "一通り(ひととおり",
             "ordinary,usual,in general,briefly"
-        ],
-        "notation": "一通り(ひととおり"
+        ]
     },
     {
         "name": "chimei",
         "trans": [
+            "地名(ちめい)",
             "place name"
-        ],
-        "notation": "地名(ちめい)"
+        ]
     },
     {
         "name": "senzai",
         "trans": [
+            "洗剤(せんざい)",
             "detergent,washing material"
-        ],
-        "notation": "洗剤(せんざい)"
+        ]
     },
     {
         "name": "uriage",
         "trans": [
+            "売上(うりあげ)",
             "amount sold,proceeds"
-        ],
-        "notation": "売上(うりあげ)"
+        ]
     },
     {
         "name": "naguru",
         "trans": [
+            "なぐる",
             "to strike,to hit"
-        ],
-        "notation": "なぐる"
+        ]
     },
     {
         "name": "nakami",
         "trans": [
+            "中味(なかみ)",
             "contents,interior,substance,filling,(sword) blade"
-        ],
-        "notation": "中味(なかみ)"
+        ]
     },
     {
         "name": "gensan",
         "trans": [
+            "原産(げんさん)",
             "place of origin,habitat"
-        ],
-        "notation": "原産(げんさん)"
+        ]
     },
     {
         "name": "ryougawa",
         "trans": [
+            "両側(りょうがわ)",
             "both sides"
-        ],
-        "notation": "両側(りょうがわ)"
+        ]
     },
     {
         "name": "oshare",
         "trans": [
+            "おしゃれ",
             "smartly dressed,someone smartly dressed,fashion-conscious"
-        ],
-        "notation": "おしゃれ"
+        ]
     },
     {
         "name": "kousei",
         "trans": [
+            "公正(こうせい)",
             "justice,fairness,impartiality"
-        ],
-        "notation": "公正(こうせい)"
+        ]
     },
     {
         "name": "okagesamade",
         "trans": [
+            "おかげさまで",
             "Thanks to god,thanks to you"
-        ],
-        "notation": "おかげさまで"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "在(あ)る",
             "to live,to be"
-        ],
-        "notation": "在(あ)る"
+        ]
     },
     {
         "name": "zukei",
         "trans": [
+            "図形(づけい)",
             "figure"
-        ],
-        "notation": "図形(づけい)"
+        ]
     },
     {
         "name": "tsumazuku",
         "trans": [
+            "つまずく",
             "to stumble,to trip"
-        ],
-        "notation": "つまずく"
+        ]
     },
     {
         "name": "norikae",
         "trans": [
+            "乗換(のりかえ)",
             "(n) transfer (trains, buses, etc.)"
-        ],
-        "notation": "乗換(のりかえ)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "溶(と)く",
             "to dissolve (paint)"
-        ],
-        "notation": "溶(と)く"
+        ]
     },
     {
         "name": "konbanha",
         "trans": [
+            "こんばんは",
             "good evening"
-        ],
-        "notation": "こんばんは"
+        ]
     },
     {
         "name": "sansuu",
         "trans": [
+            "算数(さんすう)",
             "arithmetic"
-        ],
-        "notation": "算数(さんすう)"
+        ]
     },
     {
         "name": "tokushoku",
         "trans": [
+            "特色(とくしょく)",
             "characteristic,feature"
-        ],
-        "notation": "特色(とくしょく)"
+        ]
     },
     {
         "name": "nibui",
         "trans": [
+            "鈍(にぶ)い",
             "dull (e.g. a knife),thickheaded,slow (opposite of fast),stupid"
-        ],
-        "notation": "鈍(にぶ)い"
+        ]
     },
     {
         "name": "hazureru",
         "trans": [
+            "外(はず)れる",
             "to be disconnected,to get out of place,to be off,to be out (e.g. of gear)"
-        ],
-        "notation": "外(はず)れる"
+        ]
     },
     {
         "name": "hitsujuhin",
         "trans": [
+            "必需(ひつじゅ)品(ひん)",
             "necessities,necessary article,requisite,essential"
-        ],
-        "notation": "必需(ひつじゅ)品(ひん)"
+        ]
     },
     {
         "name": "hanashiai",
         "trans": [
+            "話合(はなしあ)い",
             "discussion,conference"
-        ],
-        "notation": "話合(はなしあ)い"
+        ]
     },
     {
         "name": "choumiryou",
         "trans": [
+            "調味(ちょうみ)料(りょう)",
             "condiment,seasoning"
-        ],
-        "notation": "調味(ちょうみ)料(りょう)"
+        ]
     },
     {
         "name": "youki",
         "trans": [
+            "容器(ようき)",
             "container,vessel"
-        ],
-        "notation": "容器(ようき)"
+        ]
     },
     {
         "name": "zeikan",
         "trans": [
+            "税関(ぜいかん)",
             "customs house"
-        ],
-        "notation": "税関(ぜいかん)"
+        ]
     },
     {
         "name": "nerai",
         "trans": [
+            "狙(ねら)い",
             "aim"
-        ],
-        "notation": "狙(ねら)い"
+        ]
     },
     {
         "name": "hineru",
         "trans": [
+            "捻(ひね)る",
             "to turn (a switch) on or off,to twist,to puzzle over"
-        ],
-        "notation": "捻(ひね)る"
+        ]
     },
     {
         "name": "boushi",
         "trans": [
+            "防止(ぼうし)",
             "prevention,check"
-        ],
-        "notation": "防止(ぼうし)"
+        ]
     },
     {
         "name": "ototoi",
         "trans": [
+            "一昨日(おととい)",
             "day before yesterday"
-        ],
-        "notation": "一昨日(おととい)"
+        ]
     },
     {
         "name": "kanazukai",
         "trans": [
+            "仮名遣(かなづか)い",
             "kana orthography,syllabary spelling"
-        ],
-        "notation": "仮名遣(かなづか)い"
+        ]
     },
     {
         "name": "kanbyou",
         "trans": [
+            "看病(かんびょう)",
             "nursing (a patient)"
-        ],
-        "notation": "看病(かんびょう)"
+        ]
     },
     {
         "name": "gojuuon",
         "trans": [
+            "五十音(ごじゅうおん)",
             "the Japanese syllabary"
-        ],
-        "notation": "五十音(ごじゅうおん)"
+        ]
     },
     {
         "name": "shinrui",
         "trans": [
+            "親類(しんるい)",
             "relation,kin"
-        ],
-        "notation": "親類(しんるい)"
+        ]
     },
     {
         "name": "kayui",
         "trans": [
+            "かゆい",
             "itchy,itching"
-        ],
-        "notation": "かゆい"
+        ]
     },
     {
         "name": "hogaraka",
         "trans": [
+            "朗(ほが)らか",
             "brightness,cheerfulness,melodious"
-        ],
-        "notation": "朗(ほが)らか"
+        ]
     },
     {
         "name": "baibai",
         "trans": [
+            "売買(ばいばい)",
             "trade,buying and selling"
-        ],
-        "notation": "売買(ばいばい)"
+        ]
     },
     {
         "name": "kanban",
         "trans": [
+            "看板(かんばん)",
             "sign,signboard,doorplate,poster"
-        ],
-        "notation": "看板(かんばん)"
+        ]
     },
     {
         "name": "ukemotsu",
         "trans": [
+            "受(う)け持(も)つ",
             "to take (be in) charge of"
-        ],
-        "notation": "受(う)け持(も)つ"
+        ]
     },
     {
         "name": "youbun",
         "trans": [
+            "養分(ようぶん)",
             "nourishment,nutrient"
-        ],
-        "notation": "養分(ようぶん)"
+        ]
     },
     {
         "name": "niramu",
         "trans": [
+            "睨(にら)む",
             "to glare at,to scowl at,to keep an eye on"
-        ],
-        "notation": "睨(にら)む"
+        ]
     },
     {
         "name": "mibun",
         "trans": [
+            "身分(みぶん)",
             "social position,social status"
-        ],
-        "notation": "身分(みぶん)"
+        ]
     },
     {
         "name": "heso",
         "trans": [
+            "へそ",
             "navel,belly-button"
-        ],
-        "notation": "へそ"
+        ]
     },
     {
         "name": "mokuzai",
         "trans": [
+            "木材(もくざい)",
             "lumber,timber,wood"
-        ],
-        "notation": "木材(もくざい)"
+        ]
     },
     {
         "name": "shitamachi",
         "trans": [
+            "下町(したまち)",
             "Shitamachi,lower parts of town"
-        ],
-        "notation": "下町(したまち)"
+        ]
     },
     {
         "name": "atehameru",
         "trans": [
+            "あてはめる",
             "to apply,to adapt"
-        ],
-        "notation": "あてはめる"
+        ]
     },
     {
         "name": "yabuku",
         "trans": [
+            "破(やぶ)く",
             ""
-        ],
-        "notation": "破(やぶ)く"
+        ]
     },
     {
         "name": "bousan",
         "trans": [
+            "坊(ぼう)さん",
             "Buddhist priest,monk"
-        ],
-        "notation": "坊(ぼう)さん"
+        ]
     },
     {
         "name": "sumai",
         "trans": [
+            "住(す)まい",
             "dwelling,house,residence,address"
-        ],
-        "notation": "住(す)まい"
+        ]
     },
     {
         "name": "nagai",
         "trans": [
+            "永(なが)い",
             "long,lengthy"
-        ],
-        "notation": "永(なが)い"
+        ]
     },
     {
         "name": "yuusou",
         "trans": [
+            "郵送(ゆうそう)",
             "mailing"
-        ],
-        "notation": "郵送(ゆうそう)"
+        ]
     },
     {
         "name": "kochirakoso",
         "trans": [
+            "こちらこそ",
             "it is I who should say so"
-        ],
-        "notation": "こちらこそ"
+        ]
     },
     {
         "name": "iitsukeru",
         "trans": [
+            "言付(いいつ)ける",
             "to send word,to send a message"
-        ],
-        "notation": "言付(いいつ)ける"
+        ]
     },
     {
         "name": "kousu",
         "trans": [
+            "コース",
             "course"
-        ],
-        "notation": "コース"
+        ]
     },
     {
         "name": "tekikaku",
         "trans": [
+            "適(てき)確(かく)",
             "precise,accurate"
-        ],
-        "notation": "適(てき)確(かく)"
+        ]
     },
     {
         "name": "suichoku",
         "trans": [
+            "垂直(すいちょく)",
             "vertical,perpendicular"
-        ],
-        "notation": "垂直(すいちょく)"
+        ]
     },
     {
         "name": "tsukihi",
         "trans": [
+            "月日(つきひ)",
             "time,years,days"
-        ],
-        "notation": "月日(つきひ)"
+        ]
     },
     {
         "name": "nakami",
         "trans": [
+            "中身(なかみ)",
             "contents,interior,substance,filling,(sword) blade"
-        ],
-        "notation": "中身(なかみ)"
+        ]
     },
     {
         "name": "aidea/aidia",
         "trans": [
+            "アイデア/アイディア",
             "idea"
-        ],
-        "notation": "アイデア/アイディア"
+        ]
     },
     {
         "name": "gyangu",
         "trans": [
+            "ギャング",
             "gang"
-        ],
-        "notation": "ギャング"
+        ]
     },
     {
         "name": "choukoku",
         "trans": [
+            "彫刻(ちょうこく)",
             "carving,engraving,sculpture"
-        ],
-        "notation": "彫刻(ちょうこく)"
+        ]
     },
     {
         "name": "shaburu",
         "trans": [
+            "しゃぶる",
             "to suck,to chew"
-        ],
-        "notation": "しゃぶる"
+        ]
     },
     {
         "name": "shoumi",
         "trans": [
+            "正味(しょうみ)",
             "net (weight)"
-        ],
-        "notation": "正味(しょうみ)"
+        ]
     },
     {
         "name": "haraikomu",
         "trans": [
+            "払(はら)い込(こ)む",
             "to deposit,to pay in"
-        ],
-        "notation": "払(はら)い込(こ)む"
+        ]
     },
     {
         "name": "kudaku",
         "trans": [
+            "砕(くだ)く",
             "to break,to smash"
-        ],
-        "notation": "砕(くだ)く"
+        ]
     },
     {
         "name": "tanomoshii",
         "trans": [
+            "頼(たの)もしい",
             "reliable,trustworthy,hopeful,promising"
-        ],
-        "notation": "頼(たの)もしい"
+        ]
     },
     {
         "name": "bouya",
         "trans": [
+            "坊(ぼう)や",
             "boy"
-        ],
-        "notation": "坊(ぼう)や"
+        ]
     },
     {
         "name": "tasukaru",
         "trans": [
+            "助(たす)かる",
             "to be saved,to be rescued,to survive,to be helpful"
-        ],
-        "notation": "助(たす)かる"
+        ]
     },
     {
         "name": "kumitateru",
         "trans": [
+            "組(く)み立(た)てる",
             "to assemble,to set up,to construct"
-        ],
-        "notation": "組(く)み立(た)てる"
+        ]
     },
     {
         "name": "suiji",
         "trans": [
+            "炊事(すいじ)",
             "cooking,culinary arts"
-        ],
-        "notation": "炊事(すいじ)"
+        ]
     },
     {
         "name": "hau",
         "trans": [
+            "這(は)う",
             "to creep,to crawl"
-        ],
-        "notation": "這(は)う"
+        ]
     },
     {
         "name": "megumareru",
         "trans": [
+            "恵(めぐ)まれる",
             "to be blessed with,to be rich in"
-        ],
-        "notation": "恵(めぐ)まれる"
+        ]
     },
     {
         "name": "daiyaru",
         "trans": [
+            "ダイヤル",
             "dial"
-        ],
-        "notation": "ダイヤル"
+        ]
     },
     {
         "name": "omoikkiri",
         "trans": [
+            "思(おも)いっ切(き)り",
             ""
-        ],
-        "notation": "思(おも)いっ切(き)り"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "注(さ)す",
             "to pour (drink),to serve (drinks)"
-        ],
-        "notation": "注(さ)す"
+        ]
     },
     {
         "name": "keiyoudoushi",
         "trans": [
+            "形容動詞(けいようどうし)",
             "adjectival noun,quasi-adjective"
-        ],
-        "notation": "形容動詞(けいようどうし)"
+        ]
     },
     {
         "name": "ikubun",
         "trans": [
+            "幾分(いくぶん)",
             "somewhat"
-        ],
-        "notation": "幾分(いくぶん)"
+        ]
     },
     {
         "name": "share",
         "trans": [
+            "洒落(しゃれ)",
             "joke,pun,witticism"
-        ],
-        "notation": "洒落(しゃれ)"
+        ]
     },
     {
         "name": "sakusei",
         "trans": [
+            "作成(さくせい)",
             "frame,draw up,make,producing"
-        ],
-        "notation": "作成(さくせい)"
+        ]
     },
     {
         "name": "urayamu",
         "trans": [
+            "羨(うらや)む",
             "to envy"
-        ],
-        "notation": "羨(うらや)む"
+        ]
     },
     {
         "name": "tamaru",
         "trans": [
+            "溜(た)まる",
             "to collect,to gather,to save"
-        ],
-        "notation": "溜(た)まる"
+        ]
     },
     {
         "name": "hikage",
         "trans": [
+            "日陰(ひかげ)",
             "shadow"
-        ],
-        "notation": "日陰(ひかげ)"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "箸(はし)",
             "chopsticks"
-        ],
-        "notation": "箸(はし)"
+        ]
     },
     {
         "name": "sumou",
         "trans": [
+            "相撲(すもう)",
             "sumo wrestling"
-        ],
-        "notation": "相撲(すもう)"
+        ]
     },
     {
         "name": "karuta",
         "trans": [
+            "かるた",
             "(n) playing cards (pt: carta)"
-        ],
-        "notation": "かるた"
+        ]
     },
     {
         "name": "sankaku",
         "trans": [
+            "三角(さんかく)",
             "triangle,triangular"
-        ],
-        "notation": "三角(さんかく)"
+        ]
     },
     {
         "name": "ikiiki",
         "trans": [
+            "生(い)き生(い)き",
             "vividly,lively"
-        ],
-        "notation": "生(い)き生(い)き"
+        ]
     },
     {
         "name": "ikouru",
         "trans": [
+            "イコール",
             "equal"
-        ],
-        "notation": "イコール"
+        ]
     },
     {
         "name": "fukyuu",
         "trans": [
+            "普及(ふきゅう)",
             "diffusion,spread"
-        ],
-        "notation": "普及(ふきゅう)"
+        ]
     },
     {
         "name": "chokutsuu",
         "trans": [
+            "直通(ちょくつう)",
             "direct communication"
-        ],
-        "notation": "直通(ちょくつう)"
+        ]
     },
     {
         "name": "mawarimichi",
         "trans": [
+            "回(まわ)り道(みち)",
             "detour"
-        ],
-        "notation": "回(まわ)り道(みち)"
+        ]
     },
     {
         "name": "koukyuu",
         "trans": [
+            "高級(こうきゅう)",
             "high class,high grade"
-        ],
-        "notation": "高級(こうきゅう)"
+        ]
     },
     {
         "name": "nazonazo",
         "trans": [
+            "謎謎(なぞなぞ)",
             "riddle,puzzle,enigma"
-        ],
-        "notation": "謎謎(なぞなぞ)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "建(た)つ",
             "to erect,to be erected,to be built"
-        ],
-        "notation": "建(た)つ"
+        ]
     },
     {
         "name": "naderu",
         "trans": [
+            "撫(な)でる",
             "to brush gently,to stroke"
-        ],
-        "notation": "撫(な)でる"
+        ]
     },
     {
         "name": "kiritsu",
         "trans": [
+            "規律(きりつ)",
             "order,rules,law"
-        ],
-        "notation": "規律(きりつ)"
+        ]
     },
     {
         "name": "warizan",
         "trans": [
+            "割算(わりざん)",
             "division (math)"
-        ],
-        "notation": "割算(わりざん)"
+        ]
     },
     {
         "name": "akumade",
         "trans": [
+            "飽(あ)くまで",
             "to the end,to the last,stubbornly"
-        ],
-        "notation": "飽(あ)くまで"
+        ]
     },
     {
         "name": "shasei",
         "trans": [
+            "写生(しゃせい)",
             "sketching,drawing from nature"
-        ],
-        "notation": "写生(しゃせい)"
+        ]
     },
     {
         "name": "hikiukeru",
         "trans": [
+            "引受(ひきうけ)る",
             "to undertake,to take up,to take over"
-        ],
-        "notation": "引受(ひきうけ)る"
+        ]
     },
     {
         "name": "itoko",
         "trans": [
+            "従姉妹(いとこ)",
             "cousin (female)"
-        ],
-        "notation": "従姉妹(いとこ)"
+        ]
     },
     {
         "name": "hassha",
         "trans": [
+            "発射(はっしゃ)",
             "firing,shooting,discharge,catapult"
-        ],
-        "notation": "発射(はっしゃ)"
+        ]
     },
     {
         "name": "noudo",
         "trans": [
+            "濃度(のうど)",
             "concentration,brightness"
-        ],
-        "notation": "濃度(のうど)"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "採(と)る",
             "(1) to adopt (measure, proposal),(2) to pick (fruit)"
-        ],
-        "notation": "採(と)る"
+        ]
     },
     {
         "name": "shindai",
         "trans": [
+            "寝台(しんだい)",
             "bed,couch"
-        ],
-        "notation": "寝台(しんだい)"
+        ]
     },
     {
         "name": "hige",
         "trans": [
+            "髭(ひげ)",
             "moustache,beard,whiskers"
-        ],
-        "notation": "髭(ひげ)"
+        ]
     },
     {
         "name": "katsuryoku",
         "trans": [
+            "活力(かつりょく)",
             "vitality,energy"
-        ],
-        "notation": "活力(かつりょく)"
+        ]
     },
     {
         "name": "yajirushi",
         "trans": [
+            "矢印(やじるし)",
             "directing arrow"
-        ],
-        "notation": "矢印(やじるし)"
+        ]
     },
     {
         "name": "tokutei",
         "trans": [
+            "特定(とくてい)",
             "specific,special,particular"
-        ],
-        "notation": "特定(とくてい)"
+        ]
     },
     {
         "name": "koubutsu",
         "trans": [
+            "鉱物(こうぶつ)",
             "mineral"
-        ],
-        "notation": "鉱物(こうぶつ)"
+        ]
     },
     {
         "name": "hinoiri",
         "trans": [
+            "日(ひ)の入(い)り",
             "sunset"
-        ],
-        "notation": "日(ひ)の入(い)り"
+        ]
     },
     {
         "name": "koshikakeru",
         "trans": [
+            "腰掛(こしか)ける",
             "to sit (down)"
-        ],
-        "notation": "腰掛(こしか)ける"
+        ]
     },
     {
         "name": "matagu",
         "trans": [
+            "またぐ",
             "to straddle"
-        ],
-        "notation": "またぐ"
+        ]
     },
     {
         "name": "abareru",
         "trans": [
+            "暴(あば)れる",
             "to act violently,to rage,to struggle,to be riotous"
-        ],
-        "notation": "暴(あば)れる"
+        ]
     },
     {
         "name": "zonzuru",
         "trans": [
+            "存(ぞん)ずる",
             ""
-        ],
-        "notation": "存(ぞん)ずる"
+        ]
     },
     {
         "name": "mijime",
         "trans": [
+            "みじめ",
             "(arch) sad,pitiful,wretched"
-        ],
-        "notation": "みじめ"
+        ]
     },
     {
         "name": "okotaru",
         "trans": [
+            "怠(おこた)る",
             "to neglect,to be off guard,to be feeling better"
-        ],
-        "notation": "怠(おこた)る"
+        ]
     },
     {
         "name": "mittomonai",
         "trans": [
+            "みっともない",
             "shameful,indecent"
-        ],
-        "notation": "みっともない"
+        ]
     },
     {
         "name": "mazeru",
         "trans": [
+            "交(ま)ぜる",
             "to be mixed,to be blended with"
-        ],
-        "notation": "交(ま)ぜる"
+        ]
     },
     {
         "name": "uuru",
         "trans": [
+            "ウール",
             "wool"
-        ],
-        "notation": "ウール"
+        ]
     },
     {
         "name": "yuuryou",
         "trans": [
+            "有料(ゆうりょう)",
             "admission-paid,toll"
-        ],
-        "notation": "有料(ゆうりょう)"
+        ]
     },
     {
         "name": "souzoushii",
         "trans": [
+            "騒々しい(そうぞうしい)",
             "noisy,boisterous"
-        ],
-        "notation": "騒々しい(そうぞうしい)"
+        ]
     },
     {
         "name": "hassou",
         "trans": [
+            "発想(はっそう)",
             "expression (music),conceptualization"
-        ],
-        "notation": "発想(はっそう)"
+        ]
     },
     {
         "name": "koten",
         "trans": [
+            "古典(こてん)",
             "old book,classics,classic"
-        ],
-        "notation": "古典(こてん)"
+        ]
     },
     {
         "name": "uchiawase",
         "trans": [
+            "打合(うちあわ)せ",
             "business meeting,previous arrangement,appointment"
-        ],
-        "notation": "打合(うちあわ)せ"
+        ]
     },
     {
         "name": "tanki",
         "trans": [
+            "短期(たんき)",
             "short term"
-        ],
-        "notation": "短期(たんき)"
+        ]
     },
     {
         "name": "shashou",
         "trans": [
+            "車掌(しゃしょう)",
             "(train) conductor"
-        ],
-        "notation": "車掌(しゃしょう)"
+        ]
     },
     {
         "name": "hinode",
         "trans": [
+            "日(ひ)の出(で)",
             "sunrise"
-        ],
-        "notation": "日(ひ)の出(で)"
+        ]
     },
     {
         "name": "kogasu",
         "trans": [
+            "焦(こ)がす",
             "to burn,to scorch,to singe,to char"
-        ],
-        "notation": "焦(こ)がす"
+        ]
     },
     {
         "name": "kujou",
         "trans": [
+            "苦情(くじょう)",
             "complaint,troubles,objection"
-        ],
-        "notation": "苦情(くじょう)"
+        ]
     },
     {
         "name": "nantomo",
         "trans": [
+            "なんとも",
             "nothing (with neg. verb),quite,not a bit"
-        ],
-        "notation": "なんとも"
+        ]
     },
     {
         "name": "kuyamu",
         "trans": [
+            "悔(く)やむ",
             "to mourn"
-        ],
-        "notation": "悔(く)やむ"
+        ]
     },
     {
         "name": "akireru",
         "trans": [
+            "あきれる",
             "to be amazed,to be shocked"
-        ],
-        "notation": "あきれる"
+        ]
     },
     {
         "name": "fukisoku",
         "trans": [
+            "不規則(ふきそく)",
             "irregularity,unsteadiness,disorderly"
-        ],
-        "notation": "不規則(ふきそく)"
+        ]
     },
     {
         "name": "kaabu",
         "trans": [
+            "カーブ",
             "(1) curve,(2) curve ball (baseball)"
-        ],
-        "notation": "カーブ"
+        ]
     },
     {
         "name": "rokkaa",
         "trans": [
+            "ロッカー",
             "locker"
-        ],
-        "notation": "ロッカー"
+        ]
     },
     {
         "name": "genshi",
         "trans": [
+            "原始(げんし)",
             "origin,primeval"
-        ],
-        "notation": "原始(げんし)"
+        ]
     },
     {
         "name": "tokubai",
         "trans": [
+            "特売(とくばい)",
             "special sale"
-        ],
-        "notation": "特売(とくばい)"
+        ]
     },
     {
         "name": "omotai",
         "trans": [
+            "重(おも)たい",
             "heavy,massive,serious"
-        ],
-        "notation": "重(おも)たい"
+        ]
     },
     {
         "name": "aburu",
         "trans": [
+            "あぶる",
             "to scorch"
-        ],
-        "notation": "あぶる"
+        ]
     },
     {
         "name": "zoudai",
         "trans": [
+            "増大(ぞうだい)",
             "enlargement"
-        ],
-        "notation": "増大(ぞうだい)"
+        ]
     },
     {
         "name": "kaisuuken",
         "trans": [
+            "回数(かいすう)券(けん)",
             "book of tickets"
-        ],
-        "notation": "回数(かいすう)券(けん)"
+        ]
     },
     {
         "name": "seibetsu",
         "trans": [
+            "性別(せいべつ)",
             "distinction by sex,sex,gender"
-        ],
-        "notation": "性別(せいべつ)"
+        ]
     },
     {
         "name": "shijuu",
         "trans": [
+            "始終(しじゅう)",
             "continuously,from beginning to end"
-        ],
-        "notation": "始終(しじゅう)"
+        ]
     },
     {
         "name": "okugai",
         "trans": [
+            "屋外(おくがい)",
             "outdoors"
-        ],
-        "notation": "屋外(おくがい)"
+        ]
     },
     {
         "name": "masatsu",
         "trans": [
+            "摩擦(まさつ)",
             "friction,rubbing,rubdown,chafe"
-        ],
-        "notation": "摩擦(まさつ)"
+        ]
     },
     {
         "name": "tsuuchi",
         "trans": [
+            "通知(つうち)",
             "notice,notification"
-        ],
-        "notation": "通知(つうち)"
+        ]
     },
     {
         "name": "ukaberu",
         "trans": [
+            "浮(う)かべる",
             "to float,to express,to look (sad, glad)"
-        ],
-        "notation": "浮(う)かべる"
+        ]
     },
     {
         "name": "itterasshai",
         "trans": [
+            "いってらっしゃい",
             ""
-        ],
-        "notation": "いってらっしゃい"
+        ]
     },
     {
         "name": "mikazuki",
         "trans": [
+            "三日月(みかづき)",
             "new moon,crescent moon"
-        ],
-        "notation": "三日月(みかづき)"
+        ]
     },
     {
         "name": "zehitomo",
         "trans": [
+            "ぜひとも",
             "by all means (with sense of not taking no for an answer)"
-        ],
-        "notation": "ぜひとも"
+        ]
     },
     {
         "name": "hakike",
         "trans": [
+            "吐(は)き気(け)",
             "nausea,sickness in the stomach"
-        ],
-        "notation": "吐(は)き気(け)"
+        ]
     },
     {
         "name": "kotai",
         "trans": [
+            "個体(こたい)",
             "an individual"
-        ],
-        "notation": "個体(こたい)"
+        ]
     },
     {
         "name": "sonokoro",
         "trans": [
+            "そのころ",
             ""
-        ],
-        "notation": "そのころ"
+        ]
     },
     {
         "name": "rizumu",
         "trans": [
+            "リズム",
             "rhythm"
-        ],
-        "notation": "リズム"
+        ]
     },
     {
         "name": "moru",
         "trans": [
+            "盛(も)る",
             "(1) to serve (food, etc.),(2) to fill up,(3) to prescribe"
-        ],
-        "notation": "盛(も)る"
+        ]
     },
     {
         "name": "shoten",
         "trans": [
+            "書店(しょてん)",
             "bookshop"
-        ],
-        "notation": "書店(しょてん)"
+        ]
     },
     {
         "name": "sonoue",
         "trans": [
+            "そのうえ",
             "in addition,furthermore"
-        ],
-        "notation": "そのうえ"
+        ]
     },
     {
         "name": "nemaki",
         "trans": [
+            "寝巻(ねまき)",
             "sleep-wear,nightclothes,pyjamas,nightgown,nightdress"
-        ],
-        "notation": "寝巻(ねまき)"
+        ]
     },
     {
         "name": "motareru",
         "trans": [
+            "もたれる",
             "to lean against,to lean on,to recline on,to lie heavy (on the stomach)"
-        ],
-        "notation": "もたれる"
+        ]
     },
     {
         "name": "chawan",
         "trans": [
+            "茶碗(ちゃわん)",
             "rice bowl,tea cup,teacup"
-        ],
-        "notation": "茶碗(ちゃわん)"
+        ]
     },
     {
         "name": "jinbunkagaku",
         "trans": [
+            "人文(じんぶん)科学(かがく)",
             "social sciences,humanities"
-        ],
-        "notation": "人文(じんぶん)科学(かがく)"
+        ]
     },
     {
         "name": "seichou",
         "trans": [
+            "生長(せいちょう)",
             "growth,increment"
-        ],
-        "notation": "生長(せいちょう)"
+        ]
     },
     {
         "name": "hikikaesu",
         "trans": [
+            "引返(ひきかえ)す",
             "to repeat,to send back,to bring back"
-        ],
-        "notation": "引返(ひきかえ)す"
+        ]
     },
     {
         "name": "suitei",
         "trans": [
+            "推定(すいてい)",
             "presumption,assumption,estimation"
-        ],
-        "notation": "推定(すいてい)"
+        ]
     },
     {
         "name": "minareru",
         "trans": [
+            "見慣(みな)れる",
             "to become used to seeing,to be familiar with"
-        ],
-        "notation": "見慣(みな)れる"
+        ]
     },
     {
         "name": "chikarazuyoi",
         "trans": [
+            "力強(ちからづよ)い",
             "reassuring,emboldened"
-        ],
-        "notation": "力強(ちからづよ)い"
+        ]
     },
     {
         "name": "sukisuki",
         "trans": [
+            "好(す)き好(す)き",
             "matter of taste"
-        ],
-        "notation": "好(す)き好(す)き"
+        ]
     },
     {
         "name": "gejun",
         "trans": [
+            "下旬(げじゅん)",
             "month (last third of)"
-        ],
-        "notation": "下旬(げじゅん)"
+        ]
     },
     {
         "name": "kongou",
         "trans": [
+            "混合(こんごう)",
             "mixing,mixture"
-        ],
-        "notation": "混合(こんごう)"
+        ]
     },
     {
         "name": "subereru",
         "trans": [
+            "滑(すべ)れる",
             ""
-        ],
-        "notation": "滑(すべ)れる"
+        ]
     },
     {
         "name": "yopparai",
         "trans": [
+            "酔(よ)っ払(ぱら)い",
             "drunkard"
-        ],
-        "notation": "酔(よ)っ払(ぱら)い"
+        ]
     },
     {
         "name": "kokuritsu",
         "trans": [
+            "国立(こくりつ)",
             "national"
-        ],
-        "notation": "国立(こくりつ)"
+        ]
     },
     {
         "name": "houtai",
         "trans": [
+            "包帯(ほうたい)",
             "bandage,dressing"
-        ],
-        "notation": "包帯(ほうたい)"
+        ]
     },
     {
         "name": "nobasu",
         "trans": [
+            "延(の)ばす",
             "to lengthen,to stretch,to reach out,to grow (beard)"
-        ],
-        "notation": "延(の)ばす"
+        ]
     },
     {
         "name": "teisha",
         "trans": [
+            "停車(ていしゃ)",
             "stopping (e.g. train)"
-        ],
-        "notation": "停車(ていしゃ)"
+        ]
     },
     {
         "name": "katamaru",
         "trans": [
+            "固(かた)まる",
             "to harden,to solidify,to become firm,to become certain"
-        ],
-        "notation": "固(かた)まる"
+        ]
     },
     {
         "name": "oukesutora",
         "trans": [
+            "オーケストラ",
             "orchestra"
-        ],
-        "notation": "オーケストラ"
+        ]
     },
     {
         "name": "posutaa",
         "trans": [
+            "ポスター",
             "poster"
-        ],
-        "notation": "ポスター"
+        ]
     },
     {
         "name": "amu",
         "trans": [
+            "編(あ)む",
             "to knit"
-        ],
-        "notation": "編(あ)む"
+        ]
     },
     {
         "name": "touge",
         "trans": [
+            "峠(とうげ)",
             "ridge,(mountain) pass,difficult part"
-        ],
-        "notation": "峠(とうげ)"
+        ]
     },
     {
         "name": "hatashite",
         "trans": [
+            "果(はた)して",
             "as was expected,really"
-        ],
-        "notation": "果(はた)して"
+        ]
     },
     {
         "name": "chuusei",
         "trans": [
+            "中性(ちゅうせい)",
             "neuter gender,neutral (chem.),indifference,sterility"
-        ],
-        "notation": "中性(ちゅうせい)"
+        ]
     },
     {
         "name": "ichidanto",
         "trans": [
+            "一段(いちだん)と",
             "greater,more,further,still more"
-        ],
-        "notation": "一段(いちだん)と"
+        ]
     },
     {
         "name": "kangeki",
         "trans": [
+            "感激(かんげき)",
             "deep emotion,impression,inspiration"
-        ],
-        "notation": "感激(かんげき)"
+        ]
     },
     {
         "name": "daimeishi",
         "trans": [
+            "代名詞(だいめいし)",
             "pronoun"
-        ],
-        "notation": "代名詞(だいめいし)"
+        ]
     },
     {
         "name": "shuugou",
         "trans": [
+            "集合(しゅうごう)",
             "gathering,assembly,meeting,set (math)"
-        ],
-        "notation": "集合(しゅうごう)"
+        ]
     },
     {
         "name": "fuketsu",
         "trans": [
+            "不潔(ふけつ)",
             "unclean,dirty,filthy,impure"
-        ],
-        "notation": "不潔(ふけつ)"
+        ]
     },
     {
         "name": "shouzuru",
         "trans": [
+            "生(しょう)ずる",
             "to cause,to arise,to be generated"
-        ],
-        "notation": "生(しょう)ずる"
+        ]
     },
     {
         "name": "ichiichi",
         "trans": [
+            "いちいち",
             "one by one,separately"
-        ],
-        "notation": "いちいち"
+        ]
     },
     {
         "name": "gokurousama",
         "trans": [
+            "ごくろうさま",
             "Thank you very much for your...."
-        ],
-        "notation": "ごくろうさま"
+        ]
     },
     {
         "name": "omachidoosama",
         "trans": [
+            "おまちどおさま",
             "Sorry to have kept you waiting"
-        ],
-        "notation": "おまちどおさま"
+        ]
     },
     {
         "name": "maido",
         "trans": [
+            "毎度(まいど)",
             "each time,common service-sector greeting"
-        ],
-        "notation": "毎度(まいど)"
+        ]
     },
     {
         "name": "mechakucha",
         "trans": [
+            "めちゃくちゃ",
             "absurd,unreasonable,excessive,messed up,spoiled,wreaked"
-        ],
-        "notation": "めちゃくちゃ"
+        ]
     },
     {
         "name": "fasunaa",
         "trans": [
+            "ファスナー",
             "fastener,zipper"
-        ],
-        "notation": "ファスナー"
+        ]
     },
     {
         "name": "daburu",
         "trans": [
+            "ダブル",
             "double"
-        ],
-        "notation": "ダブル"
+        ]
     },
     {
         "name": "ojisan",
         "trans": [
+            "叔父(おじ)さん",
             "middle-aged gentleman,uncle"
-        ],
-        "notation": "叔父(おじ)さん"
+        ]
     },
     {
         "name": "tairitsu",
         "trans": [
+            "対立(たつ)",
             "confrontation,opposition,antagonism"
-        ],
-        "notation": "対立(たつ)"
+        ]
     },
     {
         "name": "sensu",
         "trans": [
+            "扇子(せんす)",
             "folding fan"
-        ],
-        "notation": "扇子(せんす)"
+        ]
     },
     {
         "name": "okakekudasai",
         "trans": [
+            "おかけください",
             ""
-        ],
-        "notation": "おかけください"
+        ]
     },
     {
         "name": "kyuuyo",
         "trans": [
+            "給与(きゅうよ)",
             "allowance,grant,supply"
-        ],
-        "notation": "給与(きゅうよ)"
+        ]
     },
     {
         "name": "itsunomanika",
         "trans": [
+            "いつのまにか",
             "before one knows,unnoticed,unawares"
-        ],
-        "notation": "いつのまにか"
+        ]
     },
     {
         "name": "afureru",
         "trans": [
+            "あふれる",
             "to flood,to overflow,to brim over"
-        ],
-        "notation": "あふれる"
+        ]
     },
     {
         "name": "darashinai",
         "trans": [
+            "だらしない",
             "slovenly,loose,a slut"
-        ],
-        "notation": "だらしない"
+        ]
     },
     {
         "name": "juwaki",
         "trans": [
+            "受話器(じゅわき)",
             "(telephone) receiver"
-        ],
-        "notation": "受話器(じゅわき)"
+        ]
     },
     {
         "name": "hagasu",
         "trans": [
+            "剥(はが)す",
             "(v5s) to tear off,to peel off,to rip off"
-        ],
-        "notation": "剥(はが)す"
+        ]
     },
     {
         "name": "keito",
         "trans": [
+            "毛糸(けいと)",
             "knitting wool"
-        ],
-        "notation": "毛糸(けいと)"
+        ]
     },
     {
         "name": "houki",
         "trans": [
+            "箒(ほうき)",
             "(n) broom"
-        ],
-        "notation": "箒(ほうき)"
+        ]
     },
     {
         "name": "kudaru",
         "trans": [
+            "下(くだ)る",
             "to get down,to descend"
-        ],
-        "notation": "下(くだ)る"
+        ]
     },
     {
         "name": "kyanpasu",
         "trans": [
+            "キャンパス",
             "campus"
-        ],
-        "notation": "キャンパス"
+        ]
     },
     {
         "name": "eeto",
         "trans": [
+            "ええと",
             "let me see,well,er...."
-        ],
-        "notation": "ええと"
+        ]
     },
     {
         "name": "taru",
         "trans": [
+            "足(た)る",
             "to be sufficient,to be enough"
-        ],
-        "notation": "足(た)る"
+        ]
     },
     {
         "name": "tsumaru",
         "trans": [
+            "詰(つ)まる",
             "to be blocked,to be packed"
-        ],
-        "notation": "詰(つ)まる"
+        ]
     },
     {
         "name": "suihei",
         "trans": [
+            "水平(すいへい)",
             "water level,horizon"
-        ],
-        "notation": "水平(すいへい)"
+        ]
     },
     {
         "name": "sentou",
         "trans": [
+            "先頭(せんとう)",
             "head,lead,vanguard,first"
-        ],
-        "notation": "先頭(せんとう)"
+        ]
     },
     {
         "name": "tsuuyaku",
         "trans": [
+            "通訳(つうやく)",
             "interpretation"
-        ],
-        "notation": "通訳(つうやく)"
+        ]
     },
     {
         "name": "shirizokeru",
         "trans": [
+            "退(しりぞ)ける",
             "to remove,to take away,to dislodge,to put something out of the way"
-        ],
-        "notation": "退(しりぞ)ける"
+        ]
     },
     {
         "name": "shinsei",
         "trans": [
+            "申請(しんせい)",
             "application,request,petition"
-        ],
-        "notation": "申請(しんせい)"
+        ]
     },
     {
         "name": "tokorodokoro",
         "trans": [
+            "所々(ところどころ)",
             "here and there,some parts (of something)"
-        ],
-        "notation": "所々(ところどころ)"
+        ]
     },
     {
         "name": "kougai",
         "trans": [
+            "公害(こうがい)",
             "public nuisance,pollution"
-        ],
-        "notation": "公害(こうがい)"
+        ]
     },
     {
         "name": "ayaui",
         "trans": [
+            "危(あや)うい",
             "dangerous,critical,grave"
-        ],
-        "notation": "危(あや)うい"
+        ]
     },
     {
         "name": "kezuru",
         "trans": [
+            "削(けず)る",
             "to cut down little by little,to take a percentage"
-        ],
-        "notation": "削(けず)る"
+        ]
     },
     {
         "name": "kyuukou",
         "trans": [
+            "休講(きゅうこう)",
             "lecture cancelled"
-        ],
-        "notation": "休講(きゅうこう)"
+        ]
     },
     {
         "name": "haiku",
         "trans": [
+            "俳句(はいく)",
             "haiku poetry"
-        ],
-        "notation": "俳句(はいく)"
+        ]
     },
     {
         "name": "konkuuru",
         "trans": [
+            "コンクール",
             "contest (fr: concours)"
-        ],
-        "notation": "コンクール"
+        ]
     },
     {
         "name": "korekushon",
         "trans": [
+            "コレクション",
             "(1) collection,(2) correction"
-        ],
-        "notation": "コレクション"
+        ]
     },
     {
         "name": "gobusata",
         "trans": [
+            "御無沙汰(ごぶさた)",
             "not writing or contacting for a while"
-        ],
-        "notation": "御無沙汰(ごぶさた)"
+        ]
     },
     {
         "name": "kushi",
         "trans": [
+            "櫛(くし)",
             "comb"
-        ],
-        "notation": "櫛(くし)"
+        ]
     },
     {
         "name": "taisou",
         "trans": [
+            "大層(たいそう)",
             "very much,exaggerated,very fine"
-        ],
-        "notation": "大層(たいそう)"
+        ]
     },
     {
         "name": "iten",
         "trans": [
+            "移転(いてん)",
             "moving,transfer,demise"
-        ],
-        "notation": "移転(いてん)"
+        ]
     },
     {
         "name": "jokyouju",
         "trans": [
+            "助教授(じょきょうじゅ)",
             "assistant professor"
-        ],
-        "notation": "助教授(じょきょうじゅ)"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "着(つ)ける",
             "(1) to attach,to join,to add,to append"
-        ],
-        "notation": "着(つ)ける"
+        ]
     },
     {
         "name": "kayou",
         "trans": [
+            "歌謡(かよう)",
             "song,ballad"
-        ],
-        "notation": "歌謡(かよう)"
+        ]
     },
     {
         "name": "shikyuu",
         "trans": [
+            "至急(しきゅう)",
             "urgent,pressing"
-        ],
-        "notation": "至急(しきゅう)"
+        ]
     },
     {
         "name": "murasaki",
         "trans": [
+            "紫(むらさき)",
             "purple colour,violet"
-        ],
-        "notation": "紫(むらさき)"
+        ]
     },
     {
         "name": "shoubu",
         "trans": [
+            "勝負(しょうぶ)",
             "victory or defeat,match,contest,game,bout"
-        ],
-        "notation": "勝負(しょうぶ)"
+        ]
     },
     {
         "name": "sosokkashii",
         "trans": [
+            "そそっかしい",
             "careless,thoughtless"
-        ],
-        "notation": "そそっかしい"
+        ]
     },
     {
         "name": "nerau",
         "trans": [
+            "狙(ねら)う",
             "to aim at"
-        ],
-        "notation": "狙(ねら)う"
+        ]
     },
     {
         "name": "kon",
         "trans": [
+            "紺(こん)",
             "navy blue,deep blue"
-        ],
-        "notation": "紺(こん)"
+        ]
     },
     {
         "name": "kegawa",
         "trans": [
+            "毛皮(けがわ)",
             "fur,skin,pelt"
-        ],
-        "notation": "毛皮(けがわ)"
+        ]
     },
     {
         "name": "bocchan",
         "trans": [
+            "坊(ぼ)っちゃん",
             "son (of others)"
-        ],
-        "notation": "坊(ぼ)っちゃん"
+        ]
     },
     {
         "name": "kaiyou",
         "trans": [
+            "海洋(かいよう)",
             "ocean"
-        ],
-        "notation": "海洋(かいよう)"
+        ]
     },
     {
         "name": "nikui",
         "trans": [
+            "憎(にく)い",
             "hateful,abominable,poor-looking,detestable"
-        ],
-        "notation": "憎(にく)い"
+        ]
     },
     {
         "name": "shako",
         "trans": [
+            "車庫(しゃこ)",
             "garage,car shed"
-        ],
-        "notation": "車庫(しゃこ)"
+        ]
     },
     {
         "name": "gouin",
         "trans": [
+            "強引(ごういん)",
             "overbearing,coercive,pushy,forcible,high-handed"
-        ],
-        "notation": "強引(ごういん)"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "著(あらわ)す",
             "to write,to publish"
-        ],
-        "notation": "著(あらわ)す"
+        ]
     },
     {
         "name": "yakkyoku",
         "trans": [
+            "薬局(やっきょく)",
             "pharmacy,drugstore"
-        ],
-        "notation": "薬局(やっきょく)"
+        ]
     },
     {
         "name": "seibun",
         "trans": [
+            "成分(せいぶん)",
             "ingredient,component,composition"
-        ],
-        "notation": "成分(せいぶん)"
+        ]
     },
     {
         "name": "bunpu",
         "trans": [
+            "分布(ぶんぷ)",
             "distribution"
-        ],
-        "notation": "分布(ぶんぷ)"
+        ]
     },
     {
         "name": "makura",
         "trans": [
+            "枕(まくら)",
             "pillow,bolster"
-        ],
-        "notation": "枕(まくら)"
+        ]
     },
     {
         "name": "janken",
         "trans": [
+            "じゃんけん",
             "(n) rock-scissors-paper game"
-        ],
-        "notation": "じゃんけん"
+        ]
     },
     {
         "name": "kiyoshimu",
         "trans": [
+            "清(きよし)む",
             ""
-        ],
-        "notation": "清(きよし)む"
+        ]
     },
     {
         "name": "bunsuu",
         "trans": [
+            "分数(ぶんすう)",
             "fraction (in math)"
-        ],
-        "notation": "分数(ぶんすう)"
+        ]
     },
     {
         "name": "gakki",
         "trans": [
+            "楽器(がっき)",
             "musical instrument"
-        ],
-        "notation": "楽器(がっき)"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "貝(かい)",
             "shell,shellfish"
-        ],
-        "notation": "貝(かい)"
+        ]
     },
     {
         "name": "hade",
         "trans": [
+            "派手(はで)",
             "showy,loud,gay,flashy,gaudy"
-        ],
-        "notation": "派手(はで)"
+        ]
     },
     {
         "name": "kuzusu",
         "trans": [
+            "崩(くず)す",
             "to destroy,to pull down,to make change (money)"
-        ],
-        "notation": "崩(くず)す"
+        ]
     },
     {
         "name": "ureyuki",
         "trans": [
+            "売行(うれゆ)き",
             "sales"
-        ],
-        "notation": "売行(うれゆ)き"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "栓(せん)",
             "stopper,cork,stopcock"
-        ],
-        "notation": "栓(せん)"
+        ]
     },
     {
         "name": "odaijini",
         "trans": [
+            "おだいじに",
             "Take care of yourself"
-        ],
-        "notation": "おだいじに"
+        ]
     },
     {
         "name": "neji",
         "trans": [
+            "ねじ",
             "(a) screw"
-        ],
-        "notation": "ねじ"
+        ]
     },
     {
         "name": "kaikan",
         "trans": [
+            "会館(かいかん)",
             "meeting hall,assembly hall"
-        ],
-        "notation": "会館(かいかん)"
+        ]
     },
     {
         "name": "purasuchikku",
         "trans": [
+            "プラスチック",
             "plastic"
-        ],
-        "notation": "プラスチック"
+        ]
     },
     {
         "name": "gomu",
         "trans": [
+            "ゴム",
             "gum,rubber,eraser"
-        ],
-        "notation": "ゴム"
+        ]
     },
     {
         "name": "suraido",
         "trans": [
+            "スライド",
             "slide"
-        ],
-        "notation": "スライド"
+        ]
     },
     {
         "name": "kigu",
         "trans": [
+            "器具(きぐ)",
             "utensil"
-        ],
-        "notation": "器具(きぐ)"
+        ]
     },
     {
         "name": "shouganai",
         "trans": [
+            "しょうがない",
             ""
-        ],
-        "notation": "しょうがない"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "境界(きょうかい)",
             "boundary"
-        ],
-        "notation": "境界(きょうかい)"
+        ]
     },
     {
         "name": "hanahadashii",
         "trans": [
+            "甚(はなは)だしい",
             "extreme,excessive,terrible"
-        ],
-        "notation": "甚(はなは)だしい"
+        ]
     },
     {
         "name": "haneru",
         "trans": [
+            "跳(は)ねる",
             "to jump,to leap"
-        ],
-        "notation": "跳(は)ねる"
+        ]
     },
     {
         "name": "shiryou",
         "trans": [
+            "資料(しりょう)",
             "materials,data"
-        ],
-        "notation": "資料(しりょう)"
+        ]
     },
     {
         "name": "minkan",
         "trans": [
+            "民間(みんかん)",
             "private,civilian,civil,popular,folk,unofficial"
-        ],
-        "notation": "民間(みんかん)"
+        ]
     },
     {
         "name": "ido",
         "trans": [
+            "井戸(いど)",
             "water well"
-        ],
-        "notation": "井戸(いど)"
+        ]
     },
     {
         "name": "karappo",
         "trans": [
+            "空(から)っぽ",
             "empty,vacant,hollow"
-        ],
-        "notation": "空(から)っぽ"
+        ]
     },
     {
         "name": "bounasu",
         "trans": [
+            "ボーナス",
             "bonus"
-        ],
-        "notation": "ボーナス"
+        ]
     },
     {
         "name": "hikitomeru",
         "trans": [
+            "引(ひ)き止(と)める",
             "to detain,to check,to restrain"
-        ],
-        "notation": "引(ひ)き止(と)める"
+        ]
     },
     {
         "name": "sakihodo",
         "trans": [
+            "先程(さきほど)",
             "some time ago"
-        ],
-        "notation": "先程(さきほど)"
+        ]
     },
     {
         "name": "minyou",
         "trans": [
+            "民謡(みんよう)",
             "folk song,popular song"
-        ],
-        "notation": "民謡(みんよう)"
+        ]
     },
     {
         "name": "kijun",
         "trans": [
+            "規準(きじゅん)",
             "standard,basis,criteria,norm"
-        ],
-        "notation": "規準(きじゅん)"
+        ]
     },
     {
         "name": "shagamu",
         "trans": [
+            "しゃがむ",
             "to squat"
-        ],
-        "notation": "しゃがむ"
+        ]
     },
     {
         "name": "hiroba",
         "trans": [
+            "広場(ひろば)",
             "plaza"
-        ],
-        "notation": "広場(ひろば)"
+        ]
     },
     {
         "name": "nakusu",
         "trans": [
+            "亡(な)くす",
             "to lose someone, wife, child, etc"
-        ],
-        "notation": "亡(な)くす"
+        ]
     },
     {
         "name": "fueru",
         "trans": [
+            "殖(ふ)える",
             "to increase,to multiply"
-        ],
-        "notation": "殖(ふ)える"
+        ]
     },
     {
         "name": "fugou",
         "trans": [
+            "符号(ふごう)",
             "sign,mark,symbol"
-        ],
-        "notation": "符号(ふごう)"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "銅(どう)",
             "copper"
-        ],
-        "notation": "銅(どう)"
+        ]
     },
     {
         "name": "hahen",
         "trans": [
+            "破片(はへん)",
             "fragment,splinter,broken piece"
-        ],
-        "notation": "破片(はへん)"
+        ]
     },
     {
         "name": "kashikomarimashita",
         "trans": [
+            "かしこまりました",
             "certainly!"
-        ],
-        "notation": "かしこまりました"
+        ]
     },
     {
         "name": "yuketsu",
         "trans": [
+            "輸血(ゆけつ)",
             "blood transfusion"
-        ],
-        "notation": "輸血(ゆけつ)"
+        ]
     },
     {
         "name": "zonjiru",
         "trans": [
+            "存(ぞん)じる",
             "(hum) to know"
-        ],
-        "notation": "存(ぞん)じる"
+        ]
     },
     {
         "name": "konaida",
         "trans": [
+            "こないだ",
             "the other day,lately,recently"
-        ],
-        "notation": "こないだ"
+        ]
     },
     {
         "name": "tokekomu",
         "trans": [
+            "溶(と)け込(こ)む",
             "to melt into"
-        ],
-        "notation": "溶(と)け込(こ)む"
+        ]
     },
     {
         "name": "furaipan",
         "trans": [
+            "フライパン",
             "fry pan,frying pan"
-        ],
-        "notation": "フライパン"
+        ]
     },
     {
         "name": "kousha",
         "trans": [
+            "校舎(こうしゃ)",
             "school building"
-        ],
-        "notation": "校舎(こうしゃ)"
+        ]
     },
     {
         "name": "tousho",
         "trans": [
+            "投書(とうしょ)",
             "letter to the editor,letter from a reader,contribution"
-        ],
-        "notation": "投書(とうしょ)"
+        ]
     },
     {
         "name": "kourasu",
         "trans": [
+            "コーラス",
             "chorus"
-        ],
-        "notation": "コーラス"
+        ]
     },
     {
         "name": "outotsu",
         "trans": [
+            "凸凹(おうとつ)",
             "unevenness,roughness,ruggedness"
-        ],
-        "notation": "凸凹(おうとつ)"
+        ]
     },
     {
         "name": "yatarani",
         "trans": [
+            "やたらに",
             "randomly,recklessly,blindly"
-        ],
-        "notation": "やたらに"
+        ]
     },
     {
         "name": "sayounara",
         "trans": [
+            "さようなら",
             "good-bye"
-        ],
-        "notation": "さようなら"
+        ]
     },
     {
         "name": "outai",
         "trans": [
+            "応対(おうたい)",
             "receiving,dealing with"
-        ],
-        "notation": "応対(おうたい)"
+        ]
     },
     {
         "name": "kikkake",
         "trans": [
+            "きっかけ",
             "chance,start,cue,excuse"
-        ],
-        "notation": "きっかけ"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "泊(と)める",
             "to give shelter to,to lodge"
-        ],
-        "notation": "泊(と)める"
+        ]
     },
     {
         "name": "datou",
         "trans": [
+            "妥当(だとう)",
             "valid,proper,right,appropriate"
-        ],
-        "notation": "妥当(だとう)"
+        ]
     },
     {
         "name": "honbu",
         "trans": [
+            "本部(ほんぶ)",
             "headquarters"
-        ],
-        "notation": "本部(ほんぶ)"
+        ]
     },
     {
         "name": "manten",
         "trans": [
+            "満点(まんてん)",
             "perfect score"
-        ],
-        "notation": "満点(まんてん)"
+        ]
     },
     {
         "name": "shikke",
         "trans": [
+            "湿気(しっけ)",
             "moisture,humidity,dampness"
-        ],
-        "notation": "湿気(しっけ)"
+        ]
     },
     {
         "name": "kobosu",
         "trans": [
+            "こぼす",
             "to spill"
-        ],
-        "notation": "こぼす"
+        ]
     },
     {
         "name": "majiru",
         "trans": [
+            "混(ま)じる",
             "to be mixed,to be blended with,to associate with"
-        ],
-        "notation": "混(ま)じる"
+        ]
     },
     {
         "name": "beteran",
         "trans": [
+            "ベテラン",
             "veteran"
-        ],
-        "notation": "ベテラン"
+        ]
     },
     {
         "name": "otoshimono",
         "trans": [
+            "落(おと)し物(もの)",
             "lost property"
-        ],
-        "notation": "落(おと)し物(もの)"
+        ]
     },
     {
         "name": "kaketsu",
         "trans": [
+            "可決(かけつ)",
             "approval,adoption (e.g. motion, bill),passage"
-        ],
-        "notation": "可決(かけつ)"
+        ]
     },
     {
         "name": "kanmuri",
         "trans": [
+            "冠(かんむり)",
             "crown,diadem,first,best"
-        ],
-        "notation": "冠(かんむり)"
+        ]
     },
     {
         "name": "saraishuu",
         "trans": [
+            "再来週(さらいしゅう)",
             "week after next"
-        ],
-        "notation": "再来週(さらいしゅう)"
+        ]
     },
     {
         "name": "chouhoukei",
         "trans": [
+            "長方形(ちょうほうけい)",
             "rectangle,oblong"
-        ],
-        "notation": "長方形(ちょうほうけい)"
+        ]
     },
     {
         "name": "katamukeraka",
         "trans": [
+            "傾(かたむ)けらか",
             ""
-        ],
-        "notation": "傾(かたむ)けらか"
+        ]
     },
     {
         "name": "urouro",
         "trans": [
+            "うろうろ",
             "loiteringly,aimless wandering"
-        ],
-        "notation": "うろうろ"
+        ]
     },
     {
         "name": "ooyoso",
         "trans": [
+            "大凡(おおよそ)",
             "about,roughly,as a rule,approximately"
-        ],
-        "notation": "大凡(おおよそ)"
+        ]
     },
     {
         "name": "shikai",
         "trans": [
+            "司会(しかい)",
             "chairmanship"
-        ],
-        "notation": "司会(しかい)"
+        ]
     },
     {
         "name": "chikajika",
         "trans": [
+            "近々(ちかぢか)",
             "nearness,before long"
-        ],
-        "notation": "近々(ちかぢか)"
+        ]
     },
     {
         "name": "yuukan",
         "trans": [
+            "夕刊(ゆうかん)",
             "evening paper"
-        ],
-        "notation": "夕刊(ゆうかん)"
+        ]
     },
     {
         "name": "shokki",
         "trans": [
+            "食器(しょっき)",
             "tableware"
-        ],
-        "notation": "食器(しょっき)"
+        ]
     },
     {
         "name": "kama",
         "trans": [
+            "釜(かま)",
             "iron pot,kettle"
-        ],
-        "notation": "釜(かま)"
+        ]
     },
     {
         "name": "jouhatsu",
         "trans": [
+            "蒸発(じょうはつ)",
             "evaporation,unexplained disappearance"
-        ],
-        "notation": "蒸発(じょうはつ)"
+        ]
     },
     {
         "name": "tachimachi",
         "trans": [
+            "たちまち",
             "at once,in a moment,suddenly,all at once"
-        ],
-        "notation": "たちまち"
+        ]
     },
     {
         "name": "haraimodosu",
         "trans": [
+            "払(はら)い戻(もど)す",
             "to repay,to pay back"
-        ],
-        "notation": "払(はら)い戻(もど)す"
+        ]
     },
     {
         "name": "ittemairimasu",
         "trans": [
+            "いってまいります",
             ""
-        ],
-        "notation": "いってまいります"
+        ]
     },
     {
         "name": "rettou",
         "trans": [
+            "列島(れっとう)",
             "chain of islands"
-        ],
-        "notation": "列島(れっとう)"
+        ]
     },
     {
         "name": "bokujou",
         "trans": [
+            "牧場(ぼくじょう)",
             "(1) farm (livestock),(2) pasture land,meadow,grazing land"
-        ],
-        "notation": "牧場(ぼくじょう)"
+        ]
     },
     {
         "name": "miorosu",
         "trans": [
+            "見下(みお)ろす",
             "to overlook,to command a view of,to look down on something"
-        ],
-        "notation": "見下(みお)ろす"
+        ]
     },
     {
         "name": "kudoi",
         "trans": [
+            "くどい",
             "verbose,importunate,heavy (taste)"
-        ],
-        "notation": "くどい"
+        ]
     },
     {
         "name": "-choutan",
         "trans": [
+            "-長短(ちょうたん)",
             "length,long and short,+"
-        ],
-        "notation": "-長短(ちょうたん)"
+        ]
     },
     {
         "name": "matomaru",
         "trans": [
+            "纏(まと)まる",
             "to be collected,to be settled,to be in order"
-        ],
-        "notation": "纏(まと)まる"
+        ]
     },
     {
         "name": "douzoyoroshiku",
         "trans": [
+            "どうぞよろしく",
             "pleased to meet you"
-        ],
-        "notation": "どうぞよろしく"
+        ]
     },
     {
         "name": "keitou",
         "trans": [
+            "系統(けいとう)",
             "system,family line,geological formation"
-        ],
-        "notation": "系統(けいとう)"
+        ]
     },
     {
         "name": "birudingu",
         "trans": [
+            "ビルディング",
             "building"
-        ],
-        "notation": "ビルディング"
+        ]
     },
     {
         "name": "sosen",
         "trans": [
+            "祖先(そせん)",
             "ancestor"
-        ],
-        "notation": "祖先(そせん)"
+        ]
     },
     {
         "name": "keiba",
         "trans": [
+            "競馬(けいば)",
             "horse racing"
-        ],
-        "notation": "競馬(けいば)"
+        ]
     },
     {
         "name": "goran",
         "trans": [
+            "御覧(ごらん)",
             "(hon) look,inspection,try"
-        ],
-        "notation": "御覧(ごらん)"
+        ]
     },
     {
         "name": "obasan",
         "trans": [
+            "伯母(おば)さん",
             "(hon) aunt"
-        ],
-        "notation": "伯母(おば)さん"
+        ]
     },
     {
         "name": "kansou",
         "trans": [
+            "乾燥(かんそう)",
             "dry,arid,insipid,dehydrated"
-        ],
-        "notation": "乾燥(かんそう)"
+        ]
     },
     {
         "name": "baransu",
         "trans": [
+            "バランス",
             "balance"
-        ],
-        "notation": "バランス"
+        ]
     },
     {
         "name": "yougo",
         "trans": [
+            "用語(ようご)",
             "term,terminology"
-        ],
-        "notation": "用語(ようご)"
+        ]
     },
     {
         "name": "saihou",
         "trans": [
+            "裁縫(さいほう)",
             "sewing"
-        ],
-        "notation": "裁縫(さいほう)"
+        ]
     },
     {
         "name": "ryoushuu",
         "trans": [
+            "領収(りょうしゅう)",
             "receipt,voucher"
-        ],
-        "notation": "領収(りょうしゅう)"
+        ]
     },
     {
         "name": "kiwotsukeru",
         "trans": [
+            "気(き)を付(つ)ける",
             "to be careful,to pay attention,to take care"
-        ],
-        "notation": "気(き)を付(つ)ける"
+        ]
     },
     {
         "name": "denryuu",
         "trans": [
+            "電流(でんりゅう)",
             "electric current"
-        ],
-        "notation": "電流(でんりゅう)"
+        ]
     },
     {
         "name": "tamerau",
         "trans": [
+            "ためらう",
             "to hesitate"
-        ],
-        "notation": "ためらう"
+        ]
     },
     {
         "name": "mei",
         "trans": [
+            "姪(めい)",
             "niece"
-        ],
-        "notation": "姪(めい)"
+        ]
     },
     {
         "name": "ikebana",
         "trans": [
+            "生(い)け花(ばな)",
             "(1) flower arrangement"
-        ],
-        "notation": "生(い)け花(ばな)"
+        ]
     },
     {
         "name": "sarariiman",
         "trans": [
+            "サラリーマン",
             "salary man,company employee"
-        ],
-        "notation": "サラリーマン"
+        ]
     },
     {
         "name": "fukamaru",
         "trans": [
+            "深(ふか)まる",
             "to deepen,to heighten,to intensify"
-        ],
-        "notation": "深(ふか)まる"
+        ]
     },
     {
         "name": "sassato",
         "trans": [
+            "さっさと",
             "quickly"
-        ],
-        "notation": "さっさと"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "突(つ)く",
             "(1) to thrust,to strike,(2) to poke"
-        ],
-        "notation": "突(つ)く"
+        ]
     },
     {
         "name": "juken",
         "trans": [
+            "受験(じゅけん)",
             "taking an examination"
-        ],
-        "notation": "受験(じゅけん)"
+        ]
     },
     {
         "name": "koyubi",
         "trans": [
+            "小指(こゆび)",
             "little finger"
-        ],
-        "notation": "小指(こゆび)"
+        ]
     },
     {
         "name": "naika",
         "trans": [
+            "内科(ないか)",
             "internist clinic,internal medicine"
-        ],
-        "notation": "内科(ないか)"
+        ]
     },
     {
         "name": "seibi",
         "trans": [
+            "整備(せいび)",
             "adjustment,completion,consolidation"
-        ],
-        "notation": "整備(せいび)"
+        ]
     },
     {
         "name": "kamotsu",
         "trans": [
+            "貨物(かもつ)",
             "cargo,freight"
-        ],
-        "notation": "貨物(かもつ)"
+        ]
     },
     {
         "name": "sonohoka",
         "trans": [
+            "そのほか",
             "otherwise"
-        ],
-        "notation": "そのほか"
+        ]
     },
     {
         "name": "nonki",
         "trans": [
+            "呑気(のんき)",
             "carefree,optimistic,careless,reckless,heedless"
-        ],
-        "notation": "呑気(のんき)"
+        ]
     },
     {
         "name": "kiyoi",
         "trans": [
+            "清(きよ)い",
             "clear,pure,noble"
-        ],
-        "notation": "清(きよ)い"
+        ]
     },
     {
         "name": "shitsudo",
         "trans": [
+            "湿度(しつど)",
             "level of humidity"
-        ],
-        "notation": "湿度(しつど)"
+        ]
     },
     {
         "name": "abura",
         "trans": [
+            "脂(あぶら)",
             "fat,tallow,lard"
-        ],
-        "notation": "脂(あぶら)"
+        ]
     },
     {
         "name": "shippitsu",
         "trans": [
+            "執筆(しっぴつ)",
             "writing"
-        ],
-        "notation": "執筆(しっぴつ)"
+        ]
     },
     {
         "name": "hikkurikaeru",
         "trans": [
+            "引(ひ)っ繰(く)り返(かえ)る",
             "to be overturned,to be upset,to topple over,to be reversed"
-        ],
-        "notation": "引(ひ)っ繰(く)り返(かえ)る"
+        ]
     },
     {
         "name": "rakudai",
         "trans": [
+            "落第(らくだい)",
             "failure,dropping out of a class"
-        ],
-        "notation": "落第(らくだい)"
+        ]
     },
     {
         "name": "teika",
         "trans": [
+            "低下(ていか)",
             "fall,decline,lowering,deterioration"
-        ],
-        "notation": "低下(ていか)"
+        ]
     },
     {
         "name": "koumu",
         "trans": [
+            "公務(こうむ)",
             "official business,public business"
-        ],
-        "notation": "公務(こうむ)"
+        ]
     },
     {
         "name": "touyou",
         "trans": [
+            "東洋(とうよう)",
             "Orient"
-        ],
-        "notation": "東洋(とうよう)"
+        ]
     },
     {
         "name": "todana",
         "trans": [
+            "戸棚(とだな)",
             "cupboard,locker,closet,wardrobe"
-        ],
-        "notation": "戸棚(とだな)"
+        ]
     },
     {
         "name": "rigai",
         "trans": [
+            "利害(りがい)",
             "advantages and disadvantages,interest"
-        ],
-        "notation": "利害(りがい)"
+        ]
     },
     {
         "name": "heibon",
         "trans": [
+            "平凡(へいぼん)",
             "common,commonplace,ordinary,mediocre"
-        ],
-        "notation": "平凡(へいぼん)"
+        ]
     },
     {
         "name": "igo",
         "trans": [
+            "以後(いご)",
             "after this,from now on,hereafter,thereafter"
-        ],
-        "notation": "以後(いご)"
+        ]
     },
     {
         "name": "shiokarai",
         "trans": [
+            "塩辛(しおから)い",
             "salty (taste)"
-        ],
-        "notation": "塩辛(しおから)い"
+        ]
     },
     {
         "name": "fukusha",
         "trans": [
+            "複写(ふくしゃ)",
             "copy,duplicate"
-        ],
-        "notation": "複写(ふくしゃ)"
+        ]
     },
     {
         "name": "fukasu",
         "trans": [
+            "蒸(ふか)す",
             "to steam,to poultice,to be sultry"
-        ],
-        "notation": "蒸(ふか)す"
+        ]
     },
     {
         "name": "junjun",
         "trans": [
+            "順々(じゅんじゅん)",
             "in order,in turn"
-        ],
-        "notation": "順々(じゅんじゅん)"
+        ]
     },
     {
         "name": "herikoputaa",
         "trans": [
+            "ヘリコプター",
             "helicopter"
-        ],
-        "notation": "ヘリコプター"
+        ]
     },
     {
         "name": "wan",
         "trans": [
+            "椀(わん)",
             "Japanese soup bowl,wooden bowl"
-        ],
-        "notation": "椀(わん)"
+        ]
     },
     {
         "name": "hyouron",
         "trans": [
+            "評論(ひょうろん)",
             "criticism,critique"
-        ],
-        "notation": "評論(ひょうろん)"
+        ]
     },
     {
         "name": "muji",
         "trans": [
+            "無地(むじ)",
             "plain,unfigured"
-        ],
-        "notation": "無地(むじ)"
+        ]
     },
     {
         "name": "koutai",
         "trans": [
+            "交替(こうたい)",
             "alternation,change,relief,relay,shift"
-        ],
-        "notation": "交替(こうたい)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "務(つと)める",
             "(1) to serve,to fill a post,to serve under,to work (for)"
-        ],
-        "notation": "務(つと)める"
+        ]
     },
     {
         "name": "shoukyokuteki",
         "trans": [
+            "消極(しょうきょく)的(てき)",
             "passive"
-        ],
-        "notation": "消極(しょうきょく)的(てき)"
+        ]
     },
     {
         "name": "omedetai",
         "trans": [
+            "おめでたい",
             "happy event,matter for congratulation,auspicious event,pregnancy"
-        ],
-        "notation": "おめでたい"
+        ]
     },
     {
         "name": "geka",
         "trans": [
+            "外科(げか)",
             "surgical department"
-        ],
-        "notation": "外科(げか)"
+        ]
     },
     {
         "name": "taia",
         "trans": [
+            "タイア",
             "tire,tyre"
-        ],
-        "notation": "タイア"
+        ]
     },
     {
         "name": "bunkai",
         "trans": [
+            "分解(ぶんかい)",
             "analysis,disassembly"
-        ],
-        "notation": "分解(ぶんかい)"
+        ]
     },
     {
         "name": "gakujutsu",
         "trans": [
+            "学術(がくじゅつ)",
             "science,learning,scholarship"
-        ],
-        "notation": "学術(がくじゅつ)"
+        ]
     },
     {
         "name": "kouhyou",
         "trans": [
+            "公表(こうひょう)",
             "official announcement,proclamation"
-        ],
-        "notation": "公表(こうひょう)"
+        ]
     },
     {
         "name": "hakari",
         "trans": [
+            "秤(はかり)",
             "scales,weighing machine"
-        ],
-        "notation": "秤(はかり)"
+        ]
     },
     {
         "name": "antena",
         "trans": [
+            "アンテナ",
             "antenna"
-        ],
-        "notation": "アンテナ"
+        ]
     },
     {
         "name": "suiyou",
         "trans": [
+            "水曜(すいよう)",
             "Wednesday"
-        ],
-        "notation": "水曜(すいよう)"
+        ]
     },
     {
         "name": "mataha",
         "trans": [
+            "又(また)は",
             "or,otherwise"
-        ],
-        "notation": "又(また)は"
+        ]
     },
     {
         "name": "kozukai",
         "trans": [
+            "小遣(こづか)い",
             "personal expenses,pocket money,spending money,incidental expenses,allowance"
-        ],
-        "notation": "小遣(こづか)い"
+        ]
     },
     {
         "name": "satsuei",
         "trans": [
+            "撮影(さつえい)",
             "photographing"
-        ],
-        "notation": "撮影(さつえい)"
+        ]
     },
     {
         "name": "hane",
         "trans": [
+            "羽根(はね)",
             "shuttlecock"
-        ],
-        "notation": "羽根(はね)"
+        ]
     },
     {
         "name": "butsukaru",
         "trans": [
+            "ぶつかる",
             "to strike,to collide with"
-        ],
-        "notation": "ぶつかる"
+        ]
     },
     {
         "name": "jiei",
         "trans": [
+            "自衛(じえい)",
             "self-defense"
-        ],
-        "notation": "自衛(じえい)"
+        ]
     },
     {
         "name": "hakki",
         "trans": [
+            "発揮(はっき)",
             "exhibition,demonstration,utilization,display"
-        ],
-        "notation": "発揮(はっき)"
+        ]
     },
     {
         "name": "houshin",
         "trans": [
+            "方針(ほうしん)",
             "objective,plan,policy"
-        ],
-        "notation": "方針(ほうしん)"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "湧(わ)く",
             "to boil,to grow hot,to get excited,to gush forth"
-        ],
-        "notation": "湧(わ)く"
+        ]
     },
     {
         "name": "kuzu",
         "trans": [
+            "屑(くず)",
             "waste,scrap"
-        ],
-        "notation": "屑(くず)"
+        ]
     },
     {
         "name": "kankaku",
         "trans": [
+            "間隔(かんかく)",
             "space,interval,SPC"
-        ],
-        "notation": "間隔(かんかく)"
+        ]
     },
     {
         "name": "toreeningu",
         "trans": [
+            "トレーニング",
             "training"
-        ],
-        "notation": "トレーニング"
+        ]
     },
     {
         "name": "koujitsu",
         "trans": [
+            "口実(こうじつ)",
             "excuse"
-        ],
-        "notation": "口実(こうじつ)"
+        ]
     },
     {
         "name": "ajiwau",
         "trans": [
+            "味(あじ)わう",
             "to taste,to savor,to relish"
-        ],
-        "notation": "味(あじ)わう"
+        ]
     },
     {
         "name": "chijin",
         "trans": [
+            "知人(ちじん)",
             "friend,acquaintance"
-        ],
-        "notation": "知人(ちじん)"
+        ]
     },
     {
         "name": "mendoukusai",
         "trans": [
+            "面倒臭(めんどうくさ)い",
             "bother to do,tiresome"
-        ],
-        "notation": "面倒臭(めんどうくさ)い"
+        ]
     },
     {
         "name": "kaiten",
         "trans": [
+            "回転(かいてん)",
             "rotation,revolution,turning"
-        ],
-        "notation": "回転(かいてん)"
+        ]
     },
     {
         "name": "mitsukaru",
         "trans": [
+            "見付(みつ)かる",
             "to be found,to be discovered"
-        ],
-        "notation": "見付(みつ)かる"
+        ]
     },
     {
         "name": "nuu",
         "trans": [
+            "縫(ぬ)う",
             "to sew"
-        ],
-        "notation": "縫(ぬ)う"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "測(はか)る",
             "to measure,to weigh,to survey"
-        ],
-        "notation": "測(はか)る"
+        ]
     },
     {
         "name": "misaki",
         "trans": [
+            "岬(みさき)",
             "cape (on coast)"
-        ],
-        "notation": "岬(みさき)"
+        ]
     },
     {
         "name": "junkan",
         "trans": [
+            "循環(じゅんかん)",
             "circulation,rotation,cycle"
-        ],
-        "notation": "循環(じゅんかん)"
+        ]
     },
     {
         "name": "hoken",
         "trans": [
+            "保健(ほけん)",
             "health preservation,hygiene,sanitation"
-        ],
-        "notation": "保健(ほけん)"
+        ]
     },
     {
         "name": "arai",
         "trans": [
+            "粗(あら)い",
             "coarse,rough"
-        ],
-        "notation": "粗(あら)い"
+        ]
     },
     {
         "name": "kishou",
         "trans": [
+            "起床(きしょう)",
             "rising,getting out of bed"
-        ],
-        "notation": "起床(きしょう)"
+        ]
     },
     {
         "name": "yurui",
         "trans": [
+            "緩(ゆる)い",
             "loose,lenient,slow"
-        ],
-        "notation": "緩(ゆる)い"
+        ]
     },
     {
         "name": "ijiwaru",
         "trans": [
+            "意地悪(いじわる)",
             "malicious,ill-tempered,unkind"
-        ],
-        "notation": "意地悪(いじわる)"
+        ]
     },
     {
         "name": "furumau",
         "trans": [
+            "振舞(ふるま)う",
             "to behave,to conduct oneself,to entertain (vt)"
-        ],
-        "notation": "振舞(ふるま)う"
+        ]
     },
     {
         "name": "marason",
         "trans": [
+            "マラソン",
             "marathon"
-        ],
-        "notation": "マラソン"
+        ]
     },
     {
         "name": "kaihou",
         "trans": [
+            "解放(かいほう)",
             "release,liberation,emancipation"
-        ],
-        "notation": "解放(かいほう)"
+        ]
     },
     {
         "name": "hakihaki",
         "trans": [
+            "はきはき",
             "lucidly"
-        ],
-        "notation": "はきはき"
+        ]
     },
     {
         "name": "boro",
         "trans": [
+            "ぼろ",
             "rag,scrap,tattered clothes,fault (esp. in a pretense)"
-        ],
-        "notation": "ぼろ"
+        ]
     },
     {
         "name": "dousa",
         "trans": [
+            "動作(どうさ)",
             "action,movements,motions,bearing,behaviour,manners"
-        ],
-        "notation": "動作(どうさ)"
+        ]
     },
     {
         "name": "menyuu",
         "trans": [
+            "メニュー",
             "menu"
-        ],
-        "notation": "メニュー"
+        ]
     },
     {
         "name": "kouryoku",
         "trans": [
+            "効力(こうりょく)",
             "effect,efficacy,validity,potency"
-        ],
-        "notation": "効力(こうりょく)"
+        ]
     },
     {
         "name": "yattsukeru",
         "trans": [
+            "やっつける",
             "to attack (an enemy),to beat,to do away with,to finish off"
-        ],
-        "notation": "やっつける"
+        ]
     },
     {
         "name": "juuryoku",
         "trans": [
+            "重力(じゅうりょく)",
             "gravity"
-        ],
-        "notation": "重力(じゅうりょく)"
+        ]
     },
     {
         "name": "gochisousama",
         "trans": [
+            "ごちそうさま",
             "feast"
-        ],
-        "notation": "ごちそうさま"
+        ]
     },
     {
         "name": "youyaku",
         "trans": [
+            "漸(ようや)く",
             "gradually,finally,hardly"
-        ],
-        "notation": "漸(ようや)く"
+        ]
     },
     {
         "name": "tsukiataru",
         "trans": [
+            "突(つ)き当(あ)たる",
             "to run into,to collide with"
-        ],
-        "notation": "突(つ)き当(あ)たる"
+        ]
     },
     {
         "name": "katakana",
         "trans": [
+            "片仮名(かたかな)",
             "katakana"
-        ],
-        "notation": "片仮名(かたかな)"
+        ]
     },
     {
         "name": "wafuku",
         "trans": [
+            "和服(わふく)",
             "Japanese clothes"
-        ],
-        "notation": "和服(わふく)"
+        ]
     },
     {
         "name": "yuge",
         "trans": [
+            "湯気(ゆげ)",
             "steam,vapour"
-        ],
-        "notation": "湯気(ゆげ)"
+        ]
     },
     {
         "name": "binsen",
         "trans": [
+            "便箋(びんせん)",
             "writing paper,stationery"
-        ],
-        "notation": "便箋(びんせん)"
+        ]
     },
     {
         "name": "aratamete",
         "trans": [
+            "改(あらた)めて",
             "another time,again,over again,anew,formally"
-        ],
-        "notation": "改(あらた)めて"
+        ]
     },
     {
         "name": "onchuu",
         "trans": [
+            "御中(おんちゅう)",
             "and Company,Messrs."
-        ],
-        "notation": "御中(おんちゅう)"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "湿(しめ)る",
             "to be wet,to become wet,to be damp"
-        ],
-        "notation": "湿(しめ)る"
+        ]
     },
     {
         "name": "kakuji",
         "trans": [
+            "各自(かくじ)",
             "individual,each"
-        ],
-        "notation": "各自(かくじ)"
+        ]
     },
     {
         "name": "omataseshimashita",
         "trans": [
+            "おまたせしました",
             "Sorry to have kept you waiting"
-        ],
-        "notation": "おまたせしました"
+        ]
     },
     {
         "name": "soreru",
         "trans": [
+            "逸(そ)れる",
             "to stray (turn) from subject,to get lost,to go astray"
-        ],
-        "notation": "逸(そ)れる"
+        ]
     },
     {
         "name": "nurasu",
         "trans": [
+            "濡(ぬ)らす",
             "to wet,to soak,to dip"
-        ],
-        "notation": "濡(ぬ)らす"
+        ]
     },
     {
         "name": "mazaru",
         "trans": [
+            "交(ま)ざる",
             "to be mixed,to be blended with,to associate with,to mingle with,to join"
-        ],
-        "notation": "交(ま)ざる"
+        ]
     },
     {
         "name": "kosu",
         "trans": [
+            "超(こ)す",
             "to cross,to pass,to tide over"
-        ],
-        "notation": "超(こ)す"
+        ]
     },
     {
         "name": "kiru",
         "trans": [
+            "斬(き)る",
             "(v5r) to behead,to murder"
-        ],
-        "notation": "斬(き)る"
+        ]
     },
     {
         "name": "noru",
         "trans": [
+            "載(の)る",
             "to appear (in print),to be recorded"
-        ],
-        "notation": "載(の)る"
+        ]
     },
     {
         "name": "jouki",
         "trans": [
+            "蒸気(じょうき)",
             "steam,vapour"
-        ],
-        "notation": "蒸気(じょうき)"
+        ]
     },
     {
         "name": "suchuwaadesu",
         "trans": [
+            "スチュワーデス",
             "stewardess"
-        ],
-        "notation": "スチュワーデス"
+        ]
     },
     {
         "name": "dankai",
         "trans": [
+            "段階(だんかい)",
             "gradation,grade,stage"
-        ],
-        "notation": "段階(だんかい)"
+        ]
     },
     {
         "name": "nigoru",
         "trans": [
+            "濁(にご)る",
             "to become muddy,to get impure"
-        ],
-        "notation": "濁(にご)る"
+        ]
     },
     {
         "name": "hatsubai",
         "trans": [
+            "発売(はつばい)",
             "sale"
-        ],
-        "notation": "発売(はつばい)"
+        ]
     },
     {
         "name": "kosuru",
         "trans": [
+            "擦(こす)る",
             "to rub,to chafe,to file,to frost (glass),to strike (match)"
-        ],
-        "notation": "擦(こす)る"
+        ]
     },
     {
         "name": "kasho",
         "trans": [
+            "個所(かしょ)",
             "passage,place,point,part"
-        ],
-        "notation": "個所(かしょ)"
+        ]
     },
     {
         "name": "masuku",
         "trans": [
+            "マスク",
             "mask"
-        ],
-        "notation": "マスク"
+        ]
     },
     {
         "name": "dekakeru",
         "trans": [
+            "出掛(でか)ける",
             "to depart,to set out,to start,to be going out"
-        ],
-        "notation": "出掛(でか)ける"
+        ]
     },
     {
         "name": "tokonoma",
         "trans": [
+            "床(とこ)の間(ま)",
             "alcove"
-        ],
-        "notation": "床(とこ)の間(ま)"
+        ]
     },
     {
         "name": "kaitsuu",
         "trans": [
+            "開通(かいつう)",
             "opening,open"
-        ],
-        "notation": "開通(かいつう)"
+        ]
     },
     {
         "name": "okurikamei",
         "trans": [
+            "送(おく)り仮名(かめい)",
             "part of word written in kana"
-        ],
-        "notation": "送(おく)り仮名(かめい)"
+        ]
     },
     {
         "name": "mekkiri",
         "trans": [
+            "めっきり",
             "remarkably"
-        ],
-        "notation": "めっきり"
+        ]
     },
     {
         "name": "kasanaru",
         "trans": [
+            "重(かさ)なる",
             "to be piled up,lie on top of one another,overlap each other"
-        ],
-        "notation": "重(かさ)なる"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "生(な)る",
             "to bear fruit"
-        ],
-        "notation": "生(な)る"
+        ]
     },
     {
         "name": "mujun",
         "trans": [
+            "矛盾(むじゅん)",
             "contradiction,inconsistency"
-        ],
-        "notation": "矛盾(むじゅん)"
+        ]
     },
     {
         "name": "jaguchi",
         "trans": [
+            "蛇口(じゃぐち)",
             "faucet,tap"
-        ],
-        "notation": "蛇口(じゃぐち)"
+        ]
     },
     {
         "name": "kudakeru",
         "trans": [
+            "砕(くだ)ける",
             "to break,to be broken"
-        ],
-        "notation": "砕(くだ)ける"
+        ]
     },
     {
         "name": "tobu",
         "trans": [
+            "跳(と)ぶ",
             "to jump,to fly,to leap"
-        ],
-        "notation": "跳(と)ぶ"
+        ]
     },
     {
         "name": "chirigami",
         "trans": [
+            "塵紙(ちりがみ)",
             "tissue paper,toilet paper"
-        ],
-        "notation": "塵紙(ちりがみ)"
+        ]
     },
     {
         "name": "shouka",
         "trans": [
+            "消化(しょうか)",
             "digestion"
-        ],
-        "notation": "消化(しょうか)"
+        ]
     },
     {
         "name": "naname",
         "trans": [
+            "斜(なな)め",
             "obliqueness"
-        ],
-        "notation": "斜(なな)め"
+        ]
     },
     {
         "name": "ooita",
         "trans": [
+            "大分(おおいた)",
             "considerably,greatly,a lot"
-        ],
-        "notation": "大分(おおいた)"
+        ]
     },
     {
         "name": "hamigaki",
         "trans": [
+            "歯磨(はみが)き",
             "dentifrice,toothpaste"
-        ],
-        "notation": "歯磨(はみが)き"
+        ]
     },
     {
         "name": "purinto",
         "trans": [
+            "プリント",
             "print,handout"
-        ],
-        "notation": "プリント"
+        ]
     },
     {
         "name": "hissha",
         "trans": [
+            "筆者(ひっしゃ)",
             "writer,author"
-        ],
-        "notation": "筆者(ひっしゃ)"
+        ]
     },
     {
         "name": "osowaru",
         "trans": [
+            "教(おそ)わる",
             "to be taught"
-        ],
-        "notation": "教(おそ)わる"
+        ]
     },
     {
         "name": "shuuji",
         "trans": [
+            "習字(しゅうじ)",
             "penmanship"
-        ],
-        "notation": "習字(しゅうじ)"
+        ]
     },
     {
         "name": "shimekiru",
         "trans": [
+            "締(し)め切(き)る",
             "to shut up"
-        ],
-        "notation": "締(し)め切(き)る"
+        ]
     },
     {
         "name": "yobikakeru",
         "trans": [
+            "呼(よ)び掛(か)ける",
             "to call out to,to accost,to address (crowd),to appeal"
-        ],
-        "notation": "呼(よ)び掛(か)ける"
+        ]
     },
     {
         "name": "genni",
         "trans": [
+            "現(げん)に",
             "actually,really"
-        ],
-        "notation": "現(げん)に"
+        ]
     },
     {
         "name": "fuzakeru",
         "trans": [
+            "ふざける",
             "to romp,to gambol,to frolic,to joke"
-        ],
-        "notation": "ふざける"
+        ]
     },
     {
         "name": "unga",
         "trans": [
+            "運河(うんが)",
             "canal,waterway"
-        ],
-        "notation": "運河(うんが)"
+        ]
     },
     {
         "name": "nikka",
         "trans": [
+            "日課(にっか)",
             "daily lesson,daily work,daily routine"
-        ],
-        "notation": "日課(にっか)"
+        ]
     },
     {
         "name": "nagabiku",
         "trans": [
+            "長引(ながび)く",
             "to be prolonged,to drag on"
-        ],
-        "notation": "長引(ながび)く"
+        ]
     },
     {
         "name": "noronoro",
         "trans": [
+            "のろのろ",
             "slowly,sluggishly"
-        ],
-        "notation": "のろのろ"
+        ]
     },
     {
         "name": "hameru",
         "trans": [
+            "はめる",
             "(col) to get in,to insert,to put on,to make love"
-        ],
-        "notation": "はめる"
+        ]
     },
     {
         "name": "kuiki",
         "trans": [
+            "区域(くいき)",
             "limits,boundary,domain,zone,sphere,territory"
-        ],
-        "notation": "区域(くいき)"
+        ]
     },
     {
         "name": "tanpen",
         "trans": [
+            "短編(たんぺん)",
             "short (e.g. story, film)"
-        ],
-        "notation": "短編(たんぺん)"
+        ]
     },
     {
         "name": "shiinto-suru",
         "trans": [
+            "しいんと-する",
             "silent (as the grave),(deathly) quiet"
-        ],
-        "notation": "しいんと-する"
+        ]
     },
     {
         "name": "zurari",
         "trans": [
+            "ずらり",
             ""
-        ],
-        "notation": "ずらり"
+        ]
     },
     {
         "name": "jiin",
         "trans": [
+            "寺院(じいん)",
             "temple"
-        ],
-        "notation": "寺院(じいん)"
+        ]
     },
     {
         "name": "shojun",
         "trans": [
+            "初旬(しょじゅん)",
             "first 10 days of the month"
-        ],
-        "notation": "初旬(しょじゅん)"
+        ]
     },
     {
         "name": "souridaijin",
         "trans": [
+            "総理(そうり)大臣(だいじん)",
             "Prime Minister"
-        ],
-        "notation": "総理(そうり)大臣(だいじん)"
+        ]
     },
     {
         "name": "chuusei",
         "trans": [
+            "中世(ちゅうせい)",
             "Middle Ages,mediaeval times"
-        ],
-        "notation": "中世(ちゅうせい)"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "四角(しかく)",
             "square"
-        ],
-        "notation": "四角(しかく)"
+        ]
     },
     {
         "name": "gakkyuu",
         "trans": [
+            "学級(がっきゅう)",
             "grade in school"
-        ],
-        "notation": "学級(がっきゅう)"
+        ]
     },
     {
         "name": "hachi",
         "trans": [
+            "鉢(はち)",
             "a bowl,a pot"
-        ],
-        "notation": "鉢(はち)"
+        ]
     },
     {
         "name": "seisaku",
         "trans": [
+            "制作(せいさく)",
             "work (film, book)"
-        ],
-        "notation": "制作(せいさく)"
+        ]
     },
     {
         "name": "meue",
         "trans": [
+            "目上(めうえ)",
             "superior(s),senior"
-        ],
-        "notation": "目上(めうえ)"
+        ]
     },
     {
         "name": "hasu",
         "trans": [
+            "斜(はす)",
             ""
-        ],
-        "notation": "斜(はす)"
+        ]
     },
     {
         "name": "yuudachi",
         "trans": [
+            "夕立(ゆうだち)",
             "(sudden) evening shower (rain)"
-        ],
-        "notation": "夕立(ゆうだち)"
+        ]
     },
     {
         "name": "shuuten",
         "trans": [
+            "終点(しゅうてん)",
             "terminus,last stop (e.g train)"
-        ],
-        "notation": "終点(しゅうてん)"
+        ]
     },
     {
         "name": "gendo",
         "trans": [
+            "限度(げんど)",
             "limit,bounds"
-        ],
-        "notation": "限度(げんど)"
+        ]
     },
     {
         "name": "kousen",
         "trans": [
+            "光線(こうせん)",
             "beam,light ray"
-        ],
-        "notation": "光線(こうせん)"
+        ]
     },
     {
         "name": "shinkansen",
         "trans": [
+            "新幹線(しんかんせん)",
             "bullet train (very high speed),shinkansen"
-        ],
-        "notation": "新幹線(しんかんせん)"
+        ]
     },
     {
         "name": "techou",
         "trans": [
+            "手帳(てちょう)",
             "notebook"
-        ],
-        "notation": "手帳(てちょう)"
+        ]
     },
     {
         "name": "kufuu",
         "trans": [
+            "工夫(くふう)",
             "labourer,worker"
-        ],
-        "notation": "工夫(くふう)"
+        ]
     },
     {
         "name": "sameru",
         "trans": [
+            "冷(さ)める",
             "to become cool,to wear off,to abate,to subside"
-        ],
-        "notation": "冷(さ)める"
+        ]
     },
     {
         "name": "tsugu",
         "trans": [
+            "次(つ)ぐ",
             "to rank next to,to come after"
-        ],
-        "notation": "次(つ)ぐ"
+        ]
     },
     {
         "name": "boshuu",
         "trans": [
+            "募集(ぼしゅう)",
             "recruiting,taking applications"
-        ],
-        "notation": "募集(ぼしゅう)"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "映(うつ)す",
             "to project,to reflect,to cast (shadow)"
-        ],
-        "notation": "映(うつ)す"
+        ]
     },
     {
         "name": "seishounen",
         "trans": [
+            "青少年(せいしょうねん)",
             "youth,young person"
-        ],
-        "notation": "青少年(せいしょうねん)"
+        ]
     },
     {
         "name": "youmou",
         "trans": [
+            "羊毛(ようもう)",
             "wool"
-        ],
-        "notation": "羊毛(ようもう)"
+        ]
     },
     {
         "name": "enogu",
         "trans": [
+            "絵(え)の具(ぐ)",
             "colors,paints"
-        ],
-        "notation": "絵(え)の具(ぐ)"
+        ]
     },
     {
         "name": "kashiya",
         "trans": [
+            "貸家(かしや)",
             "house for rent"
-        ],
-        "notation": "貸家(かしや)"
+        ]
     },
     {
         "name": "nankyoku",
         "trans": [
+            "南極(なんきょく)",
             "south pole,Antarctic"
-        ],
-        "notation": "南極(なんきょく)"
+        ]
     },
     {
         "name": "kanetsu",
         "trans": [
+            "加熱(かねつ)",
             "heating"
-        ],
-        "notation": "加熱(かねつ)"
+        ]
     },
     {
         "name": "meisho",
         "trans": [
+            "名所(めいしょ)",
             "famous place"
-        ],
-        "notation": "名所(めいしょ)"
+        ]
     },
     {
         "name": "kasokudo",
         "trans": [
+            "加速度(かそくど)",
             "acceleration"
-        ],
-        "notation": "加速度(かそくど)"
+        ]
     },
     {
         "name": "musuu",
         "trans": [
+            "無数(むすう)",
             "countless number,infinite number"
-        ],
-        "notation": "無数(むすう)"
+        ]
     },
     {
         "name": "taiseki",
         "trans": [
+            "体積(たいせき)",
             "capacity,volume"
-        ],
-        "notation": "体積(たいせき)"
+        ]
     },
     {
         "name": "shirouto",
         "trans": [
+            "素人(しろうと)",
             "amateur,novice"
-        ],
-        "notation": "素人(しろうと)"
+        ]
     },
     {
         "name": "bokuchiku",
         "trans": [
+            "牧畜(ぼくちく)",
             "stock-farming"
-        ],
-        "notation": "牧畜(ぼくちく)"
+        ]
     },
     {
         "name": "nasu",
         "trans": [
+            "為(な)す",
             "to accomplish,to do"
-        ],
-        "notation": "為(な)す"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "掃(は)く",
             "to sweep,to brush,to gather up"
-        ],
-        "notation": "掃(は)く"
+        ]
     },
     {
         "name": "nagusameru",
         "trans": [
+            "慰(なぐさ)める",
             "to comfort,to console"
-        ],
-        "notation": "慰(なぐさ)める"
+        ]
     },
     {
         "name": "shiru",
         "trans": [
+            "汁(しる)",
             "juice,sap,soup,broth"
-        ],
-        "notation": "汁(しる)"
+        ]
     },
     {
         "name": "iru",
         "trans": [
+            "炒(い)る",
             ""
-        ],
-        "notation": "炒(い)る"
+        ]
     },
     {
         "name": "terasu",
         "trans": [
+            "照(て)らす",
             "to shine on,to illuminate"
-        ],
-        "notation": "照(て)らす"
+        ]
     },
     {
         "name": "echiketto",
         "trans": [
+            "エチケット",
             "etiquette"
-        ],
-        "notation": "エチケット"
+        ]
     },
     {
         "name": "iremono",
         "trans": [
+            "入(い)れ物(もの)",
             "container,case,receptacle"
-        ],
-        "notation": "入(い)れ物(もの)"
+        ]
     },
     {
         "name": "toumei",
         "trans": [
+            "透明(とうめい)",
             "transparency,cleanness"
-        ],
-        "notation": "透明(とうめい)"
+        ]
     },
     {
         "name": "usumeru",
         "trans": [
+            "薄(うす)める",
             "to dilute,to water down"
-        ],
-        "notation": "薄(うす)める"
+        ]
     },
     {
         "name": "kayoichou",
         "trans": [
+            "通帳(かよいちょう)",
             "passbook"
-        ],
-        "notation": "通帳(かよいちょう)"
+        ]
     },
     {
         "name": "nittei",
         "trans": [
+            "日程(にってい)",
             "agenda"
-        ],
-        "notation": "日程(にってい)"
+        ]
     },
     {
         "name": "sensei",
         "trans": [
+            "専制(せんせい)",
             "despotism,autocracy"
-        ],
-        "notation": "専制(せんせい)"
+        ]
     },
     {
         "name": "bakku",
         "trans": [
+            "バック",
             "back"
-        ],
-        "notation": "バック"
+        ]
     },
     {
         "name": "kahansuu",
         "trans": [
+            "過半数(かはんすう)",
             "majority"
-        ],
-        "notation": "過半数(かはんすう)"
+        ]
     },
     {
         "name": "setsuzoku",
         "trans": [
+            "接続(せつぞく)",
             "(1) connection,union,join,link,(2) changing trains"
-        ],
-        "notation": "接続(せつぞく)"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "刺(さ)す",
             "to pierce,to stab,to prick,to thrust"
-        ],
-        "notation": "刺(さ)す"
+        ]
     },
     {
         "name": "kumiawase",
         "trans": [
+            "組合(くみあわ)せ",
             "combination"
-        ],
-        "notation": "組合(くみあわ)せ"
+        ]
     },
     {
         "name": "toiawase",
         "trans": [
+            "問(と)い合(あ)わせ",
             "enquiry,ENQ"
-        ],
-        "notation": "問(と)い合(あ)わせ"
+        ]
     },
     {
         "name": "shoubousho",
         "trans": [
+            "消防署(しょうぼうしょ)",
             "fire station"
-        ],
-        "notation": "消防署(しょうぼうしょ)"
+        ]
     },
     {
         "name": "amayakasu",
         "trans": [
+            "甘(あま)やかす",
             "to pamper,to spoil"
-        ],
-        "notation": "甘(あま)やかす"
+        ]
     },
     {
         "name": "mokuji",
         "trans": [
+            "目次(もくじ)",
             "table of contents"
-        ],
-        "notation": "目次(もくじ)"
+        ]
     },
     {
         "name": "kakujuu",
         "trans": [
+            "拡充(かくじゅう)",
             "expansion"
-        ],
-        "notation": "拡充(かくじゅう)"
+        ]
     },
     {
         "name": "sarainen",
         "trans": [
+            "再来年(さらいねん)",
             "year after next"
-        ],
-        "notation": "再来年(さらいねん)"
+        ]
     },
     {
         "name": "jichi",
         "trans": [
+            "自治(じち)",
             "self-government,autonomy"
-        ],
-        "notation": "自治(じち)"
+        ]
     },
     {
         "name": "junjo",
         "trans": [
+            "順序(じゅんじょ)",
             "order,sequence,procedure"
-        ],
-        "notation": "順序(じゅんじょ)"
+        ]
     },
     {
         "name": "zengo",
         "trans": [
+            "前後(ぜんご)",
             "around,throughout,front and back,before and behind,before and after"
-        ],
-        "notation": "前後(ぜんご)"
+        ]
     },
     {
         "name": "zaimoku",
         "trans": [
+            "材木(ざいもく)",
             "lumber,timber"
-        ],
-        "notation": "材木(ざいもく)"
+        ]
     },
     {
         "name": "rika",
         "trans": [
+            "理科(りか)",
             "science"
-        ],
-        "notation": "理科(りか)"
+        ]
     },
     {
         "name": "toudai",
         "trans": [
+            "灯台(とうだい)",
             "lighthouse"
-        ],
-        "notation": "灯台(とうだい)"
+        ]
     },
     {
         "name": "osameru",
         "trans": [
+            "納(おさ)める",
             "to obtain,to reap,to pay,to supply,to accept"
-        ],
-        "notation": "納(おさ)める"
+        ]
     },
     {
         "name": "furoshiki",
         "trans": [
+            "風呂敷(ふろしき)",
             "wrapping cloth,cloth wrapper"
-        ],
-        "notation": "風呂敷(ふろしき)"
+        ]
     },
     {
         "name": "hitorigoto",
         "trans": [
+            "独(ひと)り言(ごと)",
             "a soliloquy,a monologue,speaking to oneself"
-        ],
-        "notation": "独(ひと)り言(ごと)"
+        ]
     },
     {
         "name": "sutokkingu",
         "trans": [
+            "ストッキング",
             "stockings"
-        ],
-        "notation": "ストッキング"
+        ]
     },
     {
         "name": "hisha",
         "trans": [
+            "陽(ひ)射(しゃ)",
             "sunlight,rays of the sun"
-        ],
-        "notation": "陽(ひ)射(しゃ)"
+        ]
     },
     {
         "name": "meishi",
         "trans": [
+            "名詞(めいし)",
             "noun"
-        ],
-        "notation": "名詞(めいし)"
+        ]
     },
     {
         "name": "semaru",
         "trans": [
+            "迫(せま)る",
             "to draw near,to press"
-        ],
-        "notation": "迫(せま)る"
+        ]
     },
     {
         "name": "chirasu",
         "trans": [
+            "散(ち)らす",
             "to scatter,to disperse,to distribute"
-        ],
-        "notation": "散(ち)らす"
+        ]
     },
     {
         "name": "chippu",
         "trans": [
+            "チップ",
             "(1) gratuity,tip,(2) chip"
-        ],
-        "notation": "チップ"
+        ]
     },
     {
         "name": "mazaru",
         "trans": [
+            "混(ま)ざる",
             "to be mixed,to be blended with,to associate with,to mingle with,to join"
-        ],
-        "notation": "混(ま)ざる"
+        ]
     },
     {
         "name": "keibi",
         "trans": [
+            "警備(けいび)",
             "defense,guard,policing,security"
-        ],
-        "notation": "警備(けいび)"
+        ]
     },
     {
         "name": "kyouka",
         "trans": [
+            "強化(きょうか)",
             "strengthen,intensify,reinforce,solidify"
-        ],
-        "notation": "強化(きょうか)"
+        ]
     },
     {
         "name": "pisutoru",
         "trans": [
+            "ピストル",
             "pistol"
-        ],
-        "notation": "ピストル"
+        ]
     },
     {
         "name": "kiban",
         "trans": [
+            "基盤(きばん)",
             "foundation,basis"
-        ],
-        "notation": "基盤(きばん)"
+        ]
     },
     {
         "name": "kenbikyou",
         "trans": [
+            "顕微鏡(けんびきょう)",
             "microscope"
-        ],
-        "notation": "顕微鏡(けんびきょう)"
+        ]
     },
     {
         "name": "jutsugo",
         "trans": [
+            "述語(じゅつご)",
             "predicate"
-        ],
-        "notation": "述語(じゅつご)"
+        ]
     },
     {
         "name": "shoumen",
         "trans": [
+            "正面(しょうめん)",
             "the front,honesty"
-        ],
-        "notation": "正面(しょうめん)"
+        ]
     },
     {
         "name": "butsubutsu",
         "trans": [
+            "ぶつぶつ",
             "grumbling,complaining in a small voice"
-        ],
-        "notation": "ぶつぶつ"
+        ]
     },
     {
         "name": "kenchou",
         "trans": [
+            "県庁(けんちょう)",
             "prefectural office"
-        ],
-        "notation": "県庁(けんちょう)"
+        ]
     },
     {
         "name": "su",
         "trans": [
+            "酢(す)",
             "vinegar"
-        ],
-        "notation": "酢(す)"
+        ]
     },
     {
         "name": "yakou",
         "trans": [
+            "夜行(やこう)",
             "walking around at night,night train,night travel"
-        ],
-        "notation": "夜行(やこう)"
+        ]
     },
     {
         "name": "ittan",
         "trans": [
+            "一旦(いったん)",
             "once,for a moment,one morning,temporarily"
-        ],
-        "notation": "一旦(いったん)"
+        ]
     },
     {
         "name": "arai",
         "trans": [
+            "荒(あら)い",
             "rough,rude,wild"
-        ],
-        "notation": "荒(あら)い"
+        ]
     },
     {
         "name": "sukitooru",
         "trans": [
+            "透(す)き通(とお)る",
             "to be(come) transparent"
-        ],
-        "notation": "透(す)き通(とお)る"
+        ]
     },
     {
         "name": "kin",
         "trans": [
+            "琴(きん)",
             "Koto (Japanese harp)"
-        ],
-        "notation": "琴(きん)"
+        ]
     },
     {
         "name": "deiriguchi",
         "trans": [
+            "出入口(でいりぐち)",
             "exit and entrance"
-        ],
-        "notation": "出入口(でいりぐち)"
+        ]
     },
     {
         "name": "miseya",
         "trans": [
+            "店屋(みせや)",
             "store,shop"
-        ],
-        "notation": "店屋(みせや)"
+        ]
     },
     {
         "name": "tokasu",
         "trans": [
+            "溶(と)かす",
             "to melt,to dissolve"
-        ],
-        "notation": "溶(と)かす"
+        ]
     },
     {
         "name": "oshii",
         "trans": [
+            "惜(お)しい",
             "regrettable,disappointing,precious"
-        ],
-        "notation": "惜(お)しい"
+        ]
     },
     {
         "name": "hitoyasumi",
         "trans": [
+            "一休(ひとやす)み",
             "a rest"
-        ],
-        "notation": "一休(ひとやす)み"
+        ]
     },
     {
         "name": "oozappa",
         "trans": [
+            "おおざっぱ",
             "rough (not precise),broad,sketchy"
-        ],
-        "notation": "おおざっぱ"
+        ]
     },
     {
         "name": "bunbougu",
         "trans": [
+            "文房具(ぶんぼうぐ)",
             "stationery"
-        ],
-        "notation": "文房具(ぶんぼうぐ)"
+        ]
     },
     {
         "name": "mikake",
         "trans": [
+            "見掛(みか)け",
             "outward appearance"
-        ],
-        "notation": "見掛(みか)け"
+        ]
     },
     {
         "name": "haiiro",
         "trans": [
+            "灰色(はいいろ)",
             "grey,gray,ashen"
-        ],
-        "notation": "灰色(はいいろ)"
+        ]
     },
     {
         "name": "moyasu",
         "trans": [
+            "燃(も)やす",
             "to burn"
-        ],
-        "notation": "燃(も)やす"
+        ]
     },
     {
         "name": "samasu",
         "trans": [
+            "冷(さ)ます",
             "to cool,to dampen,to let cool"
-        ],
-        "notation": "冷(さ)ます"
+        ]
     },
     {
         "name": "gehin",
         "trans": [
+            "下品(げひん)",
             "vulgarity,meanness,indecency,coarseness"
-        ],
-        "notation": "下品(げひん)"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "堅(かた)い",
             "hard (esp. wood),steadfast,honorable,stuffy writing"
-        ],
-        "notation": "堅(かた)い"
+        ]
     },
     {
         "name": "furikamei",
         "trans": [
+            "振(ふ)り仮名(かめい)",
             ",pronunciation key"
-        ],
-        "notation": "振(ふ)り仮名(かめい)"
+        ]
     },
     {
         "name": "ichiryuu",
         "trans": [
+            "一流(いちりゅう)",
             "first class,top grade,foremost,top-notch"
-        ],
-        "notation": "一流(いちりゅう)"
+        ]
     },
     {
         "name": "zemi",
         "trans": [
+            "ゼミ",
             "(n) seminar"
-        ],
-        "notation": "ゼミ"
+        ]
     },
     {
         "name": "mageru",
         "trans": [
+            "曲(ま)げる",
             "to bend,to crook,to lean"
-        ],
-        "notation": "曲(ま)げる"
+        ]
     },
     {
         "name": "ibaru",
         "trans": [
+            "威張(いば)る",
             "to be proud,to swagger"
-        ],
-        "notation": "威張(いば)る"
+        ]
     },
     {
         "name": "yakamashii",
         "trans": [
+            "やかましい",
             "(1) noisy,(2) strict,fussy"
-        ],
-        "notation": "やかましい"
+        ]
     },
     {
         "name": "kaihou",
         "trans": [
+            "開放(かいほう)",
             "open,throw open,liberalization"
-        ],
-        "notation": "開放(かいほう)"
+        ]
     },
     {
         "name": "jimi",
         "trans": [
+            "地味(じみ)",
             "plain,simple"
-        ],
-        "notation": "地味(じみ)"
+        ]
     },
     {
         "name": "saiten",
         "trans": [
+            "採点(さいてん)",
             "marking,grading,looking over"
-        ],
-        "notation": "採点(さいてん)"
+        ]
     },
     {
         "name": "shimei",
         "trans": [
+            "氏名(しめい)",
             "full name,identity"
-        ],
-        "notation": "氏名(しめい)"
+        ]
     },
     {
         "name": "manin",
         "trans": [
+            "満員(まんいん)",
             "full house,no vacancy,sold out"
-        ],
-        "notation": "満員(まんいん)"
+        ]
     },
     {
         "name": "mejirushi",
         "trans": [
+            "目印(めじるし)",
             "mark,sign,landmark"
-        ],
-        "notation": "目印(めじるし)"
+        ]
     },
     {
         "name": "koutei",
         "trans": [
+            "肯定(こうてい)",
             "positive,affirmation"
-        ],
-        "notation": "肯定(こうてい)"
+        ]
     },
     {
         "name": "hanko",
         "trans": [
+            "判子(はんこ)",
             "seal (used for signature)"
-        ],
-        "notation": "判子(はんこ)"
+        ]
     },
     {
         "name": "namaiki",
         "trans": [
+            "生意気(なまいき)",
             "impertinent,saucy,cheeky,conceit,audacious,brazen"
-        ],
-        "notation": "生意気(なまいき)"
+        ]
     },
     {
         "name": "koushuu",
         "trans": [
+            "公衆(こうしゅう)",
             "the public"
-        ],
-        "notation": "公衆(こうしゅう)"
+        ]
     },
     {
         "name": "shouben",
         "trans": [
+            "小便(しょうべん)",
             "(col) urine,piss"
-        ],
-        "notation": "小便(しょうべん)"
+        ]
     },
     {
         "name": "tabo",
         "trans": [
+            "田(た)ぼ",
             "paddy field,farm"
-        ],
-        "notation": "田(た)ぼ"
+        ]
     },
     {
         "name": "chuujun",
         "trans": [
+            "中旬(ちゅうじゅん)",
             "second third of a month"
-        ],
-        "notation": "中旬(ちゅうじゅん)"
+        ]
     },
     {
         "name": "minaosu",
         "trans": [
+            "見直(みなお)す",
             "to look again,to get a better opinion of"
-        ],
-        "notation": "見直(みなお)す"
+        ]
     },
     {
         "name": "naisen",
         "trans": [
+            "内線(ないせん)",
             "phone extension,indoor wiring,inner line"
-        ],
-        "notation": "内線(ないせん)"
+        ]
     },
     {
         "name": "ukkari",
         "trans": [
+            "うっかり",
             "carelessly,thoughtlessly,inadvertently"
-        ],
-        "notation": "うっかり"
+        ]
     },
     {
         "name": "shinshin",
         "trans": [
+            "心身(しんしん)",
             "mind and body"
-        ],
-        "notation": "心身(しんしん)"
+        ]
     },
     {
         "name": "kouyou",
         "trans": [
+            "紅葉(こうよう)",
             "(1) (Japanese) maple"
-        ],
-        "notation": "紅葉(こうよう)"
+        ]
     },
     {
         "name": "sanrin",
         "trans": [
+            "山林(さんりん)",
             "mountain forest,mountains and forest"
-        ],
-        "notation": "山林(さんりん)"
+        ]
     },
     {
         "name": "taiboku",
         "trans": [
+            "大木(たいぼく)",
             "large tree"
-        ],
-        "notation": "大木(たいぼく)"
+        ]
     },
     {
         "name": "chuukan",
         "trans": [
+            "中間(ちゅうかん)",
             "middle,midway,interim"
-        ],
-        "notation": "中間(ちゅうかん)"
+        ]
     },
     {
         "name": "ensoku",
         "trans": [
+            "遠足(えんそく)",
             "trip,hike,picnic"
-        ],
-        "notation": "遠足(えんそく)"
+        ]
     },
     {
         "name": "hajimeni",
         "trans": [
+            "始(はじ)めに",
             "to begin with,first of all"
-        ],
-        "notation": "始(はじ)めに"
+        ]
     },
     {
         "name": "sakiototoi",
         "trans": [
+            "さきおととい",
             "two days before yesterday"
-        ],
-        "notation": "さきおととい"
+        ]
     },
     {
         "name": "zousen",
         "trans": [
+            "造船(ぞうせん)",
             "shipbuilding"
-        ],
-        "notation": "造船(ぞうせん)"
+        ]
     },
     {
         "name": "goudou",
         "trans": [
+            "合同(ごうどう)",
             "combination,incorporation,union,amalgamation"
-        ],
-        "notation": "合同(ごうどう)"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "挙(あ)げる",
             "to raise,to fly"
-        ],
-        "notation": "挙(あ)げる"
+        ]
     },
     {
         "name": "tegoro",
         "trans": [
+            "手頃(てごろ)",
             "moderate,handy"
-        ],
-        "notation": "手頃(てごろ)"
+        ]
     },
     {
         "name": "sanchi",
         "trans": [
+            "産地(さんち)",
             "producing area"
-        ],
-        "notation": "産地(さんち)"
+        ]
     },
     {
         "name": "sansei",
         "trans": [
+            "酸性(さんせい)",
             "acidity"
-        ],
-        "notation": "酸性(さんせい)"
+        ]
     },
     {
         "name": "yusou",
         "trans": [
+            "輸送(ゆそう)",
             "transport,transportation"
-        ],
-        "notation": "輸送(ゆそう)"
+        ]
     },
     {
         "name": "yakusho",
         "trans": [
+            "役所(やくしょ)",
             "government office,public office"
-        ],
-        "notation": "役所(やくしょ)"
+        ]
     },
     {
         "name": "tsuide",
         "trans": [
+            "ついで",
             "opportunity,occasion"
-        ],
-        "notation": "ついで"
+        ]
     },
     {
         "name": "jiban",
         "trans": [
+            "地盤(じばん)",
             "(the) ground"
-        ],
-        "notation": "地盤(じばん)"
+        ]
     },
     {
         "name": "kawaigaru",
         "trans": [
+            "かわいがる",
             "to love,to be affectionate"
-        ],
-        "notation": "かわいがる"
+        ]
     },
     {
         "name": "seimon",
         "trans": [
+            "正門(せいもん)",
             "main gate,main entrance"
-        ],
-        "notation": "正門(せいもん)"
+        ]
     },
     {
         "name": "nanishiro",
         "trans": [
+            "なにしろ",
             "at any rate,anyhow,anyway,in any case"
-        ],
-        "notation": "なにしろ"
+        ]
     },
     {
         "name": "omoikakenai",
         "trans": [
+            "思(おも)い掛(か)けない",
             "unexpected,casual"
-        ],
-        "notation": "思(おも)い掛(か)けない"
+        ]
     },
     {
         "name": "sashitsukae",
         "trans": [
+            "差(さ)し支(つか)え",
             "hindrance,impediment"
-        ],
-        "notation": "差(さ)し支(つか)え"
+        ]
     },
     {
         "name": "toujitsu",
         "trans": [
+            "当日(とうじつ)",
             "appointed day,very day"
-        ],
-        "notation": "当日(とうじつ)"
+        ]
     },
     {
         "name": "futsuu",
         "trans": [
+            "不通(ふつう)",
             "suspension,interruption,stoppage,tie-up,cessation"
-        ],
-        "notation": "不通(ふつう)"
+        ]
     },
     {
         "name": "nobori",
         "trans": [
+            "上(のぼ)り",
             "up-train (going to Tokyo),ascent"
-        ],
-        "notation": "上(のぼ)り"
+        ]
     },
     {
         "name": "keishiki",
         "trans": [
+            "形式(けいしき)",
             "form,formality,format,math expression"
-        ],
-        "notation": "形式(けいしき)"
+        ]
     },
     {
         "name": "shiritsu",
         "trans": [
+            "私立(しりつ)",
             "private (establishment)"
-        ],
-        "notation": "私立(しりつ)"
+        ]
     },
     {
         "name": "awatadashii",
         "trans": [
+            "あわただしい",
             "busy,hurried,confused,flurried"
-        ],
-        "notation": "あわただしい"
+        ]
     },
     {
         "name": "uuman",
         "trans": [
+            "ウーマン",
             "woman"
-        ],
-        "notation": "ウーマン"
+        ]
     },
     {
         "name": "zurui",
         "trans": [
+            "狡(ずる)い",
             "sly,cunning"
-        ],
-        "notation": "狡(ずる)い"
+        ]
     },
     {
         "name": "funabin",
         "trans": [
+            "船便(ふなびん)",
             "surface mail (ship)"
-        ],
-        "notation": "船便(ふなびん)"
+        ]
     },
     {
         "name": "purattohoumu",
         "trans": [
+            "プラットホーム",
             "platform"
-        ],
-        "notation": "プラットホーム"
+        ]
     },
     {
         "name": "shimijimi",
         "trans": [
+            "しみじみ",
             "keenly,deeply,heartily"
-        ],
-        "notation": "しみじみ"
+        ]
     },
     {
         "name": "mamonaku",
         "trans": [
+            "間(ま)も無(な)く",
             "soon,before long,in a short time"
-        ],
-        "notation": "間(ま)も無(な)く"
+        ]
     },
     {
         "name": "shouryaku",
         "trans": [
+            "省略(しょうりゃく)",
             "omission,abbreviation,abridgment"
-        ],
-        "notation": "省略(しょうりゃく)"
+        ]
     },
     {
         "name": "kuchibeni",
         "trans": [
+            "口紅(くちべに)",
             "lipstick"
-        ],
-        "notation": "口紅(くちべに)"
+        ]
     },
     {
         "name": "otonashii",
         "trans": [
+            "おとなしい",
             "obedient,docile,quiet"
-        ],
-        "notation": "おとなしい"
+        ]
     },
     {
         "name": "gakubu",
         "trans": [
+            "学部(がくぶ)",
             "department of a university,undergraduate"
-        ],
-        "notation": "学部(がくぶ)"
+        ]
     },
     {
         "name": "reberu",
         "trans": [
+            "レベル",
             "level"
-        ],
-        "notation": "レベル"
+        ]
     },
     {
         "name": "tsuuro",
         "trans": [
+            "通路(つうろ)",
             "passage,pathway"
-        ],
-        "notation": "通路(つうろ)"
+        ]
     },
     {
         "name": "uraguchi",
         "trans": [
+            "裏口(うらぐち)",
             "backdoor,rear entrance"
-        ],
-        "notation": "裏口(うらぐち)"
+        ]
     },
     {
         "name": "shihei",
         "trans": [
+            "紙幣(しへい)",
             "paper money,notes,bills"
-        ],
-        "notation": "紙幣(しへい)"
+        ]
     },
     {
         "name": "torikesu",
         "trans": [
+            "取(と)り消(け)す",
             "to cancel"
-        ],
-        "notation": "取(と)り消(け)す"
+        ]
     },
     {
         "name": "nanbei",
         "trans": [
+            "南米(なんべい)",
             "South America"
-        ],
-        "notation": "南米(なんべい)"
+        ]
     },
     {
         "name": "juutan",
         "trans": [
+            "じゅうたん",
             "carpet"
-        ],
-        "notation": "じゅうたん"
+        ]
     },
     {
         "name": "haeru",
         "trans": [
+            "生(は)える",
             "(1) to grow,to spring up,(2) to cut (teeth)"
-        ],
-        "notation": "生(は)える"
+        ]
     },
     {
         "name": "denchi",
         "trans": [
+            "電池(でんち)",
             "battery"
-        ],
-        "notation": "電池(でんち)"
+        ]
     },
     {
         "name": "renga",
         "trans": [
+            "煉瓦(れんが)",
             "brick"
-        ],
-        "notation": "煉瓦(れんが)"
+        ]
     },
     {
         "name": "monogataru",
         "trans": [
+            "物語(ものがた)る",
             "to tell,to indicate"
-        ],
-        "notation": "物語(ものがた)る"
+        ]
     },
     {
         "name": "benjo",
         "trans": [
+            "便所(べんじょ)",
             "toilet,lavatory,rest room,latrine,comfort station"
-        ],
-        "notation": "便所(べんじょ)"
+        ]
     },
     {
         "name": "bussou",
         "trans": [
+            "物騒(ぶっそう)",
             "dangerous,disturbed,insecure"
-        ],
-        "notation": "物騒(ぶっそう)"
+        ]
     },
     {
         "name": "shimekiri",
         "trans": [
+            "締切(しめきり)",
             "closing,cut-off,end,deadline,Closed,No Entrance"
-        ],
-        "notation": "締切(しめきり)"
+        ]
     },
     {
         "name": "saraigetsu",
         "trans": [
+            "再来月(さらいげつ)",
             "month after next"
-        ],
-        "notation": "再来月(さらいげつ)"
+        ]
     },
     {
         "name": "detarame",
         "trans": [
+            "でたらめ",
             "(1) irresponsible utterance,nonsense,nonsensical,(2) random"
-        ],
-        "notation": "でたらめ"
+        ]
     },
     {
         "name": "funka",
         "trans": [
+            "噴火(ふんか)",
             "eruption"
-        ],
-        "notation": "噴火(ふんか)"
+        ]
     },
     {
         "name": "hekomu",
         "trans": [
+            "凹(へこ)む",
             "to be dented,to be indented,to yield to,to give,to sink,to collapse,to cave in,to be snubbed"
-        ],
-        "notation": "凹(へこ)む"
+        ]
     },
     {
         "name": "netsusuru",
         "trans": [
+            "熱(ねつ)する",
             "to heat"
-        ],
-        "notation": "熱(ねつ)する"
+        ]
     },
     {
         "name": "isamashii",
         "trans": [
+            "勇(いさ)ましい",
             "brave,valiant,gallant,courageous"
-        ],
-        "notation": "勇(いさ)ましい"
+        ]
     },
     {
         "name": "tsuya",
         "trans": [
+            "艶(つや)",
             "gloss,glaze"
-        ],
-        "notation": "艶(つや)"
+        ]
     },
     {
         "name": "tekikaku",
         "trans": [
+            "的確(てきかく)",
             "precise,accurate"
-        ],
-        "notation": "的確(てきかく)"
+        ]
     },
     {
         "name": "ido",
         "trans": [
+            "緯度(いど)",
             "latitude (nav.)"
-        ],
-        "notation": "緯度(いど)"
+        ]
     },
     {
         "name": "mabushii",
         "trans": [
+            "まぶしい",
             "dazzling,radiant"
-        ],
-        "notation": "まぶしい"
+        ]
     },
     {
         "name": "junsa",
         "trans": [
+            "巡査(じゅんさ)",
             "police,policeman"
-        ],
-        "notation": "巡査(じゅんさ)"
+        ]
     },
     {
         "name": "yuuyuu",
         "trans": [
+            "悠々(ゆうゆう)",
             "quiet,calm,leisurely"
-        ],
-        "notation": "悠々(ゆうゆう)"
+        ]
     },
     {
         "name": "gairon",
         "trans": [
+            "概論(がいろん)",
             "intro,outline,general remarks"
-        ],
-        "notation": "概論(がいろん)"
+        ]
     },
     {
         "name": "monosugoi",
         "trans": [
+            "物凄(ものすご)い",
             "earth-shattering,staggering,to a very great extent"
-        ],
-        "notation": "物凄(ものすご)い"
+        ]
     },
     {
         "name": "fusai",
         "trans": [
+            "夫妻(ふさい)",
             "man and wife,married couple"
-        ],
-        "notation": "夫妻(ふさい)"
+        ]
     },
     {
         "name": "donaru",
         "trans": [
+            "どなる",
             "to shout,to yell"
-        ],
-        "notation": "どなる"
+        ]
     },
     {
         "name": "tokushu",
         "trans": [
+            "特殊(とくしゅ)",
             "special,unique"
-        ],
-        "notation": "特殊(とくしゅ)"
+        ]
     },
     {
         "name": "naosu",
         "trans": [
+            "治(なお)す",
             "to cure,to heal,to fix,to correct,to repair"
-        ],
-        "notation": "治(なお)す"
+        ]
     },
     {
         "name": "koboreru",
         "trans": [
+            "こぼれる",
             "to overflow,to spill"
-        ],
-        "notation": "こぼれる"
+        ]
     },
     {
         "name": "maisuu",
         "trans": [
+            "枚数(まいすう)",
             "the number of flat things"
-        ],
-        "notation": "枚数(まいすう)"
+        ]
     },
     {
         "name": "igi",
         "trans": [
+            "意義(いぎ)",
             "meaning,significance"
-        ],
-        "notation": "意義(いぎ)"
+        ]
     },
     {
         "name": "pitari",
         "trans": [
+            "ぴたり",
             ""
-        ],
-        "notation": "ぴたり"
+        ]
     },
     {
         "name": "amimono",
         "trans": [
+            "編物(あみもの)",
             "knitting,web"
-        ],
-        "notation": "編物(あみもの)"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "回答(かいとう)",
             "reply,answer"
-        ],
-        "notation": "回答(かいとう)"
+        ]
     },
     {
         "name": "saakuru",
         "trans": [
+            "サークル",
             "circle,sports club (i.e. at a company)"
-        ],
-        "notation": "サークル"
+        ]
     },
     {
         "name": "sukaafu",
         "trans": [
+            "スカーフ",
             "scarf"
-        ],
-        "notation": "スカーフ"
+        ]
     },
     {
         "name": "biniiru",
         "trans": [
+            "ビニール",
             "vinyl"
-        ],
-        "notation": "ビニール"
+        ]
     },
     {
         "name": "miokuru",
         "trans": [
+            "見送(みおく)る",
             "(1) to see off,to farewell,(2) to escort,(3) to let pass"
-        ],
-        "notation": "見送(みおく)る"
+        ]
     },
     {
         "name": "musata",
         "trans": [
+            "無(む)沙汰(さた)",
             "neglecting to stay in contact"
-        ],
-        "notation": "無(む)沙汰(さた)"
+        ]
     },
     {
         "name": "nibui",
         "trans": [
+            "鈍(にぶ)い",
             "dull (e.g. a knife),thickheaded,slow (opposite of fast),stupid"
-        ],
-        "notation": "鈍(にぶ)い"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "遭(あ)う",
             "to meet,to encounter (undesirable nuance)"
-        ],
-        "notation": "遭(あ)う"
+        ]
     },
     {
         "name": "eiwa",
         "trans": [
+            "英和(えいわ)",
             "English-Japanese (e.g. dictionary)"
-        ],
-        "notation": "英和(えいわ)"
+        ]
     },
     {
         "name": "tatoeru",
         "trans": [
+            "例(たと)える",
             "to compare,to liken,to speak figuratively,to illustrate,to use a simile"
-        ],
-        "notation": "例(たと)える"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "上(のぼ)る",
             "to ascend,to go up,to climb"
-        ],
-        "notation": "上(のぼ)る"
+        ]
     },
     {
         "name": "gomi",
         "trans": [
+            "塵芥(ごみ)",
             "trash,rubbish"
-        ],
-        "notation": "塵芥(ごみ)"
+        ]
     },
     {
         "name": "soutto",
         "trans": [
+            "そうっと",
             ""
-        ],
-        "notation": "そうっと"
+        ]
     },
     {
         "name": "miru",
         "trans": [
+            "診(み)る",
             "to examine (medical)"
-        ],
-        "notation": "診(み)る"
+        ]
     },
     {
         "name": "sesseto",
         "trans": [
+            "せっせと",
             ""
-        ],
-        "notation": "せっせと"
+        ]
     },
     {
         "name": "fukin",
         "trans": [
+            "付近(ふきん)",
             "neighbourhood,vicinity,environs"
-        ],
-        "notation": "付近(ふきん)"
+        ]
     },
     {
         "name": "pataan",
         "trans": [
+            "パターン",
             "pattern"
-        ],
-        "notation": "パターン"
+        ]
     },
     {
         "name": "hajimeni",
         "trans": [
+            "初(はじ)めに",
             ""
-        ],
-        "notation": "初(はじ)めに"
+        ]
     },
     {
         "name": "puroguramu",
         "trans": [
+            "プログラム",
             "program"
-        ],
-        "notation": "プログラム"
+        ]
     },
     {
         "name": "denkyuu",
         "trans": [
+            "電球(でんきゅう)",
             "light bulb"
-        ],
-        "notation": "電球(でんきゅう)"
+        ]
     },
     {
         "name": "hiyasu",
         "trans": [
+            "冷(ひ)やす",
             "to cool,to refrigerate"
-        ],
-        "notation": "冷(ひ)やす"
+        ]
     },
     {
         "name": "moderu",
         "trans": [
+            "モデル",
             "model"
-        ],
-        "notation": "モデル"
+        ]
     },
     {
         "name": "sotsutadashi",
         "trans": [
+            "卒(そつ)直(ただし)",
             "frankness,candour,openheartedness"
-        ],
-        "notation": "卒(そつ)直(ただし)"
+        ]
     },
     {
         "name": "hedateru",
         "trans": [
+            "隔(へだ)てる",
             "to be shut out"
-        ],
-        "notation": "隔(へだ)てる"
+        ]
     },
     {
         "name": "soru",
         "trans": [
+            "剃(そ)る",
             "to shave"
-        ],
-        "notation": "剃(そ)る"
+        ]
     },
     {
         "name": "keido",
         "trans": [
+            "経度(けいど)",
             "longitude"
-        ],
-        "notation": "経度(けいど)"
+        ]
     },
     {
         "name": "majiru",
         "trans": [
+            "交(ま)じる",
             "to be mixed,to be blended with,to associate with"
-        ],
-        "notation": "交(ま)じる"
+        ]
     },
     {
         "name": "uketori",
         "trans": [
+            "受取(うけとり)",
             "receipt"
-        ],
-        "notation": "受取(うけとり)"
+        ]
     },
     {
         "name": "chousei",
         "trans": [
+            "調整(ちょうせい)",
             "regulation,adjustment,tuning"
-        ],
-        "notation": "調整(ちょうせい)"
+        ]
     },
     {
         "name": "kaisan",
         "trans": [
+            "解散(かいさん)",
             "breakup,dissolution"
-        ],
-        "notation": "解散(かいさん)"
+        ]
     },
     {
         "name": "sukikirai",
         "trans": [
+            "好(すき)き嫌(ら)い",
             "likes and dislikes,taste"
-        ],
-        "notation": "好(すき)き嫌(ら)い"
+        ]
     },
     {
         "name": "butsukeru",
         "trans": [
+            "ぶつける",
             "to knock,to run into,to nail on,to strike hard,to hit and attack"
-        ],
-        "notation": "ぶつける"
+        ]
     },
     {
         "name": "heiya",
         "trans": [
+            "平野(へいや)",
             "plain,open field"
-        ],
-        "notation": "平野(へいや)"
+        ]
     },
     {
         "name": "taishou",
         "trans": [
+            "対照(たいしょう)",
             "contrast,antithesis,comparison"
-        ],
-        "notation": "対照(たいしょう)"
+        ]
     },
     {
         "name": "mazeru",
         "trans": [
+            "混(ま)ぜる",
             "to mix,to stir"
-        ],
-        "notation": "混(ま)ぜる"
+        ]
     },
     {
         "name": "shouhin",
         "trans": [
+            "賞品(しょうひん)",
             "prize,trophy"
-        ],
-        "notation": "賞品(しょうひん)"
+        ]
     },
     {
         "name": "kanchigai",
         "trans": [
+            "勘違(かんちが)い",
             "misunderstanding,wrong guess"
-        ],
-        "notation": "勘違(かんちが)い"
+        ]
     },
     {
         "name": "shuuhen",
         "trans": [
+            "周辺(しゅうへん)",
             "circumference,outskirts,environs,(computer) peripheral"
-        ],
-        "notation": "周辺(しゅうへん)"
+        ]
     },
     {
         "name": "kansoku",
         "trans": [
+            "観測(かんそく)",
             "observation"
-        ],
-        "notation": "観測(かんそく)"
+        ]
     },
     {
         "name": "rokuon",
         "trans": [
+            "録音(ろくおん)",
             "(audio) recording"
-        ],
-        "notation": "録音(ろくおん)"
+        ]
     },
     {
         "name": "sorenanoni",
         "trans": [
+            "それなのに",
             ""
-        ],
-        "notation": "それなのに"
+        ]
     },
     {
         "name": "daiyamondo",
         "trans": [
+            "ダイヤモンド",
             "diamond"
-        ],
-        "notation": "ダイヤモンド"
+        ]
     },
     {
         "name": "kubaru",
         "trans": [
+            "配(くば)る",
             "to distribute,to deliver"
-        ],
-        "notation": "配(くば)る"
+        ]
     },
     {
         "name": "teppou",
         "trans": [
+            "鉄砲(てっぽう)",
             "gun"
-        ],
-        "notation": "鉄砲(てっぽう)"
+        ]
     },
     {
         "name": "kyakuma",
         "trans": [
+            "客間(きゃくま)",
             "parlor,guest room"
-        ],
-        "notation": "客間(きゃくま)"
+        ]
     },
     {
         "name": "nouritsu",
         "trans": [
+            "能率(のうりつ)",
             "efficiency"
-        ],
-        "notation": "能率(のうりつ)"
+        ]
     },
     {
         "name": "suiheisen",
         "trans": [
+            "水平(すいへい)線(せん)",
             "horizon"
-        ],
-        "notation": "水平(すいへい)線(せん)"
+        ]
     },
     {
         "name": "wakaru",
         "trans": [
+            "分(わか)る",
             "to be understood"
-        ],
-        "notation": "分(わか)る"
+        ]
     },
     {
         "name": "fuzoku",
         "trans": [
+            "附属(ふぞく)",
             "attached,belonging,affiliated"
-        ],
-        "notation": "附属(ふぞく)"
+        ]
     },
     {
         "name": "hajimemashite",
         "trans": [
+            "はじめまして",
             "How do you do?,I am glad to meet you"
-        ],
-        "notation": "はじめまして"
+        ]
     },
     {
         "name": "youchi",
         "trans": [
+            "幼稚(ようち)",
             "infancy,childish,infantile"
-        ],
-        "notation": "幼稚(ようち)"
+        ]
     },
     {
         "name": "bushu",
         "trans": [
+            "部首(ぶしゅ)",
             "radical (of a kanji character)"
-        ],
-        "notation": "部首(ぶしゅ)"
+        ]
     },
     {
         "name": "shoppu",
         "trans": [
+            "ショップ",
             "a shop"
-        ],
-        "notation": "ショップ"
+        ]
     },
     {
         "name": "marui",
         "trans": [
+            "円(まる)い",
             "round,circular,spherical"
-        ],
-        "notation": "円(まる)い"
+        ]
     },
     {
         "name": "hikki",
         "trans": [
+            "筆記(ひっき)",
             "(taking) notes,copying"
-        ],
-        "notation": "筆記(ひっき)"
+        ]
     },
     {
         "name": "kashitsu",
         "trans": [
+            "過失(かしつ)",
             "error,blunder,accident"
-        ],
-        "notation": "過失(かしつ)"
+        ]
     },
     {
         "name": "tsunageru",
         "trans": [
+            "繋(つな)げる",
             "to connect"
-        ],
-        "notation": "繋(つな)げる"
+        ]
     },
     {
         "name": "banzai",
         "trans": [
+            "万歳(ばんざい)",
             "hurrah, cheers"
-        ],
-        "notation": "万歳(ばんざい)"
+        ]
     },
     {
         "name": "kemui",
         "trans": [
+            "煙(けむ)い",
             "smoky"
-        ],
-        "notation": "煙(けむ)い"
+        ]
     },
     {
         "name": "gamu",
         "trans": [
+            "ガム",
             "chewing gum"
-        ],
-        "notation": "ガム"
+        ]
     },
     {
         "name": "odekake",
         "trans": [
+            "お出掛(でか)け",
             ""
-        ],
-        "notation": "お出掛(でか)け"
+        ]
     },
     {
         "name": "baibai",
         "trans": [
+            "バイバイ",
             ""
-        ],
-        "notation": "バイバイ"
+        ]
     },
     {
         "name": "enkai",
         "trans": [
+            "宴会(えんかい)",
             "party,banquet"
-        ],
-        "notation": "宴会(えんかい)"
+        ]
     },
     {
         "name": "fuwafuwa",
         "trans": [
+            "ふわふわ",
             "light,soft"
-        ],
-        "notation": "ふわふわ"
+        ]
     },
     {
         "name": "zabuton",
         "trans": [
+            "座布団(ざぶとん)",
             "cushion (Japanese)"
-        ],
-        "notation": "座布団(ざぶとん)"
+        ]
     },
     {
         "name": "koshou",
         "trans": [
+            "胡椒(こしょう)",
             "pepper"
-        ],
-        "notation": "胡椒(こしょう)"
+        ]
     },
     {
         "name": "teiden",
         "trans": [
+            "停電(ていでん)",
             "failure of electricity"
-        ],
-        "notation": "停電(ていでん)"
+        ]
     },
     {
         "name": "chairoi",
         "trans": [
+            "茶色(ちゃいろ)い",
             ""
-        ],
-        "notation": "茶色(ちゃいろ)い"
+        ]
     },
     {
         "name": "akanbou",
         "trans": [
+            "あかんぼう",
             "baby"
-        ],
-        "notation": "あかんぼう"
+        ]
     },
     {
         "name": "seisou",
         "trans": [
+            "清掃(せいそう)",
             "cleaning"
-        ],
-        "notation": "清掃(せいそう)"
+        ]
     },
     {
         "name": "kaisatsu",
         "trans": [
+            "改札(かいさつ)",
             "examination of tickets"
-        ],
-        "notation": "改札(かいさつ)"
+        ]
     },
     {
         "name": "atatamaru",
         "trans": [
+            "暖(あたた)まる",
             "to warm up,to get warm"
-        ],
-        "notation": "暖(あたた)まる"
+        ]
     },
     {
         "name": "kogeru",
         "trans": [
+            "焦(こ)げる",
             "to burn,to be burned"
-        ],
-        "notation": "焦(こ)げる"
+        ]
     },
     {
         "name": "suisan",
         "trans": [
+            "水産(すいさん)",
             "marine products,fisheries"
-        ],
-        "notation": "水産(すいさん)"
+        ]
     },
     {
         "name": "ueki",
         "trans": [
+            "植木(うえき)",
             "garden shrubs,trees,potted plant"
-        ],
-        "notation": "植木(うえき)"
+        ]
     },
     {
         "name": "tenugui",
         "trans": [
+            "手拭(てぬぐ)い",
             "(hand) towel"
-        ],
-        "notation": "手拭(てぬぐ)い"
+        ]
     },
     {
         "name": "midashi",
         "trans": [
+            "見出(みだ)し",
             "heading,caption,subtitle,index"
-        ],
-        "notation": "見出(みだ)し"
+        ]
     },
     {
         "name": "jinzou",
         "trans": [
+            "人造(じんぞう)",
             "man-made,synthetic,artificial"
-        ],
-        "notation": "人造(じんぞう)"
+        ]
     },
     {
         "name": "kakuchou",
         "trans": [
+            "拡張(かくちょう)",
             "expansion,extension,enlargement,escape (ESC)"
-        ],
-        "notation": "拡張(かくちょう)"
+        ]
     },
     {
         "name": "sonotame",
         "trans": [
+            "そのため",
             "hence,for that reason"
-        ],
-        "notation": "そのため"
+        ]
     },
     {
         "name": "seihoukei",
         "trans": [
+            "正方形(せいほうけい)",
             "square"
-        ],
-        "notation": "正方形(せいほうけい)"
+        ]
     }
 ]

--- a/assets/dicts/JapVocabList.N3.json
+++ b/assets/dicts/JapVocabList.N3.json
@@ -2,12811 +2,12811 @@
     {
         "name": "tsugitsugi",
         "trans": [
+            "次々(つぎつぎ)",
             "in succession,one by one"
-        ],
-        "notation": "次々(つぎつぎ)"
+        ]
     },
     {
         "name": "kakomu",
         "trans": [
+            "囲(かこ)む",
             "to surround,to encircle"
-        ],
-        "notation": "囲(かこ)む"
+        ]
     },
     {
         "name": "kouhei",
         "trans": [
+            "公平(こうへい)",
             "fairness,impartial,justice"
-        ],
-        "notation": "公平(こうへい)"
+        ]
     },
     {
         "name": "happyou",
         "trans": [
+            "発表(はっぴょう)",
             "announcement,publication"
-        ],
-        "notation": "発表(はっぴょう)"
+        ]
     },
     {
         "name": "nichiyou",
         "trans": [
+            "日曜(にちよう)",
             "Sunday"
-        ],
-        "notation": "日曜(にちよう)"
+        ]
     },
     {
         "name": "hyou",
         "trans": [
+            "表(ひょう)",
             "table (e.g. Tab 1),chart,list"
-        ],
-        "notation": "表(ひょう)"
+        ]
     },
     {
         "name": "shougo",
         "trans": [
+            "正午(しょうご)",
             "noon,mid-day"
-        ],
-        "notation": "正午(しょうご)"
+        ]
     },
     {
         "name": "kyoukasho",
         "trans": [
+            "教科書(きょうかしょ)",
             "text book"
-        ],
-        "notation": "教科書(きょうかしょ)"
+        ]
     },
     {
         "name": "oka",
         "trans": [
+            "丘(おか)",
             "hill,height,knoll,rising ground"
-        ],
-        "notation": "丘(おか)"
+        ]
     },
     {
         "name": "shurui",
         "trans": [
+            "種類(しゅるい)",
             "variety,kind,type"
-        ],
-        "notation": "種類(しゅるい)"
+        ]
     },
     {
         "name": "bureeki",
         "trans": [
+            "ブレーキ",
             "a brake"
-        ],
-        "notation": "ブレーキ"
+        ]
     },
     {
         "name": "hakken",
         "trans": [
+            "発見(はっけん)",
             "discovery,detection,finding"
-        ],
-        "notation": "発見(はっけん)"
+        ]
     },
     {
         "name": "meshi",
         "trans": [
+            "飯(めし)",
             "(sl) meals,food"
-        ],
-        "notation": "飯(めし)"
+        ]
     },
     {
         "name": "hakkou",
         "trans": [
+            "発行(はっこう)",
             "issue (publications)"
-        ],
-        "notation": "発行(はっこう)"
+        ]
     },
     {
         "name": "wazato",
         "trans": [
+            "わざと",
             "on purpose"
-        ],
-        "notation": "わざと"
+        ]
     },
     {
         "name": "juutai",
         "trans": [
+            "渋滞(じゅうたい)",
             "congestion (e.g. traffic),delay,stagnation"
-        ],
-        "notation": "渋滞(じゅうたい)"
+        ]
     },
     {
         "name": "fune",
         "trans": [
+            "船(ふね)",
             "ship,boat,watercraft,shipping,vessel,steamship"
-        ],
-        "notation": "船(ふね)"
+        ]
     },
     {
         "name": "ue",
         "trans": [
+            "上(うえ)",
             "(1) first volume,(2) superior quality,(3) governmental"
-        ],
-        "notation": "上(うえ)"
+        ]
     },
     {
         "name": "senjitsu",
         "trans": [
+            "先日(せんじつ)",
             "the other day,a few days ago"
-        ],
-        "notation": "先日(せんじつ)"
+        ]
     },
     {
         "name": "honmono",
         "trans": [
+            "本物(ほんもの)",
             "genuine article"
-        ],
-        "notation": "本物(ほんもの)"
+        ]
     },
     {
         "name": "arawareru",
         "trans": [
+            "現(あらわ)れる",
             "(1) to appear,to come in sight,to become visible,(2) to express oneself"
-        ],
-        "notation": "現(あらわ)れる"
+        ]
     },
     {
         "name": "musubu",
         "trans": [
+            "結(むす)ぶ",
             "to tie,to bind,to link"
-        ],
-        "notation": "結(むす)ぶ"
+        ]
     },
     {
         "name": "koibito",
         "trans": [
+            "恋人(こいびと)",
             "lover,sweetheart"
-        ],
-        "notation": "恋人(こいびと)"
+        ]
     },
     {
         "name": "katsuyou",
         "trans": [
+            "活用(かつよう)",
             "conjugation,practical use"
-        ],
-        "notation": "活用(かつよう)"
+        ]
     },
     {
         "name": "chi",
         "trans": [
+            "地(ち)",
             "earth"
-        ],
-        "notation": "地(ち)"
+        ]
     },
     {
         "name": "uchuu",
         "trans": [
+            "宇宙(うちゅう)",
             "universe,cosmos,space"
-        ],
-        "notation": "宇宙(うちゅう)"
+        ]
     },
     {
         "name": "raitaa",
         "trans": [
+            "ライター",
             "lighter,rider,writer"
-        ],
-        "notation": "ライター"
+        ]
     },
     {
         "name": "shouhi",
         "trans": [
+            "消費(しょうひ)",
             "consumption,expenditure"
-        ],
-        "notation": "消費(しょうひ)"
+        ]
     },
     {
         "name": "seijin",
         "trans": [
+            "成人(せいじん)",
             "adult"
-        ],
-        "notation": "成人(せいじん)"
+        ]
     },
     {
         "name": "kamoku",
         "trans": [
+            "科目(かもく)",
             "(school) subject,curriculum,course"
-        ],
-        "notation": "科目(かもく)"
+        ]
     },
     {
         "name": "oitsuku",
         "trans": [
+            "追(お)い付(つ)く",
             "to overtake,to catch up (with)"
-        ],
-        "notation": "追(お)い付(つ)く"
+        ]
     },
     {
         "name": "kyuukei",
         "trans": [
+            "休憩(きゅうけい)",
             "rest,break,recess,intermission"
-        ],
-        "notation": "休憩(きゅうけい)"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "基(もと)",
             "basis"
-        ],
-        "notation": "基(もと)"
+        ]
     },
     {
         "name": "tobidasu",
         "trans": [
+            "飛(と)び出(だ)す",
             "to jump out,to rush out,to fly out"
-        ],
-        "notation": "飛(と)び出(だ)す"
+        ]
     },
     {
         "name": "me",
         "trans": [
+            "芽(め)",
             "sprout"
-        ],
-        "notation": "芽(め)"
+        ]
     },
     {
         "name": "make",
         "trans": [
+            "負(ま)け",
             "defeat,loss,losing (a game)"
-        ],
-        "notation": "負(ま)け"
+        ]
     },
     {
         "name": "buji",
         "trans": [
+            "無事(ぶじ)",
             "safety,peace,quietness"
-        ],
-        "notation": "無事(ぶじ)"
+        ]
     },
     {
         "name": "kaikei",
         "trans": [
+            "会計(かいけい)",
             "account,finance,accountant"
-        ],
-        "notation": "会計(かいけい)"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "最(もっと)も",
             "most,extremely"
-        ],
-        "notation": "最(もっと)も"
+        ]
     },
     {
         "name": "kousei",
         "trans": [
+            "構成(こうせい)",
             "organization,composition"
-        ],
-        "notation": "構成(こうせい)"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "県(けん)",
             "prefecture"
-        ],
-        "notation": "県(けん)"
+        ]
     },
     {
         "name": "shoutai",
         "trans": [
+            "招待(しょうたい)",
             "invitation"
-        ],
-        "notation": "招待(しょうたい)"
+        ]
     },
     {
         "name": "sara",
         "trans": [
+            "皿(さら)",
             "plate,dish"
-        ],
-        "notation": "皿(さら)"
+        ]
     },
     {
         "name": "shouchi",
         "trans": [
+            "承知(しょうち)",
             "consent,acceptance,assent,admitting"
-        ],
-        "notation": "承知(しょうち)"
+        ]
     },
     {
         "name": "kinko",
         "trans": [
+            "金庫(きんこ)",
             "safe,vault,treasury,provider of funds"
-        ],
-        "notation": "金庫(きんこ)"
+        ]
     },
     {
         "name": "eikyou",
         "trans": [
+            "影響(えいきょう)",
             "influence,effect"
-        ],
-        "notation": "影響(えいきょう)"
+        ]
     },
     {
         "name": "katagata",
         "trans": [
+            "方々(かたがた)",
             "persons,this and that,here and there,everywhere"
-        ],
-        "notation": "方々(かたがた)"
+        ]
     },
     {
         "name": "menkyo",
         "trans": [
+            "免許(めんきょ)",
             "license,permit,licence,certificate"
-        ],
-        "notation": "免許(めんきょ)"
+        ]
     },
     {
         "name": "tantou",
         "trans": [
+            "担当(たんとう)",
             "(in) charge"
-        ],
-        "notation": "担当(たんとう)"
+        ]
     },
     {
         "name": "sumimasen",
         "trans": [
+            "すみません",
             "sorry,excuse me"
-        ],
-        "notation": "すみません"
+        ]
     },
     {
         "name": "ita",
         "trans": [
+            "板(いた)",
             "board,plank"
-        ],
-        "notation": "板(いた)"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "撃(う)つ",
             "to attack,to defeat,to destroy"
-        ],
-        "notation": "撃(う)つ"
+        ]
     },
     {
         "name": "yonaka",
         "trans": [
+            "夜中(よなか)",
             "midnight,dead of night"
-        ],
-        "notation": "夜中(よなか)"
+        ]
     },
     {
         "name": "sabaku",
         "trans": [
+            "砂漠(さばく)",
             "desert"
-        ],
-        "notation": "砂漠(さばく)"
+        ]
     },
     {
         "name": "nioi",
         "trans": [
+            "匂(にお)い",
             "odour,scent,smell,stench"
-        ],
-        "notation": "匂(にお)い"
+        ]
     },
     {
         "name": "supiichi",
         "trans": [
+            "スピーチ",
             "speech"
-        ],
-        "notation": "スピーチ"
+        ]
     },
     {
         "name": "meikaku",
         "trans": [
+            "明確(めいかく)",
             "clear up,clarify,define"
-        ],
-        "notation": "明確(めいかく)"
+        ]
     },
     {
         "name": "shinsatsu",
         "trans": [
+            "診察(しんさつ)",
             "medical examination"
-        ],
-        "notation": "診察(しんさつ)"
+        ]
     },
     {
         "name": "sawagi",
         "trans": [
+            "騒(さわ)ぎ",
             "uproar,disturbance"
-        ],
-        "notation": "騒(さわ)ぎ"
+        ]
     },
     {
         "name": "chuushi",
         "trans": [
+            "中止(ちゅうし)",
             "suspension,stoppage,discontinuance,interruption"
-        ],
-        "notation": "中止(ちゅうし)"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "時期(じき)",
             "time,season,period"
-        ],
-        "notation": "時期(じき)"
+        ]
     },
     {
         "name": "seikaku",
         "trans": [
+            "性格(せいかく)",
             "character,personality"
-        ],
-        "notation": "性格(せいかく)"
+        ]
     },
     {
         "name": "chokin",
         "trans": [
+            "貯金(ちょきん)",
             "(bank) savings"
-        ],
-        "notation": "貯金(ちょきん)"
+        ]
     },
     {
         "name": "oshaberi",
         "trans": [
+            "おしゃべり",
             "chattering,talk,idle talk"
-        ],
-        "notation": "おしゃべり"
+        ]
     },
     {
         "name": "aisuru",
         "trans": [
+            "愛(あい)する",
             "to love"
-        ],
-        "notation": "愛(あい)する"
+        ]
     },
     {
         "name": "shougai",
         "trans": [
+            "障害(しょうがい)",
             "obstacle,impediment (fault),damage"
-        ],
-        "notation": "障害(しょうがい)"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "素(もと)",
             "prime"
-        ],
-        "notation": "素(もと)"
+        ]
     },
     {
         "name": "tsuugaku",
         "trans": [
+            "通学(つうがく)",
             "commuting to school"
-        ],
-        "notation": "通学(つうがく)"
+        ]
     },
     {
         "name": "azukeru",
         "trans": [
+            "預(あづ)ける",
             "to give into custody,to entrust,to deposit"
-        ],
-        "notation": "預(あづ)ける"
+        ]
     },
     {
         "name": "keikaku",
         "trans": [
+            "計画(けいかく)",
             "plan,project,schedule,scheme,program"
-        ],
-        "notation": "計画(けいかく)"
+        ]
     },
     {
         "name": "kyuujo",
         "trans": [
+            "救助(きゅうじょ)",
             "relief,aid,rescue"
-        ],
-        "notation": "救助(きゅうじょ)"
+        ]
     },
     {
         "name": "sutairu",
         "trans": [
+            "スタイル",
             "style"
-        ],
-        "notation": "スタイル"
+        ]
     },
     {
         "name": "sa",
         "trans": [
+            "差(さ)",
             "difference,variation"
-        ],
-        "notation": "差(さ)"
+        ]
     },
     {
         "name": "kyanpu",
         "trans": [
+            "キャンプ",
             "camp"
-        ],
-        "notation": "キャンプ"
+        ]
     },
     {
         "name": "ou",
         "trans": [
+            "王(おう)",
             "king,ruler,sovereign,monarch"
-        ],
-        "notation": "王(おう)"
+        ]
     },
     {
         "name": "tabi",
         "trans": [
+            "旅(たび)",
             "travel,trip,journey"
-        ],
-        "notation": "旅(たび)"
+        ]
     },
     {
         "name": "muryou",
         "trans": [
+            "無料(むりょう)",
             "free,no charge"
-        ],
-        "notation": "無料(むりょう)"
+        ]
     },
     {
         "name": "kaiketsu",
         "trans": [
+            "解決(かいけつ)",
             "settlement,solution,resolution"
-        ],
-        "notation": "解決(かいけつ)"
+        ]
     },
     {
         "name": "shinyou",
         "trans": [
+            "信用(しんよう)",
             "confidence,dependence,credit,faith"
-        ],
-        "notation": "信用(しんよう)"
+        ]
     },
     {
         "name": "utagau",
         "trans": [
+            "疑(うたが)う",
             "to doubt,to distrust,to be suspicious of,to suspect"
-        ],
-        "notation": "疑(うたが)う"
+        ]
     },
     {
         "name": "tochi",
         "trans": [
+            "土地(とち)",
             "plot of land,lot,soil"
-        ],
-        "notation": "土地(とち)"
+        ]
     },
     {
         "name": "wan",
         "trans": [
+            "湾(わん)",
             "bay,gulf,inlet"
-        ],
-        "notation": "湾(わん)"
+        ]
     },
     {
         "name": "koi",
         "trans": [
+            "恋(こい)",
             "love,tender passion"
-        ],
-        "notation": "恋(こい)"
+        ]
     },
     {
         "name": "tokui",
         "trans": [
+            "得意(とくい)",
             "pride,triumph,prosperity"
-        ],
-        "notation": "得意(とくい)"
+        ]
     },
     {
         "name": "hyouka",
         "trans": [
+            "評価(ひょうか)",
             "valuation,estimation,assessment,evaluation"
-        ],
-        "notation": "評価(ひょうか)"
+        ]
     },
     {
         "name": "ronbun",
         "trans": [
+            "論文(ろんぶん)",
             "thesis,essay,treatise,paper"
-        ],
-        "notation": "論文(ろんぶん)"
+        ]
     },
     {
         "name": "hara",
         "trans": [
+            "腹(はら)",
             "abdomen,belly,stomach"
-        ],
-        "notation": "腹(はら)"
+        ]
     },
     {
         "name": "nijuu",
         "trans": [
+            "二(に)十(じゅう)",
             "20 years old,20th year"
-        ],
-        "notation": "二(に)十(じゅう)"
+        ]
     },
     {
         "name": "chuushin",
         "trans": [
+            "中心(ちゅうしん)",
             "center,core,heart,pivot,emphasis,balance"
-        ],
-        "notation": "中心(ちゅうしん)"
+        ]
     },
     {
         "name": "kettei",
         "trans": [
+            "決定(けってい)",
             "decision,determination"
-        ],
-        "notation": "決定(けってい)"
+        ]
     },
     {
         "name": "katsudou",
         "trans": [
+            "活動(かつどう)",
             "action,activity"
-        ],
-        "notation": "活動(かつどう)"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "来(き)",
             ",for (10 days),next (year)"
-        ],
-        "notation": "来(き)"
+        ]
     },
     {
         "name": "saabisu",
         "trans": [
+            "サービス",
             "(1) service,support system,(2) goods or services without charge"
-        ],
-        "notation": "サービス"
+        ]
     },
     {
         "name": "iryou",
         "trans": [
+            "医療(いりょう)",
             "medical care,medical treatment"
-        ],
-        "notation": "医療(いりょう)"
+        ]
     },
     {
         "name": "kanshin",
         "trans": [
+            "関心(かんしん)",
             "concern,interest"
-        ],
-        "notation": "関心(かんしん)"
+        ]
     },
     {
         "name": "mirai",
         "trans": [
+            "未来(みらい)",
             "future (life, tense)"
-        ],
-        "notation": "未来(みらい)"
+        ]
     },
     {
         "name": "hassha",
         "trans": [
+            "発車(はっしゃ)",
             "departure of a vehicle"
-        ],
-        "notation": "発車(はっしゃ)"
+        ]
     },
     {
         "name": "nattoku",
         "trans": [
+            "納得(なっとく)",
             "consent,assent,understanding"
-        ],
-        "notation": "納得(なっとく)"
+        ]
     },
     {
         "name": "kyuuni",
         "trans": [
+            "急(きゅう)に",
             ""
-        ],
-        "notation": "急(きゅう)に"
+        ]
     },
     {
         "name": "joudan",
         "trans": [
+            "冗談(じょうだん)",
             "jest,joke"
-        ],
-        "notation": "冗談(じょうだん)"
+        ]
     },
     {
         "name": "suku",
         "trans": [
+            "空(す)く",
             "(1) to open,to become empty,(2) to be less crowded"
-        ],
-        "notation": "空(す)く"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "昇(のぼ)る",
             "to arise,to ascend,to go up"
-        ],
-        "notation": "昇(のぼ)る"
+        ]
     },
     {
         "name": "zettai",
         "trans": [
+            "絶対(ぜったい)",
             "absolute,unconditional,absoluteness"
-        ],
-        "notation": "絶対(ぜったい)"
+        ]
     },
     {
         "name": "shizumu",
         "trans": [
+            "沈(しず)む",
             "to sink,to feel depressed"
-        ],
-        "notation": "沈(しず)む"
+        ]
     },
     {
         "name": "kizuku",
         "trans": [
+            "気付(きづ)く",
             "to notice,to recognize,to become aware of"
-        ],
-        "notation": "気付(きづ)く"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "文(ぶん)",
             "sentence"
-        ],
-        "notation": "文(ぶん)"
+        ]
     },
     {
         "name": "koukuu",
         "trans": [
+            "航空(こうくう)",
             "aviation,flying"
-        ],
-        "notation": "航空(こうくう)"
+        ]
     },
     {
         "name": "pin",
         "trans": [
+            "ピン",
             "pin"
-        ],
-        "notation": "ピン"
+        ]
     },
     {
         "name": "shigeki",
         "trans": [
+            "刺激(しげき)",
             "stimulus,impetus,incentive"
-        ],
-        "notation": "刺激(しげき)"
+        ]
     },
     {
         "name": "taiki",
         "trans": [
+            "大気(たいき)",
             "atmosphere"
-        ],
-        "notation": "大気(たいき)"
+        ]
     },
     {
         "name": "penki",
         "trans": [
+            "ペンキ",
             "(n) paint (nl: pek)"
-        ],
-        "notation": "ペンキ"
+        ]
     },
     {
         "name": "shingou",
         "trans": [
+            "信号(しんごう)",
             "traffic lights,signal,semaphore"
-        ],
-        "notation": "信号(しんごう)"
+        ]
     },
     {
         "name": "ketsuron",
         "trans": [
+            "結論(けつろん)",
             "conclusion"
-        ],
-        "notation": "結論(けつろん)"
+        ]
     },
     {
         "name": "yuubin",
         "trans": [
+            "郵便(ゆうびん)",
             "mail,postal service"
-        ],
-        "notation": "郵便(ゆうびん)"
+        ]
     },
     {
         "name": "benchi",
         "trans": [
+            "ベンチ",
             "bench"
-        ],
-        "notation": "ベンチ"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "履(は)く",
             "to wear,to put on (lower body)"
-        ],
-        "notation": "履(は)く"
+        ]
     },
     {
         "name": "mukeru",
         "trans": [
+            "向(む)ける",
             "to turn towards,to point"
-        ],
-        "notation": "向(む)ける"
+        ]
     },
     {
         "name": "junban",
         "trans": [
+            "順番(じゅんばん)",
             "turn (in line),order of things"
-        ],
-        "notation": "順番(じゅんばん)"
+        ]
     },
     {
         "name": "ukagau",
         "trans": [
+            "伺(うかが)う",
             "(hon) to visit,to ask,to inquire"
-        ],
-        "notation": "伺(うかが)う"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "替(か)える",
             "to exchange,to interchange,to substitute,to replace"
-        ],
-        "notation": "替(か)える"
+        ]
     },
     {
         "name": "insatsu",
         "trans": [
+            "印刷(いんさつ)",
             "printing"
-        ],
-        "notation": "印刷(いんさつ)"
+        ]
     },
     {
         "name": "shinchou",
         "trans": [
+            "身長(しんちょう)",
             "height (of body),stature"
-        ],
-        "notation": "身長(しんちょう)"
+        ]
     },
     {
         "name": "tora",
         "trans": [
+            "虎(とら)",
             "tiger"
-        ],
-        "notation": "虎(とら)"
+        ]
     },
     {
         "name": "shoumei",
         "trans": [
+            "証明(しょうめい)",
             "proof,verification"
-        ],
-        "notation": "証明(しょうめい)"
+        ]
     },
     {
         "name": "izumi",
         "trans": [
+            "泉(いずみ)",
             "spring,fountain"
-        ],
-        "notation": "泉(いずみ)"
+        ]
     },
     {
         "name": "keiji",
         "trans": [
+            "刑事(けいじ)",
             "criminal case,(police) detective"
-        ],
-        "notation": "刑事(けいじ)"
+        ]
     },
     {
         "name": "tsukamaru",
         "trans": [
+            "捕(つか)まる",
             "to be caught,to be arrested"
-        ],
-        "notation": "捕(つか)まる"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "振(ふ)る",
             "(1) to wave,to shake,to swing,(2) to sprinkle,(3) to cast (actor),to allocate (work)"
-        ],
-        "notation": "振(ふ)る"
+        ]
     },
     {
         "name": "shijin",
         "trans": [
+            "詩人(しじん)",
             "poet"
-        ],
-        "notation": "詩人(しじん)"
+        ]
     },
     {
         "name": "tanni",
         "trans": [
+            "単(たん)に",
             "simply,merely,only,solely"
-        ],
-        "notation": "単(たん)に"
+        ]
     },
     {
         "name": "guuzen",
         "trans": [
+            "偶然(ぐうぜん)",
             "(by) chance,unexpectedly,suddenly"
-        ],
-        "notation": "偶然(ぐうぜん)"
+        ]
     },
     {
         "name": "tenkou",
         "trans": [
+            "天候(てんこう)",
             "weather"
-        ],
-        "notation": "天候(てんこう)"
+        ]
     },
     {
         "name": "moji",
         "trans": [
+            "文字(もじ)",
             "letter (of alphabet),character"
-        ],
-        "notation": "文字(もじ)"
+        ]
     },
     {
         "name": "soko",
         "trans": [
+            "そこ",
             "bottom,sole"
-        ],
-        "notation": "そこ"
+        ]
     },
     {
         "name": "michiru",
         "trans": [
+            "満(み)ちる",
             "to be full,to rise (tide),to mature,to expire"
-        ],
-        "notation": "満(み)ちる"
+        ]
     },
     {
         "name": "tekisuru",
         "trans": [
+            "適(てき)する",
             "to fit,to suit"
-        ],
-        "notation": "適(てき)する"
+        ]
     },
     {
         "name": "bonyari",
         "trans": [
+            "ぼんやり",
             "absent-minded,block-head,dim,faint,vague"
-        ],
-        "notation": "ぼんやり"
+        ]
     },
     {
         "name": "shina",
         "trans": [
+            "品(しな)",
             "thing,article,goods,dignity,article (goods),counter for meal courses"
-        ],
-        "notation": "品(しな)"
+        ]
     },
     {
         "name": "meirei",
         "trans": [
+            "命令(めいれい)",
             "order,command,decree,directive,(software) instruction"
-        ],
-        "notation": "命令(めいれい)"
+        ]
     },
     {
         "name": "ku",
         "trans": [
+            "句(く)",
             "sentence"
-        ],
-        "notation": "句(く)"
+        ]
     },
     {
         "name": "zutsuu",
         "trans": [
+            "頭痛(ずつう)",
             "headache"
-        ],
-        "notation": "頭痛(ずつう)"
+        ]
     },
     {
         "name": "tadashi",
         "trans": [
+            "正(ただし)",
             "(logical) true,regular"
-        ],
-        "notation": "正(ただし)"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "券(けん)",
             "ticket,coupon,bond,certificate"
-        ],
-        "notation": "券(けん)"
+        ]
     },
     {
         "name": "sagyou",
         "trans": [
+            "作業(さぎょう)",
             "work,operation,manufacturing,fatigue duty"
-        ],
-        "notation": "作業(さぎょう)"
+        ]
     },
     {
         "name": "tsukiai",
         "trans": [
+            "付(つ)き合(あ)い",
             "association,socializing,fellowship"
-        ],
-        "notation": "付(つ)き合(あ)い"
+        ]
     },
     {
         "name": "tada",
         "trans": [
+            "唯(ただ)",
             "free of charge,mere,sole,only,usual,common"
-        ],
-        "notation": "唯(ただ)"
+        ]
     },
     {
         "name": "uso",
         "trans": [
+            "嘘(うそ)",
             "lie,falsehood,incorrect fact,inappropriate"
-        ],
-        "notation": "嘘(うそ)"
+        ]
     },
     {
         "name": "keshou",
         "trans": [
+            "化粧(けしょう)",
             "make-up (cosmetic)"
-        ],
-        "notation": "化粧(けしょう)"
+        ]
     },
     {
         "name": "songai",
         "trans": [
+            "損害(そんがい)",
             "damage,injury,loss"
-        ],
-        "notation": "損害(そんがい)"
+        ]
     },
     {
         "name": "goukaku",
         "trans": [
+            "合格(ごうかく)",
             "success,passing (e.g. exam),eligibility"
-        ],
-        "notation": "合格(ごうかく)"
+        ]
     },
     {
         "name": "bouken",
         "trans": [
+            "冒険(ぼうけん)",
             "risk,venture,adventure"
-        ],
-        "notation": "冒険(ぼうけん)"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "成(な)る",
             "to become"
-        ],
-        "notation": "成(な)る"
+        ]
     },
     {
         "name": "mu",
         "trans": [
+            "無(む)",
             "nothing,naught,nil,zero"
-        ],
-        "notation": "無(む)"
+        ]
     },
     {
         "name": "idou",
         "trans": [
+            "移動(いどう)",
             "removal,migration,movement"
-        ],
-        "notation": "移動(いどう)"
+        ]
     },
     {
         "name": "toosu",
         "trans": [
+            "通(とお)す",
             "to let pass,to overlook,to continue"
-        ],
-        "notation": "通(とお)す"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "尤(もっと)も",
             "quite right,plausible,natural,but then,although"
-        ],
-        "notation": "尤(もっと)も"
+        ]
     },
     {
         "name": "shinken",
         "trans": [
+            "真剣(しんけん)",
             "seriousness,earnestness"
-        ],
-        "notation": "真剣(しんけん)"
+        ]
     },
     {
         "name": "nana",
         "trans": [
+            "七(なな)",
             "seven"
-        ],
-        "notation": "七(なな)"
+        ]
     },
     {
         "name": "enryo",
         "trans": [
+            "遠慮(えんりょ)",
             "diffidence,restraint,reserve"
-        ],
-        "notation": "遠慮(えんりょ)"
+        ]
     },
     {
         "name": "tameshi",
         "trans": [
+            "試(ため)し",
             "trial,test"
-        ],
-        "notation": "試(ため)し"
+        ]
     },
     {
         "name": "shikamo",
         "trans": [
+            "しかも",
             "moreover,furthermore,nevertheless,and yet"
-        ],
-        "notation": "しかも"
+        ]
     },
     {
         "name": "noki",
         "trans": [
+            "軒(のき)",
             "eaves"
-        ],
-        "notation": "軒(のき)"
+        ]
     },
     {
         "name": "kyaputen",
         "trans": [
+            "キャプテン",
             "captain"
-        ],
-        "notation": "キャプテン"
+        ]
     },
     {
         "name": "kouchi",
         "trans": [
+            "コーチ",
             "coach"
-        ],
-        "notation": "コーチ"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "日(ひ)",
             "sun,sunshine,day"
-        ],
-        "notation": "日(ひ)"
+        ]
     },
     {
         "name": "katagata",
         "trans": [
+            "方々(かたがた)",
             "persons,this and that,here and there,everywhere"
-        ],
-        "notation": "方々(かたがた)"
+        ]
     },
     {
         "name": "itadaku",
         "trans": [
+            "頂(いただ)く",
             "to receive,to take food or drink (hum)"
-        ],
-        "notation": "頂(いただ)く"
+        ]
     },
     {
         "name": "konyaku",
         "trans": [
+            "婚約(こんやく)",
             "engagement,betrothal"
-        ],
-        "notation": "婚約(こんやく)"
+        ]
     },
     {
         "name": "odayaka",
         "trans": [
+            "穏(おだ)やか",
             "calm,gentle,quiet"
-        ],
-        "notation": "穏(おだ)やか"
+        ]
     },
     {
         "name": "saichuu",
         "trans": [
+            "最中(さいちゅう)",
             "in the middle of"
-        ],
-        "notation": "最中(さいちゅう)"
+        ]
     },
     {
         "name": "chanto",
         "trans": [
+            "ちゃんと",
             "perfectly,properly,exactly"
-        ],
-        "notation": "ちゃんと"
+        ]
     },
     {
         "name": "dokuritsu",
         "trans": [
+            "独立(どくりつ)",
             "independence (e.g. Ind. Day),self-support"
-        ],
-        "notation": "独立(どくりつ)"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "約(やく)",
             "approximately,about,some"
-        ],
-        "notation": "約(やく)"
+        ]
     },
     {
         "name": "kakaru",
         "trans": [
+            "掛(か)かる",
             "to take (e.g. time, money, etc),to hang"
-        ],
-        "notation": "掛(か)かる"
+        ]
     },
     {
         "name": "gutai",
         "trans": [
+            "具体(ぐたい)",
             "concrete,tangible,material"
-        ],
-        "notation": "具体(ぐたい)"
+        ]
     },
     {
         "name": "chon",
         "trans": [
+            "全(ちょん)",
             "all,whole,entire,complete,overall,pan"
-        ],
-        "notation": "全(ちょん)"
+        ]
     },
     {
         "name": "wain",
         "trans": [
+            "ワイン",
             "wine"
-        ],
-        "notation": "ワイン"
+        ]
     },
     {
         "name": "wazuka",
         "trans": [
+            "僅(わず)か",
             "only,merely,a little,small quantity"
-        ],
-        "notation": "僅(わず)か"
+        ]
     },
     {
         "name": "sutaa",
         "trans": [
+            "スター",
             "star"
-        ],
-        "notation": "スター"
+        ]
     },
     {
         "name": "sotto",
         "trans": [
+            "そっと",
             "face of the earth"
-        ],
-        "notation": "そっと"
+        ]
     },
     {
         "name": "kanou",
         "trans": [
+            "可能(かのう)",
             "possible,practicable,feasible"
-        ],
-        "notation": "可能(かのう)"
+        ]
     },
     {
         "name": "toppu",
         "trans": [
+            "トップ",
             "top"
-        ],
-        "notation": "トップ"
+        ]
     },
     {
         "name": "hasan",
         "trans": [
+            "破産(はさん)",
             "(personal) bankruptcy"
-        ],
-        "notation": "破産(はさん)"
+        ]
     },
     {
         "name": "katana",
         "trans": [
+            "刀(かたな)",
             "sword,saber,knife,engraving tool"
-        ],
-        "notation": "刀(かたな)"
+        ]
     },
     {
         "name": "kyouryoku",
         "trans": [
+            "強力(きょうりょく)",
             "herculean strength,mountain carrier-guide"
-        ],
-        "notation": "強力(きょうりょく)"
+        ]
     },
     {
         "name": "kagi",
         "trans": [
+            "鍵(かぎ)",
             "key"
-        ],
-        "notation": "鍵(かぎ)"
+        ]
     },
     {
         "name": "shokuhin",
         "trans": [
+            "食品(しょくひん)",
             "commodity,foodstuff"
-        ],
-        "notation": "食品(しょくひん)"
+        ]
     },
     {
         "name": "chuusha",
         "trans": [
+            "駐車(ちゅうしゃ)",
             "parking (e.g. car)"
-        ],
-        "notation": "駐車(ちゅうしゃ)"
+        ]
     },
     {
         "name": "ohiru",
         "trans": [
+            "お昼(ひる)",
             "lunch,noon"
-        ],
-        "notation": "お昼(ひる)"
+        ]
     },
     {
         "name": "tachiagaru",
         "trans": [
+            "立(た)ち上(あ)がる",
             "to stand up"
-        ],
-        "notation": "立(た)ち上(あ)がる"
+        ]
     },
     {
         "name": "touhyou",
         "trans": [
+            "投票(とうひょう)",
             "voting,poll"
-        ],
-        "notation": "投票(とうひょう)"
+        ]
     },
     {
         "name": "mori",
         "trans": [
+            "盛(も)り",
             "helping,serving"
-        ],
-        "notation": "盛(も)り"
+        ]
     },
     {
         "name": "joukyou",
         "trans": [
+            "状況(じょうきょう)",
             "state of affairs,situation,circumstances"
-        ],
-        "notation": "状況(じょうきょう)"
+        ]
     },
     {
         "name": "mokuteki",
         "trans": [
+            "目的(もくてき)",
             "purpose,goal,aim,objective,intention"
-        ],
-        "notation": "目的(もくてき)"
+        ]
     },
     {
         "name": "nawa",
         "trans": [
+            "縄(なわ)",
             "rope,hemp"
-        ],
-        "notation": "縄(なわ)"
+        ]
     },
     {
         "name": "goku",
         "trans": [
+            "極(ごく)",
             "quite,very"
-        ],
-        "notation": "極(ごく)"
+        ]
     },
     {
         "name": "gakusha",
         "trans": [
+            "学者(がくしゃ)",
             "scholar"
-        ],
-        "notation": "学者(がくしゃ)"
+        ]
     },
     {
         "name": "maneku",
         "trans": [
+            "招(まね)く",
             "to invite"
-        ],
-        "notation": "招(まね)く"
+        ]
     },
     {
         "name": "sentaku",
         "trans": [
+            "選択(せんたく)",
             "selection,choice"
-        ],
-        "notation": "選択(せんたく)"
+        ]
     },
     {
         "name": "kanryou",
         "trans": [
+            "完了(かんりょう)",
             "completion,conclusion"
-        ],
-        "notation": "完了(かんりょう)"
+        ]
     },
     {
         "name": "byou",
         "trans": [
+            "秒(びょう)",
             "second (60th min)"
-        ],
-        "notation": "秒(びょう)"
+        ]
     },
     {
         "name": "dokoka",
         "trans": [
+            "どこか",
             "somewhere,anywhere"
-        ],
-        "notation": "どこか"
+        ]
     },
     {
         "name": "auto",
         "trans": [
+            "アウト",
             "out"
-        ],
-        "notation": "アウト"
+        ]
     },
     {
         "name": "sokkuri",
         "trans": [
+            "そっくり",
             "all,altogether,entirely,be just like,the splitting image of"
-        ],
-        "notation": "そっくり"
+        ]
     },
     {
         "name": "hirogaru",
         "trans": [
+            "広(ひろ)がる",
             "to spread (out),to extend,to stretch,to reach to,to get around"
-        ],
-        "notation": "広(ひろ)がる"
+        ]
     },
     {
         "name": "sora",
         "trans": [
+            "空(そら)",
             "sky"
-        ],
-        "notation": "空(そら)"
+        ]
     },
     {
         "name": "shirushi",
         "trans": [
+            "印(しるし)",
             "(1) mark,(2) symbol,(3) evidence"
-        ],
-        "notation": "印(しるし)"
+        ]
     },
     {
         "name": "hisshi",
         "trans": [
+            "必死(ひっし)",
             "inevitable death,desperation,frantic,inevitable result"
-        ],
-        "notation": "必死(ひっし)"
+        ]
     },
     {
         "name": "ryougae",
         "trans": [
+            "両替(りょうがえ)",
             "change,money exchange"
-        ],
-        "notation": "両替(りょうがえ)"
+        ]
     },
     {
         "name": "kimu",
         "trans": [
+            "金(きむ)",
             "(1) gold,(2) gold general (shogi) (abbr)"
-        ],
-        "notation": "金(きむ)"
+        ]
     },
     {
         "name": "ninki",
         "trans": [
+            "人気(にんき)",
             "sign of life"
-        ],
-        "notation": "人気(にんき)"
+        ]
     },
     {
         "name": "noberu",
         "trans": [
+            "述(の)べる",
             "to state,to express,to mention"
-        ],
-        "notation": "述(の)べる"
+        ]
     },
     {
         "name": "hatake",
         "trans": [
+            "畑(はたけ)",
             "field"
-        ],
-        "notation": "畑(はたけ)"
+        ]
     },
     {
         "name": "kooru",
         "trans": [
+            "凍(こお)る",
             "to freeze,to be frozen over,to congeal"
-        ],
-        "notation": "凍(こお)る"
+        ]
     },
     {
         "name": "deau",
         "trans": [
+            "出会(であ)う",
             "to meet by chance,to come across,to happen to encounter"
-        ],
-        "notation": "出会(であ)う"
+        ]
     },
     {
         "name": "kurou",
         "trans": [
+            "苦労(くろう)",
             "troubles,hardships"
-        ],
-        "notation": "苦労(くろう)"
+        ]
     },
     {
         "name": "yukai",
         "trans": [
+            "愉快(ゆかい)",
             "pleasant,happy"
-        ],
-        "notation": "愉快(ゆかい)"
+        ]
     },
     {
         "name": "sake",
         "trans": [
+            "酒(さけ)",
             "alcohol,sake"
-        ],
-        "notation": "酒(さけ)"
+        ]
     },
     {
         "name": "tsuukou",
         "trans": [
+            "通行(つうこう)",
             "passage,passing"
-        ],
-        "notation": "通行(つうこう)"
+        ]
     },
     {
         "name": "shimatta",
         "trans": [
+            "仕舞(しま)った",
             "Damn it!"
-        ],
-        "notation": "仕舞(しま)った"
+        ]
     },
     {
         "name": "tsubasa",
         "trans": [
+            "翼(つばさ)",
             "wings"
-        ],
-        "notation": "翼(つばさ)"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "商人(しょうにん)",
             "trader,shopkeeper,merchant"
-        ],
-        "notation": "商人(しょうにん)"
+        ]
     },
     {
         "name": "maru",
         "trans": [
+            "丸(まる)",
             "circle,full (month),perfection,purity,suffix for ship names"
-        ],
-        "notation": "丸(まる)"
+        ]
     },
     {
         "name": "an",
         "trans": [
+            "案(あん)",
             "plan,suffix meaning draft"
-        ],
-        "notation": "案(あん)"
+        ]
     },
     {
         "name": "ma",
         "trans": [
+            "間(ま)",
             "space,room,time,pause"
-        ],
-        "notation": "間(ま)"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "居(お)る",
             "to be (animate),to be,to exist"
-        ],
-        "notation": "居(お)る"
+        ]
     },
     {
         "name": "shokugyou",
         "trans": [
+            "職業(しょくぎょう)",
             "occupation,business"
-        ],
-        "notation": "職業(しょくぎょう)"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "専攻(せんこう)",
             "major subject,special study"
-        ],
-        "notation": "専攻(せんこう)"
+        ]
     },
     {
         "name": "joukyou",
         "trans": [
+            "上京(じょうきょう)",
             "proceeding to the capital (Tokyo)"
-        ],
-        "notation": "上京(じょうきょう)"
+        ]
     },
     {
         "name": "kinen",
         "trans": [
+            "記念(きねん)",
             "commemoration,memory"
-        ],
-        "notation": "記念(きねん)"
+        ]
     },
     {
         "name": "kashi",
         "trans": [
+            "菓子(かし)",
             "pastry"
-        ],
-        "notation": "菓子(かし)"
+        ]
     },
     {
         "name": "shitagatte",
         "trans": [
+            "したがって",
             "therefore,consequently,in accordance with"
-        ],
-        "notation": "したがって"
+        ]
     },
     {
         "name": "soretomo",
         "trans": [
+            "それとも",
             "or,or else"
-        ],
-        "notation": "それとも"
+        ]
     },
     {
         "name": "migoto",
         "trans": [
+            "見事(みごと)",
             "splendid,magnificent,beautiful,admirable"
-        ],
-        "notation": "見事(みごと)"
+        ]
     },
     {
         "name": "umai",
         "trans": [
+            "うまい",
             "delicious"
-        ],
-        "notation": "うまい"
+        ]
     },
     {
         "name": "taishita",
         "trans": [
+            "大(たい)した",
             "considerable,great,important,significant,a big deal"
-        ],
-        "notation": "大(たい)した"
+        ]
     },
     {
         "name": "chichioya",
         "trans": [
+            "父親(ちちおや)",
             "father"
-        ],
-        "notation": "父親(ちちおや)"
+        ]
     },
     {
         "name": "kokumin",
         "trans": [
+            "国民(こくみん)",
             "national,people,citizen"
-        ],
-        "notation": "国民(こくみん)"
+        ]
     },
     {
         "name": "sugureru",
         "trans": [
+            "優(すぐ)れる",
             "to surpass,to outstrip,to excel"
-        ],
-        "notation": "優(すぐ)れる"
+        ]
     },
     {
         "name": "tsumoru",
         "trans": [
+            "積(つ)もる",
             "to pile up"
-        ],
-        "notation": "積(つ)もる"
+        ]
     },
     {
         "name": "kanja",
         "trans": [
+            "患者(かんじゃ)",
             "a patient"
-        ],
-        "notation": "患者(かんじゃ)"
+        ]
     },
     {
         "name": "youten",
         "trans": [
+            "要点(ようてん)",
             "gist,main point"
-        ],
-        "notation": "要点(ようてん)"
+        ]
     },
     {
         "name": "mazushii",
         "trans": [
+            "貧(まず)しい",
             "poor,needy"
-        ],
-        "notation": "貧(まず)しい"
+        ]
     },
     {
         "name": "hyoujou",
         "trans": [
+            "表情(ひょうじょう)",
             "facial expression"
-        ],
-        "notation": "表情(ひょうじょう)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "自身(じしん)",
             "by oneself,personally"
-        ],
-        "notation": "自身(じしん)"
+        ]
     },
     {
         "name": "seichou",
         "trans": [
+            "成長(せいちょう)",
             "growth,grow to adulthood"
-        ],
-        "notation": "成長(せいちょう)"
+        ]
     },
     {
         "name": "kenka",
         "trans": [
+            "喧嘩(けんか)",
             "quarrel,(drunken) brawl,failure"
-        ],
-        "notation": "喧嘩(けんか)"
+        ]
     },
     {
         "name": "joou",
         "trans": [
+            "女王(じょおう)",
             "queen"
-        ],
-        "notation": "女王(じょおう)"
+        ]
     },
     {
         "name": "rikai",
         "trans": [
+            "理解(りかい)",
             "understanding,comprehension"
-        ],
-        "notation": "理解(りかい)"
+        ]
     },
     {
         "name": "doresu",
         "trans": [
+            "ドレス",
             "dress"
-        ],
-        "notation": "ドレス"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "張(は)る",
             "to stick,to paste"
-        ],
-        "notation": "張(は)る"
+        ]
     },
     {
         "name": "henka",
         "trans": [
+            "変化(へんか)",
             "goblin,ghost,apparition,bugbear"
-        ],
-        "notation": "変化(へんか)"
+        ]
     },
     {
         "name": "kankyou",
         "trans": [
+            "環境(かんきょう)",
             "environment,circumstance"
-        ],
-        "notation": "環境(かんきょう)"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "弾(たま)",
             "bullet,shot,shell"
-        ],
-        "notation": "弾(たま)"
+        ]
     },
     {
         "name": "kiri",
         "trans": [
+            "霧(きり)",
             "fog,mist"
-        ],
-        "notation": "霧(きり)"
+        ]
     },
     {
         "name": "ai",
         "trans": [
+            "愛(あい)",
             "love"
-        ],
-        "notation": "愛(あい)"
+        ]
     },
     {
         "name": "himitsu",
         "trans": [
+            "秘密(ひみつ)",
             "secret,secrecy"
-        ],
-        "notation": "秘密(ひみつ)"
+        ]
     },
     {
         "name": "seihin",
         "trans": [
+            "製品(せいひん)",
             "manufactured goods,finished goods"
-        ],
-        "notation": "製品(せいひん)"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "轢(ひ)く",
             "to run somebody over (with vehicle),to knock someone down"
-        ],
-        "notation": "轢(ひ)く"
+        ]
     },
     {
         "name": "hobo",
         "trans": [
+            "粗(ほぼ)",
             "defect,flaw,blemish,weak point"
-        ],
-        "notation": "粗(ほぼ)"
+        ]
     },
     {
         "name": "sukeeto",
         "trans": [
+            "スケート",
             "skate(s),skating"
-        ],
-        "notation": "スケート"
+        ]
     },
     {
         "name": "chigainai",
         "trans": [
+            "違(ちが)いない",
             "(phrase) sure,no mistaking it,for certain"
-        ],
-        "notation": "違(ちが)いない"
+        ]
     },
     {
         "name": "tanjou",
         "trans": [
+            "誕生(たんじょう)",
             "birth"
-        ],
-        "notation": "誕生(たんじょう)"
+        ]
     },
     {
         "name": "shushou",
         "trans": [
+            "首相(しゅしょう)",
             "Prime Minister"
-        ],
-        "notation": "首相(しゅしょう)"
+        ]
     },
     {
         "name": "maa",
         "trans": [
+            "まあ",
             "(female) you might say"
-        ],
-        "notation": "まあ"
+        ]
     },
     {
         "name": "sakana",
         "trans": [
+            "魚(さかな)",
             "fish"
-        ],
-        "notation": "魚(さかな)"
+        ]
     },
     {
         "name": "gawa",
         "trans": [
+            "側(がわ)",
             "side,edge,third person"
-        ],
-        "notation": "側(がわ)"
+        ]
     },
     {
         "name": "kashu",
         "trans": [
+            "歌手(かしゅ)",
             "singer"
-        ],
-        "notation": "歌手(かしゅ)"
+        ]
     },
     {
         "name": "douyou",
         "trans": [
+            "同様(どうよう)",
             "identical,equal to,same (kind),like"
-        ],
-        "notation": "同様(どうよう)"
+        ]
     },
     {
         "name": "shinjiru",
         "trans": [
+            "信(しん)じる",
             "to believe,to place trust in"
-        ],
-        "notation": "信(しん)じる"
+        ]
     },
     {
         "name": "nama",
         "trans": [
+            "生(なま)",
             "(1) draft (beer),(2) raw,unprocessed"
-        ],
-        "notation": "生(なま)"
+        ]
     },
     {
         "name": "sosogu",
         "trans": [
+            "注(そそ)ぐ",
             "to pour (into),to irrigate,to pay,to fill,to feed (e.g. a fire)"
-        ],
-        "notation": "注(そそ)ぐ"
+        ]
     },
     {
         "name": "kouen",
         "trans": [
+            "講演(こうえん)",
             "lecture,address"
-        ],
-        "notation": "講演(こうえん)"
+        ]
     },
     {
         "name": "masutaa",
         "trans": [
+            "マスター",
             "proprietor,manager,barowner,master (e.g. arts, science)"
-        ],
-        "notation": "マスター"
+        ]
     },
     {
         "name": "kaifuku",
         "trans": [
+            "回復(かいふく)",
             "recovery (from illness),improvement,rehabilitation,restoration"
-        ],
-        "notation": "回復(かいふく)"
+        ]
     },
     {
         "name": "doku",
         "trans": [
+            "毒(どく)",
             "poison,toxicant"
-        ],
-        "notation": "毒(どく)"
+        ]
     },
     {
         "name": "hitei",
         "trans": [
+            "否定(ひてい)",
             "negation,denial,repudiation"
-        ],
-        "notation": "否定(ひてい)"
+        ]
     },
     {
         "name": "shuu",
         "trans": [
+            "週(しゅう)",
             "week"
-        ],
-        "notation": "週(しゅう)"
+        ]
     },
     {
         "name": "akuma",
         "trans": [
+            "悪魔(あくま)",
             "devil,demon,evil spirit"
-        ],
-        "notation": "悪魔(あくま)"
+        ]
     },
     {
         "name": "gakki",
         "trans": [
+            "学期(がっき)",
             "term (school)"
-        ],
-        "notation": "学期(がっき)"
+        ]
     },
     {
         "name": "oou",
         "trans": [
+            "覆(おお)う",
             "to cover,to hide,to conceal,to wrap,to disguise"
-        ],
-        "notation": "覆(おお)う"
+        ]
     },
     {
         "name": "jikkou",
         "trans": [
+            "実行(じっこう)",
             "practice,performance,execution (e.g. program),realization"
-        ],
-        "notation": "実行(じっこう)"
+        ]
     },
     {
         "name": "masaka",
         "trans": [
+            "まさか",
             "by no means"
-        ],
-        "notation": "まさか"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "夜(よる)",
             "evening,night"
-        ],
-        "notation": "夜(よる)"
+        ]
     },
     {
         "name": "no",
         "trans": [
+            "野(の)",
             "field"
-        ],
-        "notation": "野(の)"
+        ]
     },
     {
         "name": "gishi",
         "trans": [
+            "技師(ぎし)",
             "engineer,technician"
-        ],
-        "notation": "技師(ぎし)"
+        ]
     },
     {
         "name": "dan",
         "trans": [
+            "段(だん)",
             "step,stair,flight of steps,grade,rank,level"
-        ],
-        "notation": "段(だん)"
+        ]
     },
     {
         "name": "imani",
         "trans": [
+            "今(いま)に",
             "before long,even now"
-        ],
-        "notation": "今(いま)に"
+        ]
     },
     {
         "name": "moyou",
         "trans": [
+            "模様(もよう)",
             "pattern,figure,design"
-        ],
-        "notation": "模様(もよう)"
+        ]
     },
     {
         "name": "tachiba",
         "trans": [
+            "立場(たちば)",
             "standpoint,position,situation"
-        ],
-        "notation": "立場(たちば)"
+        ]
     },
     {
         "name": "misu",
         "trans": [
+            "ミス",
             "miss (mistake, error, failure),Miss"
-        ],
-        "notation": "ミス"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "医師(いし)",
             "doctor,physician"
-        ],
-        "notation": "医師(いし)"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "身(み)",
             "body,main part,oneself,sword"
-        ],
-        "notation": "身(み)"
+        ]
     },
     {
         "name": "akiru",
         "trans": [
+            "飽(あ)きる",
             "to get tired of,to lose interest in,to have enough"
-        ],
-        "notation": "飽(あ)きる"
+        ]
     },
     {
         "name": "kansuru",
         "trans": [
+            "関(かん)する",
             "to concern,to be related"
-        ],
-        "notation": "関(かん)する"
+        ]
     },
     {
         "name": "shinseki",
         "trans": [
+            "親戚(しんせき)",
             "relative"
-        ],
-        "notation": "親戚(しんせき)"
+        ]
     },
     {
         "name": "kyouju",
         "trans": [
+            "教授(きょうじゅ)",
             "teaching,instruction,professor"
-        ],
-        "notation": "教授(きょうじゅ)"
+        ]
     },
     {
         "name": "kekkyoku",
         "trans": [
+            "結局(けっきょく)",
             "after all,eventually"
-        ],
-        "notation": "結局(けっきょく)"
+        ]
     },
     {
         "name": "chokusetsu",
         "trans": [
+            "直接(ちょくせつ)",
             "direct,immediate,personal,firsthand"
-        ],
-        "notation": "直接(ちょくせつ)"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "為(な)る",
             "to change,to be of use,to reach to"
-        ],
-        "notation": "為(な)る"
+        ]
     },
     {
         "name": "wareware",
         "trans": [
+            "我々(われわれ)",
             "we"
-        ],
-        "notation": "我々(われわれ)"
+        ]
     },
     {
         "name": "tsurai",
         "trans": [
+            "辛(つら)い",
             "painful,heart-breaking"
-        ],
-        "notation": "辛(つら)い"
+        ]
     },
     {
         "name": "houfu",
         "trans": [
+            "豊富(ほうふ)",
             "abundance,wealth,plenty,bounty"
-        ],
-        "notation": "豊富(ほうふ)"
+        ]
     },
     {
         "name": "honoo",
         "trans": [
+            "炎(ほのお)",
             "flame"
-        ],
-        "notation": "炎(ほのお)"
+        ]
     },
     {
         "name": "kakaku",
         "trans": [
+            "価格(かかく)",
             "price,value,cost"
-        ],
-        "notation": "価格(かかく)"
+        ]
     },
     {
         "name": "junchou",
         "trans": [
+            "順調(じゅんちょう)",
             "favourable,doing well,O.K.,all right"
-        ],
-        "notation": "順調(じゅんちょう)"
+        ]
     },
     {
         "name": "ue",
         "trans": [
+            "上(うえ)",
             "upper,outer,surface"
-        ],
-        "notation": "上(うえ)"
+        ]
     },
     {
         "name": "yameru",
         "trans": [
+            "辞(や)める",
             "to retire"
-        ],
-        "notation": "辞(や)める"
+        ]
     },
     {
         "name": "uma",
         "trans": [
+            "馬(うま)",
             "(1) horse,(2) promoted bishop (shogi)"
-        ],
-        "notation": "馬(うま)"
+        ]
     },
     {
         "name": "houkoku",
         "trans": [
+            "報告(ほうこく)",
             "report,information"
-        ],
-        "notation": "報告(ほうこく)"
+        ]
     },
     {
         "name": "jissai",
         "trans": [
+            "実際(じっさい)",
             "practical,actual condition,status quo"
-        ],
-        "notation": "実際(じっさい)"
+        ]
     },
     {
         "name": "zenzen",
         "trans": [
+            "全然(ぜんぜん)",
             "(1) wholly,entirely,completely,(2) not at all (with neg. verb)"
-        ],
-        "notation": "全然(ぜんぜん)"
+        ]
     },
     {
         "name": "hitoshii",
         "trans": [
+            "等(ひと)しい",
             "equal"
-        ],
-        "notation": "等(ひと)しい"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "意志(いし)",
             "will,volition"
-        ],
-        "notation": "意志(いし)"
+        ]
     },
     {
         "name": "ushinau",
         "trans": [
+            "失(うしな)う",
             "to lose,to part with"
-        ],
-        "notation": "失(うしな)う"
+        ]
     },
     {
         "name": "hanbai",
         "trans": [
+            "販売(はんばい)",
             "sale,selling,marketing"
-        ],
-        "notation": "販売(はんばい)"
+        ]
     },
     {
         "name": "sasaeru",
         "trans": [
+            "支(ささ)える",
             "to be blocked,to choke,to be obstructed"
-        ],
-        "notation": "支(ささ)える"
+        ]
     },
     {
         "name": "raketto",
         "trans": [
+            "ラケット",
             "paddle,racket"
-        ],
-        "notation": "ラケット"
+        ]
     },
     {
         "name": "kinou",
         "trans": [
+            "機能(きのう)",
             "function,faculty"
-        ],
-        "notation": "機能(きのう)"
+        ]
     },
     {
         "name": "yosoku",
         "trans": [
+            "予測(よそく)",
             "prediction,estimation"
-        ],
-        "notation": "予測(よそく)"
+        ]
     },
     {
         "name": "nagame",
         "trans": [
+            "眺(なが)め",
             "scene,view,prospect,outlook"
-        ],
-        "notation": "眺(なが)め"
+        ]
     },
     {
         "name": "kinen",
         "trans": [
+            "禁煙(きんえん)",
             "No Smoking!"
-        ],
-        "notation": "禁煙(きんえん)"
+        ]
     },
     {
         "name": "shuukan",
         "trans": [
+            "週間(しゅうかん)",
             "week,weekly"
-        ],
-        "notation": "週間(しゅうかん)"
+        ]
     },
     {
         "name": "hokori",
         "trans": [
+            "誇(ほこ)り",
             "pride"
-        ],
-        "notation": "誇(ほこ)り"
+        ]
     },
     {
         "name": "chousa",
         "trans": [
+            "調査(ちょうさ)",
             "investigation,examination,inquiry,survey"
-        ],
-        "notation": "調査(ちょうさ)"
+        ]
     },
     {
         "name": "chuumoku",
         "trans": [
+            "注目(ちゅうもく)",
             "notice,attention,observation"
-        ],
-        "notation": "注目(ちゅうもく)"
+        ]
     },
     {
         "name": "kutsuu",
         "trans": [
+            "苦痛(くつう)",
             "pain,agony"
-        ],
-        "notation": "苦痛(くつう)"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "番(ばん)",
             ""
-        ],
-        "notation": "番(ばん)"
+        ]
     },
     {
         "name": "chii",
         "trans": [
+            "地位(ちい)",
             "(social) position,status"
-        ],
-        "notation": "地位(ちい)"
+        ]
     },
     {
         "name": "mukae",
         "trans": [
+            "迎(むか)え",
             "meeting,person sent to pick up an arrival"
-        ],
-        "notation": "迎(むか)え"
+        ]
     },
     {
         "name": "nagasu",
         "trans": [
+            "流(なが)す",
             "to drain,to float,to shed (blood, tears),to cruise (e.g. taxi)"
-        ],
-        "notation": "流(なが)す"
+        ]
     },
     {
         "name": "dairi",
         "trans": [
+            "代理(だいり)",
             "representation,agency,proxy,deputy,agent"
-        ],
-        "notation": "代理(だいり)"
+        ]
     },
     {
         "name": "jouken",
         "trans": [
+            "条件(じょうけん)",
             "conditions,terms"
-        ],
-        "notation": "条件(じょうけん)"
+        ]
     },
     {
         "name": "moji",
         "trans": [
+            "文字(もじ)",
             "letter (of alphabet),character"
-        ],
-        "notation": "文字(もじ)"
+        ]
     },
     {
         "name": "hageshii",
         "trans": [
+            "激(はげ)しい",
             "violent,vehement,intense"
-        ],
-        "notation": "激(はげ)しい"
+        ]
     },
     {
         "name": "chuuou",
         "trans": [
+            "中央(ちゅうおう)",
             "centre,central,center,middle"
-        ],
-        "notation": "中央(ちゅうおう)"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "分(ぶん)",
             "dividing,part"
-        ],
-        "notation": "分(ぶん)"
+        ]
     },
     {
         "name": "mitomeru",
         "trans": [
+            "認(みと)める",
             "to recognize,to appreciate,to approve,to admit,to notice"
-        ],
-        "notation": "認(みと)める"
+        ]
     },
     {
         "name": "kumiai",
         "trans": [
+            "組合(くみあい)",
             "association,union"
-        ],
-        "notation": "組合(くみあい)"
+        ]
     },
     {
         "name": "chiimu",
         "trans": [
+            "チーム",
             "team"
-        ],
-        "notation": "チーム"
+        ]
     },
     {
         "name": "risou",
         "trans": [
+            "理想(りそう)",
             "ideal"
-        ],
-        "notation": "理想(りそう)"
+        ]
     },
     {
         "name": "jinsei",
         "trans": [
+            "人生(じんせい)",
             "(human) life (i.e. conception to death)"
-        ],
-        "notation": "人生(じんせい)"
+        ]
     },
     {
         "name": "kona",
         "trans": [
+            "粉(こな)",
             "flour,meal,powder"
-        ],
-        "notation": "粉(こな)"
+        ]
     },
     {
         "name": "hikou",
         "trans": [
+            "飛行(ひこう)",
             "aviation"
-        ],
-        "notation": "飛行(ひこう)"
+        ]
     },
     {
         "name": "tadachini",
         "trans": [
+            "直(ただ)ちに",
             "at once,immediately,directly,in person"
-        ],
-        "notation": "直(ただ)ちに"
+        ]
     },
     {
         "name": "kusari",
         "trans": [
+            "鎖(くさり)",
             "chain"
-        ],
-        "notation": "鎖(くさり)"
+        ]
     },
     {
         "name": "unaru",
         "trans": [
+            "うなる",
             "to groan,to moan"
-        ],
-        "notation": "うなる"
+        ]
     },
     {
         "name": "kachi",
         "trans": [
+            "価値(かち)",
             "value,worth,merit"
-        ],
-        "notation": "価値(かち)"
+        ]
     },
     {
         "name": "sakarau",
         "trans": [
+            "逆(さか)らう",
             "to go against,to oppose,to disobey,to defy"
-        ],
-        "notation": "逆(さか)らう"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "管(かん)",
             "pipe,tube"
-        ],
-        "notation": "管(かん)"
+        ]
     },
     {
         "name": "chuuko",
         "trans": [
+            "中古(ちゅうこ)",
             "(1) used,second-hand,old"
-        ],
-        "notation": "中古(ちゅうこ)"
+        ]
     },
     {
         "name": "hanashiau",
         "trans": [
+            "話(はな)し合(あ)う",
             "to discuss,to talk together"
-        ],
-        "notation": "話(はな)し合(あ)う"
+        ]
     },
     {
         "name": "tomo",
         "trans": [
+            "友(とも)",
             "friend,companion,pal"
-        ],
-        "notation": "友(とも)"
+        ]
     },
     {
         "name": "kumori",
         "trans": [
+            "曇(くもり)",
             "cloudiness,cloudy weather,shadow"
-        ],
-        "notation": "曇(くもり)"
+        ]
     },
     {
         "name": "bakudai",
         "trans": [
+            "莫大(ばくだい)",
             "enormous,vast"
-        ],
-        "notation": "莫大(ばくだい)"
+        ]
     },
     {
         "name": "kakunin",
         "trans": [
+            "確認(かくにん)",
             "affirmation,confirmation"
-        ],
-        "notation": "確認(かくにん)"
+        ]
     },
     {
         "name": "ine",
         "trans": [
+            "稲(いね)",
             "rice-plant"
-        ],
-        "notation": "稲(いね)"
+        ]
     },
     {
         "name": "tobasu",
         "trans": [
+            "飛(と)ばす",
             "to skip over,to omit"
-        ],
-        "notation": "飛(と)ばす"
+        ]
     },
     {
         "name": "juushi",
         "trans": [
+            "重視(じゅうし)",
             "importance,stress,serious consideration"
-        ],
-        "notation": "重視(じゅうし)"
+        ]
     },
     {
         "name": "taikutsu",
         "trans": [
+            "退屈(たいくつ)",
             "tedium,boredom"
-        ],
-        "notation": "退屈(たいくつ)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "留(と)める",
             "to fasten,to turn off,to detain"
-        ],
-        "notation": "留(と)める"
+        ]
     },
     {
         "name": "tatakai",
         "trans": [
+            "戦(たたか)い",
             "battle,fight,struggle,conflict"
-        ],
-        "notation": "戦(たたか)い"
+        ]
     },
     {
         "name": "ondan",
         "trans": [
+            "温暖(おんだん)",
             "warmth"
-        ],
-        "notation": "温暖(おんだん)"
+        ]
     },
     {
         "name": "kurasu",
         "trans": [
+            "暮(く)らす",
             "to live,to get along"
-        ],
-        "notation": "暮(く)らす"
+        ]
     },
     {
         "name": "kinniku",
         "trans": [
+            "筋肉(きんにく)",
             "muscle,sinew"
-        ],
-        "notation": "筋肉(きんにく)"
+        ]
     },
     {
         "name": "oudan",
         "trans": [
+            "横断(おうだん)",
             "crossing"
-        ],
-        "notation": "横断(おうだん)"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "玉(たま)",
             "ball,sphere,coin"
-        ],
-        "notation": "玉(たま)"
+        ]
     },
     {
         "name": "nozomu",
         "trans": [
+            "望(のぞ)む",
             "to desire,to wish for,to see,to command (a view of)"
-        ],
-        "notation": "望(のぞ)む"
+        ]
     },
     {
         "name": "sekkyokuteki",
         "trans": [
+            "積極(せっきょく)的(てき)",
             "positive,active,proactive"
-        ],
-        "notation": "積極(せっきょく)的(てき)"
+        ]
     },
     {
         "name": "totan",
         "trans": [
+            "途端(とたん)",
             "just (now, at the moment, etc.)"
-        ],
-        "notation": "途端(とたん)"
+        ]
     },
     {
         "name": "yokogiru",
         "trans": [
+            "横切(よこぎ)る",
             "to cross (e.g. arms),to traverse"
-        ],
-        "notation": "横切(よこぎ)る"
+        ]
     },
     {
         "name": "tane",
         "trans": [
+            "種(たね)",
             "(1) seed,(2) material,(3) cause,source"
-        ],
-        "notation": "種(たね)"
+        ]
     },
     {
         "name": "hadaka",
         "trans": [
+            "裸(はだか)",
             "naked,nude"
-        ],
-        "notation": "裸(はだか)"
+        ]
     },
     {
         "name": "nakama",
         "trans": [
+            "仲間(なかま)",
             "company,fellow,colleague,associate"
-        ],
-        "notation": "仲間(なかま)"
+        ]
     },
     {
         "name": "omae",
         "trans": [
+            "おまえ",
             "(fam) you (sing),presence (of a high personage)"
-        ],
-        "notation": "おまえ"
+        ]
     },
     {
         "name": "gengo",
         "trans": [
+            "言語(げんご)",
             "language"
-        ],
-        "notation": "言語(げんご)"
+        ]
     },
     {
         "name": "tamesu",
         "trans": [
+            "試(ため)す",
             "to attempt,to test"
-        ],
-        "notation": "試(ため)す"
+        ]
     },
     {
         "name": "kyodai",
         "trans": [
+            "巨大(きょだい)",
             "huge,gigantic,enormous"
-        ],
-        "notation": "巨大(きょだい)"
+        ]
     },
     {
         "name": "kiroku",
         "trans": [
+            "記録(きろく)",
             "record,minutes,document"
-        ],
-        "notation": "記録(きろく)"
+        ]
     },
     {
         "name": "kansei",
         "trans": [
+            "完成(かんせい)",
             "(1) complete,completion,(2) perfection,accomplishment"
-        ],
-        "notation": "完成(かんせい)"
+        ]
     },
     {
         "name": "nani",
         "trans": [
+            "何(なに)",
             "what"
-        ],
-        "notation": "何(なに)"
+        ]
     },
     {
         "name": "ittai",
         "trans": [
+            "一体(いったい)",
             "(1) one object,one body,(2) what on earth?,really?,(3) generally"
-        ],
-        "notation": "一体(いったい)"
+        ]
     },
     {
         "name": "nokku",
         "trans": [
+            "ノック",
             "(1) knock,(2) fungo (baseball)"
-        ],
-        "notation": "ノック"
+        ]
     },
     {
         "name": "koshou",
         "trans": [
+            "故障(こしょう)",
             "break-down,failure,accident,out of order"
-        ],
-        "notation": "故障(こしょう)"
+        ]
     },
     {
         "name": "toi",
         "trans": [
+            "問(と)い",
             "question,query"
-        ],
-        "notation": "問(と)い"
+        ]
     },
     {
         "name": "ryuugaku",
         "trans": [
+            "留学(りゅうがく)",
             "studying abroad"
-        ],
-        "notation": "留学(りゅうがく)"
+        ]
     },
     {
         "name": "tokai",
         "trans": [
+            "都会(とかい)",
             "city"
-        ],
-        "notation": "都会(とかい)"
+        ]
     },
     {
         "name": "kotonaru",
         "trans": [
+            "異(こと)なる",
             "to differ,to vary,to disagree"
-        ],
-        "notation": "異(こと)なる"
+        ]
     },
     {
         "name": "kasegu",
         "trans": [
+            "稼(かせ)ぐ",
             "to earn income,to labor"
-        ],
-        "notation": "稼(かせ)ぐ"
+        ]
     },
     {
         "name": "shoku",
         "trans": [
+            "職(しょく)",
             "employment"
-        ],
-        "notation": "職(しょく)"
+        ]
     },
     {
         "name": "machi",
         "trans": [
+            "街(まち)",
             "(1) town,(2) street,road"
-        ],
-        "notation": "街(まち)"
+        ]
     },
     {
         "name": "baiorin",
         "trans": [
+            "バイオリン",
             "violin"
-        ],
-        "notation": "バイオリン"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "行(い)き",
             "going"
-        ],
-        "notation": "行(い)き"
+        ]
     },
     {
         "name": "bukka",
         "trans": [
+            "物価(ぶっか)",
             "prices of commodities,prices (in general)"
-        ],
-        "notation": "物価(ぶっか)"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "詩(し)",
             "poem,verse of poetry"
-        ],
-        "notation": "詩(し)"
+        ]
     },
     {
         "name": "osoroshii",
         "trans": [
+            "恐(おそ)ろしい",
             "terrible,dreadful"
-        ],
-        "notation": "恐(おそ)ろしい"
+        ]
     },
     {
         "name": "douro",
         "trans": [
+            "道路(どうろ)",
             "road,highway"
-        ],
-        "notation": "道路(どうろ)"
+        ]
     },
     {
         "name": "mushiro",
         "trans": [
+            "寧(むし)ろ",
             "rather,better,instead"
-        ],
-        "notation": "寧(むし)ろ"
+        ]
     },
     {
         "name": "kaiin",
         "trans": [
+            "会員(かいいん)",
             "member,the membership"
-        ],
-        "notation": "会員(かいいん)"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "回(かい)",
             "counter for occurrences"
-        ],
-        "notation": "回(かい)"
+        ]
     },
     {
         "name": "seikyuu",
         "trans": [
+            "請求(せいきゅう)",
             "claim,demand,application,request"
-        ],
-        "notation": "請求(せいきゅう)"
+        ]
     },
     {
         "name": "eigyou",
         "trans": [
+            "営業(えいぎょう)",
             "business,trade,management"
-        ],
-        "notation": "営業(えいぎょう)"
+        ]
     },
     {
         "name": "tai",
         "trans": [
+            "対(たい)",
             "pair,couple,set"
-        ],
-        "notation": "対(たい)"
+        ]
     },
     {
         "name": "tabun",
         "trans": [
+            "多分(たぶん)",
             "perhaps,probably"
-        ],
-        "notation": "多分(たぶん)"
+        ]
     },
     {
         "name": "ataeru",
         "trans": [
+            "与(あた)える",
             "to give,to present,to award"
-        ],
-        "notation": "与(あた)える"
+        ]
     },
     {
         "name": "shokuji",
         "trans": [
+            "食事(しょくじ)",
             "meal"
-        ],
-        "notation": "食事(しょくじ)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "欠(か)ける",
             "to be lacking"
-        ],
-        "notation": "欠(か)ける"
+        ]
     },
     {
         "name": "habuku",
         "trans": [
+            "省(はぶ)く",
             "to omit,to eliminate,to curtail,to economize"
-        ],
-        "notation": "省(はぶ)く"
+        ]
     },
     {
         "name": "dekirudake",
         "trans": [
+            "出来(でき)るだけ",
             "if at all possible"
-        ],
-        "notation": "出来(でき)るだけ"
+        ]
     },
     {
         "name": "sugata",
         "trans": [
+            "姿(すがた)",
             "figure,shape,appearance"
-        ],
-        "notation": "姿(すがた)"
+        ]
     },
     {
         "name": "rippa",
         "trans": [
+            "立派(りっぱ)",
             "splendid,fine,handsome,elegant,imposing,prominent,legal,legitimate"
-        ],
-        "notation": "立派(りっぱ)"
+        ]
     },
     {
         "name": "kopii",
         "trans": [
+            "コピー",
             "(1) a (photo)copy,(2) blurb on a book jacket"
-        ],
-        "notation": "コピー"
+        ]
     },
     {
         "name": "nougyou",
         "trans": [
+            "農業(のうぎょう)",
             "agriculture"
-        ],
-        "notation": "農業(のうぎょう)"
+        ]
     },
     {
         "name": "shomei",
         "trans": [
+            "署名(しょめい)",
             "signature"
-        ],
-        "notation": "署名(しょめい)"
+        ]
     },
     {
         "name": "sakeru",
         "trans": [
+            "避(さ)ける",
             "(1) to avoid (physical contact ),(2) to ward off,to avert"
-        ],
-        "notation": "避(さ)ける"
+        ]
     },
     {
         "name": "konnan",
         "trans": [
+            "困難(こんなん)",
             "difficulty,distress"
-        ],
-        "notation": "困難(こんなん)"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "幕(まく)",
             "curtain,bunting,act (in play)"
-        ],
-        "notation": "幕(まく)"
+        ]
     },
     {
         "name": "hyouban",
         "trans": [
+            "評判(ひょうばん)",
             "fame,reputation,popularity,arrant"
-        ],
-        "notation": "評判(ひょうばん)"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "九(きゅう)",
             "nine"
-        ],
-        "notation": "九(きゅう)"
+        ]
     },
     {
         "name": "kawairashii",
         "trans": [
+            "かわいらしい",
             "lovely,sweet"
-        ],
-        "notation": "かわいらしい"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "或(ある)",
             "a certain...,some..."
-        ],
-        "notation": "或(ある)"
+        ]
     },
     {
         "name": "gaku",
         "trans": [
+            "学(がく)",
             "learning,scholarship,erudition,knowledge"
-        ],
-        "notation": "学(がく)"
+        ]
     },
     {
         "name": "kaado",
         "trans": [
+            "カード",
             "card,curd"
-        ],
-        "notation": "カード"
+        ]
     },
     {
         "name": "yosan",
         "trans": [
+            "予算(よさん)",
             "estimate,budget"
-        ],
-        "notation": "予算(よさん)"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "行(い)き",
             "going"
-        ],
-        "notation": "行(い)き"
+        ]
     },
     {
         "name": "oi",
         "trans": [
+            "老(お)い",
             "old age,old person,the old,the aged"
-        ],
-        "notation": "老(お)い"
+        ]
     },
     {
         "name": "suji",
         "trans": [
+            "筋(すじ)",
             "muscle,string,line"
-        ],
-        "notation": "筋(すじ)"
+        ]
     },
     {
         "name": "totsuzen",
         "trans": [
+            "突然(とつぜん)",
             "abruptly,suddenly,unexpectedly,all at once"
-        ],
-        "notation": "突然(とつぜん)"
+        ]
     },
     {
         "name": "itaru",
         "trans": [
+            "至(いた)る",
             "to come,to arrive"
-        ],
-        "notation": "至(いた)る"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "氏(し)",
             "family name,lineage,birth"
-        ],
-        "notation": "氏(し)"
+        ]
     },
     {
         "name": "arata",
         "trans": [
+            "新(あら)た",
             "new,fresh,novel"
-        ],
-        "notation": "新(あら)た"
+        ]
     },
     {
         "name": "gomennasai",
         "trans": [
+            "ごめんなさい",
             "I beg your pardon,excuse me"
-        ],
-        "notation": "ごめんなさい"
+        ]
     },
     {
         "name": "nippon",
         "trans": [
+            "日本(にっぽん)",
             "Japan"
-        ],
-        "notation": "日本(にっぽん)"
+        ]
     },
     {
         "name": "kaminari",
         "trans": [
+            "雷(かみなり)",
             "thunder"
-        ],
-        "notation": "雷(かみなり)"
+        ]
     },
     {
         "name": "fukuro",
         "trans": [
+            "袋(ふくろ)",
             "bag,sack"
-        ],
-        "notation": "袋(ふくろ)"
+        ]
     },
     {
         "name": "isshu",
         "trans": [
+            "一種(いっしゅ)",
             "a species,a kind,a variety"
-        ],
-        "notation": "一種(いっしゅ)"
+        ]
     },
     {
         "name": "hodo",
         "trans": [
+            "程(ほど)",
             "degree,extent,bounds,limit"
-        ],
-        "notation": "程(ほど)"
+        ]
     },
     {
         "name": "yakuwari",
         "trans": [
+            "役割(やくわり)",
             "part,assigning (allotment of) parts,role,duties"
-        ],
-        "notation": "役割(やくわり)"
+        ]
     },
     {
         "name": "taosu",
         "trans": [
+            "倒(たお)す",
             "to throw down,to beat,to bring down,to blow down"
-        ],
-        "notation": "倒(たお)す"
+        ]
     },
     {
         "name": "ina",
         "trans": [
+            "否(いな)",
             "no,the noes"
-        ],
-        "notation": "否(いな)"
+        ]
     },
     {
         "name": "tetsugaku",
         "trans": [
+            "哲学(てつがく)",
             "philosophy"
-        ],
-        "notation": "哲学(てつがく)"
+        ]
     },
     {
         "name": "yurusu",
         "trans": [
+            "許(ゆる)す",
             "to permit,to allow,to approve"
-        ],
-        "notation": "許(ゆる)す"
+        ]
     },
     {
         "name": "kentou",
         "trans": [
+            "検討(けんとう)",
             "consideration,examination,investigation,study,scrutiny"
-        ],
-        "notation": "検討(けんとう)"
+        ]
     },
     {
         "name": "enerugii",
         "trans": [
+            "エネルギー",
             "(n) energy (de: Energie)"
-        ],
-        "notation": "エネルギー"
+        ]
     },
     {
         "name": "shikirini",
         "trans": [
+            "しきりに",
             "frequently,repeatedly,incessantly,eagerly"
-        ],
-        "notation": "しきりに"
+        ]
     },
     {
         "name": "fujin",
         "trans": [
+            "夫人(ふじん)",
             "wife,Mrs,madam"
-        ],
-        "notation": "夫人(ふじん)"
+        ]
     },
     {
         "name": "jisshi",
         "trans": [
+            "実施(じっし)",
             "enforcement,enact,put into practice,carry out,operation"
-        ],
-        "notation": "実施(じっし)"
+        ]
     },
     {
         "name": "yoake",
         "trans": [
+            "夜明(よあ)け",
             "dawn,daybreak"
-        ],
-        "notation": "夜明(よあ)け"
+        ]
     },
     {
         "name": "men",
         "trans": [
+            "綿(めん)",
             "cotton,padding"
-        ],
-        "notation": "綿(めん)"
+        ]
     },
     {
         "name": "otokonohito",
         "trans": [
+            "男(おとこ)の人(ひと)",
             "man"
-        ],
-        "notation": "男(おとこ)の人(ひと)"
+        ]
     },
     {
         "name": "jikoku",
         "trans": [
+            "時刻(じこく)",
             "instant,time,moment"
-        ],
-        "notation": "時刻(じこく)"
+        ]
     },
     {
         "name": "sosogu",
         "trans": [
+            "注(そそ)ぐ",
             "to pour (into),to irrigate,to pay"
-        ],
-        "notation": "注(そそ)ぐ"
+        ]
     },
     {
         "name": "shitsubou",
         "trans": [
+            "失望(しつぼう)",
             "disappointment,despair"
-        ],
-        "notation": "失望(しつぼう)"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "硬貨(こうか)",
             "coin"
-        ],
-        "notation": "硬貨(こうか)"
+        ]
     },
     {
         "name": "ikenai",
         "trans": [
+            "いけない",
             "must not do,bad,wrong,not good"
-        ],
-        "notation": "いけない"
+        ]
     },
     {
         "name": "ugokasu",
         "trans": [
+            "動(うご)かす",
             "to move,to shift"
-        ],
-        "notation": "動(うご)かす"
+        ]
     },
     {
         "name": "sousa",
         "trans": [
+            "操作(そうさ)",
             "operation,management,processing"
-        ],
-        "notation": "操作(そうさ)"
+        ]
     },
     {
         "name": "konkai",
         "trans": [
+            "今回(こんかい)",
             "now,this time,lately"
-        ],
-        "notation": "今回(こんかい)"
+        ]
     },
     {
         "name": "tsuyu",
         "trans": [
+            "梅雨(つゆ)",
             "rainy season,rain during the rainy season"
-        ],
-        "notation": "梅雨(つゆ)"
+        ]
     },
     {
         "name": "nagameru",
         "trans": [
+            "眺(なが)める",
             "to view,to gaze at"
-        ],
-        "notation": "眺(なが)める"
+        ]
     },
     {
         "name": "gogaku",
         "trans": [
+            "語学(ごがく)",
             "language study"
-        ],
-        "notation": "語学(ごがく)"
+        ]
     },
     {
         "name": "zairyou",
         "trans": [
+            "材料(ざいりょう)",
             "ingredients,material"
-        ],
-        "notation": "材料(ざいりょう)"
+        ]
     },
     {
         "name": "kinzoku",
         "trans": [
+            "金属(きんぞく)",
             "metal"
-        ],
-        "notation": "金属(きんぞく)"
+        ]
     },
     {
         "name": "housou",
         "trans": [
+            "放送(ほうそう)",
             "broadcast,broadcasting"
-        ],
-        "notation": "放送(ほうそう)"
+        ]
     },
     {
         "name": "sukuu",
         "trans": [
+            "救(すく)う",
             "to rescue from,to help out of"
-        ],
-        "notation": "救(すく)う"
+        ]
     },
     {
         "name": "kyoukyuu",
         "trans": [
+            "供給(きょうきゅう)",
             "supply,provision"
-        ],
-        "notation": "供給(きょうきゅう)"
+        ]
     },
     {
         "name": "kaigou",
         "trans": [
+            "会合(かいごう)",
             "meeting,assembly"
-        ],
-        "notation": "会合(かいごう)"
+        ]
     },
     {
         "name": "ta",
         "trans": [
+            "他(た)",
             "other (esp. places and things)"
-        ],
-        "notation": "他(た)"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "辺(あた)り",
             "vicinity,nearby"
-        ],
-        "notation": "辺(あた)り"
+        ]
     },
     {
         "name": "nagare",
         "trans": [
+            "流(なが)れ",
             "stream,current"
-        ],
-        "notation": "流(なが)れ"
+        ]
     },
     {
         "name": "kyou",
         "trans": [
+            "今日(きょう)",
             "today,this day"
-        ],
-        "notation": "今日(きょう)"
+        ]
     },
     {
         "name": "kurushii",
         "trans": [
+            "苦(くる)しい",
             "painful,difficult"
-        ],
-        "notation": "苦(くる)しい"
+        ]
     },
     {
         "name": "osen",
         "trans": [
+            "汚染(おせん)",
             "pollution,contamination"
-        ],
-        "notation": "汚染(おせん)"
+        ]
     },
     {
         "name": "haba",
         "trans": [
+            "幅(はば)",
             "width,breadth"
-        ],
-        "notation": "幅(はば)"
+        ]
     },
     {
         "name": "tadashi",
         "trans": [
+            "直(ただし)",
             "earnestly,immediately,exactly"
-        ],
-        "notation": "直(ただし)"
+        ]
     },
     {
         "name": "juutaku",
         "trans": [
+            "住宅(じゅうたく)",
             "resident,housing"
-        ],
-        "notation": "住宅(じゅうたく)"
+        ]
     },
     {
         "name": "bin",
         "trans": [
+            "瓶(びん)",
             "bottle"
-        ],
-        "notation": "瓶(びん)"
+        ]
     },
     {
         "name": "beruto",
         "trans": [
+            "ベルト",
             "Belt for western clothes"
-        ],
-        "notation": "ベルト"
+        ]
     },
     {
         "name": "kakujitsu",
         "trans": [
+            "確実(かくじつ)",
             "certainty,reliability,soundness"
-        ],
-        "notation": "確実(かくじつ)"
+        ]
     },
     {
         "name": "kyoufu",
         "trans": [
+            "恐怖(きょうふ)",
             "be afraid,dread,dismay,terror"
-        ],
-        "notation": "恐怖(きょうふ)"
+        ]
     },
     {
         "name": "antei",
         "trans": [
+            "安定(あんてい)",
             "stability,equilibrium"
-        ],
-        "notation": "安定(あんてい)"
+        ]
     },
     {
         "name": "shinsen",
         "trans": [
+            "新鮮(しんせん)",
             "fresh"
-        ],
-        "notation": "新鮮(しんせん)"
+        ]
     },
     {
         "name": "ainiku",
         "trans": [
+            "あいにく",
             "unfortunately,Sorry, but...."
-        ],
-        "notation": "あいにく"
+        ]
     },
     {
         "name": "itsumademo",
         "trans": [
+            "いつまでも",
             "forever,for good,eternally,as long as one likes,indefinitely"
-        ],
-        "notation": "いつまでも"
+        ]
     },
     {
         "name": "ima",
         "trans": [
+            "居間(いま)",
             "living room (western style)"
-        ],
-        "notation": "居間(いま)"
+        ]
     },
     {
         "name": "mu",
         "trans": [
+            "無(む)",
             "nothing,naught,nil,zero"
-        ],
-        "notation": "無(む)"
+        ]
     },
     {
         "name": "kinyou",
         "trans": [
+            "金曜(きんよう)",
             "(abbr) Friday"
-        ],
-        "notation": "金曜(きんよう)"
+        ]
     },
     {
         "name": "koukei",
         "trans": [
+            "光景(こうけい)",
             "scene,spectacle"
-        ],
-        "notation": "光景(こうけい)"
+        ]
     },
     {
         "name": "wagamama",
         "trans": [
+            "わがまま",
             "selfishness,egoism,wilfulness,disobedience,whim"
-        ],
-        "notation": "わがまま"
+        ]
     },
     {
         "name": "sanso",
         "trans": [
+            "酸素(さんそ)",
             "oxygen"
-        ],
-        "notation": "酸素(さんそ)"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "球(たま)",
             "globe,sphere,ball"
-        ],
-        "notation": "球(たま)"
+        ]
     },
     {
         "name": "hitogomi",
         "trans": [
+            "人込(ひとご)み",
             "crowd of people"
-        ],
-        "notation": "人込(ひとご)み"
+        ]
     },
     {
         "name": "pikunikku",
         "trans": [
+            "ピクニック",
             "picnic"
-        ],
-        "notation": "ピクニック"
+        ]
     },
     {
         "name": "taikai",
         "trans": [
+            "大会(たいかい)",
             "convention,tournament,mass meeting,rally"
-        ],
-        "notation": "大会(たいかい)"
+        ]
     },
     {
         "name": "enzetsu",
         "trans": [
+            "演説(えんぜつ)",
             "speech,address"
-        ],
-        "notation": "演説(えんぜつ)"
+        ]
     },
     {
         "name": "daiya",
         "trans": [
+            "ダイヤ",
             "(1) dyer,(2) diagram,(3) (railway) schedule,(4) diamond"
-        ],
-        "notation": "ダイヤ"
+        ]
     },
     {
         "name": "wareru",
         "trans": [
+            "割(われ)る",
             "to divide,to cut,to break,to halve"
-        ],
-        "notation": "割(われ)る"
+        ]
     },
     {
         "name": "urusai",
         "trans": [
+            "うるさい",
             "noisy,loud,fussy"
-        ],
-        "notation": "うるさい"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "実(み)",
             "fruit,nut,seed,content,good result"
-        ],
-        "notation": "実(み)"
+        ]
     },
     {
         "name": "kudasu",
         "trans": [
+            "下(くだ)す",
             "to lower,to let go down"
-        ],
-        "notation": "下(くだ)す"
+        ]
     },
     {
         "name": "shihon",
         "trans": [
+            "資本(しほん)",
             "funds,capital"
-        ],
-        "notation": "資本(しほん)"
+        ]
     },
     {
         "name": "kakaru",
         "trans": [
+            "罹(かか)る",
             "to suffer from"
-        ],
-        "notation": "罹(かか)る"
+        ]
     },
     {
         "name": "sekinin",
         "trans": [
+            "責任(せきにん)",
             "duty,responsibility"
-        ],
-        "notation": "責任(せきにん)"
+        ]
     },
     {
         "name": "negai",
         "trans": [
+            "願(ねが)い",
             "desire,wish,request"
-        ],
-        "notation": "願(ねが)い"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "機関(きかん)",
             "organ,mechanism,facility,engine"
-        ],
-        "notation": "機関(きかん)"
+        ]
     },
     {
         "name": "hane",
         "trans": [
+            "羽(はね)",
             "counter for birds,counter for rabbits"
-        ],
-        "notation": "羽(はね)"
+        ]
     },
     {
         "name": "susumeru",
         "trans": [
+            "勧(すす)める",
             "to recommend,to advise,to encourage,to offer (wine)"
-        ],
-        "notation": "勧(すす)める"
+        ]
     },
     {
         "name": "fukou",
         "trans": [
+            "不幸(ふこう)",
             "unhappiness,sorrow,misfortune,disaster,accident,death"
-        ],
-        "notation": "不幸(ふこう)"
+        ]
     },
     {
         "name": "shiten",
         "trans": [
+            "支店(してん)",
             "branch store (office)"
-        ],
-        "notation": "支店(してん)"
+        ]
     },
     {
         "name": "mimai",
         "trans": [
+            "見舞(みま)い",
             "enquiry,expression of sympathy,expression of concern"
-        ],
-        "notation": "見舞(みま)い"
+        ]
     },
     {
         "name": "hada",
         "trans": [
+            "肌(はだ)",
             "skin"
-        ],
-        "notation": "肌(はだ)"
+        ]
     },
     {
         "name": "fu",
         "trans": [
+            "不(ふ)",
             "un,non,negative prefix"
-        ],
-        "notation": "不(ふ)"
+        ]
     },
     {
         "name": "sugosu",
         "trans": [
+            "過(す)ごす",
             "to pass,to spend,to go through,to tide over"
-        ],
-        "notation": "過(す)ごす"
+        ]
     },
     {
         "name": "itadakimasu",
         "trans": [
+            "いただきます",
             "expression of gratitude before meals"
-        ],
-        "notation": "いただきます"
+        ]
     },
     {
         "name": "taihen",
         "trans": [
+            "大変(たいへん)",
             "awful,dreadful,terrible,very"
-        ],
-        "notation": "大変(たいへん)"
+        ]
     },
     {
         "name": "kinchou",
         "trans": [
+            "緊張(きんちょう)",
             "tension,mental strain,nervousness"
-        ],
-        "notation": "緊張(きんちょう)"
+        ]
     },
     {
         "name": "ofisu",
         "trans": [
+            "オフィス",
             "office"
-        ],
-        "notation": "オフィス"
+        ]
     },
     {
         "name": "kentou",
         "trans": [
+            "見当(けんとう)",
             "be found,aim,estimate,guess,approx"
-        ],
-        "notation": "見当(けんとう)"
+        ]
     },
     {
         "name": "naka",
         "trans": [
+            "仲(なか)",
             "relation,relationship"
-        ],
-        "notation": "仲(なか)"
+        ]
     },
     {
         "name": "seigen",
         "trans": [
+            "制限(せいげん)",
             "restriction,restraint,limitation"
-        ],
-        "notation": "制限(せいげん)"
+        ]
     },
     {
         "name": "atsukau",
         "trans": [
+            "扱(あつか)う",
             "to handle,to deal with,to treat"
-        ],
-        "notation": "扱(あつか)う"
+        ]
     },
     {
         "name": "chuushoku",
         "trans": [
+            "昼食(ちゅうしょく)",
             "lunch,midday meal"
-        ],
-        "notation": "昼食(ちゅうしょく)"
+        ]
     },
     {
         "name": "chouki",
         "trans": [
+            "長期(ちょうき)",
             "long time period"
-        ],
-        "notation": "長期(ちょうき)"
+        ]
     },
     {
         "name": "nou",
         "trans": [
+            "能(のう)",
             "being skilled in,nicely,properly"
-        ],
-        "notation": "能(のう)"
+        ]
     },
     {
         "name": "touchaku",
         "trans": [
+            "到着(とうちゃく)",
             "arrival"
-        ],
-        "notation": "到着(とうちゃく)"
+        ]
     },
     {
         "name": "hazusu",
         "trans": [
+            "外(はず)す",
             "to unfasten,to remove"
-        ],
-        "notation": "外(はず)す"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "頬(ほお)",
             "cheek (of face)"
-        ],
-        "notation": "頬(ほお)"
+        ]
     },
     {
         "name": "sukoshimo",
         "trans": [
+            "少(すこ)しも",
             "anything of,not one bit"
-        ],
-        "notation": "少(すこ)しも"
+        ]
     },
     {
         "name": "kusaru",
         "trans": [
+            "腐(くさ)る",
             "to rot,to go bad"
-        ],
-        "notation": "腐(くさ)る"
+        ]
     },
     {
         "name": "gaku",
         "trans": [
+            "額(がく)",
             "forehead,brow"
-        ],
-        "notation": "額(がく)"
+        ]
     },
     {
         "name": "shinzou",
         "trans": [
+            "心臓(しんぞう)",
             "heart"
-        ],
-        "notation": "心臓(しんぞう)"
+        ]
     },
     {
         "name": "manabu",
         "trans": [
+            "学(まな)ぶ",
             "to study (in depth),to learn,to take lessons in"
-        ],
-        "notation": "学(まな)ぶ"
+        ]
     },
     {
         "name": "cha",
         "trans": [
+            "茶(ちゃ)",
             "tea"
-        ],
-        "notation": "茶(ちゃ)"
+        ]
     },
     {
         "name": "taion",
         "trans": [
+            "体温(たいおん)",
             "temperature (body)"
-        ],
-        "notation": "体温(たいおん)"
+        ]
     },
     {
         "name": "necchuu",
         "trans": [
+            "熱中(ねっちゅう)",
             "nuts!,enthusiasm,zeal,mania"
-        ],
-        "notation": "熱中(ねっちゅう)"
+        ]
     },
     {
         "name": "intai",
         "trans": [
+            "引退(いんたい)",
             "retire"
-        ],
-        "notation": "引退(いんたい)"
+        ]
     },
     {
         "name": "betsuni",
         "trans": [
+            "別(べつ)に",
             "(not) particularly,nothing"
-        ],
-        "notation": "別(べつ)に"
+        ]
     },
     {
         "name": "zaseki",
         "trans": [
+            "座席(ざせき)",
             "seat"
-        ],
-        "notation": "座席(ざせき)"
+        ]
     },
     {
         "name": "nyuujou",
         "trans": [
+            "入場(にゅうじょう)",
             "entrance,admission,entering"
-        ],
-        "notation": "入場(にゅうじょう)"
+        ]
     },
     {
         "name": "shitashii",
         "trans": [
+            "親(した)しい",
             "intimate,close (e.g. friend)"
-        ],
-        "notation": "親(した)しい"
+        ]
     },
     {
         "name": "araware",
         "trans": [
+            "現(あらわ)れ",
             "embodiment,materialization"
-        ],
-        "notation": "現(あらわ)れ"
+        ]
     },
     {
         "name": "ayamari",
         "trans": [
+            "誤(あやま)り",
             "error"
-        ],
-        "notation": "誤(あやま)り"
+        ]
     },
     {
         "name": "kusai",
         "trans": [
+            "臭(くさ)い",
             "odour,scent,smell,stench"
-        ],
-        "notation": "臭(くさ)い"
+        ]
     },
     {
         "name": "zu",
         "trans": [
+            "図(ず)",
             "figure (e.g. Fig 1),drawing,picture,illustration"
-        ],
-        "notation": "図(ず)"
+        ]
     },
     {
         "name": "desukara",
         "trans": [
+            "ですから",
             "therefore"
-        ],
-        "notation": "ですから"
+        ]
     },
     {
         "name": "unten",
         "trans": [
+            "運転(うんてん)",
             "operation,motion,driving"
-        ],
-        "notation": "運転(うんてん)"
+        ]
     },
     {
         "name": "kuwawaru",
         "trans": [
+            "加(くわ)わる",
             "to join in,to accede to,to increase,to gain in (influence)"
-        ],
-        "notation": "加(くわ)わる"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "役(やく)",
             "use,service,role,position"
-        ],
-        "notation": "役(やく)"
+        ]
     },
     {
         "name": "yaburu",
         "trans": [
+            "破(やぶ)る",
             "to tear,to violate,to defeat,to smash,to destroy"
-        ],
-        "notation": "破(やぶ)る"
+        ]
     },
     {
         "name": "zaisan",
         "trans": [
+            "財産(ざいさん)",
             "property,fortune,assets"
-        ],
-        "notation": "財産(ざいさん)"
+        ]
     },
     {
         "name": "kenchiku",
         "trans": [
+            "建築(けんちく)",
             "construction,architecture"
-        ],
-        "notation": "建築(けんちく)"
+        ]
     },
     {
         "name": "houseki",
         "trans": [
+            "宝石(ほうせき)",
             "gem,jewel"
-        ],
-        "notation": "宝石(ほうせき)"
+        ]
     },
     {
         "name": "sekkei",
         "trans": [
+            "設計(せっけい)",
             "plan,design"
-        ],
-        "notation": "設計(せっけい)"
+        ]
     },
     {
         "name": "yononaka",
         "trans": [
+            "世(よ)の中(なか)",
             "society,the world,the times"
-        ],
-        "notation": "世(よ)の中(なか)"
+        ]
     },
     {
         "name": "dakara",
         "trans": [
+            "だから",
             "so,therefore"
-        ],
-        "notation": "だから"
+        ]
     },
     {
         "name": "uwasa",
         "trans": [
+            "噂(うわさ)",
             "rumour,report,gossip,common talk"
-        ],
-        "notation": "噂(うわさ)"
+        ]
     },
     {
         "name": "shujutsu",
         "trans": [
+            "手術(しゅじゅつ)",
             "surgical operation"
-        ],
-        "notation": "手術(しゅじゅつ)"
+        ]
     },
     {
         "name": "sodatsu",
         "trans": [
+            "育(そだ)つ",
             "to raise (child),to be brought up,to grow (up)"
-        ],
-        "notation": "育(そだ)つ"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "川(かわ)",
             "river"
-        ],
-        "notation": "川(かわ)"
+        ]
     },
     {
         "name": "de",
         "trans": [
+            "で",
             "outflow,coming (going) out,graduate (of)"
-        ],
-        "notation": "で"
+        ]
     },
     {
         "name": "gakushuu",
         "trans": [
+            "学習(がくしゅう)",
             "study,learning"
-        ],
-        "notation": "学習(がくしゅう)"
+        ]
     },
     {
         "name": "sei",
         "trans": [
+            "性(せい)",
             "sex,gender"
-        ],
-        "notation": "性(せい)"
+        ]
     },
     {
         "name": "-kyuu",
         "trans": [
+            "-旧(きゅう)",
             "ex"
-        ],
-        "notation": "-旧(きゅう)"
+        ]
     },
     {
         "name": "seifu",
         "trans": [
+            "政府(せいふ)",
             "government,administration"
-        ],
-        "notation": "政府(せいふ)"
+        ]
     },
     {
         "name": "seizou",
         "trans": [
+            "製造(せいぞう)",
             "manufacture,production"
-        ],
-        "notation": "製造(せいぞう)"
+        ]
     },
     {
         "name": "doryoku",
         "trans": [
+            "努力(どりょく)",
             "great effort,exertion,endeavour,effort"
-        ],
-        "notation": "努力(どりょく)"
+        ]
     },
     {
         "name": "tsuki",
         "trans": [
+            "月(つき)",
             "moon,month"
-        ],
-        "notation": "月(つき)"
+        ]
     },
     {
         "name": "jouhou",
         "trans": [
+            "情報(じょうほう)",
             "information,(military) intelligence"
-        ],
-        "notation": "情報(じょうほう)"
+        ]
     },
     {
         "name": "tani",
         "trans": [
+            "単位(たんい)",
             "unit,denomination,credit (in school)"
-        ],
-        "notation": "単位(たんい)"
+        ]
     },
     {
         "name": "modosu",
         "trans": [
+            "戻(もど)す",
             "to restore,to put back,to return"
-        ],
-        "notation": "戻(もど)す"
+        ]
     },
     {
         "name": "shoujo",
         "trans": [
+            "少女(しょうじょ)",
             "daughter,young lady,virgin,maiden,little girl"
-        ],
-        "notation": "少女(しょうじょ)"
+        ]
     },
     {
         "name": "konnichiha",
         "trans": [
+            "こんにちは",
             "hello,good day (daytime greeting, id)"
-        ],
-        "notation": "こんにちは"
+        ]
     },
     {
         "name": "datte",
         "trans": [
+            "だって",
             "but,because,even,also,too"
-        ],
-        "notation": "だって"
+        ]
     },
     {
         "name": "gaka",
         "trans": [
+            "画家(がか)",
             "painter,artist"
-        ],
-        "notation": "画家(がか)"
+        ]
     },
     {
         "name": "genzai",
         "trans": [
+            "現在(げんざい)",
             "present,up to now,nowadays,modern times,current"
-        ],
-        "notation": "現在(げんざい)"
+        ]
     },
     {
         "name": "kawaisou",
         "trans": [
+            "かわいそう",
             "poor,pitiable,pathetic"
-        ],
-        "notation": "かわいそう"
+        ]
     },
     {
         "name": "funiki",
         "trans": [
+            "雰囲気(ふんいき)",
             "atmosphere (e.g. musical),mood,ambience"
-        ],
-        "notation": "雰囲気(ふんいき)"
+        ]
     },
     {
         "name": "do",
         "trans": [
+            "土(ど)",
             "earth,soil"
-        ],
-        "notation": "土(ど)"
+        ]
     },
     {
         "name": "doutoku",
         "trans": [
+            "道徳(どうとく)",
             "morals"
-        ],
-        "notation": "道徳(どうとく)"
+        ]
     },
     {
         "name": "irai",
         "trans": [
+            "依頼(いらい)",
             "(1) request,commission,dispatch,(2) dependence,trust"
-        ],
-        "notation": "依頼(いらい)"
+        ]
     },
     {
         "name": "sanka",
         "trans": [
+            "参加(さんか)",
             "participation"
-        ],
-        "notation": "参加(さんか)"
+        ]
     },
     {
         "name": "arashi",
         "trans": [
+            "嵐(あらし)",
             "storm,tempest"
-        ],
-        "notation": "嵐(あらし)"
+        ]
     },
     {
         "name": "douryou",
         "trans": [
+            "同僚(どうりょう)",
             "coworker,colleague,associate"
-        ],
-        "notation": "同僚(どうりょう)"
+        ]
     },
     {
         "name": "maaketto",
         "trans": [
+            "マーケット",
             "market"
-        ],
-        "notation": "マーケット"
+        ]
     },
     {
         "name": "biiru",
         "trans": [
+            "ビール",
             "beer"
-        ],
-        "notation": "ビール"
+        ]
     },
     {
         "name": "soreto",
         "trans": [
+            "それと",
             ""
-        ],
-        "notation": "それと"
+        ]
     },
     {
         "name": "kakugo",
         "trans": [
+            "覚悟(かくご)",
             "resolution,resignation,readiness,preparedness"
-        ],
-        "notation": "覚悟(かくご)"
+        ]
     },
     {
         "name": "osoraku",
         "trans": [
+            "おそらく",
             "perhaps"
-        ],
-        "notation": "おそらく"
+        ]
     },
     {
         "name": "kanri",
         "trans": [
+            "管理(かんり)",
             "control,management (e.g. of a business)"
-        ],
-        "notation": "管理(かんり)"
+        ]
     },
     {
         "name": "tokoroga",
         "trans": [
+            "ところが",
             "however,while,even if"
-        ],
-        "notation": "ところが"
+        ]
     },
     {
         "name": "juuyou",
         "trans": [
+            "重要(じゅうよう)",
             "important,momentous,essential,principal,major"
-        ],
-        "notation": "重要(じゅうよう)"
+        ]
     },
     {
         "name": "kashi",
         "trans": [
+            "貸(か)し",
             "loan,lending"
-        ],
-        "notation": "貸(か)し"
+        ]
     },
     {
         "name": "shori",
         "trans": [
+            "処理(しょり)",
             "processing,dealing with,treatment,disposition,disposal"
-        ],
-        "notation": "処理(しょり)"
+        ]
     },
     {
         "name": "waruguchi",
         "trans": [
+            "悪口(わるぐち)",
             "abuse,insult,slander,evil speaking"
-        ],
-        "notation": "悪口(わるぐち)"
+        ]
     },
     {
         "name": "kurai",
         "trans": [
+            "位(くらい)",
             "grade,rank,about"
-        ],
-        "notation": "位(くらい)"
+        ]
     },
     {
         "name": "manichi",
         "trans": [
+            "万一(まんいち)",
             "by some chance,by some possibility,if by any chance,10E4:1 odds"
-        ],
-        "notation": "万一(まんいち)"
+        ]
     },
     {
         "name": "kanemochi",
         "trans": [
+            "金持(かねも)ち",
             "rich man"
-        ],
-        "notation": "金持(かねも)ち"
+        ]
     },
     {
         "name": "touji",
         "trans": [
+            "当時(とうじ)",
             "at that time,in those days"
-        ],
-        "notation": "当時(とうじ)"
+        ]
     },
     {
         "name": "sainou",
         "trans": [
+            "才能(さいのう)",
             "talent,ability"
-        ],
-        "notation": "才能(さいのう)"
+        ]
     },
     {
         "name": "jitsuni",
         "trans": [
+            "実(じつ)に",
             "indeed,truly,surely"
-        ],
-        "notation": "実(じつ)に"
+        ]
     },
     {
         "name": "fushi",
         "trans": [
+            "節(ふし)",
             "tune,tone,knot,knob,point"
-        ],
-        "notation": "節(ふし)"
+        ]
     },
     {
         "name": "sayuu",
         "trans": [
+            "左右(さゆう)",
             "(1) left and right,(2) influence,control,domination"
-        ],
-        "notation": "左右(さゆう)"
+        ]
     },
     {
         "name": "shokuryou",
         "trans": [
+            "食糧(しょくりょう)",
             "provisions,rations"
-        ],
-        "notation": "食糧(しょくりょう)"
+        ]
     },
     {
         "name": "kaishi",
         "trans": [
+            "開始(かいし)",
             "start,commencement,beginning"
-        ],
-        "notation": "開始(かいし)"
+        ]
     },
     {
         "name": "sonouchi",
         "trans": [
+            "そのうち",
             "eventually,sooner or later,of the previously mentioned"
-        ],
-        "notation": "そのうち"
+        ]
     },
     {
         "name": "kagu",
         "trans": [
+            "家具(かぐ)",
             "furniture"
-        ],
-        "notation": "家具(かぐ)"
+        ]
     },
     {
         "name": "kosu",
         "trans": [
+            "越(こ)す",
             "to go over (e.g. with audience)"
-        ],
-        "notation": "越(こ)す"
+        ]
     },
     {
         "name": "kinyuu",
         "trans": [
+            "金融(きんゆう)",
             "monetary circulation,credit situation"
-        ],
-        "notation": "金融(きんゆう)"
+        ]
     },
     {
         "name": "nenkan",
         "trans": [
+            "年間(ねんかん)",
             "year"
-        ],
-        "notation": "年間(ねんかん)"
+        ]
     },
     {
         "name": "uketoru",
         "trans": [
+            "受(う)け取(と)る",
             "to receive,to get,to accept,to take"
-        ],
-        "notation": "受(う)け取(と)る"
+        ]
     },
     {
         "name": "marui",
         "trans": [
+            "丸(まる)い",
             "round,circular,spherical"
-        ],
-        "notation": "丸(まる)い"
+        ]
     },
     {
         "name": "kouryo",
         "trans": [
+            "考慮(こうりょ)",
             "consideration,taking into account"
-        ],
-        "notation": "考慮(こうりょ)"
+        ]
     },
     {
         "name": "souchi",
         "trans": [
+            "装置(そうち)",
             "equipment,installation,apparatus"
-        ],
-        "notation": "装置(そうち)"
+        ]
     },
     {
         "name": "annani",
         "trans": [
+            "あんなに",
             "to that extent,to that degree"
-        ],
-        "notation": "あんなに"
+        ]
     },
     {
         "name": "shimesu",
         "trans": [
+            "示(しめ)す",
             "to denote,to show,to point out,to indicate"
-        ],
-        "notation": "示(しめ)す"
+        ]
     },
     {
         "name": "kagayaku",
         "trans": [
+            "輝(かがや)く",
             "to shine,to glitter,to sparkle"
-        ],
-        "notation": "輝(かがや)く"
+        ]
     },
     {
         "name": "nazo",
         "trans": [
+            "謎(なぞ)",
             "riddle,puzzle,enigma"
-        ],
-        "notation": "謎(なぞ)"
+        ]
     },
     {
         "name": "noki",
         "trans": [
+            "軒(のき)",
             "eaves"
-        ],
-        "notation": "軒(のき)"
+        ]
     },
     {
         "name": "gokai",
         "trans": [
+            "誤解(ごかい)",
             "misunderstanding"
-        ],
-        "notation": "誤解(ごかい)"
+        ]
     },
     {
         "name": "saitei",
         "trans": [
+            "最低(さいてい)",
             "least,lowest,worst"
-        ],
-        "notation": "最低(さいてい)"
+        ]
     },
     {
         "name": "nokori",
         "trans": [
+            "残(のこ)り",
             "remnant,residue,remaining,left-over"
-        ],
-        "notation": "残(のこ)り"
+        ]
     },
     {
         "name": "shuunyuu",
         "trans": [
+            "収入(しゅうにゅう)",
             "income,receipts,revenue"
-        ],
-        "notation": "収入(しゅうにゅう)"
+        ]
     },
     {
         "name": "yuka",
         "trans": [
+            "床(ゆか)",
             "floor"
-        ],
-        "notation": "床(ゆか)"
+        ]
     },
     {
         "name": "joutou",
         "trans": [
+            "上等(じょうとう)",
             "superiority,first class,very good"
-        ],
-        "notation": "上等(じょうとう)"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "九(きゅう)",
             "nine"
-        ],
-        "notation": "九(きゅう)"
+        ]
     },
     {
         "name": "riku",
         "trans": [
+            "陸(りく)",
             "six (used in legal documents)"
-        ],
-        "notation": "陸(りく)"
+        ]
     },
     {
         "name": "hodou",
         "trans": [
+            "歩道(ほどう)",
             "footpath,walkway,sidewalk"
-        ],
-        "notation": "歩道(ほどう)"
+        ]
     },
     {
         "name": "shuusei",
         "trans": [
+            "修正(しゅうせい)",
             "amendment,correction,revision,modification"
-        ],
-        "notation": "修正(しゅうせい)"
+        ]
     },
     {
         "name": "getsuyou",
         "trans": [
+            "月曜(げつよう)",
             "Monday"
-        ],
-        "notation": "月曜(げつよう)"
+        ]
     },
     {
         "name": "furo",
         "trans": [
+            "風呂(ふろ)",
             "bath"
-        ],
-        "notation": "風呂(ふろ)"
+        ]
     },
     {
         "name": "tennen",
         "trans": [
+            "天然(てんねん)",
             "nature,spontaneity"
-        ],
-        "notation": "天然(てんねん)"
+        ]
     },
     {
         "name": "anki",
         "trans": [
+            "暗記(あんき)",
             "memorization,learning by heart"
-        ],
-        "notation": "暗記(あんき)"
+        ]
     },
     {
         "name": "kazu",
         "trans": [
+            "数(かず)",
             "number,figure"
-        ],
-        "notation": "数(かず)"
+        ]
     },
     {
         "name": "shisou",
         "trans": [
+            "思想(しそう)",
             "thought,idea"
-        ],
-        "notation": "思想(しそう)"
+        ]
     },
     {
         "name": "mawasu",
         "trans": [
+            "回(まわ)す",
             "to turn,to revolve"
-        ],
-        "notation": "回(まわ)す"
+        ]
     },
     {
         "name": "yatou",
         "trans": [
+            "雇(やと)う",
             "to employ,to hire"
-        ],
-        "notation": "雇(やと)う"
+        ]
     },
     {
         "name": "saru",
         "trans": [
+            "去(さ)る",
             "to leave,to go away"
-        ],
-        "notation": "去(さ)る"
+        ]
     },
     {
         "name": "ikura",
         "trans": [
+            "幾(いく)ら",
             "how much?,how many?"
-        ],
-        "notation": "幾(いく)ら"
+        ]
     },
     {
         "name": "toranpu",
         "trans": [
+            "トランプ",
             "playing cards (lit: trump)"
-        ],
-        "notation": "トランプ"
+        ]
     },
     {
         "name": "keiken",
         "trans": [
+            "経験(けいけん)",
             "experience"
-        ],
-        "notation": "経験(けいけん)"
+        ]
     },
     {
         "name": "toki",
         "trans": [
+            "時(とき)",
             "(1) time,hour,(2) occasion,moment"
-        ],
-        "notation": "時(とき)"
+        ]
     },
     {
         "name": "doraibu",
         "trans": [
+            "ドライブ",
             "drive,trip by car,driving"
-        ],
-        "notation": "ドライブ"
+        ]
     },
     {
         "name": "chishiki",
         "trans": [
+            "知識(ちしき)",
             "knowledge,information"
-        ],
-        "notation": "知識(ちしき)"
+        ]
     },
     {
         "name": "kiyou",
         "trans": [
+            "器用(きよう)",
             "skillful,handy"
-        ],
-        "notation": "器用(きよう)"
+        ]
     },
     {
         "name": "zeitaku",
         "trans": [
+            "贅沢(ぜいたく)",
             "luxury,extravagance"
-        ],
-        "notation": "贅沢(ぜいたく)"
+        ]
     },
     {
         "name": "seiri",
         "trans": [
+            "整理(せいり)",
             "sorting,arrangement,adjustment,regulation"
-        ],
-        "notation": "整理(せいり)"
+        ]
     },
     {
         "name": "mukai",
         "trans": [
+            "向(む)かい",
             "facing,opposite,across the street,other side"
-        ],
-        "notation": "向(む)かい"
+        ]
     },
     {
         "name": "keiyaku",
         "trans": [
+            "契約(けいやく)",
             "contract,compact,agreement"
-        ],
-        "notation": "契約(けいやく)"
+        ]
     },
     {
         "name": "yunyuu",
         "trans": [
+            "輸入(ゆにゅう)",
             "importation,import,introduction"
-        ],
-        "notation": "輸入(ゆにゅう)"
+        ]
     },
     {
         "name": "ataru",
         "trans": [
+            "当(あ)たる",
             "to be hit,to be successful,to be equivalent to"
-        ],
-        "notation": "当(あ)たる"
+        ]
     },
     {
         "name": "nyuuin",
         "trans": [
+            "入院(にゅういん)",
             "hospitalization"
-        ],
-        "notation": "入院(にゅういん)"
+        ]
     },
     {
         "name": "itsumo",
         "trans": [
+            "いつも",
             "always,usually,every time,never (with neg. verb)"
-        ],
-        "notation": "いつも"
+        ]
     },
     {
         "name": "yuiitsu",
         "trans": [
+            "唯一(ゆいいつ)",
             "only,sole,unique"
-        ],
-        "notation": "唯一(ゆいいつ)"
+        ]
     },
     {
         "name": "hanzai",
         "trans": [
+            "犯罪(はんざい)",
             "crime"
-        ],
-        "notation": "犯罪(はんざい)"
+        ]
     },
     {
         "name": "suimin",
         "trans": [
+            "睡眠(すいみん)",
             "sleep"
-        ],
-        "notation": "睡眠(すいみん)"
+        ]
     },
     {
         "name": "umare",
         "trans": [
+            "生(う)まれ",
             "birth,birth-place"
-        ],
-        "notation": "生(う)まれ"
+        ]
     },
     {
         "name": "hata",
         "trans": [
+            "旗(はた)",
             "flag"
-        ],
-        "notation": "旗(はた)"
+        ]
     },
     {
         "name": "wa",
         "trans": [
+            "輪(わ)",
             "ring,hoop,circle"
-        ],
-        "notation": "輪(わ)"
+        ]
     },
     {
         "name": "yahari",
         "trans": [
+            "やはり",
             "also,as I thought,still,in spite of,absolutely,of course"
-        ],
-        "notation": "やはり"
+        ]
     },
     {
         "name": "kigyou",
         "trans": [
+            "企業(きぎょう)",
             "enterprise,undertaking"
-        ],
-        "notation": "企業(きぎょう)"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "円(えん)",
             "circle,money"
-        ],
-        "notation": "円(えん)"
+        ]
     },
     {
         "name": "nande",
         "trans": [
+            "何(なん)で",
             "Why?,What for?"
-        ],
-        "notation": "何(なん)で"
+        ]
     },
     {
         "name": "shina",
         "trans": [
+            "品(しな)",
             "thing,article,goods,dignity,article (goods),counter for meal courses"
-        ],
-        "notation": "品(しな)"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "勘(かん)",
             "perception,intuition,the sixth sense"
-        ],
-        "notation": "勘(かん)"
+        ]
     },
     {
         "name": "damaru",
         "trans": [
+            "黙(だま)る",
             "to be silent"
-        ],
-        "notation": "黙(だま)る"
+        ]
     },
     {
         "name": "gun",
         "trans": [
+            "軍(ぐん)",
             "army,force,troops"
-        ],
-        "notation": "軍(ぐん)"
+        ]
     },
     {
         "name": "yousuruni",
         "trans": [
+            "要(よう)するに",
             "in a word,after all,the point is ..,in short .."
-        ],
-        "notation": "要(よう)するに"
+        ]
     },
     {
         "name": "ii",
         "trans": [
+            "いい",
             "good"
-        ],
-        "notation": "いい"
+        ]
     },
     {
         "name": "menbaa",
         "trans": [
+            "メンバー",
             "member"
-        ],
-        "notation": "メンバー"
+        ]
     },
     {
         "name": "seido",
         "trans": [
+            "制度(せいど)",
             "system,institution,organization"
-        ],
-        "notation": "制度(せいど)"
+        ]
     },
     {
         "name": "teishutsu",
         "trans": [
+            "提出(ていしゅつ)",
             "presentation,submission,filing"
-        ],
-        "notation": "提出(ていしゅつ)"
+        ]
     },
     {
         "name": "shinpai",
         "trans": [
+            "心配(しんぱい)",
             "worry,concern,anxiety,care"
-        ],
-        "notation": "心配(しんぱい)"
+        ]
     },
     {
         "name": "yobun",
         "trans": [
+            "余分(よぶん)",
             "extra,excess,surplus"
-        ],
-        "notation": "余分(よぶん)"
+        ]
     },
     {
         "name": "sue",
         "trans": [
+            "末(すえ)",
             "the end of,powder"
-        ],
-        "notation": "末(すえ)"
+        ]
     },
     {
         "name": "soudan",
         "trans": [
+            "相談(そうだん)",
             "consultation,discussion"
-        ],
-        "notation": "相談(そうだん)"
+        ]
     },
     {
         "name": "uisukii",
         "trans": [
+            "ウイスキー",
             "whisky"
-        ],
-        "notation": "ウイスキー"
+        ]
     },
     {
         "name": "jikken",
         "trans": [
+            "実験(じっけん)",
             "experiment"
-        ],
-        "notation": "実験(じっけん)"
+        ]
     },
     {
         "name": "kinsen",
         "trans": [
+            "金銭(きんせん)",
             "money,cash"
-        ],
-        "notation": "金銭(きんせん)"
+        ]
     },
     {
         "name": "kyougi",
         "trans": [
+            "競技(きょうぎ)",
             "game,match,contest"
-        ],
-        "notation": "競技(きょうぎ)"
+        ]
     },
     {
         "name": "kazu",
         "trans": [
+            "数(かず)",
             "number,figure"
-        ],
-        "notation": "数(かず)"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "組(く)む",
             "to put together"
-        ],
-        "notation": "組(く)む"
+        ]
     },
     {
         "name": "yobou",
         "trans": [
+            "予防(よぼう)",
             "prevention,precaution,protection against"
-        ],
-        "notation": "予防(よぼう)"
+        ]
     },
     {
         "name": "tsutome",
         "trans": [
+            "務(つと)め",
             "(1) service,duty,(2) Buddhist religious services"
-        ],
-        "notation": "務(つと)め"
+        ]
     },
     {
         "name": "kokumotsu",
         "trans": [
+            "穀物(こくもつ)",
             "grain,cereal,corn"
-        ],
-        "notation": "穀物(こくもつ)"
+        ]
     },
     {
         "name": "tamatama",
         "trans": [
+            "偶々(たまたま)",
             "casually,unexpectedly,accidentally,by chance"
-        ],
-        "notation": "偶々(たまたま)"
+        ]
     },
     {
         "name": "renzoku",
         "trans": [
+            "連続(れんぞく)",
             "serial,consecutive,continuity,continuing"
-        ],
-        "notation": "連続(れんぞく)"
+        ]
     },
     {
         "name": "bentou",
         "trans": [
+            "弁当(べんとう)",
             "box lunch"
-        ],
-        "notation": "弁当(べんとう)"
+        ]
     },
     {
         "name": "tatoe",
         "trans": [
+            "たとえ",
             "simile,metaphor,allegory"
-        ],
-        "notation": "たとえ"
+        ]
     },
     {
         "name": "egaku",
         "trans": [
+            "描(えが)く",
             "to draw,to paint,to sketch,to depict,to describe"
-        ],
-        "notation": "描(えが)く"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "付(つ)ける",
             "to attach,to join,to add,to append"
-        ],
-        "notation": "付(つ)ける"
+        ]
     },
     {
         "name": "son",
         "trans": [
+            "損(そん)",
             "loss,disadvantage"
-        ],
-        "notation": "損(そん)"
+        ]
     },
     {
         "name": "dareka",
         "trans": [
+            "誰(だれ)か",
             "someone,somebody"
-        ],
-        "notation": "誰(だれ)か"
+        ]
     },
     {
         "name": "hihan",
         "trans": [
+            "批判(ひはん)",
             "criticism,judgement,comment"
-        ],
-        "notation": "批判(ひはん)"
+        ]
     },
     {
         "name": "deha",
         "trans": [
+            "では",
             "chance of going out,opportunity (to succeed),moment of departure,beginning of work"
-        ],
-        "notation": "では"
+        ]
     },
     {
         "name": "kekkan",
         "trans": [
+            "欠陥(けっかん)",
             "defect,fault,deficiency"
-        ],
-        "notation": "欠陥(けっかん)"
+        ]
     },
     {
         "name": "gurasu",
         "trans": [
+            "グラス",
             "(1) glass,(2) grass"
-        ],
-        "notation": "グラス"
+        ]
     },
     {
         "name": "sono",
         "trans": [
+            "その",
             "the,that"
-        ],
-        "notation": "その"
+        ]
     },
     {
         "name": "kaa",
         "trans": [
+            "カー",
             "car"
-        ],
-        "notation": "カー"
+        ]
     },
     {
         "name": "shuudan",
         "trans": [
+            "集団(しゅうだん)",
             "group,mass"
-        ],
-        "notation": "集団(しゅうだん)"
+        ]
     },
     {
         "name": "shimai",
         "trans": [
+            "姉妹(しまい)",
             "sisters"
-        ],
-        "notation": "姉妹(しまい)"
+        ]
     },
     {
         "name": "paasento",
         "trans": [
+            "パーセント",
             "percent"
-        ],
-        "notation": "パーセント"
+        ]
     },
     {
         "name": "jettoki",
         "trans": [
+            "ジェット機(き)",
             "jet aeroplane"
-        ],
-        "notation": "ジェット機(き)"
+        ]
     },
     {
         "name": "hori",
         "trans": [
+            "濠(ほり)",
             "moat"
-        ],
-        "notation": "濠(ほり)"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "酔(よ)う",
             "to get drunk,to become intoxicated"
-        ],
-        "notation": "酔(よ)う"
+        ]
     },
     {
         "name": "mina",
         "trans": [
+            "皆(みな)",
             "all,everyone,everybody"
-        ],
-        "notation": "皆(みな)"
+        ]
     },
     {
         "name": "yushutsu",
         "trans": [
+            "輸出(ゆしゅつ)",
             "export"
-        ],
-        "notation": "輸出(ゆしゅつ)"
+        ]
     },
     {
         "name": "kei",
         "trans": [
+            "計(けい)",
             "plan"
-        ],
-        "notation": "計(けい)"
+        ]
     },
     {
         "name": "oyobosu",
         "trans": [
+            "及(およ)ぼす",
             "to exert,to cause,to exercise"
-        ],
-        "notation": "及(およ)ぼす"
+        ]
     },
     {
         "name": "tema",
         "trans": [
+            "手間(てま)",
             "time,labour"
-        ],
-        "notation": "手間(てま)"
+        ]
     },
     {
         "name": "shitaku",
         "trans": [
+            "支度(したく)",
             "preparation"
-        ],
-        "notation": "支度(したく)"
+        ]
     },
     {
         "name": "kokugo",
         "trans": [
+            "国語(こくご)",
             "national language"
-        ],
-        "notation": "国語(こくご)"
+        ]
     },
     {
         "name": "daijin",
         "trans": [
+            "大臣(だいじん)",
             "cabinet minister"
-        ],
-        "notation": "大臣(だいじん)"
+        ]
     },
     {
         "name": "kago",
         "trans": [
+            "籠(かご)",
             "basket,cage"
-        ],
-        "notation": "籠(かご)"
+        ]
     },
     {
         "name": "irasshai",
         "trans": [
+            "いらっしゃい",
             "welcome"
-        ],
-        "notation": "いらっしゃい"
+        ]
     },
     {
         "name": "chuu",
         "trans": [
+            "注(ちゅう)",
             "annotation,explanatory note"
-        ],
-        "notation": "注(ちゅう)"
+        ]
     },
     {
         "name": "arubamu",
         "trans": [
+            "アルバム",
             "album"
-        ],
-        "notation": "アルバム"
+        ]
     },
     {
         "name": "shosai",
         "trans": [
+            "書斎(しょさい)",
             "study"
-        ],
-        "notation": "書斎(しょさい)"
+        ]
     },
     {
         "name": "abiru",
         "trans": [
+            "浴(あ)びる",
             "to bathe,to bask in the sun,to shower"
-        ],
-        "notation": "浴(あ)びる"
+        ]
     },
     {
         "name": "iwau",
         "trans": [
+            "祝(いわ)う",
             "to congratulate,to celebrate"
-        ],
-        "notation": "祝(いわ)う"
+        ]
     },
     {
         "name": "juyou",
         "trans": [
+            "需要(じゅよう)",
             "demand,request"
-        ],
-        "notation": "需要(じゅよう)"
+        ]
     },
     {
         "name": "oyogi",
         "trans": [
+            "泳(およ)ぎ",
             "swimming"
-        ],
-        "notation": "泳(およ)ぎ"
+        ]
     },
     {
         "name": "ikioi",
         "trans": [
+            "勢(いきお)い",
             "force,vigor,energy,spirit"
-        ],
-        "notation": "勢(いきお)い"
+        ]
     },
     {
         "name": "chikagoro",
         "trans": [
+            "近頃(ちかごろ)",
             "lately,recently,nowadays"
-        ],
-        "notation": "近頃(ちかごろ)"
+        ]
     },
     {
         "name": "tasukeru",
         "trans": [
+            "助(たす)ける",
             "to help,to save,to rescue"
-        ],
-        "notation": "助(たす)ける"
+        ]
     },
     {
         "name": "shoujiru",
         "trans": [
+            "生(しょう)じる",
             "to produce,to yield,to result from,to arise,to be generated"
-        ],
-        "notation": "生(しょう)じる"
+        ]
     },
     {
         "name": "ne",
         "trans": [
+            "値(ね)",
             "value,price,cost"
-        ],
-        "notation": "値(ね)"
+        ]
     },
     {
         "name": "kouho",
         "trans": [
+            "候補(こうほ)",
             "candidacy"
-        ],
-        "notation": "候補(こうほ)"
+        ]
     },
     {
         "name": "geemu",
         "trans": [
+            "ゲーム",
             "game"
-        ],
-        "notation": "ゲーム"
+        ]
     },
     {
         "name": "chikyuu",
         "trans": [
+            "地球(ちきゅう)",
             "the earth"
-        ],
-        "notation": "地球(ちきゅう)"
+        ]
     },
     {
         "name": "naiyou",
         "trans": [
+            "内容(ないよう)",
             "subject,contents,matter,substance,detail,import"
-        ],
-        "notation": "内容(ないよう)"
+        ]
     },
     {
         "name": "sameru",
         "trans": [
+            "覚(さ)める",
             "to wake,to wake up"
-        ],
-        "notation": "覚(さ)める"
+        ]
     },
     {
         "name": "soutou",
         "trans": [
+            "相当(そうとう)",
             "suitable,fair,tolerable,proper"
-        ],
-        "notation": "相当(そうとう)"
+        ]
     },
     {
         "name": "kotowaru",
         "trans": [
+            "断(ことわ)る",
             "to refuse,to decline,to dismiss"
-        ],
-        "notation": "断(ことわ)る"
+        ]
     },
     {
         "name": "mata",
         "trans": [
+            "又(また)",
             "again,and"
-        ],
-        "notation": "又(また)"
+        ]
     },
     {
         "name": "bouru",
         "trans": [
+            "ボール",
             "ball,bowl"
-        ],
-        "notation": "ボール"
+        ]
     },
     {
         "name": "oboreru",
         "trans": [
+            "溺(おぼ)れる",
             "to be drowned,to indulge in"
-        ],
-        "notation": "溺(おぼ)れる"
+        ]
     },
     {
         "name": "kire",
         "trans": [
+            "切(き)れ",
             "cloth,piece,cut,chop"
-        ],
-        "notation": "切(き)れ"
+        ]
     },
     {
         "name": "tada",
         "trans": [
+            "唯(ただ)",
             "free of charge,mere,sole,only,usual,common"
-        ],
-        "notation": "唯(ただ)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "十(じゅう)",
             "10,ten"
-        ],
-        "notation": "十(じゅう)"
+        ]
     },
     {
         "name": "choujou",
         "trans": [
+            "頂上(ちょうじょう)",
             "top,summit,peak"
-        ],
-        "notation": "頂上(ちょうじょう)"
+        ]
     },
     {
         "name": "seishiki",
         "trans": [
+            "正式(せいしき)",
             "due form,official,formality"
-        ],
-        "notation": "正式(せいしき)"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "機械(きかい)",
             "machine,mechanism"
-        ],
-        "notation": "機械(きかい)"
+        ]
     },
     {
         "name": "ifuku",
         "trans": [
+            "衣服(いふく)",
             "clothes"
-        ],
-        "notation": "衣服(いふく)"
+        ]
     },
     {
         "name": "monogatari",
         "trans": [
+            "物語(ものがたり)",
             "tale,story,legend"
-        ],
-        "notation": "物語(ものがたり)"
+        ]
     },
     {
         "name": "kakaeru",
         "trans": [
+            "抱(かか)える",
             "to hold or carry under or in the arms"
-        ],
-        "notation": "抱(かか)える"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "生命(せいめい)",
             "life,existence"
-        ],
-        "notation": "生命(せいめい)"
+        ]
     },
     {
         "name": "goukei",
         "trans": [
+            "合計(ごうけい)",
             "sum total,total amount"
-        ],
-        "notation": "合計(ごうけい)"
+        ]
     },
     {
         "name": "taiiku",
         "trans": [
+            "体育(たいいく)",
             "physical education,gymnastics,athletics"
-        ],
-        "notation": "体育(たいいく)"
+        ]
     },
     {
         "name": "toshitsuki",
         "trans": [
+            "年月(としつき)",
             "months and years"
-        ],
-        "notation": "年月(としつき)"
+        ]
     },
     {
         "name": "gaishutsu",
         "trans": [
+            "外出(がいしゅつ)",
             "outing,going out"
-        ],
-        "notation": "外出(がいしゅつ)"
+        ]
     },
     {
         "name": "kinodoku",
         "trans": [
+            "気(き)の毒(どく)",
             "pitiful,a pity"
-        ],
-        "notation": "気(き)の毒(どく)"
+        ]
     },
     {
         "name": "surudoi",
         "trans": [
+            "鋭(するど)い",
             "pointed,sharp"
-        ],
-        "notation": "鋭(するど)い"
+        ]
     },
     {
         "name": "egao",
         "trans": [
+            "笑顔(えがお)",
             "smiling face"
-        ],
-        "notation": "笑顔(えがお)"
+        ]
     },
     {
         "name": "tsumeru",
         "trans": [
+            "詰(つ)める",
             "to pack,to shorten,to work out (details)"
-        ],
-        "notation": "詰(つ)める"
+        ]
     },
     {
         "name": "konomu",
         "trans": [
+            "好(この)む",
             "to like,to prefer"
-        ],
-        "notation": "好(この)む"
+        ]
     },
     {
         "name": "toriageru",
         "trans": [
+            "取(と)り上(あ)げる",
             "to take up,to pick up,to disqualify,to confiscate,to deprive"
-        ],
-        "notation": "取(と)り上(あ)げる"
+        ]
     },
     {
         "name": "hansamu",
         "trans": [
+            "ハンサム",
             "handsome"
-        ],
-        "notation": "ハンサム"
+        ]
     },
     {
         "name": "irai",
         "trans": [
+            "以来(いらい)",
             "since,henceforth"
-        ],
-        "notation": "以来(いらい)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "生産(せいさん)",
             "production,manufacture"
-        ],
-        "notation": "生産(せいさん)"
+        ]
     },
     {
         "name": "shingaku",
         "trans": [
+            "進学(しんがく)",
             "going on to university"
-        ],
-        "notation": "進学(しんがく)"
+        ]
     },
     {
         "name": "jinbutsu",
         "trans": [
+            "人物(じんぶつ)",
             "character,personality,person,man,personage,talented man"
-        ],
-        "notation": "人物(じんぶつ)"
+        ]
     },
     {
         "name": "nuku",
         "trans": [
+            "抜(ぬ)く",
             "to extract,to omit,to surpass,to draw out,to unplug"
-        ],
-        "notation": "抜(ぬ)く"
+        ]
     },
     {
         "name": "kachi",
         "trans": [
+            "勝(か)ち",
             "win,victory"
-        ],
-        "notation": "勝(か)ち"
+        ]
     },
     {
         "name": "akira",
         "trans": [
+            "章(あきら)",
             "(1) chapter,section,(2) medal"
-        ],
-        "notation": "章(あきら)"
+        ]
     },
     {
         "name": "juusu",
         "trans": [
+            "ジュース",
             "juice,soft drink,deuce"
-        ],
-        "notation": "ジュース"
+        ]
     },
     {
         "name": "choudai",
         "trans": [
+            "ちょうだい",
             "(1) please do for me (preceded by -te),(2) reception,being given,get"
-        ],
-        "notation": "ちょうだい"
+        ]
     },
     {
         "name": "tou",
         "trans": [
+            "党(とう)",
             "party (political)"
-        ],
-        "notation": "党(とう)"
+        ]
     },
     {
         "name": "nanidemo",
         "trans": [
+            "何(なに)でも",
             "by all means,everything"
-        ],
-        "notation": "何(なに)でも"
+        ]
     },
     {
         "name": "tekido",
         "trans": [
+            "適度(てきど)",
             "moderate"
-        ],
-        "notation": "適度(てきど)"
+        ]
     },
     {
         "name": "oujiru",
         "trans": [
+            "応(おう)じる",
             "to respond,to satisfy,to accept,to comply with,to apply for"
-        ],
-        "notation": "応(おう)じる"
+        ]
     },
     {
         "name": "shuto",
         "trans": [
+            "首都(しゅと)",
             "capital city"
-        ],
-        "notation": "首都(しゅと)"
+        ]
     },
     {
         "name": "nochi",
         "trans": [
+            "後(のち)",
             "afterwards,since then,in the future"
-        ],
-        "notation": "後(のち)"
+        ]
     },
     {
         "name": "keikoku",
         "trans": [
+            "警告(けいこく)",
             "warning,advice"
-        ],
-        "notation": "警告(けいこく)"
+        ]
     },
     {
         "name": "bubun",
         "trans": [
+            "部分(ぶぶん)",
             "portion,section,part"
-        ],
-        "notation": "部分(ぶぶん)"
+        ]
     },
     {
         "name": "yuujou",
         "trans": [
+            "友情(ゆうじょう)",
             "friendship,fellowship"
-        ],
-        "notation": "友情(ゆうじょう)"
+        ]
     },
     {
         "name": "setsu",
         "trans": [
+            "説(せつ)",
             "theory"
-        ],
-        "notation": "説(せつ)"
+        ]
     },
     {
         "name": "wakare",
         "trans": [
+            "別(わか)れ",
             "parting,separation,farewell"
-        ],
-        "notation": "別(わか)れ"
+        ]
     },
     {
         "name": "houkou",
         "trans": [
+            "方向(ほうこう)",
             "direction,course,way"
-        ],
-        "notation": "方向(ほうこう)"
+        ]
     },
     {
         "name": "homeru",
         "trans": [
+            "褒(ほ)める",
             "to praise,to admire,to speak well"
-        ],
-        "notation": "褒(ほ)める"
+        ]
     },
     {
         "name": "yuuri",
         "trans": [
+            "有利(ゆうり)",
             "advantageous,better,profitable,lucrative"
-        ],
-        "notation": "有利(ゆうり)"
+        ]
     },
     {
         "name": "nukeru",
         "trans": [
+            "抜(ぬ)ける",
             "to come out,to fall out,to be omitted"
-        ],
-        "notation": "抜(ぬ)ける"
+        ]
     },
     {
         "name": "roujin",
         "trans": [
+            "老人(ろうじん)",
             "the aged,old person"
-        ],
-        "notation": "老人(ろうじん)"
+        ]
     },
     {
         "name": "puro",
         "trans": [
+            "プロ",
             "professional"
-        ],
-        "notation": "プロ"
+        ]
     },
     {
         "name": "i",
         "trans": [
+            "胃(い)",
             "stomach"
-        ],
-        "notation": "胃(い)"
+        ]
     },
     {
         "name": "nobasu",
         "trans": [
+            "伸(の)ばす",
             "to lengthen,to stretch,to reach out,to grow (beard)"
-        ],
-        "notation": "伸(の)ばす"
+        ]
     },
     {
         "name": "jama",
         "trans": [
+            "邪魔(じゃま)",
             "hindrance,intrusion"
-        ],
-        "notation": "邪魔(じゃま)"
+        ]
     },
     {
         "name": "samazama",
         "trans": [
+            "様々(さまざま)",
             "varied,various"
-        ],
-        "notation": "様々(さまざま)"
+        ]
     },
     {
         "name": "ase",
         "trans": [
+            "汗(あせ)",
             "sweat,perspiration"
-        ],
-        "notation": "汗(あせ)"
+        ]
     },
     {
         "name": "shoujou",
         "trans": [
+            "症状(しょうじょう)",
             "symptoms,condition"
-        ],
-        "notation": "症状(しょうじょう)"
+        ]
     },
     {
         "name": "marude",
         "trans": [
+            "まるで",
             "quite,entirely,completely"
-        ],
-        "notation": "まるで"
+        ]
     },
     {
         "name": "ashita",
         "trans": [
+            "あした",
             "tomorrow"
-        ],
-        "notation": "あした"
+        ]
     },
     {
         "name": "dokutoku",
         "trans": [
+            "独特(どくとく)",
             "peculiarity,uniqueness,characteristic"
-        ],
-        "notation": "独特(どくとく)"
+        ]
     },
     {
         "name": "suruto",
         "trans": [
+            "すると",
             "thereupon,hereupon"
-        ],
-        "notation": "すると"
+        ]
     },
     {
         "name": "zetsumetsu",
         "trans": [
+            "絶滅(ぜつめつ)",
             "destruction,extinction"
-        ],
-        "notation": "絶滅(ぜつめつ)"
+        ]
     },
     {
         "name": "kaiga",
         "trans": [
+            "絵画(かいが)",
             "picture"
-        ],
-        "notation": "絵画(かいが)"
+        ]
     },
     {
         "name": "shiri",
         "trans": [
+            "尻(しり)",
             "buttocks,bottom"
-        ],
-        "notation": "尻(しり)"
+        ]
     },
     {
         "name": "gaku",
         "trans": [
+            "額(がく)",
             "forehead,brow"
-        ],
-        "notation": "額(がく)"
+        ]
     },
     {
         "name": "aite",
         "trans": [
+            "相手(あいて)",
             "companion,partner,company"
-        ],
-        "notation": "相手(あいて)"
+        ]
     },
     {
         "name": "tani",
         "trans": [
+            "谷(たに)",
             "valley"
-        ],
-        "notation": "谷(たに)"
+        ]
     },
     {
         "name": "kankyaku",
         "trans": [
+            "観客(かんきゃく)",
             "audience,spectator(s)"
-        ],
-        "notation": "観客(かんきゃく)"
+        ]
     },
     {
         "name": "gaikou",
         "trans": [
+            "外交(がいこう)",
             "diplomacy"
-        ],
-        "notation": "外交(がいこう)"
+        ]
     },
     {
         "name": "yoki",
         "trans": [
+            "予期(よき)",
             "expectation,assume will happen,forecast"
-        ],
-        "notation": "予期(よき)"
+        ]
     },
     {
         "name": "byoudou",
         "trans": [
+            "平等(びょうどう)",
             "equality (a),impartiality,evenness"
-        ],
-        "notation": "平等(びょうどう)"
+        ]
     },
     {
         "name": "kimyou",
         "trans": [
+            "奇妙(きみょう)",
             "strange,queer,curious"
-        ],
-        "notation": "奇妙(きみょう)"
+        ]
     },
     {
         "name": "furi",
         "trans": [
+            "不利(ふり)",
             "disadvantage,handicap,unfavorable,drawback"
-        ],
-        "notation": "不利(ふり)"
+        ]
     },
     {
         "name": "fuan",
         "trans": [
+            "不安(ふあん)",
             "anxiety,uneasiness,insecurity,suspense"
-        ],
-        "notation": "不安(ふあん)"
+        ]
     },
     {
         "name": "shinrai",
         "trans": [
+            "信頼(しんらい)",
             "reliance,trust,confidence"
-        ],
-        "notation": "信頼(しんらい)"
+        ]
     },
     {
         "name": "keisan",
         "trans": [
+            "計算(けいさん)",
             "calculation,reckoning"
-        ],
-        "notation": "計算(けいさん)"
+        ]
     },
     {
         "name": "ouji",
         "trans": [
+            "王子(おうじ)",
             "prince"
-        ],
-        "notation": "王子(おうじ)"
+        ]
     },
     {
         "name": "souzou",
         "trans": [
+            "想像(そうぞう)",
             "imagination,guess"
-        ],
-        "notation": "想像(そうぞう)"
+        ]
     },
     {
         "name": "masumasu",
         "trans": [
+            "ますます",
             "increasingly,more and more"
-        ],
-        "notation": "ますます"
+        ]
     },
     {
         "name": "zutto",
         "trans": [
+            "ずっと",
             "consecutively,throughout,a lot"
-        ],
-        "notation": "ずっと"
+        ]
     },
     {
         "name": "awaseru",
         "trans": [
+            "合(あ)わせる",
             "to join together,to be opposite,to face,to unite"
-        ],
-        "notation": "合(あ)わせる"
+        ]
     },
     {
         "name": "daga",
         "trans": [
+            "だが",
             ""
-        ],
-        "notation": "だが"
+        ]
     },
     {
         "name": "kakki",
         "trans": [
+            "活気(かっき)",
             "energy,liveliness"
-        ],
-        "notation": "活気(かっき)"
+        ]
     },
     {
         "name": "enjin",
         "trans": [
+            "エンジン",
             "engine"
-        ],
-        "notation": "エンジン"
+        ]
     },
     {
         "name": "fukusou",
         "trans": [
+            "服装(ふくそう)",
             "garments"
-        ],
-        "notation": "服装(ふくそう)"
+        ]
     },
     {
         "name": "sutando",
         "trans": [
+            "スタンド",
             "stand"
-        ],
-        "notation": "スタンド"
+        ]
     },
     {
         "name": "akari",
         "trans": [
+            "灯(あかり)",
             "light"
-        ],
-        "notation": "灯(あかり)"
+        ]
     },
     {
         "name": "gin",
         "trans": [
+            "銀(ぎん)",
             "(1) silver,silver coin,silver paint"
-        ],
-        "notation": "銀(ぎん)"
+        ]
     },
     {
         "name": "kanjou",
         "trans": [
+            "勘定(かんじょう)",
             "calculation,counting,consideration"
-        ],
-        "notation": "勘定(かんじょう)"
+        ]
     },
     {
         "name": "nanika",
         "trans": [
+            "何(なに)か",
             "something"
-        ],
-        "notation": "何(なに)か"
+        ]
     },
     {
         "name": "shusshin",
         "trans": [
+            "出身(しゅっしん)",
             "graduate from,come from"
-        ],
-        "notation": "出身(しゅっしん)"
+        ]
     },
     {
         "name": "moushikomu",
         "trans": [
+            "申(もう)し込(こ)む",
             "to apply for,to make an application"
-        ],
-        "notation": "申(もう)し込(こ)む"
+        ]
     },
     {
         "name": "shitsugyou",
         "trans": [
+            "失業(しつぎょう)",
             "unemployment"
-        ],
-        "notation": "失業(しつぎょう)"
+        ]
     },
     {
         "name": "seiseki",
         "trans": [
+            "成績(せいせき)",
             "results,record"
-        ],
-        "notation": "成績(せいせき)"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "息(いき)",
             "breath,tone"
-        ],
-        "notation": "息(いき)"
+        ]
     },
     {
         "name": "e",
         "trans": [
+            "柄(え)",
             "hilt (of a sword),haft (of a dagger),handgrip"
-        ],
-        "notation": "柄(え)"
+        ]
     },
     {
         "name": "koto",
         "trans": [
+            "事(こと)",
             "thing,matter,fact,circumstances"
-        ],
-        "notation": "事(こと)"
+        ]
     },
     {
         "name": "taisuru",
         "trans": [
+            "対(たい)する",
             "to face,to confront,to oppose"
-        ],
-        "notation": "対(たい)する"
+        ]
     },
     {
         "name": "arayuru",
         "trans": [
+            "あらゆる",
             "all,every"
-        ],
-        "notation": "あらゆる"
+        ]
     },
     {
         "name": "su",
         "trans": [
+            "巣(す)",
             "nest,rookery,breeding place,beehive,cobweb"
-        ],
-        "notation": "巣(す)"
+        ]
     },
     {
         "name": "kioku",
         "trans": [
+            "記憶(きおく)",
             "memory,recollection,remembrance"
-        ],
-        "notation": "記憶(きおく)"
+        ]
     },
     {
         "name": "tanin",
         "trans": [
+            "他人(たにん)",
             "another person,unrelated person,outsider,stranger"
-        ],
-        "notation": "他人(たにん)"
+        ]
     },
     {
         "name": "sankou",
         "trans": [
+            "参考(さんこう)",
             "reference,consultation"
-        ],
-        "notation": "参考(さんこう)"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "様(よう)",
             "way,manner,kind"
-        ],
-        "notation": "様(よう)"
+        ]
     },
     {
         "name": "kansha",
         "trans": [
+            "感謝(かんしゃ)",
             "thanks,gratitude"
-        ],
-        "notation": "感謝(かんしゃ)"
+        ]
     },
     {
         "name": "inshou",
         "trans": [
+            "印象(いんしょう)",
             "impression"
-        ],
-        "notation": "印象(いんしょう)"
+        ]
     },
     {
         "name": "butsuri",
         "trans": [
+            "物理(ぶつり)",
             "physics"
-        ],
-        "notation": "物理(ぶつり)"
+        ]
     },
     {
         "name": "tsutsumi",
         "trans": [
+            "包(つつ)み",
             "bundle,package,parcel,bale"
-        ],
-        "notation": "包(つつ)み"
+        ]
     },
     {
         "name": "un",
         "trans": [
+            "うん",
             "hum, hmmm, well, erm, huh?"
-        ],
-        "notation": "うん"
+        ]
     },
     {
         "name": "kagaku",
         "trans": [
+            "化学(かがく)",
             "chemistry"
-        ],
-        "notation": "化学(かがく)"
+        ]
     },
     {
         "name": "gussuri",
         "trans": [
+            "ぐっすり",
             "sound asleep,fast asleep"
-        ],
-        "notation": "ぐっすり"
+        ]
     },
     {
         "name": "omedetou",
         "trans": [
+            "おめでとう",
             "Congratulations!,an auspicious occasion!"
-        ],
-        "notation": "おめでとう"
+        ]
     },
     {
         "name": "uchi",
         "trans": [
+            "内(うち)",
             "inside"
-        ],
-        "notation": "内(うち)"
+        ]
     },
     {
         "name": "saikou",
         "trans": [
+            "最高(さいこう)",
             "highest,supreme,the most"
-        ],
-        "notation": "最高(さいこう)"
+        ]
     },
     {
         "name": "shouhin",
         "trans": [
+            "商品(しょうひん)",
             "commodity,article of commerce,goods,stock,merchandise"
-        ],
-        "notation": "商品(しょうひん)"
+        ]
     },
     {
         "name": "do",
         "trans": [
+            "度(ど)",
             "counter for occurrences"
-        ],
-        "notation": "度(ど)"
+        ]
     },
     {
         "name": "bideo",
         "trans": [
+            "ビデオ",
             "video"
-        ],
-        "notation": "ビデオ"
+        ]
     },
     {
         "name": "kindai",
         "trans": [
+            "近代(きんだい)",
             "present day"
-        ],
-        "notation": "近代(きんだい)"
+        ]
     },
     {
         "name": "hani",
         "trans": [
+            "範囲(はんい)",
             "extent,scope,sphere,range"
-        ],
-        "notation": "範囲(はんい)"
+        ]
     },
     {
         "name": "kaori",
         "trans": [
+            "香(かお)り",
             "aroma,fragrance,scent,smell"
-        ],
-        "notation": "香(かお)り"
+        ]
     },
     {
         "name": "kau",
         "trans": [
+            "飼(か)う",
             "to keep,to raise,to feed"
-        ],
-        "notation": "飼(か)う"
+        ]
     },
     {
         "name": "noseru",
         "trans": [
+            "乗(の)せる",
             "to place on (something),to take on board,to give a ride"
-        ],
-        "notation": "乗(の)せる"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "計(はか)る",
             "to measure,to weigh,to survey"
-        ],
-        "notation": "計(はか)る"
+        ]
     },
     {
         "name": "sokudo",
         "trans": [
+            "速度(そくど)",
             "speed,velocity,rate"
-        ],
-        "notation": "速度(そくど)"
+        ]
     },
     {
         "name": "genjitsu",
         "trans": [
+            "現実(げんじつ)",
             "reality"
-        ],
-        "notation": "現実(げんじつ)"
+        ]
     },
     {
         "name": "yachin",
         "trans": [
+            "家賃(やちん)",
             "rent"
-        ],
-        "notation": "家賃(やちん)"
+        ]
     },
     {
         "name": "shougakukin",
         "trans": [
+            "奨学(しょうがく)金(きん)",
             "scholarship"
-        ],
-        "notation": "奨学(しょうがく)金(きん)"
+        ]
     },
     {
         "name": "mushiba",
         "trans": [
+            "虫歯(むしば)",
             "cavity,tooth decay,decayed tooth,caries"
-        ],
-        "notation": "虫歯(むしば)"
+        ]
     },
     {
         "name": "youroppa",
         "trans": [
+            "ヨーロッパ",
             "Europe"
-        ],
-        "notation": "ヨーロッパ"
+        ]
     },
     {
         "name": "toreru",
         "trans": [
+            "取(と)れる",
             "to come off,to be taken off,to be removed"
-        ],
-        "notation": "取(と)れる"
+        ]
     },
     {
         "name": "fudan",
         "trans": [
+            "普段(ふだん)",
             "usually,habitually,ordinarily,always"
-        ],
-        "notation": "普段(ふだん)"
+        ]
     },
     {
         "name": "nashi",
         "trans": [
+            "無(な)し",
             "without"
-        ],
-        "notation": "無(な)し"
+        ]
     },
     {
         "name": "kakari",
         "trans": [
+            "係(かかり)",
             "official,duty,person in charge"
-        ],
-        "notation": "係(かかり)"
+        ]
     },
     {
         "name": "rensou",
         "trans": [
+            "連想(れんそう)",
             "association (of ideas),suggestion"
-        ],
-        "notation": "連想(れんそう)"
+        ]
     },
     {
         "name": "shitagau",
         "trans": [
+            "従(したが)う",
             "to abide (by the rules),to obey,to follow,to accompany"
-        ],
-        "notation": "従(したが)う"
+        ]
     },
     {
         "name": "shuukaku",
         "trans": [
+            "収穫(しゅうかく)",
             "harvest,crop,ingathering"
-        ],
-        "notation": "収穫(しゅうかく)"
+        ]
     },
     {
         "name": "tsutome",
         "trans": [
+            "勤(つと)め",
             "(1) service,duty,business,responsibility,task,(2) Buddhist religious services"
-        ],
-        "notation": "勤(つと)め"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "法(ほう)",
             "Act (law: the X Act)"
-        ],
-        "notation": "法(ほう)"
+        ]
     },
     {
         "name": "yuunou",
         "trans": [
+            "有能(ゆうのう)",
             "able,capable,efficient,skill"
-        ],
-        "notation": "有能(ゆうのう)"
+        ]
     },
     {
         "name": "mune",
         "trans": [
+            "胸(むね)",
             "breast,chest"
-        ],
-        "notation": "胸(むね)"
+        ]
     },
     {
         "name": "uttaeru",
         "trans": [
+            "訴(うった)える",
             "to sue (a person),to resort to,to appeal to"
-        ],
-        "notation": "訴(うった)える"
+        ]
     },
     {
         "name": "yoruto",
         "trans": [
+            "よると",
             "according to"
-        ],
-        "notation": "よると"
+        ]
     },
     {
         "name": "chie",
         "trans": [
+            "知恵(ちえ)",
             "wisdom,wit,sagacity,sense,intelligence,advice"
-        ],
-        "notation": "知恵(ちえ)"
+        ]
     },
     {
         "name": "itazura",
         "trans": [
+            "いたずら",
             "tease,prank,trick,practical joke"
-        ],
-        "notation": "いたずら"
+        ]
     },
     {
         "name": "chihou",
         "trans": [
+            "地方(ちほう)",
             "area,locality,district,region,the coast"
-        ],
-        "notation": "地方(ちほう)"
+        ]
     },
     {
         "name": "keii",
         "trans": [
+            "敬意(けいい)",
             "respect,honour"
-        ],
-        "notation": "敬意(けいい)"
+        ]
     },
     {
         "name": "reigi",
         "trans": [
+            "礼儀(れいぎ)",
             "manners,courtesy,etiquette"
-        ],
-        "notation": "礼儀(れいぎ)"
+        ]
     },
     {
         "name": "kimari",
         "trans": [
+            "決(き)まり",
             "settlement,conclusion,regulation,rule"
-        ],
-        "notation": "決(き)まり"
+        ]
     },
     {
         "name": "zenshin",
         "trans": [
+            "前進(ぜんしん)",
             "advance,drive,progress"
-        ],
-        "notation": "前進(ぜんしん)"
+        ]
     },
     {
         "name": "kumi",
         "trans": [
+            "組(くみ)",
             "class,group,team,set"
-        ],
-        "notation": "組(くみ)"
+        ]
     },
     {
         "name": "hari",
         "trans": [
+            "針(はり)",
             "needle,hand (e.g. clock)"
-        ],
-        "notation": "針(はり)"
+        ]
     },
     {
         "name": "junbi",
         "trans": [
+            "準備(じゅんび)",
             "preparation,arrangements,provision,reserve"
-        ],
-        "notation": "準備(じゅんび)"
+        ]
     },
     {
         "name": "imada",
         "trans": [
+            "未(いま)だ",
             "yet,still,more,besides"
-        ],
-        "notation": "未(いま)だ"
+        ]
     },
     {
         "name": "kandou",
         "trans": [
+            "感動(かんどう)",
             "being deeply moved,excitement,impression,deep emotion"
-        ],
-        "notation": "感動(かんどう)"
+        ]
     },
     {
         "name": "keikou",
         "trans": [
+            "傾向(けいこう)",
             "tendency,trend,inclination"
-        ],
-        "notation": "傾向(けいこう)"
+        ]
     },
     {
         "name": "keesu",
         "trans": [
+            "ケース",
             "case"
-        ],
-        "notation": "ケース"
+        ]
     },
     {
         "name": "koeru",
         "trans": [
+            "越(こ)える",
             "to exceed,to cross over,to cross"
-        ],
-        "notation": "越(こ)える"
+        ]
     },
     {
         "name": "nodo",
         "trans": [
+            "喉(のど)",
             "throat"
-        ],
-        "notation": "喉(のど)"
+        ]
     },
     {
         "name": "kyoutsuu",
         "trans": [
+            "共通(きょうつう)",
             "commonness,community"
-        ],
-        "notation": "共通(きょうつう)"
+        ]
     },
     {
         "name": "engi",
         "trans": [
+            "演技(えんぎ)",
             "acting,performance"
-        ],
-        "notation": "演技(えんぎ)"
+        ]
     },
     {
         "name": "fukumu",
         "trans": [
+            "含(ふく)む",
             "to hold in the mouth,to bear in mind"
-        ],
-        "notation": "含(ふく)む"
+        ]
     },
     {
         "name": "shuukyou",
         "trans": [
+            "宗教(しゅうきょう)",
             "religion"
-        ],
-        "notation": "宗教(しゅうきょう)"
+        ]
     },
     {
         "name": "fusegu",
         "trans": [
+            "防(ふせ)ぐ",
             "to defend (against),to protect,to prevent"
-        ],
-        "notation": "防(ふせ)ぐ"
+        ]
     },
     {
         "name": "tenkei",
         "trans": [
+            "典型(てんけい)",
             "type,pattern,archetypal"
-        ],
-        "notation": "典型(てんけい)"
+        ]
     },
     {
         "name": "shuuchuu",
         "trans": [
+            "集中(しゅうちゅう)",
             "concentration,focusing the mind"
-        ],
-        "notation": "集中(しゅうちゅう)"
+        ]
     },
     {
         "name": "nabe",
         "trans": [
+            "鍋(なべ)",
             "saucepan,pot"
-        ],
-        "notation": "鍋(なべ)"
+        ]
     },
     {
         "name": "yotto",
         "trans": [
+            "ヨット",
             "yacht"
-        ],
-        "notation": "ヨット"
+        ]
     },
     {
         "name": "soshite",
         "trans": [
+            "そして",
             "and"
-        ],
-        "notation": "そして"
+        ]
     },
     {
         "name": "tekiyou",
         "trans": [
+            "適用(てきよう)",
             "applying"
-        ],
-        "notation": "適用(てきよう)"
+        ]
     },
     {
         "name": "inemuri",
         "trans": [
+            "居眠(いねむ)り",
             "dozing,nodding off"
-        ],
-        "notation": "居眠(いねむ)り"
+        ]
     },
     {
         "name": "ume",
         "trans": [
+            "梅(うめ)",
             "plum,plum-tree,lowest (of a three-tier ranking system)"
-        ],
-        "notation": "梅(うめ)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "灰(はい)",
             "ash"
-        ],
-        "notation": "灰(はい)"
+        ]
     },
     {
         "name": "nenrei",
         "trans": [
+            "年齢(ねんれい)",
             "age,years"
-        ],
-        "notation": "年齢(ねんれい)"
+        ]
     },
     {
         "name": "kuwashii",
         "trans": [
+            "詳(くわ)しい",
             "knowing very well,detailed,full,accurate"
-        ],
-        "notation": "詳(くわ)しい"
+        ]
     },
     {
         "name": "oni",
         "trans": [
+            "鬼(おに)",
             "ogre,demon,it (i.e., in a game of tag)"
-        ],
-        "notation": "鬼(おに)"
+        ]
     },
     {
         "name": "houhou",
         "trans": [
+            "方法(ほうほう)",
             "method,manner,way,means,technique"
-        ],
-        "notation": "方法(ほうほう)"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "バン",
             "bun,van (caravan),VAN (value-added network)"
-        ],
-        "notation": "バン"
+        ]
     },
     {
         "name": "kamoshirenai",
         "trans": [
+            "かもしれない",
             "may,might,perhaps,may be,possibly"
-        ],
-        "notation": "かもしれない"
+        ]
     },
     {
         "name": "juumin",
         "trans": [
+            "住民(じゅうみん)",
             "citizens,inhabitants,residents,population"
-        ],
-        "notation": "住民(じゅうみん)"
+        ]
     },
     {
         "name": "shudan",
         "trans": [
+            "手段(しゅだん)",
             "means,way,measure"
-        ],
-        "notation": "手段(しゅだん)"
+        ]
     },
     {
         "name": "abura",
         "trans": [
+            "油(あぶら)",
             "oil"
-        ],
-        "notation": "油(あぶら)"
+        ]
     },
     {
         "name": "hikaku",
         "trans": [
+            "比較(ひかく)",
             "comparison"
-        ],
-        "notation": "比較(ひかく)"
+        ]
     },
     {
         "name": "esa",
         "trans": [
+            "餌(えさ)",
             "feed,bait"
-        ],
-        "notation": "餌(えさ)"
+        ]
     },
     {
         "name": "gimon",
         "trans": [
+            "疑問(ぎもん)",
             "question,problem,doubt,guess"
-        ],
-        "notation": "疑問(ぎもん)"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "就(つ)く",
             "to settle in (place),to take (seat, position),to study (under teacher)"
-        ],
-        "notation": "就(つ)く"
+        ]
     },
     {
         "name": "sappari",
         "trans": [
+            "さっぱり",
             "feeling refreshed,feeling relieved,neat,trimmed"
-        ],
-        "notation": "さっぱり"
+        ]
     },
     {
         "name": "somatsu",
         "trans": [
+            "粗末(そまつ)",
             "crude,rough,plain,humble"
-        ],
-        "notation": "粗末(そまつ)"
+        ]
     },
     {
         "name": "fuka",
         "trans": [
+            "不可(ふか)",
             "wrong,bad,improper,unjustifiable,inadvisable"
-        ],
-        "notation": "不可(ふか)"
+        ]
     },
     {
         "name": "koukoku",
         "trans": [
+            "広告(こうこく)",
             "advertisement"
-        ],
-        "notation": "広告(こうこく)"
+        ]
     },
     {
         "name": "yuushou",
         "trans": [
+            "優勝(ゆうしょう)",
             "overall victory,championship"
-        ],
-        "notation": "優勝(ゆうしょう)"
+        ]
     },
     {
         "name": "yosu",
         "trans": [
+            "止(よ)す",
             "to cease,to abolish,to resign,to give up"
-        ],
-        "notation": "止(よ)す"
+        ]
     },
     {
         "name": "mikata",
         "trans": [
+            "味方(みかた)",
             "friend,ally,supporter"
-        ],
-        "notation": "味方(みかた)"
+        ]
     },
     {
         "name": "hakushu",
         "trans": [
+            "拍手(はくしゅ)",
             "clapping hands,applause"
-        ],
-        "notation": "拍手(はくしゅ)"
+        ]
     },
     {
         "name": "nochi",
         "trans": [
+            "後(のち)",
             "afterwards,since then,in the future"
-        ],
-        "notation": "後(のち)"
+        ]
     },
     {
         "name": "kega",
         "trans": [
+            "怪我(けが)",
             "injury (to animate object),hurt"
-        ],
-        "notation": "怪我(けが)"
+        ]
     },
     {
         "name": "daibubun",
         "trans": [
+            "大(だい)部分(ぶぶん)",
             "most part,greater part,majority"
-        ],
-        "notation": "大(だい)部分(ぶぶん)"
+        ]
     },
     {
         "name": "oto",
         "trans": [
+            "音(おと)",
             "sound,note"
-        ],
-        "notation": "音(おと)"
+        ]
     },
     {
         "name": "omowazu",
         "trans": [
+            "思(おも)わず",
             "unintentional,spontaneous"
-        ],
-        "notation": "思(おも)わず"
+        ]
     },
     {
         "name": "eien",
         "trans": [
+            "永遠(えいえん)",
             "eternity,perpetuity,immortality,permanence"
-        ],
-        "notation": "永遠(えいえん)"
+        ]
     },
     {
         "name": "gendai",
         "trans": [
+            "現代(げんだい)",
             "nowadays,modern times,present-day"
-        ],
-        "notation": "現代(げんだい)"
+        ]
     },
     {
         "name": "tondemonai",
         "trans": [
+            "とんでもない",
             "unexpected,offensive,What a thing to say!,No way!"
-        ],
-        "notation": "とんでもない"
+        ]
     },
     {
         "name": "joukyaku",
         "trans": [
+            "乗客(じょうきゃく)",
             "passenger"
-        ],
-        "notation": "乗客(じょうきゃく)"
+        ]
     },
     {
         "name": "taiyou",
         "trans": [
+            "太陽(たいよう)",
             "sun,solar"
-        ],
-        "notation": "太陽(たいよう)"
+        ]
     },
     {
         "name": "kanari",
         "trans": [
+            "かなり",
             "considerably,fairly,quite"
-        ],
-        "notation": "かなり"
+        ]
     },
     {
         "name": "mendou",
         "trans": [
+            "面倒(めんどう)",
             "trouble,difficulty,care,attention"
-        ],
-        "notation": "面倒(めんどう)"
+        ]
     },
     {
         "name": "atsu",
         "trans": [
+            "あっ",
             "Ah!,Oh!"
-        ],
-        "notation": "あっ"
+        ]
     },
     {
         "name": "masu",
         "trans": [
+            "増(ま)す",
             "to increase,to grow"
-        ],
-        "notation": "増(ま)す"
+        ]
     },
     {
         "name": "dame",
         "trans": [
+            "駄目(だめ)",
             "useless,no good,hopeless"
-        ],
-        "notation": "駄目(だめ)"
+        ]
     },
     {
         "name": "kuwaeru",
         "trans": [
+            "加(くわ)える",
             "to append,to sum up,to add (up)"
-        ],
-        "notation": "加(くわ)える"
+        ]
     },
     {
         "name": "taido",
         "trans": [
+            "態度(たいど)",
             "attitude,manner"
-        ],
-        "notation": "態度(たいど)"
+        ]
     },
     {
         "name": "fu",
         "trans": [
+            "不(ふ)",
             "un,non,negative prefix"
-        ],
-        "notation": "不(ふ)"
+        ]
     },
     {
         "name": "noumin",
         "trans": [
+            "農民(のうみん)",
             "farmers,peasants"
-        ],
-        "notation": "農民(のうみん)"
+        ]
     },
     {
         "name": "shiharai",
         "trans": [
+            "支払(しはらい)",
             "payment"
-        ],
-        "notation": "支払(しはらい)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "銃(じゅう)",
             "gun"
-        ],
-        "notation": "銃(じゅう)"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "機嫌(きげん)",
             "humour,temper,mood"
-        ],
-        "notation": "機嫌(きげん)"
+        ]
     },
     {
         "name": "sonomama",
         "trans": [
+            "そのまま",
             "without change,as it is (i.e. now)"
-        ],
-        "notation": "そのまま"
+        ]
     },
     {
         "name": "meijiru",
         "trans": [
+            "命(めい)じる",
             "to order,to command,to appoint"
-        ],
-        "notation": "命(めい)じる"
+        ]
     },
     {
         "name": "kunren",
         "trans": [
+            "訓練(くんれん)",
             "practice,training"
-        ],
-        "notation": "訓練(くんれん)"
+        ]
     },
     {
         "name": "koujou",
         "trans": [
+            "工場(こうじょう)",
             "factory,plant,mill,workshop"
-        ],
-        "notation": "工場(こうじょう)"
+        ]
     },
     {
         "name": "monogoto",
         "trans": [
+            "物事(ものごと)",
             "things,everything"
-        ],
-        "notation": "物事(ものごと)"
+        ]
     },
     {
         "name": "shufu",
         "trans": [
+            "主婦(しゅふ)",
             "housewife,mistress"
-        ],
-        "notation": "主婦(しゅふ)"
+        ]
     },
     {
         "name": "kimi",
         "trans": [
+            "気味(きみ)",
             "-like,-looking,-looked"
-        ],
-        "notation": "気味(きみ)"
+        ]
     },
     {
         "name": "kurashi",
         "trans": [
+            "暮(く)らし",
             "living,livelihood,subsistence,circumstances"
-        ],
-        "notation": "暮(く)らし"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "球(たま)",
             "globe,sphere,ball"
-        ],
-        "notation": "球(たま)"
+        ]
     },
     {
         "name": "keiyu",
         "trans": [
+            "経由(けいゆ)",
             "go by the way,via"
-        ],
-        "notation": "経由(けいゆ)"
+        ]
     },
     {
         "name": "kotowaza",
         "trans": [
+            "諺(ことわざ)",
             "proverb,maxim"
-        ],
-        "notation": "諺(ことわざ)"
+        ]
     },
     {
         "name": "kokufuku",
         "trans": [
+            "克服(こくふく)",
             "subjugation,conquest"
-        ],
-        "notation": "克服(こくふく)"
+        ]
     },
     {
         "name": "kozutsumi",
         "trans": [
+            "小包(こづつみ)",
             "parcel,package"
-        ],
-        "notation": "小包(こづつみ)"
+        ]
     },
     {
         "name": "ousama",
         "trans": [
+            "王様(おうさま)",
             "king"
-        ],
-        "notation": "王様(おうさま)"
+        ]
     },
     {
         "name": "nama",
         "trans": [
+            "生(なま)",
             "(1) draft (beer),(2) raw,unprocessed"
-        ],
-        "notation": "生(なま)"
+        ]
     },
     {
         "name": "tetsudou",
         "trans": [
+            "鉄道(てつどう)",
             "railroad"
-        ],
-        "notation": "鉄道(てつどう)"
+        ]
     },
     {
         "name": "jidou",
         "trans": [
+            "自動(じどう)",
             "automatic,self-motion"
-        ],
-        "notation": "自動(じどう)"
+        ]
     },
     {
         "name": "gichou",
         "trans": [
+            "議長(ぎちょう)",
             "chairman"
-        ],
-        "notation": "議長(ぎちょう)"
+        ]
     },
     {
         "name": "sokode",
         "trans": [
+            "そこで",
             "so (conj),accordingly,now,then,thereupon"
-        ],
-        "notation": "そこで"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "級(きゅう)",
             "class, grade, rank,school class, grade"
-        ],
-        "notation": "級(きゅう)"
+        ]
     },
     {
         "name": "shihai",
         "trans": [
+            "支配(しはい)",
             "rule,control,direction"
-        ],
-        "notation": "支配(しはい)"
+        ]
     },
     {
         "name": "benkyou",
         "trans": [
+            "勉強(べんきょう)",
             "study,diligence,discount,reduction"
-        ],
-        "notation": "勉強(べんきょう)"
+        ]
     },
     {
         "name": "dentou",
         "trans": [
+            "伝統(でんとう)",
             "tradition,convention"
-        ],
-        "notation": "伝統(でんとう)"
+        ]
     },
     {
         "name": "yori",
         "trans": [
+            "より",
             "twist,ply"
-        ],
-        "notation": "より"
+        ]
     },
     {
         "name": "miruku",
         "trans": [
+            "ミルク",
             "milk"
-        ],
-        "notation": "ミルク"
+        ]
     },
     {
         "name": "buki",
         "trans": [
+            "武器(ぶき)",
             "weapon,arms,ordinance"
-        ],
-        "notation": "武器(ぶき)"
+        ]
     },
     {
         "name": "konzatsu",
         "trans": [
+            "混雑(こんざつ)",
             "confusion,congestion"
-        ],
-        "notation": "混雑(こんざつ)"
+        ]
     },
     {
         "name": "tsuujiru",
         "trans": [
+            "通(つう)じる",
             "to run to,to lead to,to communicate,to understand"
-        ],
-        "notation": "通(つう)じる"
+        ]
     },
     {
         "name": "tomoni",
         "trans": [
+            "共(とも)に",
             "sharing with,participate in"
-        ],
-        "notation": "共(とも)に"
+        ]
     },
     {
         "name": "tayoru",
         "trans": [
+            "頼(たよ)る",
             "to rely on,to have recourse to,to depend on"
-        ],
-        "notation": "頼(たよ)る"
+        ]
     },
     {
         "name": "soto",
         "trans": [
+            "外(そと)",
             "other place,the rest"
-        ],
-        "notation": "外(そと)"
+        ]
     },
     {
         "name": "kizu",
         "trans": [
+            "傷(きず)",
             "wound,injury,hurt,cut"
-        ],
-        "notation": "傷(きず)"
+        ]
     },
     {
         "name": "chosha",
         "trans": [
+            "著者(ちょしゃ)",
             "author,writer"
-        ],
-        "notation": "著者(ちょしゃ)"
+        ]
     },
     {
         "name": "atsumari",
         "trans": [
+            "集(あつ)まり",
             "gathering,meeting,assembly,collection"
-        ],
-        "notation": "集(あつ)まり"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "昨(さく)",
             "last (year),yesterday"
-        ],
-        "notation": "昨(さく)"
+        ]
     },
     {
         "name": "annai",
         "trans": [
+            "案内(あんない)",
             "information,guidance,leading"
-        ],
-        "notation": "案内(あんない)"
+        ]
     },
     {
         "name": "zei",
         "trans": [
+            "税(ぜい)",
             ""
-        ],
-        "notation": "税(ぜい)"
+        ]
     },
     {
         "name": "keiki",
         "trans": [
+            "景気(けいき)",
             "condition,state,business (condition)"
-        ],
-        "notation": "景気(けいき)"
+        ]
     },
     {
         "name": "tsumari",
         "trans": [
+            "つまり",
             "in short,in brief,in other words"
-        ],
-        "notation": "つまり"
+        ]
     },
     {
         "name": "ou",
         "trans": [
+            "追(お)う",
             "to chase,to run after"
-        ],
-        "notation": "追(お)う"
+        ]
     },
     {
         "name": "undou",
         "trans": [
+            "運動(うんどう)",
             "motion,exercise"
-        ],
-        "notation": "運動(うんどう)"
+        ]
     },
     {
         "name": "achikochi",
         "trans": [
+            "あちこち",
             "here and there"
-        ],
-        "notation": "あちこち"
+        ]
     },
     {
         "name": "yane",
         "trans": [
+            "屋根(やね)",
             "roof"
-        ],
-        "notation": "屋根(やね)"
+        ]
     },
     {
         "name": "mawari",
         "trans": [
+            "回(まわ)り",
             "circumference,surroundings,circulation"
-        ],
-        "notation": "回(まわ)り"
+        ]
     },
     {
         "name": "tsukare",
         "trans": [
+            "疲(つか)れ",
             "tiredness,fatigue"
-        ],
-        "notation": "疲(つか)れ"
+        ]
     },
     {
         "name": "dai",
         "trans": [
+            "台(だい)",
             "stand,rack,table,support"
-        ],
-        "notation": "台(だい)"
+        ]
     },
     {
         "name": "owari",
         "trans": [
+            "終(おわり)",
             "the end"
-        ],
-        "notation": "終(おわり)"
+        ]
     },
     {
         "name": "renshuu",
         "trans": [
+            "練習(れんしゅう)",
             "practice"
-        ],
-        "notation": "練習(れんしゅう)"
+        ]
     },
     {
         "name": "hakubutsukan",
         "trans": [
+            "博物館(はくぶつかん)",
             "museum"
-        ],
-        "notation": "博物館(はくぶつかん)"
+        ]
     },
     {
         "name": "chiizu",
         "trans": [
+            "チーズ",
             "cheese"
-        ],
-        "notation": "チーズ"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "離(はな)す",
             "to part,divide,separate"
-        ],
-        "notation": "離(はな)す"
+        ]
     },
     {
         "name": "youjin",
         "trans": [
+            "用心(ようじん)",
             "care,precaution,guarding,caution"
-        ],
-        "notation": "用心(ようじん)"
+        ]
     },
     {
         "name": "yuujin",
         "trans": [
+            "友人(ゆうじん)",
             "friend"
-        ],
-        "notation": "友人(ゆうじん)"
+        ]
     },
     {
         "name": "semeru",
         "trans": [
+            "責(せ)める",
             "to condemn,to blame,to criticize"
-        ],
-        "notation": "責(せ)める"
+        ]
     },
     {
         "name": "okoru",
         "trans": [
+            "起(お)こる",
             "to occur,to happen"
-        ],
-        "notation": "起(お)こる"
+        ]
     },
     {
         "name": "gouru",
         "trans": [
+            "ゴール",
             "goal"
-        ],
-        "notation": "ゴール"
+        ]
     },
     {
         "name": "shintai",
         "trans": [
+            "身体(しんたい)",
             "the body"
-        ],
-        "notation": "身体(しんたい)"
+        ]
     },
     {
         "name": "mago",
         "trans": [
+            "孫(まご)",
             "grandchild"
-        ],
-        "notation": "孫(まご)"
+        ]
     },
     {
         "name": "korosu",
         "trans": [
+            "殺(ころ)す",
             "to kill"
-        ],
-        "notation": "殺(ころ)す"
+        ]
     },
     {
         "name": "koya",
         "trans": [
+            "小屋(こや)",
             "hut,cabin,shed,(animal) pen"
-        ],
-        "notation": "小屋(こや)"
+        ]
     },
     {
         "name": "dantai",
         "trans": [
+            "団体(だんたい)",
             "organization,association"
-        ],
-        "notation": "団体(だんたい)"
+        ]
     },
     {
         "name": "hiza",
         "trans": [
+            "膝(ひざ)",
             "knee,lap"
-        ],
-        "notation": "膝(ひざ)"
+        ]
     },
     {
         "name": "jinshu",
         "trans": [
+            "人種(じんしゅ)",
             "race (of people)"
-        ],
-        "notation": "人種(じんしゅ)"
+        ]
     },
     {
         "name": "yon",
         "trans": [
+            "四(よん)",
             "four"
-        ],
-        "notation": "四(よん)"
+        ]
     },
     {
         "name": "arigatou",
         "trans": [
+            "ありがとう",
             "(conj,exp,int) Thank you"
-        ],
-        "notation": "ありがとう"
+        ]
     },
     {
         "name": "shinkei",
         "trans": [
+            "神経(しんけい)",
             "nerve,sensitivity"
-        ],
-        "notation": "神経(しんけい)"
+        ]
     },
     {
         "name": "bunseki",
         "trans": [
+            "分析(ぶんせき)",
             "analysis"
-        ],
-        "notation": "分析(ぶんせき)"
+        ]
     },
     {
         "name": "ensou",
         "trans": [
+            "演奏(えんそう)",
             "musical performance"
-        ],
-        "notation": "演奏(えんそう)"
+        ]
     },
     {
         "name": "jitto",
         "trans": [
+            "じっと",
             "fixedly,firmly,patiently,quietly"
-        ],
-        "notation": "じっと"
+        ]
     },
     {
         "name": "on",
         "trans": [
+            "恩(おん)",
             "favour,obligation,debt of gratitude"
-        ],
-        "notation": "恩(おん)"
+        ]
     },
     {
         "name": "sore",
         "trans": [
+            "それ",
             "it,that"
-        ],
-        "notation": "それ"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "有(あ)る",
             "to be,to have"
-        ],
-        "notation": "有(あ)る"
+        ]
     },
     {
         "name": "yomi",
         "trans": [
+            "読(よ)み",
             "reading"
-        ],
-        "notation": "読(よ)み"
+        ]
     },
     {
         "name": "tojiru",
         "trans": [
+            "閉(と)じる",
             "to close (e.g. book, eyes),to shut"
-        ],
-        "notation": "閉(と)じる"
+        ]
     },
     {
         "name": "zenkoku",
         "trans": [
+            "全国(ぜんこく)",
             "country-wide,nation-wide,whole country,national"
-        ],
-        "notation": "全国(ぜんこく)"
+        ]
     },
     {
         "name": "shiki",
         "trans": [
+            "式(しき)",
             "equation,formula,ceremony"
-        ],
-        "notation": "式(しき)"
+        ]
     },
     {
         "name": "setsuyaku",
         "trans": [
+            "節約(せつやく)",
             "economising,saving"
-        ],
-        "notation": "節約(せつやく)"
+        ]
     },
     {
         "name": "maigo",
         "trans": [
+            "迷子(まいご)",
             "lost (stray) child"
-        ],
-        "notation": "迷子(まいご)"
+        ]
     },
     {
         "name": "itsudemo",
         "trans": [
+            "いつでも",
             "(at) any time,always,at all times,never (neg)"
-        ],
-        "notation": "いつでも"
+        ]
     },
     {
         "name": "bin",
         "trans": [
+            "便(びん)",
             "way,means"
-        ],
-        "notation": "便(びん)"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "効(き)く",
             "to be effective"
-        ],
-        "notation": "効(き)く"
+        ]
     },
     {
         "name": "uragiru",
         "trans": [
+            "裏切(うらぎ)る",
             "to betray,to turn traitor to,to double-cross"
-        ],
-        "notation": "裏切(うらぎ)る"
+        ]
     },
     {
         "name": "geki",
         "trans": [
+            "劇(げき)",
             "drama,play"
-        ],
-        "notation": "劇(げき)"
+        ]
     },
     {
         "name": "chigai",
         "trans": [
+            "違(ちが)い",
             "difference,discrepancy"
-        ],
-        "notation": "違(ちが)い"
+        ]
     },
     {
         "name": "kataru",
         "trans": [
+            "語(かた)る",
             "to talk,to tell,to recite"
-        ],
-        "notation": "語(かた)る"
+        ]
     },
     {
         "name": "kako",
         "trans": [
+            "過去(かこ)",
             "the past,bygone days,the previous"
-        ],
-        "notation": "過去(かこ)"
+        ]
     },
     {
         "name": "sorezore",
         "trans": [
+            "それぞれ",
             "each,every,either,respectively,severally"
-        ],
-        "notation": "それぞれ"
+        ]
     },
     {
         "name": "muda",
         "trans": [
+            "無駄(むだ)",
             "futility,uselessness"
-        ],
-        "notation": "無駄(むだ)"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "効果(こうか)",
             "effect,effectiveness,efficacy,result"
-        ],
-        "notation": "効果(こうか)"
+        ]
     },
     {
         "name": "chinou",
         "trans": [
+            "知能(ちのう)",
             "intelligence,brains"
-        ],
-        "notation": "知能(ちのう)"
+        ]
     },
     {
         "name": "konnani",
         "trans": [
+            "こんなに",
             "so,like this,in this way"
-        ],
-        "notation": "こんなに"
+        ]
     },
     {
         "name": "gyaku",
         "trans": [
+            "逆(ぎゃく)",
             "reverse,opposite"
-        ],
-        "notation": "逆(ぎゃく)"
+        ]
     },
     {
         "name": "zatto",
         "trans": [
+            "ざっと",
             "roughly,in round numbers"
-        ],
-        "notation": "ざっと"
+        ]
     },
     {
         "name": "yoyuu",
         "trans": [
+            "余裕(よゆう)",
             "surplus,composure,margin,room,time,allowance,scope,rope"
-        ],
-        "notation": "余裕(よゆう)"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "舌(した)",
             "tongue"
-        ],
-        "notation": "舌(した)"
+        ]
     },
     {
         "name": "isshun",
         "trans": [
+            "一瞬(いっしゅん)",
             "a moment,an instant"
-        ],
-        "notation": "一瞬(いっしゅん)"
+        ]
     },
     {
         "name": "ne",
         "trans": [
+            "根(ね)",
             "root"
-        ],
-        "notation": "根(ね)"
+        ]
     },
     {
         "name": "jiinzu",
         "trans": [
+            "ジーンズ",
             "jeans"
-        ],
-        "notation": "ジーンズ"
+        ]
     },
     {
         "name": "yousu",
         "trans": [
+            "様子(ようす)",
             "aspect,state,appearance"
-        ],
-        "notation": "様子(ようす)"
+        ]
     },
     {
         "name": "men",
         "trans": [
+            "面(めん)",
             "face,mug,surface,facial features,mask,face guard,side or facet,corner,page"
-        ],
-        "notation": "面(めん)"
+        ]
     },
     {
         "name": "mushi",
         "trans": [
+            "無視(むし)",
             "disregard,ignore"
-        ],
-        "notation": "無視(むし)"
+        ]
     },
     {
         "name": "kokka",
         "trans": [
+            "国家(こっか)",
             "state,country,nation"
-        ],
-        "notation": "国家(こっか)"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "御(お)",
             "honourable"
-        ],
-        "notation": "御(お)"
+        ]
     },
     {
         "name": "tsuushin",
         "trans": [
+            "通信(つうしん)",
             "correspondence,communication,news,signal"
-        ],
-        "notation": "通信(つうしん)"
+        ]
     },
     {
         "name": "tsunagu",
         "trans": [
+            "繋(つな)ぐ",
             "to tie,to fasten,to connect,to transfer (phone call)"
-        ],
-        "notation": "繋(つな)ぐ"
+        ]
     },
     {
         "name": "ippou",
         "trans": [
+            "一方(いっぽう)",
             "(1) on the other hand,(2) meanwhile,(3) only,simple,in turn"
-        ],
-        "notation": "一方(いっぽう)"
+        ]
     },
     {
         "name": "akushu",
         "trans": [
+            "握手(あくしゅ)",
             "handshake"
-        ],
-        "notation": "握手(あくしゅ)"
+        ]
     },
     {
         "name": "naka",
         "trans": [
+            "中(なか)",
             "inside,middle,among"
-        ],
-        "notation": "中(なか)"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "硬(かた)い",
             "solid,hard (esp. metal, stone),unpolished writing"
-        ],
-        "notation": "硬(かた)い"
+        ]
     },
     {
         "name": "gimu",
         "trans": [
+            "義務(ぎむ)",
             "duty,obligation,responsibility"
-        ],
-        "notation": "義務(ぎむ)"
+        ]
     },
     {
         "name": "yome",
         "trans": [
+            "嫁(よめ)",
             "bride,daughter-in-law"
-        ],
-        "notation": "嫁(よめ)"
+        ]
     },
     {
         "name": "shuuri",
         "trans": [
+            "修理(しゅうり)",
             "repairing,mending"
-        ],
-        "notation": "修理(しゅうり)"
+        ]
     },
     {
         "name": "haikingu",
         "trans": [
+            "ハイキング",
             "hiking"
-        ],
-        "notation": "ハイキング"
+        ]
     },
     {
         "name": "youbi",
         "trans": [
+            "曜日(ようび)",
             "day of the week"
-        ],
-        "notation": "曜日(ようび)"
+        ]
     },
     {
         "name": "nana",
         "trans": [
+            "七(なな)",
             "seven"
-        ],
-        "notation": "七(なな)"
+        ]
     },
     {
         "name": "kouri",
         "trans": [
+            "氷(こおり)",
             "ice,hail"
-        ],
-        "notation": "氷(こおり)"
+        ]
     },
     {
         "name": "nokosu",
         "trans": [
+            "残(のこ)す",
             "to leave (behind, over),to bequeath,to save,to reserve"
-        ],
-        "notation": "残(のこ)す"
+        ]
     },
     {
         "name": "zuibun",
         "trans": [
+            "随分(ずいぶん)",
             "extremely"
-        ],
-        "notation": "随分(ずいぶん)"
+        ]
     },
     {
         "name": "ichininichinin",
         "trans": [
+            "一(いち)人(にん)一(いち)人(にん)",
             "one by one,each,one at a time"
-        ],
-        "notation": "一(いち)人(にん)一(いち)人(にん)"
+        ]
     },
     {
         "name": "bunya",
         "trans": [
+            "分野(ぶんや)",
             "field,sphere,realm,division,branch"
-        ],
-        "notation": "分野(ぶんや)"
+        ]
     },
     {
         "name": "todoku",
         "trans": [
+            "届(とど)く",
             "to reach"
-        ],
-        "notation": "届(とど)く"
+        ]
     },
     {
         "name": "meiwaku",
         "trans": [
+            "迷惑(めいわく)",
             "trouble,bother,annoyance"
-        ],
-        "notation": "迷惑(めいわく)"
+        ]
     },
     {
         "name": "makaseru",
         "trans": [
+            "任(まか)せる",
             "to entrust to another,to leave to"
-        ],
-        "notation": "任(まか)せる"
+        ]
     },
     {
         "name": "warai",
         "trans": [
+            "笑(わら)い",
             "laugh,laughter,smile"
-        ],
-        "notation": "笑(わら)い"
+        ]
     },
     {
         "name": "zenin",
         "trans": [
+            "全員(ぜんいん)",
             "all members (unanimity),all hands,the whole crew"
-        ],
-        "notation": "全員(ぜんいん)"
+        ]
     },
     {
         "name": "kitaku",
         "trans": [
+            "帰宅(きたく)",
             "returning home"
-        ],
-        "notation": "帰宅(きたく)"
+        ]
     },
     {
         "name": "haka",
         "trans": [
+            "墓(はか)",
             "grave,tomb"
-        ],
-        "notation": "墓(はか)"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "分(ぶん)",
             "dividing,part,segment"
-        ],
-        "notation": "分(ぶん)"
+        ]
     },
     {
         "name": "iwai",
         "trans": [
+            "祝(いわ)い",
             "celebration,festival"
-        ],
-        "notation": "祝(いわ)い"
+        ]
     },
     {
         "name": "dokusho",
         "trans": [
+            "読書(どくしょ)",
             "reading"
-        ],
-        "notation": "読書(どくしょ)"
+        ]
     },
     {
         "name": "moufu",
         "trans": [
+            "毛布(もうふ)",
             "blanket"
-        ],
-        "notation": "毛布(もうふ)"
+        ]
     },
     {
         "name": "ryoukin",
         "trans": [
+            "料金(りょうきん)",
             "fee,charge,fare"
-        ],
-        "notation": "料金(りょうきん)"
+        ]
     },
     {
         "name": "osameru",
         "trans": [
+            "収(おさ)める",
             "to obtain,to reap,to pay,to supply,to accept"
-        ],
-        "notation": "収(おさ)める"
+        ]
     },
     {
         "name": "paipu",
         "trans": [
+            "パイプ",
             "(1) pipe,tube,(2) channels, official or otherwise"
-        ],
-        "notation": "パイプ"
+        ]
     },
     {
         "name": "shaberu",
         "trans": [
+            "しゃべる",
             "to talk,to chat,to chatter"
-        ],
-        "notation": "しゃべる"
+        ]
     },
     {
         "name": "shijou",
         "trans": [
+            "市場(しじょう)",
             "(the) market (as a concept)"
-        ],
-        "notation": "市場(しじょう)"
+        ]
     },
     {
         "name": "kaigai",
         "trans": [
+            "海外(かいがい)",
             "foreign,abroad,overseas"
-        ],
-        "notation": "海外(かいがい)"
+        ]
     },
     {
         "name": "futsu",
         "trans": [
+            "仏(ふつ)",
             "Buddha,merciful person,Buddhist image,the dead"
-        ],
-        "notation": "仏(ふつ)"
+        ]
     },
     {
         "name": "oya",
         "trans": [
+            "おや",
             "parents"
-        ],
-        "notation": "おや"
+        ]
     },
     {
         "name": "tagai",
         "trans": [
+            "互(たが)い",
             "mutual,reciprocal"
-        ],
-        "notation": "互(たが)い"
+        ]
     },
     {
         "name": "sonaeru",
         "trans": [
+            "備(そな)える",
             "to furnish,to provide for,to equip,to install"
-        ],
-        "notation": "備(そな)える"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "下(した)",
             "under,below,beneath"
-        ],
-        "notation": "下(した)"
+        ]
     },
     {
         "name": "doushi",
         "trans": [
+            "動詞(どうし)",
             "verb"
-        ],
-        "notation": "動詞(どうし)"
+        ]
     },
     {
         "name": "nigiru",
         "trans": [
+            "握(にぎ)る",
             "to grasp,to seize,to mould sushi"
-        ],
-        "notation": "握(にぎ)る"
+        ]
     },
     {
         "name": "kuu",
         "trans": [
+            "食(く)う",
             "(male) (vulg) to eat"
-        ],
-        "notation": "食(く)う"
+        ]
     },
     {
         "name": "higai",
         "trans": [
+            "被害(ひがい)",
             "damage"
-        ],
-        "notation": "被害(ひがい)"
+        ]
     },
     {
         "name": "pasupouto",
         "trans": [
+            "パスポート",
             "passport"
-        ],
-        "notation": "パスポート"
+        ]
     },
     {
         "name": "kichou",
         "trans": [
+            "貴重(きちょう)",
             "precious,valuable"
-        ],
-        "notation": "貴重(きちょう)"
+        ]
     },
     {
         "name": "bijin",
         "trans": [
+            "美人(びじん)",
             "beautiful person (woman)"
-        ],
-        "notation": "美人(びじん)"
+        ]
     },
     {
         "name": "icchi",
         "trans": [
+            "一致(いっち)",
             "(1) coincidence,agreement,(2) conformity"
-        ],
-        "notation": "一致(いっち)"
+        ]
     },
     {
         "name": "kakureru",
         "trans": [
+            "隠(かく)れる",
             "to hide,to be hidden,to conceal oneself,to disappear"
-        ],
-        "notation": "隠(かく)れる"
+        ]
     },
     {
         "name": "nichijou",
         "trans": [
+            "日常(にちじょう)",
             "ordinary,regular,everyday,usual"
-        ],
-        "notation": "日常(にちじょう)"
+        ]
     },
     {
         "name": "tayori",
         "trans": [
+            "便(たよ)り",
             "news,tidings,information,correspondence,letter"
-        ],
-        "notation": "便(たよ)り"
+        ]
     },
     {
         "name": "otoru",
         "trans": [
+            "劣(おと)る",
             "to fall behind,to be inferior to"
-        ],
-        "notation": "劣(おと)る"
+        ]
     },
     {
         "name": "rikou",
         "trans": [
+            "利口(りこう)",
             "clever,shrewd,bright,sharp,wise,intelligent"
-        ],
-        "notation": "利口(りこう)"
+        ]
     },
     {
         "name": "toorisugiru",
         "trans": [
+            "通(とお)り過(す)ぎる",
             "to pass,to pass through"
-        ],
-        "notation": "通(とお)り過(す)ぎる"
+        ]
     },
     {
         "name": "tozan",
         "trans": [
+            "登山(とざん)",
             "mountain-climbing"
-        ],
-        "notation": "登山(とざん)"
+        ]
     },
     {
         "name": "kireru",
         "trans": [
+            "切(き)れる",
             "(1) to cut well,to be sharp,(2) to break (off)"
-        ],
-        "notation": "切(き)れる"
+        ]
     },
     {
         "name": "heikin",
         "trans": [
+            "平均(へいきん)",
             "equilibrium,balance,average,mean"
-        ],
-        "notation": "平均(へいきん)"
+        ]
     },
     {
         "name": "kokyuu",
         "trans": [
+            "呼吸(こきゅう)",
             "breath,respiration"
-        ],
-        "notation": "呼吸(こきゅう)"
+        ]
     },
     {
         "name": "inku",
         "trans": [
+            "インク",
             "ink"
-        ],
-        "notation": "インク"
+        ]
     },
     {
         "name": "guntai",
         "trans": [
+            "軍隊(ぐんたい)",
             "army,troops"
-        ],
-        "notation": "軍隊(ぐんたい)"
+        ]
     },
     {
         "name": "kagen",
         "trans": [
+            "加減(かげん)",
             "addition and subtraction,allowance for"
-        ],
-        "notation": "加減(かげん)"
+        ]
     },
     {
         "name": "haiyuu",
         "trans": [
+            "俳優(はいゆう)",
             "actor,actress,player,performer"
-        ],
-        "notation": "俳優(はいゆう)"
+        ]
     },
     {
         "name": "nami",
         "trans": [
+            "波(なみ)",
             "wave"
-        ],
-        "notation": "波(なみ)"
+        ]
     },
     {
         "name": "kudari",
         "trans": [
+            "下(くだ)り",
             "down-train (going away from Tokyo)"
-        ],
-        "notation": "下(くだ)り"
+        ]
     },
     {
         "name": "tekisetsu",
         "trans": [
+            "適切(てきせつ)",
             "pertinent,appropriate,adequate,relevance"
-        ],
-        "notation": "適切(てきせつ)"
+        ]
     },
     {
         "name": "enki",
         "trans": [
+            "延期(えんき)",
             "postponement,adjournment"
-        ],
-        "notation": "延期(えんき)"
+        ]
     },
     {
         "name": "sakebu",
         "trans": [
+            "叫(さけ)ぶ",
             "to shout,to cry"
-        ],
-        "notation": "叫(さけ)ぶ"
+        ]
     },
     {
         "name": "kure",
         "trans": [
+            "暮(く)れ",
             "year end,sunset,nightfall,end"
-        ],
-        "notation": "暮(く)れ"
+        ]
     },
     {
         "name": "tamaranai",
         "trans": [
+            "たまらない",
             "intolerable,unbearable,unendurable"
-        ],
-        "notation": "たまらない"
+        ]
     },
     {
         "name": "shuppan",
         "trans": [
+            "出版(しゅっぱん)",
             "publication"
-        ],
-        "notation": "出版(しゅっぱん)"
+        ]
     },
     {
         "name": "koufuku",
         "trans": [
+            "幸福(こうふく)",
             "happiness,blessedness"
-        ],
-        "notation": "幸福(こうふく)"
+        ]
     },
     {
         "name": "dekiru",
         "trans": [
+            "できる",
             "to be able to,to be ready,to occur"
-        ],
-        "notation": "できる"
+        ]
     },
     {
         "name": "yuushuu",
         "trans": [
+            "優秀(ゆうしゅう)",
             "superiority,excellence"
-        ],
-        "notation": "優秀(ゆうしゅう)"
+        ]
     },
     {
         "name": "atatakai",
         "trans": [
+            "暖(あたた)かい",
             "warm,mild"
-        ],
-        "notation": "暖(あたた)かい"
+        ]
     },
     {
         "name": "youso",
         "trans": [
+            "要素(ようそ)",
             "element"
-        ],
-        "notation": "要素(ようそ)"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "承認(しょうにん)",
             "recognition,acknowledgement,approval,consent,agreement"
-        ],
-        "notation": "承認(しょうにん)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "経(た)つ",
             "to pass,to lapse"
-        ],
-        "notation": "経(た)つ"
+        ]
     },
     {
         "name": "kagiru",
         "trans": [
+            "限(かぎ)る",
             "to restrict,to limit,to confine"
-        ],
-        "notation": "限(かぎ)る"
+        ]
     },
     {
         "name": "wadai",
         "trans": [
+            "話題(わだい)",
             "topic,subject"
-        ],
-        "notation": "話題(わだい)"
+        ]
     },
     {
         "name": "jijou",
         "trans": [
+            "事情(じじょう)",
             "circumstances,consideration,conditions,situation,reasons"
-        ],
-        "notation": "事情(じじょう)"
+        ]
     },
     {
         "name": "masani",
         "trans": [
+            "まさに",
             "correctly,surely"
-        ],
-        "notation": "まさに"
+        ]
     },
     {
         "name": "miru",
         "trans": [
+            "見(み)る",
             "to see,to watch"
-        ],
-        "notation": "見(み)る"
+        ]
     },
     {
         "name": "miokuri",
         "trans": [
+            "見送(みおく)り",
             "seeing one off,farewell,escort"
-        ],
-        "notation": "見送(みおく)り"
+        ]
     },
     {
         "name": "taisen",
         "trans": [
+            "大戦(たいせん)",
             "great war,great battle"
-        ],
-        "notation": "大戦(たいせん)"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "移(うつ)す",
             "to remove,to transfer,to infect"
-        ],
-        "notation": "移(うつ)す"
+        ]
     },
     {
         "name": "oeru",
         "trans": [
+            "終(お)える",
             "to finish"
-        ],
-        "notation": "終(お)える"
+        ]
     },
     {
         "name": "kihon",
         "trans": [
+            "基本(きほん)",
             "foundation,basis,standard"
-        ],
-        "notation": "基本(きほん)"
+        ]
     },
     {
         "name": "shinyuu",
         "trans": [
+            "親友(しんゆう)",
             "close friend,buddy"
-        ],
-        "notation": "親友(しんゆう)"
+        ]
     },
     {
         "name": "kono",
         "trans": [
+            "この",
             "this"
-        ],
-        "notation": "この"
+        ]
     },
     {
         "name": "teiki",
         "trans": [
+            "定期(ていき)",
             "fixed term"
-        ],
-        "notation": "定期(ていき)"
+        ]
     },
     {
         "name": "kuse",
         "trans": [
+            "癖(くせ)",
             "a habit (often a bad habit),peculiarity"
-        ],
-        "notation": "癖(くせ)"
+        ]
     },
     {
         "name": "retsu",
         "trans": [
+            "列(れつ)",
             "queue,line,row"
-        ],
-        "notation": "列(れつ)"
+        ]
     },
     {
         "name": "futago",
         "trans": [
+            "双子(ふたご)",
             "twins,a twin"
-        ],
-        "notation": "双子(ふたご)"
+        ]
     },
     {
         "name": "bou",
         "trans": [
+            "棒(ぼう)",
             "pole,rod,stick"
-        ],
-        "notation": "棒(ぼう)"
+        ]
     },
     {
         "name": "chikoku",
         "trans": [
+            "遅刻(ちこく)",
             "lateness,late coming"
-        ],
-        "notation": "遅刻(ちこく)"
+        ]
     },
     {
         "name": "fude",
         "trans": [
+            "筆(ふで)",
             "writing brush"
-        ],
-        "notation": "筆(ふで)"
+        ]
     },
     {
         "name": "shishutsu",
         "trans": [
+            "支出(ししゅつ)",
             "expenditure,expenses"
-        ],
-        "notation": "支出(ししゅつ)"
+        ]
     },
     {
         "name": "shimo",
         "trans": [
+            "霜(しも)",
             "frost"
-        ],
-        "notation": "霜(しも)"
+        ]
     },
     {
         "name": "daihyou",
         "trans": [
+            "代表(だいひょう)",
             "representative,representation,delegation,type,example,model"
-        ],
-        "notation": "代表(だいひょう)"
+        ]
     },
     {
         "name": "zensha",
         "trans": [
+            "前者(ぜんしゃ)",
             "the former"
-        ],
-        "notation": "前者(ぜんしゃ)"
+        ]
     },
     {
         "name": "shukuhaku",
         "trans": [
+            "宿泊(しゅくはく)",
             "lodging"
-        ],
-        "notation": "宿泊(しゅくはく)"
+        ]
     },
     {
         "name": "tonikaku",
         "trans": [
+            "とにかく",
             "anyhow,at any rate,anyway,somehow or other,generally speaking,in any case"
-        ],
-        "notation": "とにかく"
+        ]
     },
     {
         "name": "eiyou",
         "trans": [
+            "栄養(えいよう)",
             "nutrition,nourishment"
-        ],
-        "notation": "栄養(えいよう)"
+        ]
     },
     {
         "name": "ressha",
         "trans": [
+            "列車(れっしゃ)",
             "train (ordinary)"
-        ],
-        "notation": "列車(れっしゃ)"
+        ]
     },
     {
         "name": "taitei",
         "trans": [
+            "大抵(たいてい)",
             "usually,generally"
-        ],
-        "notation": "大抵(たいてい)"
+        ]
     },
     {
         "name": "kata",
         "trans": [
+            "肩(かた)",
             "shoulder"
-        ],
-        "notation": "肩(かた)"
+        ]
     },
     {
         "name": "katari",
         "trans": [
+            "語(かたり)",
             "language,word"
-        ],
-        "notation": "語(かたり)"
+        ]
     },
     {
         "name": "teiryuujo",
         "trans": [
+            "停留所(ていりゅうじょ)",
             "bus or tram stop"
-        ],
-        "notation": "停留所(ていりゅうじょ)"
+        ]
     },
     {
         "name": "shidou",
         "trans": [
+            "指導(しどう)",
             "leadership,guidance,coaching"
-        ],
-        "notation": "指導(しどう)"
+        ]
     },
     {
         "name": "monku",
         "trans": [
+            "文句(もんく)",
             "phrase,complaint"
-        ],
-        "notation": "文句(もんく)"
+        ]
     },
     {
         "name": "hitori",
         "trans": [
+            "独(ひと)り",
             "alone,unmarried"
-        ],
-        "notation": "独(ひと)り"
+        ]
     },
     {
         "name": "nanimo",
         "trans": [
+            "なにも",
             "nothing"
-        ],
-        "notation": "なにも"
+        ]
     },
     {
         "name": "yakkai",
         "trans": [
+            "厄介(やっかい)",
             "trouble,burden,care,bother"
-        ],
-        "notation": "厄介(やっかい)"
+        ]
     },
     {
         "name": "wakeru",
         "trans": [
+            "分(わ)ける",
             "to divide,to separate"
-        ],
-        "notation": "分(わ)ける"
+        ]
     },
     {
         "name": "hakase",
         "trans": [
+            "博士(はかせ)",
             "doctorate,PhD"
-        ],
-        "notation": "博士(はかせ)"
+        ]
     },
     {
         "name": "fusei",
         "trans": [
+            "不正(ふせい)",
             "injustice,unfairness"
-        ],
-        "notation": "不正(ふせい)"
+        ]
     },
     {
         "name": "kakkou",
         "trans": [
+            "格好(かっこう)",
             "shape,form,posture,suitability"
-        ],
-        "notation": "格好(かっこう)"
+        ]
     },
     {
         "name": "kaminoke",
         "trans": [
+            "髪(かみ)の毛(け)",
             "hair (head)"
-        ],
-        "notation": "髪(かみ)の毛(け)"
+        ]
     },
     {
         "name": "hatten",
         "trans": [
+            "発展(はってん)",
             "development,growth"
-        ],
-        "notation": "発展(はってん)"
+        ]
     },
     {
         "name": "shiawase",
         "trans": [
+            "幸(しあわ)せ",
             "happiness,good fortune,luck,blessing"
-        ],
-        "notation": "幸(しあわ)せ"
+        ]
     },
     {
         "name": "subarashii",
         "trans": [
+            "素晴(すば)らしい",
             "wonderful,splendid,magnificent"
-        ],
-        "notation": "素晴(すば)らしい"
+        ]
     },
     {
         "name": "iji",
         "trans": [
+            "維持(いじ)",
             "maintenance,preservation"
-        ],
-        "notation": "維持(いじ)"
+        ]
     },
     {
         "name": "kousai",
         "trans": [
+            "交際(こうさい)",
             "company,friendship,association,society,acquaintance"
-        ],
-        "notation": "交際(こうさい)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "角(かく)",
             "horn"
-        ],
-        "notation": "角(かく)"
+        ]
     },
     {
         "name": "nani",
         "trans": [
+            "何(なに)",
             "what"
-        ],
-        "notation": "何(なに)"
+        ]
     },
     {
         "name": "goutou",
         "trans": [
+            "強盗(ごうとう)",
             "robbery,burglary"
-        ],
-        "notation": "強盗(ごうとう)"
+        ]
     },
     {
         "name": "kurashikku",
         "trans": [
+            "クラシック",
             "classic(s)"
-        ],
-        "notation": "クラシック"
+        ]
     },
     {
         "name": "mame",
         "trans": [
+            "豆(まめ)",
             "beans,peas"
-        ],
-        "notation": "豆(まめ)"
+        ]
     },
     {
         "name": "joshu",
         "trans": [
+            "助手(じょしゅ)",
             "helper,helpmeet,assistant,tutor"
-        ],
-        "notation": "助手(じょしゅ)"
+        ]
     },
     {
         "name": "osanai",
         "trans": [
+            "幼(おさな)い",
             "very young,childish"
-        ],
-        "notation": "幼(おさな)い"
+        ]
     },
     {
         "name": "kage",
         "trans": [
+            "影(かげ)",
             "shade,shadow,other side"
-        ],
-        "notation": "影(かげ)"
+        ]
     },
     {
         "name": "seikou",
         "trans": [
+            "成功(せいこう)",
             "success,hit"
-        ],
-        "notation": "成功(せいこう)"
+        ]
     },
     {
         "name": "shinkoku",
         "trans": [
+            "深刻(しんこく)",
             "serious"
-        ],
-        "notation": "深刻(しんこく)"
+        ]
     },
     {
         "name": "dansu",
         "trans": [
+            "ダンス",
             "dance"
-        ],
-        "notation": "ダンス"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "高価(こうか)",
             "high price"
-        ],
-        "notation": "高価(こうか)"
+        ]
     },
     {
         "name": "chiji",
         "trans": [
+            "知事(ちじ)",
             "prefectural governor"
-        ],
-        "notation": "知事(ちじ)"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "現(あらわ)す",
             "to show,to indicate,to display"
-        ],
-        "notation": "現(あらわ)す"
+        ]
     },
     {
         "name": "shokuyoku",
         "trans": [
+            "食欲(しょくよく)",
             "appetite (for food)"
-        ],
-        "notation": "食欲(しょくよく)"
+        ]
     },
     {
         "name": "korera",
         "trans": [
+            "これら",
             "these"
-        ],
-        "notation": "これら"
+        ]
     },
     {
         "name": "souji",
         "trans": [
+            "掃除(そうじ)",
             "cleaning,sweeping"
-        ],
-        "notation": "掃除(そうじ)"
+        ]
     },
     {
         "name": "heru",
         "trans": [
+            "減(へ)る",
             "to decrease (in size or number),to diminish,to abate"
-        ],
-        "notation": "減(へ)る"
+        ]
     },
     {
         "name": "gakkari",
         "trans": [
+            "がっかり",
             "feel disappointed,be dejected,lose heart"
-        ],
-        "notation": "がっかり"
+        ]
     },
     {
         "name": "dekireba",
         "trans": [
+            "できれば",
             ""
-        ],
-        "notation": "できれば"
+        ]
     },
     {
         "name": "kesshin",
         "trans": [
+            "決心(けっしん)",
             "determination,resolution"
-        ],
-        "notation": "決心(けっしん)"
+        ]
     },
     {
         "name": "tejina",
         "trans": [
+            "手品(てじな)",
             "sleight of hand,conjuring trick,magic,juggling"
-        ],
-        "notation": "手品(てじな)"
+        ]
     },
     {
         "name": "niau",
         "trans": [
+            "似合(にあ)う",
             "to suit,to match,to become,to be like"
-        ],
-        "notation": "似合(にあ)う"
+        ]
     },
     {
         "name": "kakusu",
         "trans": [
+            "隠(かく)す",
             "to hide,to conceal"
-        ],
-        "notation": "隠(かく)す"
+        ]
     },
     {
         "name": "suijun",
         "trans": [
+            "水準(すいじゅん)",
             "(1) water level,(2) level,standard"
-        ],
-        "notation": "水準(すいじゅん)"
+        ]
     },
     {
         "name": "mattaku",
         "trans": [
+            "全(まった)く",
             "really,truly,entirely,completely"
-        ],
-        "notation": "全(まった)く"
+        ]
     },
     {
         "name": "chuugaku",
         "trans": [
+            "中学(ちゅうがく)",
             "middle school,junior high school"
-        ],
-        "notation": "中学(ちゅうがく)"
+        ]
     },
     {
         "name": "nikkori",
         "trans": [
+            "にっこり",
             "smile sweetly,smile,grin"
-        ],
-        "notation": "にっこり"
+        ]
     },
     {
         "name": "itoko",
         "trans": [
+            "従兄弟(いとこ)",
             "cousin (male)"
-        ],
-        "notation": "従兄弟(いとこ)"
+        ]
     },
     {
         "name": "ateru",
         "trans": [
+            "当(あ)てる",
             "to hit,to apply a patch"
-        ],
-        "notation": "当(あ)てる"
+        ]
     },
     {
         "name": "hone",
         "trans": [
+            "骨(ほね)",
             "bone"
-        ],
-        "notation": "骨(ほね)"
+        ]
     },
     {
         "name": "namida",
         "trans": [
+            "涙(なみだ)",
             "tear"
-        ],
-        "notation": "涙(なみだ)"
+        ]
     },
     {
         "name": "sunawachi",
         "trans": [
+            "すなわち",
             "that is,namely,i.e."
-        ],
-        "notation": "すなわち"
+        ]
     },
     {
         "name": "gekijou",
         "trans": [
+            "劇場(げきじょう)",
             "theatre,playhouse"
-        ],
-        "notation": "劇場(げきじょう)"
+        ]
     },
     {
         "name": "mitsu",
         "trans": [
+            "密(みつ)",
             ""
-        ],
-        "notation": "密(みつ)"
+        ]
     },
     {
         "name": "nezumi",
         "trans": [
+            "鼠(ねずみ)",
             "(1) mouse,rat,(2) dark gray,slate color"
-        ],
-        "notation": "鼠(ねずみ)"
+        ]
     },
     {
         "name": "morau",
         "trans": [
+            "貰(もら)う",
             "to receive"
-        ],
-        "notation": "貰(もら)う"
+        ]
     },
     {
         "name": "haji",
         "trans": [
+            "端(はじ)",
             "end (e.g. of street),edge,tip,margin,point"
-        ],
-        "notation": "端(はじ)"
+        ]
     },
     {
         "name": "eikyuu",
         "trans": [
+            "永久(えいきゅう)",
             "eternity,perpetuity,immortality"
-        ],
-        "notation": "永久(えいきゅう)"
+        ]
     },
     {
         "name": "otagai",
         "trans": [
+            "お互(たが)い",
             "mutual,reciprocal,each other"
-        ],
-        "notation": "お互(たが)い"
+        ]
     },
     {
         "name": "shuppatsu",
         "trans": [
+            "出発(しゅっぱつ)",
             "departure"
-        ],
-        "notation": "出発(しゅっぱつ)"
+        ]
     },
     {
         "name": "hokasu",
         "trans": [
+            "放(ほか)す",
             "to separate,to set free"
-        ],
-        "notation": "放(ほか)す"
+        ]
     },
     {
         "name": "sekiyu",
         "trans": [
+            "石油(せきゆ)",
             "oil,petroleum,kerosene"
-        ],
-        "notation": "石油(せきゆ)"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "革(かわ)",
             "leather"
-        ],
-        "notation": "革(かわ)"
+        ]
     },
     {
         "name": "shizen",
         "trans": [
+            "自然(しぜん)",
             "nature,spontaneous"
-        ],
-        "notation": "自然(しぜん)"
+        ]
     },
     {
         "name": "kangei",
         "trans": [
+            "歓迎(かんげい)",
             "welcome,reception"
-        ],
-        "notation": "歓迎(かんげい)"
+        ]
     },
     {
         "name": "kanjiru",
         "trans": [
+            "感(かん)じる",
             "to feel,to sense,to experience"
-        ],
-        "notation": "感(かん)じる"
+        ]
     },
     {
         "name": "chiri",
         "trans": [
+            "塵(ちり)",
             "dust,dirt"
-        ],
-        "notation": "塵(ちり)"
+        ]
     },
     {
         "name": "sakkyoku",
         "trans": [
+            "作曲(さっきょく)",
             "composition,setting (of music)"
-        ],
-        "notation": "作曲(さっきょく)"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "為(な)る",
             "to change,to be of use,to reach to"
-        ],
-        "notation": "為(な)る"
+        ]
     },
     {
         "name": "kokkai",
         "trans": [
+            "国会(こっかい)",
             "National Diet,parliament,congress"
-        ],
-        "notation": "国会(こっかい)"
+        ]
     },
     {
         "name": "bouto",
         "trans": [
+            "ボート",
             "rowing boat"
-        ],
-        "notation": "ボート"
+        ]
     },
     {
         "name": "donnani",
         "trans": [
+            "どんなに",
             "how,how much"
-        ],
-        "notation": "どんなに"
+        ]
     },
     {
         "name": "iu",
         "trans": [
+            "言(い)う",
             "to say"
-        ],
-        "notation": "言(い)う"
+        ]
     },
     {
         "name": "mochiageru",
         "trans": [
+            "持(も)ち上(あ)げる",
             "to raise,to lift up,to flatter"
-        ],
-        "notation": "持(も)ち上(あ)げる"
+        ]
     },
     {
         "name": "shuushoku",
         "trans": [
+            "就職(しゅうしょく)",
             "finding employment,inauguration"
-        ],
-        "notation": "就職(しゅうしょく)"
+        ]
     },
     {
         "name": "tada",
         "trans": [
+            "ただ",
             "free of charge,mere,only"
-        ],
-        "notation": "ただ"
+        ]
     },
     {
         "name": "dai",
         "trans": [
+            "大(だい)",
             ""
-        ],
-        "notation": "大(だい)"
+        ]
     },
     {
         "name": "shibai",
         "trans": [
+            "芝居(しばい)",
             "play,drama"
-        ],
-        "notation": "芝居(しばい)"
+        ]
     },
     {
         "name": "kokkyou",
         "trans": [
+            "国境(こっきょう)",
             "national or state border"
-        ],
-        "notation": "国境(こっきょう)"
+        ]
     },
     {
         "name": "kyoka",
         "trans": [
+            "許可(きょか)",
             "permission,approval"
-        ],
-        "notation": "許可(きょか)"
+        ]
     },
     {
         "name": "seiki",
         "trans": [
+            "世紀(せいき)",
             "century,era"
-        ],
-        "notation": "世紀(せいき)"
+        ]
     },
     {
         "name": "tanjun",
         "trans": [
+            "単純(たんじゅん)",
             "simplicity"
-        ],
-        "notation": "単純(たんじゅん)"
+        ]
     },
     {
         "name": "kekka",
         "trans": [
+            "結果(けっか)",
             "result,consequence"
-        ],
-        "notation": "結果(けっか)"
+        ]
     },
     {
         "name": "kubetsu",
         "trans": [
+            "区別(くべつ)",
             "distinction,differentiation,classification"
-        ],
-        "notation": "区別(くべつ)"
+        ]
     },
     {
         "name": "ikka",
         "trans": [
+            "一家(いっか)",
             "a house,a home,a family,a household"
-        ],
-        "notation": "一家(いっか)"
+        ]
     },
     {
         "name": "un",
         "trans": [
+            "運(うん)",
             "fortune,luck"
-        ],
-        "notation": "運(うん)"
+        ]
     },
     {
         "name": "okuru",
         "trans": [
+            "贈(おく)る",
             "to send,to give to,to award to,to confer on"
-        ],
-        "notation": "贈(おく)る"
+        ]
     },
     {
         "name": "kyouchou",
         "trans": [
+            "強調(きょうちょう)",
             "emphasis,stress,stressed point"
-        ],
-        "notation": "強調(きょうちょう)"
+        ]
     },
     {
         "name": "ojiisan",
         "trans": [
+            "おじいさん",
             "grandfather,male senior-citizen"
-        ],
-        "notation": "おじいさん"
+        ]
     },
     {
         "name": "takara",
         "trans": [
+            "宝(たから)",
             "treasure"
-        ],
-        "notation": "宝(たから)"
+        ]
     },
     {
         "name": "taizai",
         "trans": [
+            "滞在(たいざい)",
             "stay,sojourn"
-        ],
-        "notation": "滞在(たいざい)"
+        ]
     },
     {
         "name": "yuuki",
         "trans": [
+            "勇気(ゆうき)",
             "courage,bravery,valour,nerve,boldness"
-        ],
-        "notation": "勇気(ゆうき)"
+        ]
     },
     {
         "name": "koshi",
         "trans": [
+            "腰(こし)",
             "hip"
-        ],
-        "notation": "腰(こし)"
+        ]
     },
     {
         "name": "ooya",
         "trans": [
+            "大家(おおや)",
             "rich family,distinguished family"
-        ],
-        "notation": "大家(おおや)"
+        ]
     },
     {
         "name": "kanashimu",
         "trans": [
+            "悲(かな)しむ",
             "to be sad,to mourn for,to regret"
-        ],
-        "notation": "悲(かな)しむ"
+        ]
     },
     {
         "name": "genkin",
         "trans": [
+            "現金(げんきん)",
             "cash,ready money,mercenary,self-interested"
-        ],
-        "notation": "現金(げんきん)"
+        ]
     },
     {
         "name": "airon",
         "trans": [
+            "アイロン",
             "(electric) iron"
-        ],
-        "notation": "アイロン"
+        ]
     },
     {
         "name": "jiman",
         "trans": [
+            "自慢(じまん)",
             "pride,boast"
-        ],
-        "notation": "自慢(じまん)"
+        ]
     },
     {
         "name": "shuui",
         "trans": [
+            "周囲(しゅうい)",
             "surroundings,circumference,environs"
-        ],
-        "notation": "周囲(しゅうい)"
+        ]
     },
     {
         "name": "suuji",
         "trans": [
+            "数字(すうじ)",
             "numeral,figure"
-        ],
-        "notation": "数字(すうじ)"
+        ]
     },
     {
         "name": "osoreru",
         "trans": [
+            "恐(おそ)れる",
             "to fear,to be afraid of"
-        ],
-        "notation": "恐(おそ)れる"
+        ]
     },
     {
         "name": "majime",
         "trans": [
+            "真面目(まじめ)",
             "diligent,serious,honest"
-        ],
-        "notation": "真面目(まじめ)"
+        ]
     },
     {
         "name": "ishiki",
         "trans": [
+            "意識(いしき)",
             "consciousness,senses"
-        ],
-        "notation": "意識(いしき)"
+        ]
     },
     {
         "name": "kingaku",
         "trans": [
+            "金額(きんがく)",
             "amount of money"
-        ],
-        "notation": "金額(きんがく)"
+        ]
     },
     {
         "name": "kurisumasu",
         "trans": [
+            "クリスマス",
             "Christmas"
-        ],
-        "notation": "クリスマス"
+        ]
     },
     {
         "name": "nichichuu",
         "trans": [
+            "日(にち)中(ちゅう)",
             "daytime,broad daylight"
-        ],
-        "notation": "日(にち)中(ちゅう)"
+        ]
     },
     {
         "name": "omoni",
         "trans": [
+            "主(おも)に",
             "mainly,primarily"
-        ],
-        "notation": "主(おも)に"
+        ]
     },
     {
         "name": "moshimo",
         "trans": [
+            "もしも",
             "if"
-        ],
-        "notation": "もしも"
+        ]
     },
     {
         "name": "akari",
         "trans": [
+            "明(あ)かり",
             "lamplight,light (in general),brightness"
-        ],
-        "notation": "明(あ)かり"
+        ]
     },
     {
         "name": "shokumotsu",
         "trans": [
+            "食物(しょくもつ)",
             "food,foodstuff"
-        ],
-        "notation": "食物(しょくもつ)"
+        ]
     },
     {
         "name": "bamen",
         "trans": [
+            "場面(ばめん)",
             "scene,setting (e.g. of novel)"
-        ],
-        "notation": "場面(ばめん)"
+        ]
     },
     {
         "name": "ronjiru",
         "trans": [
+            "論(ろん)じる",
             "to argue,to discuss,to debate"
-        ],
-        "notation": "論(ろん)じる"
+        ]
     },
     {
         "name": "mochiiru",
         "trans": [
+            "用(もち)いる",
             "to use,to make use of"
-        ],
-        "notation": "用(もち)いる"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "下(した)",
             "under,below,beneath"
-        ],
-        "notation": "下(した)"
+        ]
     },
     {
         "name": "tento",
         "trans": [
+            "テント",
             "tent"
-        ],
-        "notation": "テント"
+        ]
     },
     {
         "name": "kamau",
         "trans": [
+            "構(かま)う",
             "to mind,to care about,to be concerned about"
-        ],
-        "notation": "構(かま)う"
+        ]
     },
     {
         "name": "yado",
         "trans": [
+            "宿(やど)",
             "inn,lodging"
-        ],
-        "notation": "宿(やど)"
+        ]
     },
     {
         "name": "gakumon",
         "trans": [
+            "学問(がくもん)",
             "scholarship,study,learning"
-        ],
-        "notation": "学問(がくもん)"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "吐(は)く",
             "(1) to breathe,(2) to tell (lies),(3) to vomit,to disgorge"
-        ],
-        "notation": "吐(は)く"
+        ]
     },
     {
         "name": "kabu",
         "trans": [
+            "株(かぶ)",
             "share,stock,stump (of tree)"
-        ],
-        "notation": "株(かぶ)"
+        ]
     },
     {
         "name": "jun",
         "trans": [
+            "順(じゅん)",
             "order,turn"
-        ],
-        "notation": "順(じゅん)"
+        ]
     },
     {
         "name": "anmari",
         "trans": [
+            "あんまり",
             "not very,not much,remainder,rest"
-        ],
-        "notation": "あんまり"
+        ]
     },
     {
         "name": "konomi",
         "trans": [
+            "好(この)み",
             "liking,taste,choice"
-        ],
-        "notation": "好(この)み"
+        ]
     },
     {
         "name": "ushi",
         "trans": [
+            "牛(うし)",
             "cattle,cow"
-        ],
-        "notation": "牛(うし)"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "意思(いし)",
             "intention,purpose"
-        ],
-        "notation": "意思(いし)"
+        ]
     },
     {
         "name": "jisatsu",
         "trans": [
+            "自殺(じさつ)",
             "suicide"
-        ],
-        "notation": "自殺(じさつ)"
+        ]
     },
     {
         "name": "nonbiri",
         "trans": [
+            "のんびり",
             "carefree,at leisure"
-        ],
-        "notation": "のんびり"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "換(か)える",
             "to exchange,to interchange,to substitute,to replace"
-        ],
-        "notation": "換(か)える"
+        ]
     },
     {
         "name": "honnin",
         "trans": [
+            "本人(ほんにん)",
             "the person himself"
-        ],
-        "notation": "本人(ほんにん)"
+        ]
     },
     {
         "name": "daitouryou",
         "trans": [
+            "大統領(だいとうりょう)",
             "president,chief executive"
-        ],
-        "notation": "大統領(だいとうりょう)"
+        ]
     },
     {
         "name": "doro",
         "trans": [
+            "泥(どろ)",
             "mud"
-        ],
-        "notation": "泥(どろ)"
+        ]
     },
     {
         "name": "karu",
         "trans": [
+            "刈(か)る",
             "to cut (hair),to mow (grass),to harvest"
-        ],
-        "notation": "刈(か)る"
+        ]
     },
     {
         "name": "gikai",
         "trans": [
+            "議会(ぎかい)",
             "Diet,congress,parliament"
-        ],
-        "notation": "議会(ぎかい)"
+        ]
     },
     {
         "name": "koudo",
         "trans": [
+            "コード",
             "code,cord,chord"
-        ],
-        "notation": "コード"
+        ]
     },
     {
         "name": "hannin",
         "trans": [
+            "犯人(はんにん)",
             "offender,criminal"
-        ],
-        "notation": "犯人(はんにん)"
+        ]
     },
     {
         "name": "pittari",
         "trans": [
+            "ぴったり",
             "exactly,neatly,sharp"
-        ],
-        "notation": "ぴったり"
+        ]
     },
     {
         "name": "kouken",
         "trans": [
+            "貢献(こうけん)",
             "contribution,services"
-        ],
-        "notation": "貢献(こうけん)"
+        ]
     },
     {
         "name": "nureru",
         "trans": [
+            "濡(ぬ)れる",
             "to get wet"
-        ],
-        "notation": "濡(ぬ)れる"
+        ]
     },
     {
         "name": "rieki",
         "trans": [
+            "利益(りえき)",
             "profits,gains,(political, economic) interest"
-        ],
-        "notation": "利益(りえき)"
+        ]
     },
     {
         "name": "baggu",
         "trans": [
+            "バッグ",
             "bag,bug"
-        ],
-        "notation": "バッグ"
+        ]
     },
     {
         "name": "jijitsu",
         "trans": [
+            "事実(じじつ)",
             "fact,truth,reality"
-        ],
-        "notation": "事実(じじつ)"
+        ]
     },
     {
         "name": "massugu",
         "trans": [
+            "真(ま)っ直(す)ぐ",
             "straight (ahead),direct,upright"
-        ],
-        "notation": "真(ま)っ直(す)ぐ"
+        ]
     },
     {
         "name": "sate",
         "trans": [
+            "さて",
             "well,now,then"
-        ],
-        "notation": "さて"
+        ]
     },
     {
         "name": "yagate",
         "trans": [
+            "やがて",
             "before long,soon,at length"
-        ],
-        "notation": "やがて"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "打(う)つ",
             "to hit,to strike"
-        ],
-        "notation": "打(う)つ"
+        ]
     },
     {
         "name": "nakaba",
         "trans": [
+            "半(なか)ば",
             "middle,half,semi,halfway,partly"
-        ],
-        "notation": "半(なか)ば"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "縁(えん)",
             "a means, e.g. of living"
-        ],
-        "notation": "縁(えん)"
+        ]
     },
     {
         "name": "susumeru",
         "trans": [
+            "進(すす)める",
             "to advance,to promote,to hasten"
-        ],
-        "notation": "進(すす)める"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "保証(ほしょう)",
             "guarantee,security,assurance,pledge,warranty"
-        ],
-        "notation": "保証(ほしょう)"
+        ]
     },
     {
         "name": "usagi",
         "trans": [
+            "兎(うさぎ)",
             "rabbit,hare,cony"
-        ],
-        "notation": "兎(うさぎ)"
+        ]
     },
     {
         "name": "sasou",
         "trans": [
+            "誘(さそ)う",
             "(1) to invite,to ask,(2) to tempt,to lure,to induce"
-        ],
-        "notation": "誘(さそ)う"
+        ]
     },
     {
         "name": "nakanaka",
         "trans": [
+            "なかなか",
             "very,considerably,easily"
-        ],
-        "notation": "なかなか"
+        ]
     },
     {
         "name": "gurando",
         "trans": [
+            "グランド",
             "gland,grand,(electrical) ground"
-        ],
-        "notation": "グランド"
+        ]
     },
     {
         "name": "hankou",
         "trans": [
+            "反抗(はんこう)",
             "opposition,resistance"
-        ],
-        "notation": "反抗(はんこう)"
+        ]
     },
     {
         "name": "taishou",
         "trans": [
+            "対象(たいしょう)",
             "target,object (of worship, study, etc),subject (of taxation, etc)"
-        ],
-        "notation": "対象(たいしょう)"
+        ]
     },
     {
         "name": "ihan",
         "trans": [
+            "違反(いはん)",
             "violation (of law),transgression,infringement,breach"
-        ],
-        "notation": "違反(いはん)"
+        ]
     },
     {
         "name": "mokuhyou",
         "trans": [
+            "目標(もくひょう)",
             "mark,objective,target"
-        ],
-        "notation": "目標(もくひょう)"
+        ]
     },
     {
         "name": "kyuuryou",
         "trans": [
+            "給料(きゅうりょう)",
             "salary,wages"
-        ],
-        "notation": "給料(きゅうりょう)"
+        ]
     },
     {
         "name": "nigate",
         "trans": [
+            "苦手(にがて)",
             "poor (at),weak (in),dislike (of)"
-        ],
-        "notation": "苦手(にがて)"
+        ]
     },
     {
         "name": "meijin",
         "trans": [
+            "名人(めいじん)",
             "master,expert"
-        ],
-        "notation": "名人(めいじん)"
+        ]
     },
     {
         "name": "kyuushuu",
         "trans": [
+            "吸収(きゅうしゅう)",
             "absorption,suction,attraction"
-        ],
-        "notation": "吸収(きゅうしゅう)"
+        ]
     },
     {
         "name": "hontou",
         "trans": [
+            "本当(ほんとう)",
             "truth,reality"
-        ],
-        "notation": "本当(ほんとう)"
+        ]
     },
     {
         "name": "tokeru",
         "trans": [
+            "解(と)ける",
             "to come untied,to come apart"
-        ],
-        "notation": "解(と)ける"
+        ]
     },
     {
         "name": "sentaa",
         "trans": [
+            "センター",
             "a center"
-        ],
-        "notation": "センター"
+        ]
     },
     {
         "name": "awa",
         "trans": [
+            "泡(あわ)",
             "bubble,foam,froth,head on beer"
-        ],
-        "notation": "泡(あわ)"
+        ]
     },
     {
         "name": "idaku",
         "trans": [
+            "抱(いだ)く",
             "(sl) to embrace,to hug,to harbour,to entertain"
-        ],
-        "notation": "抱(いだ)く"
+        ]
     },
     {
         "name": "hiyou",
         "trans": [
+            "費用(ひよう)",
             "cost,expense"
-        ],
-        "notation": "費用(ひよう)"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "小(しょう)",
             ""
-        ],
-        "notation": "小(しょう)"
+        ]
     },
     {
         "name": "tabitabi",
         "trans": [
+            "たびたび",
             "often,repeatedly,frequently"
-        ],
-        "notation": "たびたび"
+        ]
     },
     {
         "name": "douitsu",
         "trans": [
+            "同一(どういつ)",
             "identity,sameness,similarity"
-        ],
-        "notation": "同一(どういつ)"
+        ]
     },
     {
         "name": "yoroshii",
         "trans": [
+            "宜(よろ)しい",
             "(hon) good,OK,all right,fine,very well,will do,may,can"
-        ],
-        "notation": "宜(よろ)しい"
+        ]
     },
     {
         "name": "sanpo",
         "trans": [
+            "散歩(さんぽ)",
             "walk,stroll"
-        ],
-        "notation": "散歩(さんぽ)"
+        ]
     },
     {
         "name": "yohou",
         "trans": [
+            "予報(よほう)",
             "forecast,prediction"
-        ],
-        "notation": "予報(よほう)"
+        ]
     },
     {
         "name": "ue",
         "trans": [
+            "上(うえ)",
             "(1) first volume,(2) superior quality,(3) governmental"
-        ],
-        "notation": "上(うえ)"
+        ]
     },
     {
         "name": "jojoni",
         "trans": [
+            "徐々に(じょじょに)",
             "slowly,little by little,gradually,steadily,quietly"
-        ],
-        "notation": "徐々に(じょじょに)"
+        ]
     },
     {
         "name": "kichinto",
         "trans": [
+            "きちんと",
             "precisely,accurately"
-        ],
-        "notation": "きちんと"
+        ]
     },
     {
         "name": "toori",
         "trans": [
+            "通(とお)り",
             "in accordance with ~,following ~,~ Street,~ Avenue"
-        ],
-        "notation": "通(とお)り"
+        ]
     },
     {
         "name": "mettani",
         "trans": [
+            "滅多(めった)に",
             "rarely (with neg. verb),seldom"
-        ],
-        "notation": "滅多(めった)に"
+        ]
     },
     {
         "name": "hihyou",
         "trans": [
+            "批評(ひひょう)",
             "criticism,review,commentary"
-        ],
-        "notation": "批評(ひひょう)"
+        ]
     },
     {
         "name": "teikou",
         "trans": [
+            "抵抗(ていこう)",
             "electrical resistance,resistance,opposition"
-        ],
-        "notation": "抵抗(ていこう)"
+        ]
     },
     {
         "name": "shoi",
         "trans": [
+            "所為(しょい)",
             "cause,reason,fault"
-        ],
-        "notation": "所為(しょい)"
+        ]
     },
     {
         "name": "ritsu",
         "trans": [
+            "率(りつ)",
             "rate,ratio,proportion,percentage"
-        ],
-        "notation": "率(りつ)"
+        ]
     },
     {
         "name": "shounen",
         "trans": [
+            "少年(しょうねん)",
             "boys,juveniles"
-        ],
-        "notation": "少年(しょうねん)"
+        ]
     },
     {
         "name": "yuumoa",
         "trans": [
+            "ユーモア",
             "humor"
-        ],
-        "notation": "ユーモア"
+        ]
     },
     {
         "name": "kuruu",
         "trans": [
+            "狂(くる)う",
             "to go mad,to get out of order"
-        ],
-        "notation": "狂(くる)う"
+        ]
     },
     {
         "name": "shokuryou",
         "trans": [
+            "食料(しょくりょう)",
             "food"
-        ],
-        "notation": "食料(しょくりょう)"
+        ]
     },
     {
         "name": "dokushin",
         "trans": [
+            "独身(どくしん)",
             "bachelorhood,single,unmarried,celibate"
-        ],
-        "notation": "独身(どくしん)"
+        ]
     },
     {
         "name": "jaa",
         "trans": [
+            "じゃあ",
             "well,well then"
-        ],
-        "notation": "じゃあ"
+        ]
     },
     {
         "name": "hara",
         "trans": [
+            "原(はら)",
             "field,plain,prairie,tundra,moor,wilderness"
-        ],
-        "notation": "原(はら)"
+        ]
     },
     {
         "name": "hizuke",
         "trans": [
+            "日付(ひづけ)",
             "date,dating"
-        ],
-        "notation": "日付(ひづけ)"
+        ]
     },
     {
         "name": "henkou",
         "trans": [
+            "変更(へんこう)",
             "change,modification,alteration"
-        ],
-        "notation": "変更(へんこう)"
+        ]
     },
     {
         "name": "ato",
         "trans": [
+            "跡(あと)",
             "(1) trace,tracks,mark,sign,(2) remains,ruins,(3) scar"
-        ],
-        "notation": "跡(あと)"
+        ]
     },
     {
         "name": "oki",
         "trans": [
+            "沖(おき)",
             "open sea"
-        ],
-        "notation": "沖(おき)"
+        ]
     },
     {
         "name": "kage",
         "trans": [
+            "陰(かげ)",
             "shade,shadow,other side"
-        ],
-        "notation": "陰(かげ)"
+        ]
     },
     {
         "name": "nayamu",
         "trans": [
+            "悩(なや)む",
             "to be worried,to be troubled"
-        ],
-        "notation": "悩(なや)む"
+        ]
     },
     {
         "name": "handan",
         "trans": [
+            "判断(はんだん)",
             "judgement,decision"
-        ],
-        "notation": "判断(はんだん)"
+        ]
     },
     {
         "name": "hataraki",
         "trans": [
+            "働(はたら)き",
             "work,labor"
-        ],
-        "notation": "働(はたら)き"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "頬(ほお)",
             "cheek (of face)"
-        ],
-        "notation": "頬(ほお)"
+        ]
     },
     {
         "name": "tetsu",
         "trans": [
+            "鉄(てつ)",
             "iron"
-        ],
-        "notation": "鉄(てつ)"
+        ]
     },
     {
         "name": "ikutsu",
         "trans": [
+            "幾(いく)つ",
             "how many?,how old?"
-        ],
-        "notation": "幾(いく)つ"
+        ]
     },
     {
         "name": "shibafu",
         "trans": [
+            "芝生(しばふ)",
             "lawn"
-        ],
-        "notation": "芝生(しばふ)"
+        ]
     },
     {
         "name": "sonkei",
         "trans": [
+            "尊敬(そんけい)",
             "respect,esteem,reverence,honour"
-        ],
-        "notation": "尊敬(そんけい)"
+        ]
     },
     {
         "name": "e",
         "trans": [
+            "柄(え)",
             "handle,grip"
-        ],
-        "notation": "柄(え)"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "神(かみ)",
             "god"
-        ],
-        "notation": "神(かみ)"
+        ]
     },
     {
         "name": "juudai",
         "trans": [
+            "重大(じゅうだい)",
             "serious,important,grave,weighty"
-        ],
-        "notation": "重大(じゅうだい)"
+        ]
     },
     {
         "name": "itsuka",
         "trans": [
+            "いつか",
             "sometime,someday,one day"
-        ],
-        "notation": "いつか"
+        ]
     },
     {
         "name": "ureru",
         "trans": [
+            "売(う)れる",
             "to be sold"
-        ],
-        "notation": "売(う)れる"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "賞(しょう)",
             "prize,award"
-        ],
-        "notation": "賞(しょう)"
+        ]
     },
     {
         "name": "makka",
         "trans": [
+            "真(ま)っ赤(か)",
             "deep red,flushed (of face)"
-        ],
-        "notation": "真(ま)っ赤(か)"
+        ]
     },
     {
         "name": "joushiki",
         "trans": [
+            "常識(じょうしき)",
             "common sense"
-        ],
-        "notation": "常識(じょうしき)"
+        ]
     },
     {
         "name": "suteki",
         "trans": [
+            "すてき",
             "lovely,dreamy,beautiful,great"
-        ],
-        "notation": "すてき"
+        ]
     },
     {
         "name": "nozomi",
         "trans": [
+            "望(のぞ)み",
             "wish,desire,(a) hope"
-        ],
-        "notation": "望(のぞ)み"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "観光(かんこう)",
             "sightseeing"
-        ],
-        "notation": "観光(かんこう)"
+        ]
     },
     {
         "name": "tetsudai",
         "trans": [
+            "手伝(てつだ)い",
             "help,helper,assistant"
-        ],
-        "notation": "手伝(てつだ)い"
+        ]
     },
     {
         "name": "reisei",
         "trans": [
+            "冷静(れいせい)",
             "calm,composure,coolness,serenity"
-        ],
-        "notation": "冷静(れいせい)"
+        ]
     },
     {
         "name": "akirameru",
         "trans": [
+            "諦(あきら)める",
             "to give up,to abandon"
-        ],
-        "notation": "諦(あきら)める"
+        ]
     },
     {
         "name": "kifu",
         "trans": [
+            "寄付(きふ)",
             "contribution,donation"
-        ],
-        "notation": "寄付(きふ)"
+        ]
     },
     {
         "name": "kiniiru",
         "trans": [
+            "気(き)に入(い)る",
             "to be pleased with,to suit"
-        ],
-        "notation": "気(き)に入(い)る"
+        ]
     },
     {
         "name": "ta",
         "trans": [
+            "他(た)",
             "other (esp. places and things)"
-        ],
-        "notation": "他(た)"
+        ]
     },
     {
         "name": "kechi",
         "trans": [
+            "けち",
             "stinginess,miser,miserliness"
-        ],
-        "notation": "けち"
+        ]
     },
     {
         "name": "aijou",
         "trans": [
+            "愛情(あいじょう)",
             "love,affection"
-        ],
-        "notation": "愛情(あいじょう)"
+        ]
     },
     {
         "name": "motomeru",
         "trans": [
+            "求(もと)める",
             "to seek,to request,to demand,to want,to wish for,to search for,to pursue (pleasure),to hunt (a job),"
-        ],
-        "notation": "求(もと)める"
+        ]
     },
     {
         "name": "tassuru",
         "trans": [
+            "達(たっ)する",
             "to reach,to get to"
-        ],
-        "notation": "達(たっ)する"
+        ]
     },
     {
         "name": "joshi",
         "trans": [
+            "女子(じょし)",
             "woman,girl"
-        ],
-        "notation": "女子(じょし)"
+        ]
     },
     {
         "name": "kojin",
         "trans": [
+            "個人(こじん)",
             "individual,private person,personal,private"
-        ],
-        "notation": "個人(こじん)"
+        ]
     },
     {
         "name": "genkai",
         "trans": [
+            "限界(げんかい)",
             "limit,bound"
-        ],
-        "notation": "限界(げんかい)"
+        ]
     },
     {
         "name": "sukii",
         "trans": [
+            "スキー",
             "skiing"
-        ],
-        "notation": "スキー"
+        ]
     },
     {
         "name": "kai",
         "trans": [
+            "会(かい)",
             "meeting,assembly,party,association,club"
-        ],
-        "notation": "会(かい)"
+        ]
     },
     {
         "name": "eisei",
         "trans": [
+            "衛星(えいせい)",
             "satellite"
-        ],
-        "notation": "衛星(えいせい)"
+        ]
     },
     {
         "name": "matsu",
         "trans": [
+            "松(まつ)",
             "(1) pine tree,(2) highest (of a three-tier ranking system)"
-        ],
-        "notation": "松(まつ)"
+        ]
     },
     {
         "name": "hasami",
         "trans": [
+            "はさみ",
             "scissors"
-        ],
-        "notation": "はさみ"
+        ]
     },
     {
         "name": "jitai",
         "trans": [
+            "事態(じたい)",
             "situation,present state of affairs"
-        ],
-        "notation": "事態(じたい)"
+        ]
     },
     {
         "name": "manzoku",
         "trans": [
+            "満足(まんぞく)",
             "satisfaction"
-        ],
-        "notation": "満足(まんぞく)"
+        ]
     },
     {
         "name": "taipuraitaa",
         "trans": [
+            "タイプライター",
             "typewriter"
-        ],
-        "notation": "タイプライター"
+        ]
     },
     {
         "name": "izure",
         "trans": [
+            "いずれ",
             "where,which,who"
-        ],
-        "notation": "いずれ"
+        ]
     },
     {
         "name": "shoutotsu",
         "trans": [
+            "衝突(しょうとつ)",
             "collision,conflict"
-        ],
-        "notation": "衝突(しょうとつ)"
+        ]
     },
     {
         "name": "koudou",
         "trans": [
+            "行動(こうどう)",
             "action,conduct,behaviour,mobilization"
-        ],
-        "notation": "行動(こうどう)"
+        ]
     },
     {
         "name": "ana",
         "trans": [
+            "穴(あな)",
             "hole"
-        ],
-        "notation": "穴(あな)"
+        ]
     },
     {
         "name": "boui",
         "trans": [
+            "ボーイ",
             "boy"
-        ],
-        "notation": "ボーイ"
+        ]
     },
     {
         "name": "shoushou",
         "trans": [
+            "少々(しょうしょう)",
             "just a minute,small quantity"
-        ],
-        "notation": "少々(しょうしょう)"
+        ]
     },
     {
         "name": "doyou",
         "trans": [
+            "土曜(どよう)",
             "Saturday"
-        ],
-        "notation": "土曜(どよう)"
+        ]
     },
     {
         "name": "kemuri",
         "trans": [
+            "煙(けむり)",
             "smoke,fumes"
-        ],
-        "notation": "煙(けむり)"
+        ]
     },
     {
         "name": "zentai",
         "trans": [
+            "全体(ぜんたい)",
             "whole,entirety,whatever (is the matter)"
-        ],
-        "notation": "全体(ぜんたい)"
+        ]
     },
     {
         "name": "chiku",
         "trans": [
+            "地区(ちく)",
             "district,section,sector"
-        ],
-        "notation": "地区(ちく)"
+        ]
     },
     {
         "name": "teido",
         "trans": [
+            "程度(ていど)",
             "degree,amount,grade,standard,of the order of (following a number)"
-        ],
-        "notation": "程度(ていど)"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "量(りょう)",
             "quantity,amount,volume,portion (of food)"
-        ],
-        "notation": "量(りょう)"
+        ]
     },
     {
         "name": "genba",
         "trans": [
+            "現場(げんば)",
             "actual spot,scene,scene of the crime"
-        ],
-        "notation": "現場(げんば)"
+        ]
     },
     {
         "name": "fushigi",
         "trans": [
+            "不思議(ふしぎ)",
             "mystery,curiosity"
-        ],
-        "notation": "不思議(ふしぎ)"
+        ]
     },
     {
         "name": "sonzai",
         "trans": [
+            "存在(そんざい)",
             "existence,being"
-        ],
-        "notation": "存在(そんざい)"
+        ]
     },
     {
         "name": "nouka",
         "trans": [
+            "農家(のうか)",
             "farmer,farm family"
-        ],
-        "notation": "農家(のうか)"
+        ]
     },
     {
         "name": "shibou",
         "trans": [
+            "死亡(しぼう)",
             "death,mortality"
-        ],
-        "notation": "死亡(しぼう)"
+        ]
     },
     {
         "name": "gaman",
         "trans": [
+            "我慢(がまん)",
             "patience,endurance,perseverance"
-        ],
-        "notation": "我慢(がまん)"
+        ]
     },
     {
         "name": "issou",
         "trans": [
+            "一層(いっそう)",
             "much more,still more,all the more"
-        ],
-        "notation": "一層(いっそう)"
+        ]
     },
     {
         "name": "dakedo",
         "trans": [
+            "だけど",
             "however"
-        ],
-        "notation": "だけど"
+        ]
     },
     {
         "name": "haitatsu",
         "trans": [
+            "配達(はいたつ)",
             "delivery,distribution"
-        ],
-        "notation": "配達(はいたつ)"
+        ]
     },
     {
         "name": "orosu",
         "trans": [
+            "降(お)ろす",
             "to take down,to launch,to drop"
-        ],
-        "notation": "降(お)ろす"
+        ]
     },
     {
         "name": "mazu",
         "trans": [
+            "先(ま)ず",
             "first (of all),to start with,about,almost,hardly (with neg. verb)"
-        ],
-        "notation": "先(ま)ず"
+        ]
     },
     {
         "name": "yoroshii",
         "trans": [
+            "宜(よろ)しい",
             "well,properly,suitably,best regards,please remember me"
-        ],
-        "notation": "宜(よろ)しい"
+        ]
     },
     {
         "name": "kaiteki",
         "trans": [
+            "快適(かいてき)",
             "pleasant,agreeable,comfortable"
-        ],
-        "notation": "快適(かいてき)"
+        ]
     },
     {
         "name": "raku",
         "trans": [
+            "楽(らく)",
             "comfort,ease"
-        ],
-        "notation": "楽(らく)"
+        ]
     },
     {
         "name": "aki",
         "trans": [
+            "空(あ)き",
             "room,time to spare,emptiness"
-        ],
-        "notation": "空(あ)き"
+        ]
     },
     {
         "name": "kasai",
         "trans": [
+            "火災(かさい)",
             "conflagration,fire"
-        ],
-        "notation": "火災(かさい)"
+        ]
     },
     {
         "name": "baka",
         "trans": [
+            "馬鹿(ばか)",
             "fool,idiot,trivial matter,folly"
-        ],
-        "notation": "馬鹿(ばか)"
+        ]
     },
     {
         "name": "hokori",
         "trans": [
+            "埃(ほこり)",
             "dust"
-        ],
-        "notation": "埃(ほこり)"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "缶(かん)",
             "can,tin"
-        ],
-        "notation": "缶(かん)"
+        ]
     },
     {
         "name": "torakku",
         "trans": [
+            "トラック",
             "(1) truck,(2) (running) track"
-        ],
-        "notation": "トラック"
+        ]
     },
     {
         "name": "sakuhin",
         "trans": [
+            "作品(さくひん)",
             "work,opus,performance,production"
-        ],
-        "notation": "作品(さくひん)"
+        ]
     },
     {
         "name": "nikkou",
         "trans": [
+            "日光(にっこう)",
             "sunlight"
-        ],
-        "notation": "日光(にっこう)"
+        ]
     },
     {
         "name": "tokuchou",
         "trans": [
+            "特徴(とくちょう)",
             "feature,characteristic"
-        ],
-        "notation": "特徴(とくちょう)"
+        ]
     },
     {
         "name": "myou",
         "trans": [
+            "妙(みょう)",
             "strange,unusual"
-        ],
-        "notation": "妙(みょう)"
+        ]
     },
     {
         "name": "chuumon",
         "trans": [
+            "注文(ちゅうもん)",
             "order,request"
-        ],
-        "notation": "注文(ちゅうもん)"
+        ]
     },
     {
         "name": "zen",
         "trans": [
+            "善(ぜん)",
             "good,goodness,right,virtue"
-        ],
-        "notation": "善(ぜん)"
+        ]
     },
     {
         "name": "oku",
         "trans": [
+            "奥(おく)",
             "interior,inner part"
-        ],
-        "notation": "奥(おく)"
+        ]
     },
     {
         "name": "onaka",
         "trans": [
+            "お腹(なか)",
             "stomach"
-        ],
-        "notation": "お腹(なか)"
+        ]
     },
     {
         "name": "tsuyu",
         "trans": [
+            "梅雨(つゆ)",
             "rainy season,rain during the rainy season"
-        ],
-        "notation": "梅雨(つゆ)"
+        ]
     },
     {
         "name": "kiji",
         "trans": [
+            "生地(きじ)",
             "birthplace"
-        ],
-        "notation": "生地(きじ)"
+        ]
     },
     {
         "name": "jinrui",
         "trans": [
+            "人類(じんるい)",
             "mankind,humanity"
-        ],
-        "notation": "人類(じんるい)"
+        ]
     },
     {
         "name": "karera",
         "trans": [
+            "彼等(かれら)",
             "they (usually male)"
-        ],
-        "notation": "彼等(かれら)"
+        ]
     },
     {
         "name": "muku",
         "trans": [
+            "向(む)く",
             "to face"
-        ],
-        "notation": "向(む)く"
+        ]
     },
     {
         "name": "hyoumen",
         "trans": [
+            "表面(ひょうめん)",
             "surface,outside,face,appearance"
-        ],
-        "notation": "表面(ひょうめん)"
+        ]
     },
     {
         "name": "tannaru",
         "trans": [
+            "単(たん)なる",
             "mere,simple,sheer"
-        ],
-        "notation": "単(たん)なる"
+        ]
     },
     {
         "name": "seiketsu",
         "trans": [
+            "清潔(せいけつ)",
             "clean"
-        ],
-        "notation": "清潔(せいけつ)"
+        ]
     },
     {
         "name": "kyoudou",
         "trans": [
+            "共同(きょうどう)",
             "cooperation,association,collaboration,joint"
-        ],
-        "notation": "共同(きょうどう)"
+        ]
     },
     {
         "name": "ugai",
         "trans": [
+            "うがい",
             "gargle,rinse mouth"
-        ],
-        "notation": "うがい"
+        ]
     },
     {
         "name": "keiji",
         "trans": [
+            "掲示(けいじ)",
             "notice,bulletin"
-        ],
-        "notation": "掲示(けいじ)"
+        ]
     },
     {
         "name": "namakeru",
         "trans": [
+            "怠(なま)ける",
             "to be idle,to neglect"
-        ],
-        "notation": "怠(なま)ける"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "都(と)",
             "capital"
-        ],
-        "notation": "都(と)"
+        ]
     },
     {
         "name": "isshou",
         "trans": [
+            "一生(いっしょう)",
             "whole life,a lifetime,all through life"
-        ],
-        "notation": "一生(いっしょう)"
+        ]
     },
     {
         "name": "setto",
         "trans": [
+            "セット",
             "set"
-        ],
-        "notation": "セット"
+        ]
     },
     {
         "name": "battari",
         "trans": [
+            "ばったり",
             "with a clash (thud),with a bang,plump,flop"
-        ],
-        "notation": "ばったり"
+        ]
     },
     {
         "name": "puran",
         "trans": [
+            "プラン",
             "plan"
-        ],
-        "notation": "プラン"
+        ]
     },
     {
         "name": "wake",
         "trans": [
+            "訳(わけ)",
             "meaning,reason,circumstances,can be deduced,situation"
-        ],
-        "notation": "訳(わけ)"
+        ]
     },
     {
         "name": "shiro",
         "trans": [
+            "城(しろ)",
             "castle"
-        ],
-        "notation": "城(しろ)"
+        ]
     },
     {
         "name": "hitokoto",
         "trans": [
+            "一言(ひとこと)",
             "single word"
-        ],
-        "notation": "一言(ひとこと)"
+        ]
     },
     {
         "name": "kanarazushimo",
         "trans": [
+            "必(かなら)ずしも",
             "(not) always,(not) necessarily,(not) all,(not) entirely"
-        ],
-        "notation": "必(かなら)ずしも"
+        ]
     },
     {
         "name": "kankaku",
         "trans": [
+            "感覚(かんかく)",
             "sense,sensation"
-        ],
-        "notation": "感覚(かんかく)"
+        ]
     },
     {
         "name": "kokuban",
         "trans": [
+            "黒板(こくばん)",
             "blackboard"
-        ],
-        "notation": "黒板(こくばん)"
+        ]
     },
     {
         "name": "youi",
         "trans": [
+            "容易(ようい)",
             "easy,simple,plain"
-        ],
-        "notation": "容易(ようい)"
+        ]
     },
     {
         "name": "tsure",
         "trans": [
+            "連(つ)れ",
             "companion,company"
-        ],
-        "notation": "連(つ)れ"
+        ]
     },
     {
         "name": "fureru",
         "trans": [
+            "触(ふ)れる",
             "to touch,to be touched,to touch on a subject,to feel,to violate (law, copyright, etc.),to perceive,t"
-        ],
-        "notation": "触(ふ)れる"
+        ]
     },
     {
         "name": "shinpan",
         "trans": [
+            "審判(しんぱん)",
             "refereeing,trial,judgement,umpire,referee"
-        ],
-        "notation": "審判(しんぱん)"
+        ]
     },
     {
         "name": "taishi",
         "trans": [
+            "大使(たいし)",
             "ambassador"
-        ],
-        "notation": "大使(たいし)"
+        ]
     },
     {
         "name": "sakura",
         "trans": [
+            "桜(さくら)",
             "cherry blossom,cherry tree"
-        ],
-        "notation": "桜(さくら)"
+        ]
     },
     {
         "name": "kanjou",
         "trans": [
+            "感情(かんじょう)",
             "emotion(s),feeling(s),sentiment"
-        ],
-        "notation": "感情(かんじょう)"
+        ]
     },
     {
         "name": "sabetsu",
         "trans": [
+            "差別(さべつ)",
             "discrimination,distinction,differentiation"
-        ],
-        "notation": "差別(さべつ)"
+        ]
     },
     {
         "name": "kayou",
         "trans": [
+            "火曜(かよう)",
             "(abbr) Tuesday"
-        ],
-        "notation": "火曜(かよう)"
+        ]
     },
     {
         "name": "tonneru",
         "trans": [
+            "トンネル",
             "tunnel"
-        ],
-        "notation": "トンネル"
+        ]
     },
     {
         "name": "kun",
         "trans": [
+            "訓(くん)",
             "native Japanese reading of a Chinese character"
-        ],
-        "notation": "訓(くん)"
+        ]
     },
     {
         "name": "nyuugaku",
         "trans": [
+            "入学(にゅうがく)",
             "entry to school or university,matriculation"
-        ],
-        "notation": "入学(にゅうがく)"
+        ]
     },
     {
         "name": "tairiku",
         "trans": [
+            "大陸(たいりく)",
             "continent"
-        ],
-        "notation": "大陸(たいりく)"
+        ]
     },
     {
         "name": "aizu",
         "trans": [
+            "合図(あいず)",
             "sign,signal"
-        ],
-        "notation": "合図(あいず)"
+        ]
     },
     {
         "name": "teki",
         "trans": [
+            "敵(てき)",
             "enemy,rival"
-        ],
-        "notation": "敵(てき)"
+        ]
     },
     {
         "name": "oubaa",
         "trans": [
+            "オーバー",
             "(1) overcoat,(2) over"
-        ],
-        "notation": "オーバー"
+        ]
     },
     {
         "name": "kudasaru",
         "trans": [
+            "下(くだ)さる",
             "(hon) to give,to confer"
-        ],
-        "notation": "下(くだ)さる"
+        ]
     },
     {
         "name": "taku",
         "trans": [
+            "宅(たく)",
             "house,home,husband"
-        ],
-        "notation": "宅(たく)"
+        ]
     },
     {
         "name": "yuukou",
         "trans": [
+            "有効(ゆうこう)",
             "validity,availability,effectiveness"
-        ],
-        "notation": "有効(ゆうこう)"
+        ]
     },
     {
         "name": "seinen",
         "trans": [
+            "青年(せいねん)",
             "youth,young man"
-        ],
-        "notation": "青年(せいねん)"
+        ]
     },
     {
         "name": "ton",
         "trans": [
+            "とん",
             "tap, knock, bonk"
-        ],
-        "notation": "とん"
+        ]
     },
     {
         "name": "saiban",
         "trans": [
+            "裁判(さいばん)",
             "trial,judgement"
-        ],
-        "notation": "裁判(さいばん)"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "いち",
             "market,fair"
-        ],
-        "notation": "いち"
+        ]
     },
     {
         "name": "hohoemu",
         "trans": [
+            "微笑(ほほえ)む",
             "to smile"
-        ],
-        "notation": "微笑(ほほえ)む"
+        ]
     },
     {
         "name": "itami",
         "trans": [
+            "痛(いた)み",
             "pain,ache,sore,grief,distress"
-        ],
-        "notation": "痛(いた)み"
+        ]
     },
     {
         "name": "dore",
         "trans": [
+            "どれ",
             "well,now,let me see,which (of three or more)"
-        ],
-        "notation": "どれ"
+        ]
     },
     {
         "name": "fuukei",
         "trans": [
+            "風景(ふうけい)",
             "scenery"
-        ],
-        "notation": "風景(ふうけい)"
+        ]
     },
     {
         "name": "koumuru",
         "trans": [
+            "被(こうむ)る",
             "to suffer"
-        ],
-        "notation": "被(こうむ)る"
+        ]
     },
     {
         "name": "suisen",
         "trans": [
+            "推薦(すいせん)",
             "recommendation"
-        ],
-        "notation": "推薦(すいせん)"
+        ]
     },
     {
         "name": "nuno",
         "trans": [
+            "布(ぬの)",
             "cloth"
-        ],
-        "notation": "布(ぬの)"
+        ]
     },
     {
         "name": "hajimari",
         "trans": [
+            "始(はじ)まり",
             "origin,beginning"
-        ],
-        "notation": "始(はじ)まり"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "どう",
             "how, in what way, how about"
-        ],
-        "notation": "どう"
+        ]
     },
     {
         "name": "shuchou",
         "trans": [
+            "主張(しゅちょう)",
             "claim,request,insistence,assertion"
-        ],
-        "notation": "主張(しゅちょう)"
+        ]
     },
     {
         "name": "sewa",
         "trans": [
+            "世話(せわ)",
             "looking after,help,aid,assistance"
-        ],
-        "notation": "世話(せわ)"
+        ]
     },
     {
         "name": "kinshi",
         "trans": [
+            "禁止(きんし)",
             "prohibition,ban"
-        ],
-        "notation": "禁止(きんし)"
+        ]
     },
     {
         "name": "samasu",
         "trans": [
+            "覚(さ)ます",
             "to awaken"
-        ],
-        "notation": "覚(さ)ます"
+        ]
     },
     {
         "name": "sekitan",
         "trans": [
+            "石炭(せきたん)",
             "coal"
-        ],
-        "notation": "石炭(せきたん)"
+        ]
     },
     {
         "name": "monooto",
         "trans": [
+            "物音(ものおと)",
             "sounds"
-        ],
-        "notation": "物音(ものおと)"
+        ]
     },
     {
         "name": "shoubai",
         "trans": [
+            "商売(しょうばい)",
             "trade,business,commerce,transaction,occupation"
-        ],
-        "notation": "商売(しょうばい)"
+        ]
     },
     {
         "name": "ondo",
         "trans": [
+            "温度(おんど)",
             "temperature"
-        ],
-        "notation": "温度(おんど)"
+        ]
     },
     {
         "name": "ronsou",
         "trans": [
+            "論争(ろんそう)",
             "controversy,dispute"
-        ],
-        "notation": "論争(ろんそう)"
+        ]
     },
     {
         "name": "souon",
         "trans": [
+            "騒音(そうおん)",
             "noise"
-        ],
-        "notation": "騒音(そうおん)"
+        ]
     },
     {
         "name": "kurikaesu",
         "trans": [
+            "繰(く)り返(かえ)す",
             "to repeat,to do something over again"
-        ],
-        "notation": "繰(く)り返(かえ)す"
+        ]
     },
     {
         "name": "kuriimu",
         "trans": [
+            "クリーム",
             "cream"
-        ],
-        "notation": "クリーム"
+        ]
     },
     {
         "name": "fujin",
         "trans": [
+            "婦人(ふじん)",
             "woman,female"
-        ],
-        "notation": "婦人(ふじん)"
+        ]
     },
     {
         "name": "mochiron",
         "trans": [
+            "勿論(もちろん)",
             "of course,certainly,naturally"
-        ],
-        "notation": "勿論(もちろん)"
+        ]
     },
     {
         "name": "seizei",
         "trans": [
+            "精々(せいぜい)",
             "at the most,at best,to the utmost,as much (far) as possible"
-        ],
-        "notation": "精々(せいぜい)"
+        ]
     },
     {
         "name": "seikaku",
         "trans": [
+            "正確(せいかく)",
             "accurate,punctuality,exactness,authenticity,veracity"
-        ],
-        "notation": "正確(せいかく)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "縦(たて)",
             "length,height"
-        ],
-        "notation": "縦(たて)"
+        ]
     },
     {
         "name": "roketto",
         "trans": [
+            "ロケット",
             "locket,rocket"
-        ],
-        "notation": "ロケット"
+        ]
     },
     {
         "name": "kansatsu",
         "trans": [
+            "観察(かんさつ)",
             "observation,survey"
-        ],
-        "notation": "観察(かんさつ)"
+        ]
     },
     {
         "name": "futatabi",
         "trans": [
+            "再(ふたた)び",
             "again,once more,a second time"
-        ],
-        "notation": "再(ふたた)び"
+        ]
     },
     {
         "name": "hatsumei",
         "trans": [
+            "発明(はつめい)",
             "invention"
-        ],
-        "notation": "発明(はつめい)"
+        ]
     },
     {
         "name": "soshiki",
         "trans": [
+            "組織(そしき)",
             "(1) organization,(2) structure,construction,(3) tissue,(4) system"
-        ],
-        "notation": "組織(そしき)"
+        ]
     },
     {
         "name": "kensetsu",
         "trans": [
+            "建設(けんせつ)",
             "construction,establishment"
-        ],
-        "notation": "建設(けんせつ)"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "方(ほう)",
             "side"
-        ],
-        "notation": "方(ほう)"
+        ]
     },
     {
         "name": "deeto",
         "trans": [
+            "デート",
             "date,go on a date"
-        ],
-        "notation": "デート"
+        ]
     },
     {
         "name": "saru",
         "trans": [
+            "猿(さる)",
             "monkey"
-        ],
-        "notation": "猿(さる)"
+        ]
     },
     {
         "name": "kenkai",
         "trans": [
+            "見解(けんかい)",
             "opinion,point of view"
-        ],
-        "notation": "見解(けんかい)"
+        ]
     },
     {
         "name": "zehi",
         "trans": [
+            "是非(ぜひ)",
             "certainly,without fail"
-        ],
-        "notation": "是非(ぜひ)"
+        ]
     },
     {
         "name": "nendai",
         "trans": [
+            "年代(ねんだい)",
             "age,era,period,date"
-        ],
-        "notation": "年代(ねんだい)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "信仰(しんこう)",
             "(religious) faith,belief,creed"
-        ],
-        "notation": "信仰(しんこう)"
+        ]
     },
     {
         "name": "zouka",
         "trans": [
+            "増加(ぞうか)",
             "increase,addition"
-        ],
-        "notation": "増加(ぞうか)"
+        ]
     },
     {
         "name": "repouto",
         "trans": [
+            "レポート",
             "report,paper"
-        ],
-        "notation": "レポート"
+        ]
     },
     {
         "name": "ta",
         "trans": [
+            "田(た)",
             "rice field"
-        ],
-        "notation": "田(た)"
+        ]
     },
     {
         "name": "nettai",
         "trans": [
+            "熱帯(ねったい)",
             "tropics"
-        ],
-        "notation": "熱帯(ねったい)"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "そう",
             "so"
-        ],
-        "notation": "そう"
+        ]
     },
     {
         "name": "sansei",
         "trans": [
+            "賛成(さんせい)",
             "approval,agreement,support,favour"
-        ],
-        "notation": "賛成(さんせい)"
+        ]
     },
     {
         "name": "chiiki",
         "trans": [
+            "地域(ちいき)",
             "area,region"
-        ],
-        "notation": "地域(ちいき)"
+        ]
     },
     {
         "name": "ka",
         "trans": [
+            "課(か)",
             "counter for chapters (of a book)"
-        ],
-        "notation": "課(か)"
+        ]
     },
     {
         "name": "akeru",
         "trans": [
+            "明(あ)ける",
             "to dawn,to become daylight"
-        ],
-        "notation": "明(あ)ける"
+        ]
     },
     {
         "name": "toshi",
         "trans": [
+            "都市(とし)",
             "town,city,municipal,urban"
-        ],
-        "notation": "都市(とし)"
+        ]
     },
     {
         "name": "jimu",
         "trans": [
+            "事務(じむ)",
             "business,office work"
-        ],
-        "notation": "事務(じむ)"
+        ]
     },
     {
         "name": "giron",
         "trans": [
+            "議論(ぎろん)",
             "argument,discussion,dispute"
-        ],
-        "notation": "議論(ぎろん)"
+        ]
     },
     {
         "name": "nao",
         "trans": [
+            "なお",
             "straight,mischief,ordinary,common"
-        ],
-        "notation": "なお"
+        ]
     },
     {
         "name": "sudeni",
         "trans": [
+            "既(すで)に",
             "already,too late"
-        ],
-        "notation": "既(すで)に"
+        ]
     },
     {
         "name": "tappuri",
         "trans": [
+            "たっぷり",
             "full,in plenty,ample"
-        ],
-        "notation": "たっぷり"
+        ]
     },
     {
         "name": "setsubi",
         "trans": [
+            "設備(せつび)",
             "equipment,device,facilities,installation"
-        ],
-        "notation": "設備(せつび)"
+        ]
     },
     {
         "name": "fujiyuu",
         "trans": [
+            "不自由(ふじゆう)",
             "discomfort,disability,inconvenience,destitution"
-        ],
-        "notation": "不自由(ふじゆう)"
+        ]
     },
     {
         "name": "izen",
         "trans": [
+            "以前(いぜん)",
             "ago,since,before,previous"
-        ],
-        "notation": "以前(いぜん)"
+        ]
     },
     {
         "name": "isu",
         "trans": [
+            "椅子(いす)",
             "chair"
-        ],
-        "notation": "椅子(いす)"
+        ]
     },
     {
         "name": "koukan",
         "trans": [
+            "交換(こうかん)",
             "exchange,interchange,reciprocity"
-        ],
-        "notation": "交換(こうかん)"
+        ]
     },
     {
         "name": "korobu",
         "trans": [
+            "転(ころ)ぶ",
             "to fall down,to fall over"
-        ],
-        "notation": "転(ころ)ぶ"
+        ]
     },
     {
         "name": "tsuri",
         "trans": [
+            "釣(つり)",
             ""
-        ],
-        "notation": "釣(つり)"
+        ]
     },
     {
         "name": "kangae",
         "trans": [
+            "考(かんが)え",
             "thinking,thought,ideas,intention"
-        ],
-        "notation": "考(かんが)え"
+        ]
     },
     {
         "name": "joutatsu",
         "trans": [
+            "上達(じょうたつ)",
             "improvement,advance,progress"
-        ],
-        "notation": "上達(じょうたつ)"
+        ]
     },
     {
         "name": "konpyuutaa",
         "trans": [
+            "コンピューター",
             "computer"
-        ],
-        "notation": "コンピューター"
+        ]
     },
     {
         "name": "kata",
         "trans": [
+            "型(かた)",
             "mold,model,style,shape,data-type"
-        ],
-        "notation": "型(かた)"
+        ]
     },
     {
         "name": "fuufu",
         "trans": [
+            "夫婦(ふうふ)",
             "married couple,husband and wife"
-        ],
-        "notation": "夫婦(ふうふ)"
+        ]
     },
     {
         "name": "nochi",
         "trans": [
+            "後(のち)",
             "afterwards,since then,in the future"
-        ],
-        "notation": "後(のち)"
+        ]
     },
     {
         "name": "guruupu",
         "trans": [
+            "グループ",
             "group"
-        ],
-        "notation": "グループ"
+        ]
     },
     {
         "name": "senshu",
         "trans": [
+            "選手(せんしゅ)",
             "(1) player (in game),(2) team"
-        ],
-        "notation": "選手(せんしゅ)"
+        ]
     },
     {
         "name": "shinchou",
         "trans": [
+            "慎重(しんちょう)",
             "discretion,prudence"
-        ],
-        "notation": "慎重(しんちょう)"
+        ]
     },
     {
         "name": "houmon",
         "trans": [
+            "訪問(ほうもん)",
             "call,visit"
-        ],
-        "notation": "訪問(ほうもん)"
+        ]
     },
     {
         "name": "dorama",
         "trans": [
+            "ドラマ",
             "drama"
-        ],
-        "notation": "ドラマ"
+        ]
     },
     {
         "name": "kisha",
         "trans": [
+            "記者(きしゃ)",
             "reporter"
-        ],
-        "notation": "記者(きしゃ)"
+        ]
     },
     {
         "name": "shiyou",
         "trans": [
+            "使用(しよう)",
             "use,application,employment,utilization"
-        ],
-        "notation": "使用(しよう)"
+        ]
     },
     {
         "name": "sakumotsu",
         "trans": [
+            "作物(さくもつ)",
             "produce (e.g. agricultural),crops"
-        ],
-        "notation": "作物(さくもつ)"
+        ]
     },
     {
         "name": "douka",
         "trans": [
+            "どうか",
             "copper coin"
-        ],
-        "notation": "どうか"
+        ]
     },
     {
         "name": "dai",
         "trans": [
+            "題(だい)",
             "title,subject,theme,topic"
-        ],
-        "notation": "題(だい)"
+        ]
     },
     {
         "name": "kaji",
         "trans": [
+            "家事(かじ)",
             "housework,domestic chores"
-        ],
-        "notation": "家事(かじ)"
+        ]
     },
     {
         "name": "taira",
         "trans": [
+            "平(たい)ら",
             "flatness,level,smooth,calm,plain"
-        ],
-        "notation": "平(たい)ら"
+        ]
     },
     {
         "name": "ureshii",
         "trans": [
+            "嬉(うれ)しい",
             "happy,glad,pleasant"
-        ],
-        "notation": "嬉(うれ)しい"
+        ]
     },
     {
         "name": "omenikakaru",
         "trans": [
+            "お目(め)に掛(か)かる",
             ""
-        ],
-        "notation": "お目(め)に掛(か)かる"
+        ]
     },
     {
         "name": "tsumi",
         "trans": [
+            "罪(つみ)",
             "crime,fault,indiscretion"
-        ],
-        "notation": "罪(つみ)"
+        ]
     },
     {
         "name": "teian",
         "trans": [
+            "提案(ていあん)",
             "proposal,proposition,suggestion"
-        ],
-        "notation": "提案(ていあん)"
+        ]
     },
     {
         "name": "shorui",
         "trans": [
+            "書類(しょるい)",
             "documents,official papers"
-        ],
-        "notation": "書類(しょるい)"
+        ]
     },
     {
         "name": "aisatsu",
         "trans": [
+            "挨拶(あいさつ)",
             "greeting,salutation"
-        ],
-        "notation": "挨拶(あいさつ)"
+        ]
     },
     {
         "name": "sahou",
         "trans": [
+            "作法(さほう)",
             "manners,etiquette,propriety"
-        ],
-        "notation": "作法(さほう)"
+        ]
     },
     {
         "name": "yukkuri",
         "trans": [
+            "ゆっくり",
             "slowly,at ease"
-        ],
-        "notation": "ゆっくり"
+        ]
     },
     {
         "name": "shikyuu",
         "trans": [
+            "支給(しきゅう)",
             "payment,allowance"
-        ],
-        "notation": "支給(しきゅう)"
+        ]
     },
     {
         "name": "kossetsu",
         "trans": [
+            "骨折(こっせつ)",
             "bone fracture"
-        ],
-        "notation": "骨折(こっせつ)"
+        ]
     },
     {
         "name": "tsuzuki",
         "trans": [
+            "続(つづ)き",
             "sequel,continuation"
-        ],
-        "notation": "続(つづ)き"
+        ]
     },
     {
         "name": "shomotsu",
         "trans": [
+            "書物(しょもつ)",
             "books"
-        ],
-        "notation": "書物(しょもつ)"
+        ]
     },
     {
         "name": "hijou",
         "trans": [
+            "非常(ひじょう)",
             "emergency,extraordinary,unusual"
-        ],
-        "notation": "非常(ひじょう)"
+        ]
     },
     {
         "name": "aisukuriimu",
         "trans": [
+            "アイスクリーム",
             "ice cream"
-        ],
-        "notation": "アイスクリーム"
+        ]
     },
     {
         "name": "fuman",
         "trans": [
+            "不満(ふまん)",
             "dissatisfaction,displeasure,discontent,complaints,unhappiness"
-        ],
-        "notation": "不満(ふまん)"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "偶(たま)",
             "even number,couple,man and wife,friend"
-        ],
-        "notation": "偶(たま)"
+        ]
     },
     {
         "name": "iin",
         "trans": [
+            "委員(いいん)",
             "committee member"
-        ],
-        "notation": "委員(いいん)"
+        ]
     },
     {
         "name": "kouun",
         "trans": [
+            "幸運(こううん)",
             "good luck,fortune"
-        ],
-        "notation": "幸運(こううん)"
+        ]
     },
     {
         "name": "shigen",
         "trans": [
+            "資源(しげん)",
             "resources"
-        ],
-        "notation": "資源(しげん)"
+        ]
     },
     {
         "name": "muchuu",
         "trans": [
+            "夢中(むちゅう)",
             "daze,(in a) trance,ecstasy,delirium,engrossment"
-        ],
-        "notation": "夢中(むちゅう)"
+        ]
     },
     {
         "name": "igai",
         "trans": [
+            "意外(いがい)",
             "unexpected,surprising"
-        ],
-        "notation": "意外(いがい)"
+        ]
     },
     {
         "name": "fuhei",
         "trans": [
+            "不平(ふへい)",
             "complaint,discontent,dissatisfaction"
-        ],
-        "notation": "不平(ふへい)"
+        ]
     },
     {
         "name": "shinpo",
         "trans": [
+            "進歩(しんぽ)",
             "progress,development"
-        ],
-        "notation": "進歩(しんぽ)"
+        ]
     },
     {
         "name": "jiken",
         "trans": [
+            "事件(じけん)",
             "event,affair,incident"
-        ],
-        "notation": "事件(じけん)"
+        ]
     },
     {
         "name": "kenkou",
         "trans": [
+            "健康(けんこう)",
             "health,sound,wholesome"
-        ],
-        "notation": "健康(けんこう)"
+        ]
     },
     {
         "name": "heiwa",
         "trans": [
+            "平和(へいわ)",
             "peace,harmony"
-        ],
-        "notation": "平和(へいわ)"
+        ]
     },
     {
         "name": "owaru",
         "trans": [
+            "終(お)わる",
             "to finish,to close,to do something completely"
-        ],
-        "notation": "終(お)わる"
+        ]
     },
     {
         "name": "nagareru",
         "trans": [
+            "流(なが)れる",
             "to stream,to flow,to run (ink),to be washed away"
-        ],
-        "notation": "流(なが)れる"
+        ]
     },
     {
         "name": "tatakau",
         "trans": [
+            "戦(たたか)う",
             "to fight,to battle,to combat"
-        ],
-        "notation": "戦(たたか)う"
+        ]
     },
     {
         "name": "kousha",
         "trans": [
+            "後者(こうしゃ)",
             "the latter"
-        ],
-        "notation": "後者(こうしゃ)"
+        ]
     },
     {
         "name": "hipparu",
         "trans": [
+            "引(ひ)っ張(ぱ)る",
             "(1) to pull,to draw,to stretch,to drag,(2) to pull the ball (baseball)"
-        ],
-        "notation": "引(ひ)っ張(ぱ)る"
+        ]
     },
     {
         "name": "kibou",
         "trans": [
+            "希望(きぼう)",
             "hope,wish,aspiration"
-        ],
-        "notation": "希望(きぼう)"
+        ]
     },
     {
         "name": "shokutaku",
         "trans": [
+            "食卓(しょくたく)",
             "dining table"
-        ],
-        "notation": "食卓(しょくたく)"
+        ]
     },
     {
         "name": "taiho",
         "trans": [
+            "逮捕(たいほ)",
             "arrest,apprehension,capture"
-        ],
-        "notation": "逮捕(たいほ)"
+        ]
     },
     {
         "name": "hitoshi",
         "trans": [
+            "等(ひとし)",
             "et cetera,etc.,and the like"
-        ],
-        "notation": "等(ひとし)"
+        ]
     },
     {
         "name": "negau",
         "trans": [
+            "願(ねが)う",
             "to desire,to wish,to request"
-        ],
-        "notation": "願(ねが)う"
+        ]
     },
     {
         "name": "gai",
         "trans": [
+            "害(がい)",
             "injury,harm,evil influence,damage"
-        ],
-        "notation": "害(がい)"
+        ]
     },
     {
         "name": "aruiha",
         "trans": [
+            "あるいは",
             "or,possibly"
-        ],
-        "notation": "あるいは"
+        ]
     },
     {
         "name": "shunkan",
         "trans": [
+            "瞬間(しゅんかん)",
             "moment,second,instant"
-        ],
-        "notation": "瞬間(しゅんかん)"
+        ]
     },
     {
         "name": "seken",
         "trans": [
+            "世間(せけん)",
             "world,society"
-        ],
-        "notation": "世間(せけん)"
+        ]
     },
     {
         "name": "tashikameru",
         "trans": [
+            "確(たし)かめる",
             "to ascertain"
-        ],
-        "notation": "確(たし)かめる"
+        ]
     },
     {
         "name": "kirau",
         "trans": [
+            "嫌(きら)う",
             "to hate,to dislike,to loathe"
-        ],
-        "notation": "嫌(きら)う"
+        ]
     },
     {
         "name": "inochi",
         "trans": [
+            "命(いのち)",
             "command,decree,life,destiny"
-        ],
-        "notation": "命(いのち)"
+        ]
     },
     {
         "name": "kinyuu",
         "trans": [
+            "記入(きにゅう)",
             "entry,filling in of forms"
-        ],
-        "notation": "記入(きにゅう)"
+        ]
     },
     {
         "name": "sakka",
         "trans": [
+            "作家(さっか)",
             "author,writer,novelist,artist"
-        ],
-        "notation": "作家(さっか)"
+        ]
     },
     {
         "name": "iraira",
         "trans": [
+            "いらいら",
             "getting nervous,irritation"
-        ],
-        "notation": "いらいら"
+        ]
     },
     {
         "name": "giin",
         "trans": [
+            "議員(ぎいん)",
             "member of the Diet, congress or parliament"
-        ],
-        "notation": "議員(ぎいん)"
+        ]
     },
     {
         "name": "sonchou",
         "trans": [
+            "尊重(そんちょう)",
             "respect,esteem,regard"
-        ],
-        "notation": "尊重(そんちょう)"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "占(し)める",
             "(1) to comprise,to account for,to make up (of),(2) to hold,to occupy"
-        ],
-        "notation": "占(し)める"
+        ]
     },
     {
         "name": "daikin",
         "trans": [
+            "代金(だいきん)",
             "price,payment,cost,charge"
-        ],
-        "notation": "代金(だいきん)"
+        ]
     },
     {
         "name": "hyougen",
         "trans": [
+            "表現(ひょうげん)",
             "expression,presentation,representation (math)"
-        ],
-        "notation": "表現(ひょうげん)"
+        ]
     },
     {
         "name": "zeikin",
         "trans": [
+            "税金(ぜいきん)",
             "tax,duty"
-        ],
-        "notation": "税金(ぜいきん)"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "礼(れい)",
             "expression of gratitude"
-        ],
-        "notation": "礼(れい)"
+        ]
     },
     {
         "name": "moeru",
         "trans": [
+            "燃(も)える",
             "to burn"
-        ],
-        "notation": "燃(も)える"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "皮(かわ)",
             "skin,hide,leather,fur,pelt,bark,shell"
-        ],
-        "notation": "皮(かわ)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "十(じゅう)",
             "10,ten"
-        ],
-        "notation": "十(じゅう)"
+        ]
     },
     {
         "name": "sarani",
         "trans": [
+            "更(さら)に",
             "furthermore,again,after all,more and more,moreover"
-        ],
-        "notation": "更(さら)に"
+        ]
     },
     {
         "name": "shuyou",
         "trans": [
+            "主要(しゅよう)",
             "chief,main,principal,major"
-        ],
-        "notation": "主要(しゅよう)"
+        ]
     },
     {
         "name": "jikani",
         "trans": [
+            "直(じか)に",
             "immediately,readily,directly"
-        ],
-        "notation": "直(じか)に"
+        ]
     },
     {
         "name": "oyoso",
         "trans": [
+            "およそ",
             "about,roughly,as a rule,approximately"
-        ],
-        "notation": "およそ"
+        ]
     },
     {
         "name": "suupu",
         "trans": [
+            "スープ",
             "(Western) soup"
-        ],
-        "notation": "スープ"
+        ]
     },
     {
         "name": "nazenara",
         "trans": [
+            "なぜなら",
             "because"
-        ],
-        "notation": "なぜなら"
+        ]
     },
     {
         "name": "shugi",
         "trans": [
+            "主義(しゅぎ)",
             "doctrine,rule,principle"
-        ],
-        "notation": "主義(しゅぎ)"
+        ]
     },
     {
         "name": "nesshin",
         "trans": [
+            "熱心(ねっしん)",
             "zeal,enthusiasm"
-        ],
-        "notation": "熱心(ねっしん)"
+        ]
     },
     {
         "name": "jitsugen",
         "trans": [
+            "実現(じつげん)",
             "implementation,materialization,realization"
-        ],
-        "notation": "実現(じつげん)"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "河(かわ)",
             "river,stream"
-        ],
-        "notation": "河(かわ)"
+        ]
     },
     {
         "name": "kurushimu",
         "trans": [
+            "苦(くる)しむ",
             "to suffer,to groan,to be worried"
-        ],
-        "notation": "苦(くる)しむ"
+        ]
     },
     {
         "name": "soko",
         "trans": [
+            "底(そこ)",
             "bottom,sole"
-        ],
-        "notation": "底(そこ)"
+        ]
     },
     {
         "name": "fue",
         "trans": [
+            "笛(ふえ)",
             "flute,pipe"
-        ],
-        "notation": "笛(ふえ)"
+        ]
     },
     {
         "name": "sumaseru",
         "trans": [
+            "済(す)ませる",
             "to be finished"
-        ],
-        "notation": "済(す)ませる"
+        ]
     },
     {
         "name": "hontou",
         "trans": [
+            "本当(ほんとう)",
             "truth,reality"
-        ],
-        "notation": "本当(ほんとう)"
+        ]
     },
     {
         "name": "ichiji",
         "trans": [
+            "一時(いちじ)",
             "moment,time"
-        ],
-        "notation": "一時(いちじ)"
+        ]
     },
     {
         "name": "eru",
         "trans": [
+            "得(え)る",
             "to get,to gain,to win"
-        ],
-        "notation": "得(え)る"
+        ]
     },
     {
         "name": "kokyou",
         "trans": [
+            "故郷(こきょう)",
             "home town,birthplace,old village,historic village"
-        ],
-        "notation": "故郷(こきょう)"
+        ]
     },
     {
         "name": "shirase",
         "trans": [
+            "知(し)らせ",
             "notice"
-        ],
-        "notation": "知(し)らせ"
+        ]
     },
     {
         "name": "kanzen",
         "trans": [
+            "完全(かんぜん)",
             "perfection,completeness"
-        ],
-        "notation": "完全(かんぜん)"
+        ]
     },
     {
         "name": "kyoushi",
         "trans": [
+            "教師(きょうし)",
             "teacher (classroom)"
-        ],
-        "notation": "教師(きょうし)"
+        ]
     },
     {
         "name": "kishi",
         "trans": [
+            "岸(きし)",
             "bank,coast,shore"
-        ],
-        "notation": "岸(きし)"
+        ]
     },
     {
         "name": "enjo",
         "trans": [
+            "援助(えんじょ)",
             "assistance,aid,support"
-        ],
-        "notation": "援助(えんじょ)"
+        ]
     },
     {
         "name": "ryuukou",
         "trans": [
+            "流行(りゅうこう)",
             "fashionable,fad,in vogue,prevailing"
-        ],
-        "notation": "流行(りゅうこう)"
+        ]
     },
     {
         "name": "miryoku",
         "trans": [
+            "魅力(みりょく)",
             "charm,fascination,glamour"
-        ],
-        "notation": "魅力(みりょく)"
+        ]
     },
     {
         "name": "waki",
         "trans": [
+            "脇(わき)",
             "side"
-        ],
-        "notation": "脇(わき)"
+        ]
     },
     {
         "name": "kyouryoku",
         "trans": [
+            "協力(きょうりょく)",
             "cooperation,collaboration"
-        ],
-        "notation": "協力(きょうりょく)"
+        ]
     },
     {
         "name": "hoeru",
         "trans": [
+            "吠(ほ)える",
             "to bark,to bay,to howl,to bellow,to roar,to cry"
-        ],
-        "notation": "吠(ほ)える"
+        ]
     },
     {
         "name": "kanren",
         "trans": [
+            "関連(かんれん)",
             "relation,connection,relevance"
-        ],
-        "notation": "関連(かんれん)"
+        ]
     },
     {
         "name": "tsubone",
         "trans": [
+            "局(つぼね)",
             "court lady,lady in waiting"
-        ],
-        "notation": "局(つぼね)"
+        ]
     },
     {
         "name": "sugoi",
         "trans": [
+            "すごい",
             "terrible,dreadful,terrific,amazing,great"
-        ],
-        "notation": "すごい"
+        ]
     },
     {
         "name": "youkyuu",
         "trans": [
+            "要求(ようきゅう)",
             "request,demand,requisition"
-        ],
-        "notation": "要求(ようきゅう)"
+        ]
     },
     {
         "name": "soredemo",
         "trans": [
+            "それでも",
             "but (still),and yet,nevertheless,even so,notwithstanding"
-        ],
-        "notation": "それでも"
+        ]
     },
     {
         "name": "kiji",
         "trans": [
+            "記事(きじ)",
             "article,news story,report,account"
-        ],
-        "notation": "記事(きじ)"
+        ]
     },
     {
         "name": "donna",
         "trans": [
+            "どんな",
             "what,what kind of"
-        ],
-        "notation": "どんな"
+        ]
     },
     {
         "name": "nantoka",
         "trans": [
+            "何(なん)とか",
             "somehow,anyhow,one way or another"
-        ],
-        "notation": "何(なん)とか"
+        ]
     },
     {
         "name": "jitsuha",
         "trans": [
+            "実(じつ)は",
             "as a matter of fact,by the way"
-        ],
-        "notation": "実(じつ)は"
+        ]
     },
     {
         "name": "pasu",
         "trans": [
+            "パス",
             "path,pass (in games)"
-        ],
-        "notation": "パス"
+        ]
     },
     {
         "name": "akiraka",
         "trans": [
+            "明(あき)らか",
             "obvious,evident,clear"
-        ],
-        "notation": "明(あき)らか"
+        ]
     },
     {
         "name": "yoi",
         "trans": [
+            "よい",
             "good,nice,pleasant,ok"
-        ],
-        "notation": "よい"
+        ]
     },
     {
         "name": "higeki",
         "trans": [
+            "悲劇(ひげき)",
             "tragedy"
-        ],
-        "notation": "悲劇(ひげき)"
+        ]
     },
     {
         "name": "hobo",
         "trans": [
+            "ほぼ",
             "almost,roughly,approximately"
-        ],
-        "notation": "ほぼ"
+        ]
     },
     {
         "name": "kaizen",
         "trans": [
+            "改善(かいぜん)",
             "betterment,improvement"
-        ],
-        "notation": "改善(かいぜん)"
+        ]
     },
     {
         "name": "moushiwake",
         "trans": [
+            "申(もう)し訳(わけ)",
             "apology,excuse"
-        ],
-        "notation": "申(もう)し訳(わけ)"
+        ]
     },
     {
         "name": "ijou",
         "trans": [
+            "異常(いじょう)",
             "strangeness,abnormality,disorder"
-        ],
-        "notation": "異常(いじょう)"
+        ]
     },
     {
         "name": "tosho",
         "trans": [
+            "図書(としょ)",
             "books"
-        ],
-        "notation": "図書(としょ)"
+        ]
     },
     {
         "name": "furueru",
         "trans": [
+            "震(ふる)える",
             "to shiver,to shake,to quake"
-        ],
-        "notation": "震(ふる)える"
+        ]
     },
     {
         "name": "sofaa",
         "trans": [
+            "ソファー",
             "sofa,couch"
-        ],
-        "notation": "ソファー"
+        ]
     },
     {
         "name": "tetsuya",
         "trans": [
+            "徹夜(てつや)",
             "all night,all night vigil,sleepless night"
-        ],
-        "notation": "徹夜(てつや)"
+        ]
     },
     {
         "name": "yaya",
         "trans": [
+            "やや",
             "a little,partially,somewhat,a short time,a while"
-        ],
-        "notation": "やや"
+        ]
     },
     {
         "name": "pairotto",
         "trans": [
+            "パイロット",
             "pilot"
-        ],
-        "notation": "パイロット"
+        ]
     },
     {
         "name": "tataku",
         "trans": [
+            "叩(たた)く",
             "to strike,to clap,to dust,to beat"
-        ],
-        "notation": "叩(たた)く"
+        ]
     },
     {
         "name": "seibutsu",
         "trans": [
+            "生物(せいぶつ)",
             "raw food"
-        ],
-        "notation": "生物(せいぶつ)"
+        ]
     },
     {
         "name": "kyuugeki",
         "trans": [
+            "急激(きゅうげき)",
             "sudden,precipitous,radical"
-        ],
-        "notation": "急激(きゅうげき)"
+        ]
     },
     {
         "name": "houmu",
         "trans": [
+            "ホーム",
             "(1) platform,(2) home"
-        ],
-        "notation": "ホーム"
+        ]
     },
     {
         "name": "danshi",
         "trans": [
+            "男子(だんし)",
             "youth,young man"
-        ],
-        "notation": "男子(だんし)"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "期間(きかん)",
             "period,term"
-        ],
-        "notation": "期間(きかん)"
+        ]
     },
     {
         "name": "jinkou",
         "trans": [
+            "人工(じんこう)",
             "artificial,manmade,human work,human skill,artificiality"
-        ],
-        "notation": "人工(じんこう)"
+        ]
     },
     {
         "name": "doushitemo",
         "trans": [
+            "どうしても",
             "by all means,at any cost,no matter what"
-        ],
-        "notation": "どうしても"
+        ]
     },
     {
         "name": "ketten",
         "trans": [
+            "欠点(けってん)",
             "faults,defect,weakness"
-        ],
-        "notation": "欠点(けってん)"
+        ]
     },
     {
         "name": "iwa",
         "trans": [
+            "岩(いわ)",
             "rock,crag"
-        ],
-        "notation": "岩(いわ)"
+        ]
     },
     {
         "name": "kesseki",
         "trans": [
+            "欠席(けっせき)",
             "absence,non-attendance"
-        ],
-        "notation": "欠席(けっせき)"
+        ]
     },
     {
         "name": "genjou",
         "trans": [
+            "現状(げんじょう)",
             "present condition,existing state,status quo"
-        ],
-        "notation": "現状(げんじょう)"
+        ]
     },
     {
         "name": "sakai",
         "trans": [
+            "境(さかい)",
             "border,boundary,mental state"
-        ],
-        "notation": "境(さかい)"
+        ]
     },
     {
         "name": "shikaru",
         "trans": [
+            "叱(しか)る",
             "to scold"
-        ],
-        "notation": "叱(しか)る"
+        ]
     },
     {
         "name": "kongo",
         "trans": [
+            "今後(こんご)",
             "from now on,hereafter"
-        ],
-        "notation": "今後(こんご)"
+        ]
     },
     {
         "name": "tettei",
         "trans": [
+            "徹底(てってい)",
             "thoroughness,completeness"
-        ],
-        "notation": "徹底(てってい)"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "指(さ)す",
             "to point,to put up umbrella,to play"
-        ],
-        "notation": "指(さ)す"
+        ]
     },
     {
         "name": "zou",
         "trans": [
+            "象(ぞう)",
             "elephant"
-        ],
-        "notation": "象(ぞう)"
+        ]
     },
     {
         "name": "kion",
         "trans": [
+            "気温(きおん)",
             "temperature"
-        ],
-        "notation": "気温(きおん)"
+        ]
     },
     {
         "name": "sain",
         "trans": [
+            "サイン",
             "(1) autograph,(2) sign,(3) sine"
-        ],
-        "notation": "サイン"
+        ]
     },
     {
         "name": "kantoku",
         "trans": [
+            "監督(かんとく)",
             "supervision,control,superintendence"
-        ],
-        "notation": "監督(かんとく)"
+        ]
     },
     {
         "name": "mane",
         "trans": [
+            "真似(まね)",
             "mimicry,imitation,behavior,pretense"
-        ],
-        "notation": "真似(まね)"
+        ]
     },
     {
         "name": "amari",
         "trans": [
+            "余(あま)り",
             "not very (used as adverb),not much"
-        ],
-        "notation": "余(あま)り"
+        ]
     },
     {
         "name": "ooini",
         "trans": [
+            "大(おお)いに",
             "very,much,greatly"
-        ],
-        "notation": "大(おお)いに"
+        ]
     },
     {
         "name": "touan",
         "trans": [
+            "答案(とうあん)",
             "examination paper,examination script"
-        ],
-        "notation": "答案(とうあん)"
+        ]
     },
     {
         "name": "joutai",
         "trans": [
+            "状態(じょうたい)",
             "condition,situation,circumstances,state"
-        ],
-        "notation": "状態(じょうたい)"
+        ]
     },
     {
         "name": "kitai",
         "trans": [
+            "期待(きたい)",
             "expectation,anticipation,hope"
-        ],
-        "notation": "期待(きたい)"
+        ]
     },
     {
         "name": "joyuu",
         "trans": [
+            "女優(じょゆう)",
             "actress"
-        ],
-        "notation": "女優(じょゆう)"
+        ]
     },
     {
         "name": "kougeki",
         "trans": [
+            "攻撃(こうげき)",
             "attack,strike,offensive,criticism,censure"
-        ],
-        "notation": "攻撃(こうげき)"
+        ]
     },
     {
         "name": "yon",
         "trans": [
+            "四(よん)",
             "four"
-        ],
-        "notation": "四(よん)"
+        ]
     },
     {
         "name": "omoide",
         "trans": [
+            "思(おも)い出(で)",
             "memories,recollections,reminiscence"
-        ],
-        "notation": "思(おも)い出(で)"
+        ]
     },
     {
         "name": "kakudai",
         "trans": [
+            "拡大(かくだい)",
             "magnification,enlargement"
-        ],
-        "notation": "拡大(かくだい)"
+        ]
     },
     {
         "name": "saishuu",
         "trans": [
+            "最終(さいしゅう)",
             "last,final,closing"
-        ],
-        "notation": "最終(さいしゅう)"
+        ]
     },
     {
         "name": "sai",
         "trans": [
+            "際(さい)",
             "on the occasion of,circumstances"
-        ],
-        "notation": "際(さい)"
+        ]
     },
     {
         "name": "demo",
         "trans": [
+            "でも",
             "but,however"
-        ],
-        "notation": "でも"
+        ]
     },
     {
         "name": "kanshin",
         "trans": [
+            "感心(かんしん)",
             "admiration,Well done!"
-        ],
-        "notation": "感心(かんしん)"
+        ]
     },
     {
         "name": "kashikoi",
         "trans": [
+            "賢(かしこ)い",
             "wise,clever,smart"
-        ],
-        "notation": "賢(かしこ)い"
+        ]
     },
     {
         "name": "nenjuu",
         "trans": [
+            "年中(ねんじゅう)",
             "whole year,always,everyday"
-        ],
-        "notation": "年中(ねんじゅう)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "解(と)く",
             "to unfasten"
-        ],
-        "notation": "解(と)く"
+        ]
     },
     {
         "name": "kyuuka",
         "trans": [
+            "休暇(きゅうか)",
             "holiday,day off,furlough"
-        ],
-        "notation": "休暇(きゅうか)"
+        ]
     },
     {
         "name": "komugi",
         "trans": [
+            "小麦(こむぎ)",
             "wheat"
-        ],
-        "notation": "小麦(こむぎ)"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "元(もと)",
             "(1) origin,original,(2) former"
-        ],
-        "notation": "元(もと)"
+        ]
     },
     {
         "name": "kiro",
         "trans": [
+            "キロ",
             "(abbr) kilo-,kilogram,kilometre,10^3"
-        ],
-        "notation": "キロ"
+        ]
     },
     {
         "name": "koi",
         "trans": [
+            "濃(こ)い",
             "thick (as of color, liquid),dense,strong"
-        ],
-        "notation": "濃(こ)い"
+        ]
     },
     {
         "name": "rikon",
         "trans": [
+            "離婚(りこん)",
             "divorce"
-        ],
-        "notation": "離婚(りこん)"
+        ]
     },
     {
         "name": "ba",
         "trans": [
+            "場(ば)",
             "place,field (physics)"
-        ],
-        "notation": "場(ば)"
+        ]
     },
     {
         "name": "koro",
         "trans": [
+            "頃(ころ)",
             "time,about,toward,approximately (time)"
-        ],
-        "notation": "頃(ころ)"
+        ]
     },
     {
         "name": "nippon",
         "trans": [
+            "日本(にっぽん)",
             "Japan"
-        ],
-        "notation": "日本(にっぽん)"
+        ]
     },
     {
         "name": "yutaka",
         "trans": [
+            "豊(ゆた)か",
             "abundant,wealthy,plentiful,rich"
-        ],
-        "notation": "豊(ゆた)か"
+        ]
     },
     {
         "name": "kenpou",
         "trans": [
+            "憲法(けんぽう)",
             "constitution"
-        ],
-        "notation": "憲法(けんぽう)"
+        ]
     },
     {
         "name": "tsuini",
         "trans": [
+            "遂(つい)に",
             "finally,at last"
-        ],
-        "notation": "遂(つい)に"
+        ]
     },
     {
         "name": "tashou",
         "trans": [
+            "多少(たしょう)",
             "more or less,somewhat,a little,some"
-        ],
-        "notation": "多少(たしょう)"
+        ]
     },
     {
         "name": "kensa",
         "trans": [
+            "検査(けんさ)",
             "inspection (e.g. customs, factory),examination"
-        ],
-        "notation": "検査(けんさ)"
+        ]
     },
     {
         "name": "matsuri",
         "trans": [
+            "祭(まつり)",
             "festival,feast"
-        ],
-        "notation": "祭(まつり)"
+        ]
     },
     {
         "name": "youki",
         "trans": [
+            "陽気(ようき)",
             "season,weather,cheerfulness"
-        ],
-        "notation": "陽気(ようき)"
+        ]
     },
     {
         "name": "mamoru",
         "trans": [
+            "守(まも)る",
             "to protect,to obey,to guard,to abide (by the rules)"
-        ],
-        "notation": "守(まも)る"
+        ]
     },
     {
         "name": "kanji",
         "trans": [
+            "感(かん)じ",
             "feeling,sense,impression"
-        ],
-        "notation": "感(かん)じ"
+        ]
     },
     {
         "name": "yuube",
         "trans": [
+            "夕(ゆう)べ",
             "evening"
-        ],
-        "notation": "夕(ゆう)べ"
+        ]
     },
     {
         "name": "bimyou",
         "trans": [
+            "微妙(びみょう)",
             "delicate,subtle"
-        ],
-        "notation": "微妙(びみょう)"
+        ]
     },
     {
         "name": "kitsui",
         "trans": [
+            "きつい",
             "tight,close,intense"
-        ],
-        "notation": "きつい"
+        ]
     },
     {
         "name": "idai",
         "trans": [
+            "偉大(いだい)",
             "greatness"
-        ],
-        "notation": "偉大(いだい)"
+        ]
     },
     {
         "name": "genshou",
         "trans": [
+            "現象(げんしょう)",
             "phenomenon"
-        ],
-        "notation": "現象(げんしょう)"
+        ]
     },
     {
         "name": "saiwai",
         "trans": [
+            "幸(さいわ)い",
             "happiness,blessedness"
-        ],
-        "notation": "幸(さいわ)い"
+        ]
     },
     {
         "name": "herasu",
         "trans": [
+            "減(へ)らす",
             "to abate,to decrease,to diminish,to shorten"
-        ],
-        "notation": "減(へ)らす"
+        ]
     },
     {
         "name": "ichidoni",
         "trans": [
+            "一(いち)度(ど)に",
             "all at once"
-        ],
-        "notation": "一(いち)度(ど)に"
+        ]
     },
     {
         "name": "kenri",
         "trans": [
+            "権利(けんり)",
             "right,privilege"
-        ],
-        "notation": "権利(けんり)"
+        ]
     },
     {
         "name": "deai",
         "trans": [
+            "出会(であ)い",
             "meeting,rendezvous,encounter"
-        ],
-        "notation": "出会(であ)い"
+        ]
     },
     {
         "name": "fuzu",
         "trans": [
+            "不(ふ)図(ず)",
             "suddenly,casually,accidentally,incidentally,unexpectedly,unintentionally"
-        ],
-        "notation": "不(ふ)図(ず)"
+        ]
     },
     {
         "name": "mono",
         "trans": [
+            "者(もの)",
             "person"
-        ],
-        "notation": "者(もの)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "佩(はい)",
             "wear,put on (sword)"
-        ],
-        "notation": "佩(はい)"
+        ]
     },
     {
         "name": "tsukamu",
         "trans": [
+            "掴(つか)む",
             "to seize,to catch,to grasp"
-        ],
-        "notation": "掴(つか)む"
+        ]
     },
     {
         "name": "souzoku",
         "trans": [
+            "相続(そうぞく)",
             "succession,inheritance"
-        ],
-        "notation": "相続(そうぞく)"
+        ]
     },
     {
         "name": "tango",
         "trans": [
+            "単語(たんご)",
             "word,vocabulary,(usually) single-character word"
-        ],
-        "notation": "単語(たんご)"
+        ]
     },
     {
         "name": "bakuhatsu",
         "trans": [
+            "爆発(ばくはつ)",
             "explosion,detonation,eruption"
-        ],
-        "notation": "爆発(ばくはつ)"
+        ]
     },
     {
         "name": "kousoku",
         "trans": [
+            "高速(こうそく)",
             "high speed,high gear"
-        ],
-        "notation": "高速(こうそく)"
+        ]
     },
     {
         "name": "yuzuru",
         "trans": [
+            "譲(ゆず)る",
             "to turn over,to assign,to hand over"
-        ],
-        "notation": "譲(ゆず)る"
+        ]
     },
     {
         "name": "hanareru",
         "trans": [
+            "離(はな)れる",
             "to be separated from,to leave,to go away,to be a long way off"
-        ],
-        "notation": "離(はな)れる"
+        ]
     },
     {
         "name": "geijutsu",
         "trans": [
+            "芸術(げいじゅつ)",
             "(fine) art,the arts"
-        ],
-        "notation": "芸術(げいじゅつ)"
+        ]
     },
     {
         "name": "miyage",
         "trans": [
+            "土産(みやげ)",
             "present,souvenir"
-        ],
-        "notation": "土産(みやげ)"
+        ]
     },
     {
         "name": "toshiyori",
         "trans": [
+            "年寄(としより)",
             "old people,the aged"
-        ],
-        "notation": "年寄(としより)"
+        ]
     },
     {
         "name": "chika",
         "trans": [
+            "地下(ちか)",
             "basement,underground"
-        ],
-        "notation": "地下(ちか)"
+        ]
     },
     {
         "name": "dekigoto",
         "trans": [
+            "出来事(できごと)",
             "incident,affair,happening,event"
-        ],
-        "notation": "出来事(できごと)"
+        ]
     },
     {
         "name": "keiei",
         "trans": [
+            "経営(けいえい)",
             "management,administration"
-        ],
-        "notation": "経営(けいえい)"
+        ]
     },
     {
         "name": "seki",
         "trans": [
+            "咳(せき)",
             "cough"
-        ],
-        "notation": "咳(せき)"
+        ]
     },
     {
         "name": "machigai",
         "trans": [
+            "間違(まちが)い",
             "mistake"
-        ],
-        "notation": "間違(まちが)い"
+        ]
     },
     {
         "name": "mokuyou",
         "trans": [
+            "木曜(もくよう)",
             "Thursday"
-        ],
-        "notation": "木曜(もくよう)"
+        ]
     },
     {
         "name": "taihan",
         "trans": [
+            "大半(たいはん)",
             "majority,mostly,generally"
-        ],
-        "notation": "大半(たいはん)"
+        ]
     },
     {
         "name": "shuu",
         "trans": [
+            "州(しゅう)",
             "sandbank"
-        ],
-        "notation": "州(しゅう)"
+        ]
     },
     {
         "name": "butai",
         "trans": [
+            "舞台(ぶたい)",
             "stage (theatre)"
-        ],
-        "notation": "舞台(ぶたい)"
+        ]
     },
     {
         "name": "tou",
         "trans": [
+            "塔(とう)",
             "tower,pagoda"
-        ],
-        "notation": "塔(とう)"
+        ]
     },
     {
         "name": "douji",
         "trans": [
+            "同時(どうじ)",
             "simultaneous(ly),concurrent,same time,synchronous"
-        ],
-        "notation": "同時(どうじ)"
+        ]
     },
     {
         "name": "chiheisen",
         "trans": [
+            "地平線(ちへいせん)",
             "horizon"
-        ],
-        "notation": "地平線(ちへいせん)"
+        ]
     },
     {
         "name": "shakkin",
         "trans": [
+            "借金(しゃっきん)",
             "debt,loan,liabilities"
-        ],
-        "notation": "借金(しゃっきん)"
+        ]
     },
     {
         "name": "aware",
         "trans": [
+            "哀(あわ)れ",
             "helpless,pity,sorrow,grief"
-        ],
-        "notation": "哀(あわ)れ"
+        ]
     },
     {
         "name": "ato",
         "trans": [
+            "あと",
             "(1) trace,tracks,(2) remains,ruins,(3) scar"
-        ],
-        "notation": "あと"
+        ]
     },
     {
         "name": "bunmei",
         "trans": [
+            "文明(ぶんめい)",
             "civilization,culture"
-        ],
-        "notation": "文明(ぶんめい)"
+        ]
     },
     {
         "name": "suicchi",
         "trans": [
+            "スイッチ",
             "switch"
-        ],
-        "notation": "スイッチ"
+        ]
     },
     {
         "name": "seishin",
         "trans": [
+            "精神(せいしん)",
             "mind,soul,heart,spirit,intention"
-        ],
-        "notation": "精神(せいしん)"
+        ]
     },
     {
         "name": "himo",
         "trans": [
+            "紐(ひも)",
             "(1) string,cord,(2) pimp"
-        ],
-        "notation": "紐(ひも)"
+        ]
     },
     {
         "name": "kyuusoku",
         "trans": [
+            "急速(きゅうそく)",
             "rapid (e.g. progress)"
-        ],
-        "notation": "急速(きゅうそく)"
+        ]
     },
     {
         "name": "nobiru",
         "trans": [
+            "伸(の)びる",
             "to stretch,to extend,to make progress,to grow (beard, body height)"
-        ],
-        "notation": "伸(の)びる"
+        ]
     },
     {
         "name": "taba",
         "trans": [
+            "束(たば)",
             "handbreadth,bundle"
-        ],
-        "notation": "束(たば)"
+        ]
     },
     {
         "name": "shoubou",
         "trans": [
+            "消防(しょうぼう)",
             "fire fighting,fire department"
-        ],
-        "notation": "消防(しょうぼう)"
+        ]
     },
     {
         "name": "busshitsu",
         "trans": [
+            "物質(ぶっしつ)",
             "material,substance"
-        ],
-        "notation": "物質(ぶっしつ)"
+        ]
     },
     {
         "name": "fusoku",
         "trans": [
+            "不足(ふそく)",
             "insufficiency,shortage,deficiency,lack,dearth"
-        ],
-        "notation": "不足(ふそく)"
+        ]
     },
     {
         "name": "ka",
         "trans": [
+            "可(か)",
             "passable"
-        ],
-        "notation": "可(か)"
+        ]
     },
     {
         "name": "imanimo",
         "trans": [
+            "今(いま)にも",
             "at any time,soon"
-        ],
-        "notation": "今(いま)にも"
+        ]
     },
     {
         "name": "kimu",
         "trans": [
+            "金(きむ)",
             "(1) gold,(2) gold general (shogi) (abbr)"
-        ],
-        "notation": "金(きむ)"
+        ]
     },
     {
         "name": "hei",
         "trans": [
+            "塀(へい)",
             "wall,fence"
-        ],
-        "notation": "塀(へい)"
+        ]
     },
     {
         "name": "kaishaku",
         "trans": [
+            "解釈(かいしゃく)",
             "explanation,interpretation"
-        ],
-        "notation": "解釈(かいしゃく)"
+        ]
     },
     {
         "name": "bassuru",
         "trans": [
+            "罰(ばっ)する",
             "to punish,to penalize"
-        ],
-        "notation": "罰(ばっ)する"
+        ]
     },
     {
         "name": "gouka",
         "trans": [
+            "豪華(ごうか)",
             "wonderful,gorgeous,splendor,pomp,extravagance"
-        ],
-        "notation": "豪華(ごうか)"
+        ]
     },
     {
         "name": "inyou",
         "trans": [
+            "引用(いんよう)",
             "quotation,citation"
-        ],
-        "notation": "引用(いんよう)"
+        ]
     },
     {
         "name": "shokubutsu",
         "trans": [
+            "植物(しょくぶつ)",
             "plant,vegetation"
-        ],
-        "notation": "植物(しょくぶつ)"
+        ]
     },
     {
         "name": "konran",
         "trans": [
+            "混乱(こんらん)",
             "disorder,chaos,confusion,mayhem"
-        ],
-        "notation": "混乱(こんらん)"
+        ]
     },
     {
         "name": "shiharau",
         "trans": [
+            "支払(しはら)う",
             "to pay"
-        ],
-        "notation": "支払(しはら)う"
+        ]
     },
     {
         "name": "hattatsu",
         "trans": [
+            "発達(はったつ)",
             "development,growth"
-        ],
-        "notation": "発達(はったつ)"
+        ]
     },
     {
         "name": "chansu",
         "trans": [
+            "チャンス",
             "chance,opportunity"
-        ],
-        "notation": "チャンス"
+        ]
     },
     {
         "name": "shidai",
         "trans": [
+            "次第(しだい)",
             "(1) order,precedence,(2) circumstances,(3) immediate(ly)"
-        ],
-        "notation": "次第(しだい)"
+        ]
     },
     {
         "name": "satsu",
         "trans": [
+            "札(さつ)",
             "(1) token,label,(2) ticket,(3) charm"
-        ],
-        "notation": "札(さつ)"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "円(えん)",
             "circle,money"
-        ],
-        "notation": "円(えん)"
+        ]
     },
     {
         "name": "toshitsuki",
         "trans": [
+            "年月(としつき)",
             "months and years"
-        ],
-        "notation": "年月(としつき)"
+        ]
     },
     {
         "name": "shusseki",
         "trans": [
+            "出席(しゅっせき)",
             "attendance,presence"
-        ],
-        "notation": "出席(しゅっせき)"
+        ]
     },
     {
         "name": "eru",
         "trans": [
+            "得(え)る",
             "to get,to gain,to win"
-        ],
-        "notation": "得(え)る"
+        ]
     },
     {
         "name": "mama",
         "trans": [
+            "ママ",
             "Mama"
-        ],
-        "notation": "ママ"
+        ]
     },
     {
         "name": "koko",
         "trans": [
+            "ここ",
             "here"
-        ],
-        "notation": "ここ"
+        ]
     },
     {
         "name": "shitsu",
         "trans": [
+            "質(しつ)",
             "quality,nature (of person)"
-        ],
-        "notation": "質(しつ)"
+        ]
     },
     {
         "name": "tokorode",
         "trans": [
+            "ところで",
             "by the way,even if,no matter what"
-        ],
-        "notation": "ところで"
+        ]
     },
     {
         "name": "tsuneni",
         "trans": [
+            "常(つね)に",
             "always,constantly"
-        ],
-        "notation": "常(つね)に"
+        ]
     },
     {
         "name": "ubau",
         "trans": [
+            "奪(うば)う",
             "to snatch away"
-        ],
-        "notation": "奪(うば)う"
+        ]
     },
     {
         "name": "men",
         "trans": [
+            "綿(めん)",
             "cotton,padding"
-        ],
-        "notation": "綿(めん)"
+        ]
     },
     {
         "name": "na",
         "trans": [
+            "名(な)",
             "name,reputation"
-        ],
-        "notation": "名(な)"
+        ]
     },
     {
         "name": "hozon",
         "trans": [
+            "保存(ほぞん)",
             "preservation,conservation,storage,maintenance"
-        ],
-        "notation": "保存(ほぞん)"
+        ]
     },
     {
         "name": "roudou",
         "trans": [
+            "労働(ろうどう)",
             "manual labor,toil,work"
-        ],
-        "notation": "労働(ろうどう)"
+        ]
     },
     {
         "name": "maiku",
         "trans": [
+            "マイク",
             "mike"
-        ],
-        "notation": "マイク"
+        ]
     },
     {
         "name": "iwaba",
         "trans": [
+            "言(い)わば",
             "so to speak"
-        ],
-        "notation": "言(い)わば"
+        ]
     },
     {
         "name": "bikkuri",
         "trans": [
+            "びっくり",
             "be surprised,be amazed,be frightened,astonishment"
-        ],
-        "notation": "びっくり"
+        ]
     },
     {
         "name": "taoru",
         "trans": [
+            "タオル",
             "(hand) towel"
-        ],
-        "notation": "タオル"
+        ]
     },
     {
         "name": "sode",
         "trans": [
+            "袖(そで)",
             "sleeve"
-        ],
-        "notation": "袖(そで)"
+        ]
     },
     {
         "name": "do",
         "trans": [
+            "度(ど)",
             "counter for occurrences"
-        ],
-        "notation": "度(ど)"
+        ]
     },
     {
         "name": "purasu",
         "trans": [
+            "プラス",
             "plus"
-        ],
-        "notation": "プラス"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "例(れい)",
             "instance,example,case"
-        ],
-        "notation": "例(れい)"
+        ]
     },
     {
         "name": "ichiban",
         "trans": [
+            "一番(いちばん)",
             "best,first,number one"
-        ],
-        "notation": "一番(いちばん)"
+        ]
     },
     {
         "name": "se",
         "trans": [
+            "背(せ)",
             "height,stature"
-        ],
-        "notation": "背(せ)"
+        ]
     },
     {
         "name": "kazoeru",
         "trans": [
+            "数(かぞ)える",
             "to count"
-        ],
-        "notation": "数(かぞ)える"
+        ]
     },
     {
         "name": "yorokobi",
         "trans": [
+            "喜(よろこ)び",
             "(a) joy,(a) delight,rapture,pleasure,gratification,rejoicing,congratulations,felicitations"
-        ],
-        "notation": "喜(よろこ)び"
+        ]
     },
     {
         "name": "myougonichi",
         "trans": [
+            "明後日(みょうごにち)",
             "day after tomorrow"
-        ],
-        "notation": "明後日(みょうごにち)"
+        ]
     },
     {
         "name": "hahaoya",
         "trans": [
+            "母親(ははおや)",
             "mother"
-        ],
-        "notation": "母親(ははおや)"
+        ]
     },
     {
         "name": "ningen",
         "trans": [
+            "人間(にんげん)",
             "human being,man,person"
-        ],
-        "notation": "人間(にんげん)"
+        ]
     },
     {
         "name": "ippan",
         "trans": [
+            "一般(いっぱん)",
             "general,liberal,universal,ordinary,average"
-        ],
-        "notation": "一般(いっぱん)"
+        ]
     },
     {
         "name": "subete",
         "trans": [
+            "全(すべ)て",
             "all,the whole,entirely,in general,wholly"
-        ],
-        "notation": "全(すべ)て"
+        ]
     },
     {
         "name": "shinri",
         "trans": [
+            "心理(しんり)",
             "mentality"
-        ],
-        "notation": "心理(しんり)"
+        ]
     },
     {
         "name": "memo",
         "trans": [
+            "メモ",
             "memorandum"
-        ],
-        "notation": "メモ"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "位置(いち)",
             "place,situation,position,location"
-        ],
-        "notation": "位置(いち)"
+        ]
     },
     {
         "name": "nouryoku",
         "trans": [
+            "能力(のうりょく)",
             "ability,faculty"
-        ],
-        "notation": "能力(のうりょく)"
+        ]
     },
     {
         "name": "demo",
         "trans": [
+            "デモ",
             "(abbr) demo,demonstration"
-        ],
-        "notation": "デモ"
+        ]
     },
     {
         "name": "kikou",
         "trans": [
+            "気候(きこう)",
             "climate"
-        ],
-        "notation": "気候(きこう)"
+        ]
     },
     {
         "name": "motozuku",
         "trans": [
+            "基(もと)づく",
             "to be grounded on,to be based on,to be due to,to originate from"
-        ],
-        "notation": "基(もと)づく"
+        ]
     },
     {
         "name": "nedan",
         "trans": [
+            "値段(ねだん)",
             "price,cost"
-        ],
-        "notation": "値段(ねだん)"
+        ]
     },
     {
         "name": "denshi",
         "trans": [
+            "電子(でんし)",
             "electron"
-        ],
-        "notation": "電子(でんし)"
+        ]
     },
     {
         "name": "ikimono",
         "trans": [
+            "生(い)き物(もの)",
             "living thing,animal"
-        ],
-        "notation": "生(い)き物(もの)"
+        ]
     },
     {
         "name": "obi",
         "trans": [
+            "帯(おび)",
             "band (e.g. conduction, valence)"
-        ],
-        "notation": "帯(おび)"
+        ]
     },
     {
         "name": "nozoku",
         "trans": [
+            "除(のぞ)く",
             "to remove,to exclude,to except"
-        ],
-        "notation": "除(のぞ)く"
+        ]
     },
     {
         "name": "iwayuru",
         "trans": [
+            "いわゆる",
             "the so-called,so to speak"
-        ],
-        "notation": "いわゆる"
+        ]
     },
     {
         "name": "choushi",
         "trans": [
+            "調子(ちょうし)",
             "tune,tone,key"
-        ],
-        "notation": "調子(ちょうし)"
+        ]
     },
     {
         "name": "shibashiba",
         "trans": [
+            "しばしば",
             "often,again and again,frequently"
-        ],
-        "notation": "しばしば"
+        ]
     },
     {
         "name": "gyougi",
         "trans": [
+            "行儀(ぎょうぎ)",
             "manners"
-        ],
-        "notation": "行儀(ぎょうぎ)"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "表(あらわ)す",
             "to express,to show,to reveal"
-        ],
-        "notation": "表(あらわ)す"
+        ]
     },
     {
         "name": "shoujiki",
         "trans": [
+            "正直(しょうじき)",
             "honesty,integrity,frankness"
-        ],
-        "notation": "正直(しょうじき)"
+        ]
     },
     {
         "name": "tsuuka",
         "trans": [
+            "通過(つうか)",
             "passage through,passing"
-        ],
-        "notation": "通過(つうか)"
+        ]
     },
     {
         "name": "egaku",
         "trans": [
+            "描(えが)く",
             "to draw,to paint,to sketch,to depict,to describe"
-        ],
-        "notation": "描(えが)く"
+        ]
     }
 ]

--- a/assets/dicts/JapVocabList.N4.json
+++ b/assets/dicts/JapVocabList.N4.json
@@ -2,4439 +2,4439 @@
     {
         "name": "kaijou",
         "trans": [
+            "会場(かいじょう)",
             "assembly hall or meeting place"
-        ],
-        "notation": "会場(かいじょう)"
+        ]
     },
     {
         "name": "ikiru",
         "trans": [
+            "生(い)きる",
             "to live"
-        ],
-        "notation": "生(い)きる"
+        ]
     },
     {
         "name": "pasokon",
         "trans": [
+            "パソコン",
             "personal computer"
-        ],
-        "notation": "パソコン"
+        ]
     },
     {
         "name": "kare",
         "trans": [
+            "彼(かれ)",
             "he,boyfriend"
-        ],
-        "notation": "彼(かれ)"
+        ]
     },
     {
         "name": "bikkuri/suru",
         "trans": [
+            "びっくり・する",
             "to be surprised"
-        ],
-        "notation": "びっくり・する"
+        ]
     },
     {
         "name": "yoshuu",
         "trans": [
+            "予習(よしゅう)",
             "preparation for a lesson"
-        ],
-        "notation": "予習(よしゅう)"
+        ]
     },
     {
         "name": "dame",
         "trans": [
+            "だめ",
             "no good"
-        ],
-        "notation": "だめ"
+        ]
     },
     {
         "name": "kagami",
         "trans": [
+            "鏡(かがみ)",
             "mirror"
-        ],
-        "notation": "鏡(かがみ)"
+        ]
     },
     {
         "name": "gomi",
         "trans": [
+            "ごみ",
             "rubbish"
-        ],
-        "notation": "ごみ"
+        ]
     },
     {
         "name": "outobai",
         "trans": [
+            "オートバイ",
             "motorcycle"
-        ],
-        "notation": "オートバイ"
+        ]
     },
     {
         "name": "utsukushii",
         "trans": [
+            "美(うつく)しい",
             "beautiful"
-        ],
-        "notation": "美(うつく)しい"
+        ]
     },
     {
         "name": "kibun",
         "trans": [
+            "気分(きぶん)",
             "mood"
-        ],
-        "notation": "気分(きぶん)"
+        ]
     },
     {
         "name": "oiwai",
         "trans": [
+            "お祝(いわ)い",
             "congratulation"
-        ],
-        "notation": "お祝(いわ)い"
+        ]
     },
     {
         "name": "kangofu",
         "trans": [
+            "看護(かんご)婦(ふ)",
             "female nurse"
-        ],
-        "notation": "看護(かんご)婦(ふ)"
+        ]
     },
     {
         "name": "unten",
         "trans": [
+            "運転(うんてん)",
             "to drive"
-        ],
-        "notation": "運転(うんてん)"
+        ]
     },
     {
         "name": "hyou",
         "trans": [
+            "表(ひょう)",
             "the front"
-        ],
-        "notation": "表(ひょう)"
+        ]
     },
     {
         "name": "kuukou",
         "trans": [
+            "空港(くうこう)",
             "airport"
-        ],
-        "notation": "空港(くうこう)"
+        ]
     },
     {
         "name": "hiruma",
         "trans": [
+            "昼間(ひるま)",
             "daytime,during the day"
-        ],
-        "notation": "昼間(ひるま)"
+        ]
     },
     {
         "name": "koutougakkou",
         "trans": [
+            "高等(こうとう)学校(がっこう)",
             "high school"
-        ],
-        "notation": "高等(こうとう)学校(がっこう)"
+        ]
     },
     {
         "name": "kayou",
         "trans": [
+            "通(かよ)う",
             "to commute"
-        ],
-        "notation": "通(かよ)う"
+        ]
     },
     {
         "name": "takaru",
         "trans": [
+            "集(たか)る",
             "to gather"
-        ],
-        "notation": "集(たか)る"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "漬(つ)ける",
             "to soak,to pickle"
-        ],
-        "notation": "漬(つ)ける"
+        ]
     },
     {
         "name": "mizuumi",
         "trans": [
+            "湖(みずうみ)",
             "lake"
-        ],
-        "notation": "湖(みずうみ)"
+        ]
     },
     {
         "name": "suberu",
         "trans": [
+            "滑(すべ)る",
             "to slide,to slip"
-        ],
-        "notation": "滑(すべ)る"
+        ]
     },
     {
         "name": "aa",
         "trans": [
+            "ああ",
             "like that"
-        ],
-        "notation": "ああ"
+        ]
     },
     {
         "name": "tamani",
         "trans": [
+            "たまに",
             "occasionally"
-        ],
-        "notation": "たまに"
+        ]
     },
     {
         "name": "keshiki",
         "trans": [
+            "景色(けしき)",
             "scene,landscape"
-        ],
-        "notation": "景色(けしき)"
+        ]
     },
     {
         "name": "odori",
         "trans": [
+            "踊(おど)り",
             "a dance"
-        ],
-        "notation": "踊(おど)り"
+        ]
     },
     {
         "name": "akusesarii",
         "trans": [
+            "アクセサリー",
             "accessory"
-        ],
-        "notation": "アクセサリー"
+        ]
     },
     {
         "name": "umai",
         "trans": [
+            "うまい",
             "delicious"
-        ],
-        "notation": "うまい"
+        ]
     },
     {
         "name": "amerika",
         "trans": [
+            "アメリカ",
             "America"
-        ],
-        "notation": "アメリカ"
+        ]
     },
     {
         "name": "sutereo",
         "trans": [
+            "ステレオ",
             "stereo"
-        ],
-        "notation": "ステレオ"
+        ]
     },
     {
         "name": "yubiwa",
         "trans": [
+            "指輪(ゆびわ)",
             "finger ring"
-        ],
-        "notation": "指輪(ゆびわ)"
+        ]
     },
     {
         "name": "sotsugyou",
         "trans": [
+            "卒業(そつぎょう)",
             "graduation"
-        ],
-        "notation": "卒業(そつぎょう)"
+        ]
     },
     {
         "name": "tadashii",
         "trans": [
+            "正(ただ)しい",
             "correct"
-        ],
-        "notation": "正(ただ)しい"
+        ]
     },
     {
         "name": "sumi",
         "trans": [
+            "隅(すみ)",
             "corner,nook"
-        ],
-        "notation": "隅(すみ)"
+        ]
     },
     {
         "name": "kaigi",
         "trans": [
+            "会議(かいぎ)",
             "meeting"
-        ],
-        "notation": "会議(かいぎ)"
+        ]
     },
     {
         "name": "kawari",
         "trans": [
+            "代(か)わり",
             "substitute,alternate"
-        ],
-        "notation": "代(か)わり"
+        ]
     },
     {
         "name": "kisha",
         "trans": [
+            "汽車(きしゃ)",
             "steam train"
-        ],
-        "notation": "汽車(きしゃ)"
+        ]
     },
     {
         "name": "igaku",
         "trans": [
+            "医学(いがく)",
             "medical science"
-        ],
-        "notation": "医学(いがく)"
+        ]
     },
     {
         "name": "ashita",
         "trans": [
+            "明日(あした)",
             "tomorrow"
-        ],
-        "notation": "明日(あした)"
+        ]
     },
     {
         "name": "omatsuri",
         "trans": [
+            "お祭(まつ)り",
             "festival"
-        ],
-        "notation": "お祭(まつ)り"
+        ]
     },
     {
         "name": "zuibun",
         "trans": [
+            "ずいぶん",
             "extremely"
-        ],
-        "notation": "ずいぶん"
+        ]
     },
     {
         "name": "saikin",
         "trans": [
+            "最近(さいきん)",
             "latest,nowadays"
-        ],
-        "notation": "最近(さいきん)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "止(と)める",
             "to stop"
-        ],
-        "notation": "止(と)める"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "移(うつ)る",
             "to move house or transfer"
-        ],
-        "notation": "移(うつ)る"
+        ]
     },
     {
         "name": "nokoru",
         "trans": [
+            "残(のこ)る",
             "to remain"
-        ],
-        "notation": "残(のこ)る"
+        ]
     },
     {
         "name": "musuko",
         "trans": [
+            "息子(むすこ)",
             "(humble) son"
-        ],
-        "notation": "息子(むすこ)"
+        ]
     },
     {
         "name": "okuru",
         "trans": [
+            "送(おく)る",
             "to send"
-        ],
-        "notation": "送(おく)る"
+        ]
     },
     {
         "name": "sangyou",
         "trans": [
+            "産業(さんぎょう)",
             "industry"
-        ],
-        "notation": "産業(さんぎょう)"
+        ]
     },
     {
         "name": "ugoku",
         "trans": [
+            "動(うご)く",
             "to move"
-        ],
-        "notation": "動(うご)く"
+        ]
     },
     {
         "name": "warau",
         "trans": [
+            "笑(わら)う",
             "to laugh,to smile"
-        ],
-        "notation": "笑(わら)う"
+        ]
     },
     {
         "name": "keredo/keredomo",
         "trans": [
+            "けれど/けれども",
             "however"
-        ],
-        "notation": "けれど/けれども"
+        ]
     },
     {
         "name": "baai",
         "trans": [
+            "場合(ばあい)",
             "situation"
-        ],
-        "notation": "場合(ばあい)"
+        ]
     },
     {
         "name": "reji",
         "trans": [
+            "レジ",
             "register"
-        ],
-        "notation": "レジ"
+        ]
     },
     {
         "name": "hieru",
         "trans": [
+            "冷(ひ)える",
             "to grow cold"
-        ],
-        "notation": "冷(ひ)える"
+        ]
     },
     {
         "name": "seki",
         "trans": [
+            "席(せき)",
             "seat"
-        ],
-        "notation": "席(せき)"
+        ]
     },
     {
         "name": "ueru",
         "trans": [
+            "植(う)える",
             "to plant,to grow"
-        ],
-        "notation": "植(う)える"
+        ]
     },
     {
         "name": "shikaru",
         "trans": [
+            "しかる",
             "a particular"
-        ],
-        "notation": "しかる"
+        ]
     },
     {
         "name": "seiyou",
         "trans": [
+            "西洋(せいよう)",
             "western countries"
-        ],
-        "notation": "西洋(せいよう)"
+        ]
     },
     {
         "name": "shachou",
         "trans": [
+            "社長(しゃちょう)",
             "company president"
-        ],
-        "notation": "社長(しゃちょう)"
+        ]
     },
     {
         "name": "rakumu",
         "trans": [
+            "楽(らく)む",
             "to enjoy oneself"
-        ],
-        "notation": "楽(らく)む"
+        ]
     },
     {
         "name": "konsaato",
         "trans": [
+            "コンサート",
             "concert"
-        ],
-        "notation": "コンサート"
+        ]
     },
     {
         "name": "yatto",
         "trans": [
+            "やっと",
             "at last"
-        ],
-        "notation": "やっと"
+        ]
     },
     {
         "name": "omou",
         "trans": [
+            "思(おも)う",
             "to think,to feel"
-        ],
-        "notation": "思(おも)う"
+        ]
     },
     {
         "name": "jimusho",
         "trans": [
+            "事務所(じむしょ)",
             "office"
-        ],
-        "notation": "事務所(じむしょ)"
+        ]
     },
     {
         "name": "sandaru",
         "trans": [
+            "サンダル",
             "sandal"
-        ],
-        "notation": "サンダル"
+        ]
     },
     {
         "name": "enryo",
         "trans": [
+            "遠慮(えんりょ)",
             "to be reserved, to be restrained"
-        ],
-        "notation": "遠慮(えんりょ)"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "もっとも",
             "extremely"
-        ],
-        "notation": "もっとも"
+        ]
     },
     {
         "name": "shousetsu",
         "trans": [
+            "小説(しょうせつ)",
             "novel"
-        ],
-        "notation": "小説(しょうせつ)"
+        ]
     },
     {
         "name": "fuben",
         "trans": [
+            "不便(ふべん)",
             "inconvenience"
-        ],
-        "notation": "不便(ふべん)"
+        ]
     },
     {
         "name": "kinu",
         "trans": [
+            "絹(きぬ)",
             "silk"
-        ],
-        "notation": "絹(きぬ)"
+        ]
     },
     {
         "name": "naosu",
         "trans": [
+            "直(なお)す",
             "to fix,to repair"
-        ],
-        "notation": "直(なお)す"
+        ]
     },
     {
         "name": "senpai",
         "trans": [
+            "先輩(せんぱい)",
             "senior"
-        ],
-        "notation": "先輩(せんぱい)"
+        ]
     },
     {
         "name": "netsu",
         "trans": [
+            "熱(ねつ)",
             "fever"
-        ],
-        "notation": "熱(ねつ)"
+        ]
     },
     {
         "name": "kibishii",
         "trans": [
+            "厳(きび)しい",
             "strict"
-        ],
-        "notation": "厳(きび)しい"
+        ]
     },
     {
         "name": "ningyou",
         "trans": [
+            "人形(にんぎょう)",
             "doll, figure"
-        ],
-        "notation": "人形(にんぎょう)"
+        ]
     },
     {
         "name": "fukuzatsu",
         "trans": [
+            "複雑(ふくざつ)",
             "complexity,complication"
-        ],
-        "notation": "複雑(ふくざつ)"
+        ]
     },
     {
         "name": "jamu",
         "trans": [
+            "ジャム",
             "jam"
-        ],
-        "notation": "ジャム"
+        ]
     },
     {
         "name": "oku",
         "trans": [
+            "億(おく)",
             "one hundred million"
-        ],
-        "notation": "億(おく)"
+        ]
     },
     {
         "name": "anshin",
         "trans": [
+            "安心(あんしん)",
             "relief"
-        ],
-        "notation": "安心(あんしん)"
+        ]
     },
     {
         "name": "sekai",
         "trans": [
+            "世界(せかい)",
             "the world"
-        ],
-        "notation": "世界(せかい)"
+        ]
     },
     {
         "name": "denpou",
         "trans": [
+            "電報(でんぽう)",
             "telegram"
-        ],
-        "notation": "電報(でんぽう)"
+        ]
     },
     {
         "name": "tekisuto",
         "trans": [
+            "テキスト",
             "text,text book"
-        ],
-        "notation": "テキスト"
+        ]
     },
     {
         "name": "zannen",
         "trans": [
+            "残念(ざんねん)",
             "disappointment"
-        ],
-        "notation": "残念(ざんねん)"
+        ]
     },
     {
         "name": "chekku/suru",
         "trans": [
+            "チェック・する",
             "to check"
-        ],
-        "notation": "チェック・する"
+        ]
     },
     {
         "name": "komakai",
         "trans": [
+            "細(こま)かい",
             "small, fine"
-        ],
-        "notation": "細(こま)かい"
+        ]
     },
     {
         "name": "kanashii",
         "trans": [
+            "悲(かな)しい",
             "sad"
-        ],
-        "notation": "悲(かな)しい"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "焼(や)く",
             "to bake,to grill"
-        ],
-        "notation": "焼(や)く"
+        ]
     },
     {
         "name": "kougi",
         "trans": [
+            "講義(こうぎ)",
             "lecture"
-        ],
-        "notation": "講義(こうぎ)"
+        ]
     },
     {
         "name": "hakkiri",
         "trans": [
+            "はっきり",
             "clearly"
-        ],
-        "notation": "はっきり"
+        ]
     },
     {
         "name": "hikidashi",
         "trans": [
+            "引(ひ)き出(だ)し",
             "drawer,drawing out"
-        ],
-        "notation": "引(ひ)き出(だ)し"
+        ]
     },
     {
         "name": "purezento",
         "trans": [
+            "プレゼント",
             "present"
-        ],
-        "notation": "プレゼント"
+        ]
     },
     {
         "name": "korekara",
         "trans": [
+            "これから",
             "after this"
-        ],
-        "notation": "これから"
+        ]
     },
     {
         "name": "tenin",
         "trans": [
+            "店員(てんいん)",
             "shop assistant"
-        ],
-        "notation": "店員(てんいん)"
+        ]
     },
     {
         "name": "hikari",
         "trans": [
+            "光(ひかり)",
             "light"
-        ],
-        "notation": "光(ひかり)"
+        ]
     },
     {
         "name": "irassharu",
         "trans": [
+            "いらっしゃる",
             "(respectful) to be,to come or to go"
-        ],
-        "notation": "いらっしゃる"
+        ]
     },
     {
         "name": "dansei",
         "trans": [
+            "男性(だんせい)",
             "male"
-        ],
-        "notation": "男性(だんせい)"
+        ]
     },
     {
         "name": "nodo",
         "trans": [
+            "のど",
             "throat"
-        ],
-        "notation": "のど"
+        ]
     },
     {
         "name": "otosu",
         "trans": [
+            "落(おと)す",
             "to drop"
-        ],
-        "notation": "落(おと)す"
+        ]
     },
     {
         "name": "sonnani",
         "trans": [
+            "そんなに",
             "so much,like that"
-        ],
-        "notation": "そんなに"
+        ]
     },
     {
         "name": "homeru",
         "trans": [
+            "ほめる",
             "to praise"
-        ],
-        "notation": "ほめる"
+        ]
     },
     {
         "name": "sawagu",
         "trans": [
+            "騒(さわ)ぐ",
             "to make noise,to be excited"
-        ],
-        "notation": "騒(さわ)ぐ"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "済(す)む",
             "to finish"
-        ],
-        "notation": "済(す)む"
+        ]
     },
     {
         "name": "ryokan",
         "trans": [
+            "旅館(りょかん)",
             "Japanese hotel"
-        ],
-        "notation": "旅館(りょかん)"
+        ]
     },
     {
         "name": "oyogikata",
         "trans": [
+            "泳(およ)ぎ方(かた)",
             "way of swimming"
-        ],
-        "notation": "泳(およ)ぎ方(かた)"
+        ]
     },
     {
         "name": "ude",
         "trans": [
+            "腕(うで)",
             "arm"
-        ],
-        "notation": "腕(うで)"
+        ]
     },
     {
         "name": "annai",
         "trans": [
+            "案内(あんない)",
             "to guide"
-        ],
-        "notation": "案内(あんない)"
+        ]
     },
     {
         "name": "daigakusei",
         "trans": [
+            "大学生(だいがくせい)",
             "university student"
-        ],
-        "notation": "大学生(だいがくせい)"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "火(ひ)",
             "fire"
-        ],
-        "notation": "火(ひ)"
+        ]
     },
     {
         "name": "kenka/suru",
         "trans": [
+            "けんか・する",
             "to quarrel"
-        ],
-        "notation": "けんか・する"
+        ]
     },
     {
         "name": "juufun",
         "trans": [
+            "十(じゅう)分(ふん)",
             "enough"
-        ],
-        "notation": "十(じゅう)分(ふん)"
+        ]
     },
     {
         "name": "renraku",
         "trans": [
+            "連絡(れんらく)",
             "contact"
-        ],
-        "notation": "連絡(れんらく)"
+        ]
     },
     {
         "name": "gochisou",
         "trans": [
+            "ごちそう",
             "a feast"
-        ],
-        "notation": "ごちそう"
+        ]
     },
     {
         "name": "nureru",
         "trans": [
+            "ぬれる",
             "to get wet"
-        ],
-        "notation": "ぬれる"
+        ]
     },
     {
         "name": "kenkyuu",
         "trans": [
+            "研究(けんきゅう)",
             "research"
-        ],
-        "notation": "研究(けんきゅう)"
+        ]
     },
     {
         "name": "tsukamaeru",
         "trans": [
+            "捕(つか)まえる",
             "to seize"
-        ],
-        "notation": "捕(つか)まえる"
+        ]
     },
     {
         "name": "kimeru",
         "trans": [
+            "決(き)める",
             "to decide"
-        ],
-        "notation": "決(き)める"
+        ]
     },
     {
         "name": "tooru",
         "trans": [
+            "通(とお)る",
             "to go through"
-        ],
-        "notation": "通(とお)る"
+        ]
     },
     {
         "name": "ippai",
         "trans": [
+            "いっぱい",
             "full"
-        ],
-        "notation": "いっぱい"
+        ]
     },
     {
         "name": "okoru",
         "trans": [
+            "怒(おこ)る",
             "to get angry,to be angry"
-        ],
-        "notation": "怒(おこ)る"
+        ]
     },
     {
         "name": "suutsu",
         "trans": [
+            "スーツ",
             "suit"
-        ],
-        "notation": "スーツ"
+        ]
     },
     {
         "name": "untenshu",
         "trans": [
+            "運転(うんてん)手(しゅ)",
             "driver"
-        ],
-        "notation": "運転(うんてん)手(しゅ)"
+        ]
     },
     {
         "name": "jama",
         "trans": [
+            "じゃま",
             "hindrance,intrusion"
-        ],
-        "notation": "じゃま"
+        ]
     },
     {
         "name": "juudou",
         "trans": [
+            "柔道(じゅうどう)",
             "judo"
-        ],
-        "notation": "柔道(じゅうどう)"
+        ]
     },
     {
         "name": "kureru",
         "trans": [
+            "くれる",
             "to give"
-        ],
-        "notation": "くれる"
+        ]
     },
     {
         "name": "ma",
         "trans": [
+            "間(ま)",
             "a space"
-        ],
-        "notation": "間(ま)"
+        ]
     },
     {
         "name": "ika",
         "trans": [
+            "以下(いか)",
             "less than"
-        ],
-        "notation": "以下(いか)"
+        ]
     },
     {
         "name": "kimi",
         "trans": [
+            "君(きみ)",
             "(informal) You (used by men towards women)"
-        ],
-        "notation": "君(きみ)"
+        ]
     },
     {
         "name": "shima",
         "trans": [
+            "島(しま)",
             "island"
-        ],
-        "notation": "島(しま)"
+        ]
     },
     {
         "name": "kitto",
         "trans": [
+            "きっと",
             "surely"
-        ],
-        "notation": "きっと"
+        ]
     },
     {
         "name": "ochiru",
         "trans": [
+            "落(おち)る",
             "to fall or drop"
-        ],
-        "notation": "落(おち)る"
+        ]
     },
     {
         "name": "okage",
         "trans": [
+            "おかげ",
             "owing to"
-        ],
-        "notation": "おかげ"
+        ]
     },
     {
         "name": "shouchi",
         "trans": [
+            "承知(しょうち)",
             "to consent"
-        ],
-        "notation": "承知(しょうち)"
+        ]
     },
     {
         "name": "bunpou",
         "trans": [
+            "文法(ぶんぽう)",
             "grammar"
-        ],
-        "notation": "文法(ぶんぽう)"
+        ]
     },
     {
         "name": "shuppatsu",
         "trans": [
+            "出発(しゅっぱつ)",
             "to depart"
-        ],
-        "notation": "出発(しゅっぱつ)"
+        ]
     },
     {
         "name": "kamau",
         "trans": [
+            "かまう",
             "to mind"
-        ],
-        "notation": "かまう"
+        ]
     },
     {
         "name": "akanbou",
         "trans": [
+            "赤(あか)ん坊(ぼう)",
             "baby"
-        ],
-        "notation": "赤(あか)ん坊(ぼう)"
+        ]
     },
     {
         "name": "kinjo",
         "trans": [
+            "近所(きんじょ)",
             "neighbourhood"
-        ],
-        "notation": "近所(きんじょ)"
+        ]
     },
     {
         "name": "anaunsaa",
         "trans": [
+            "アナウンサー",
             "announcer"
-        ],
-        "notation": "アナウンサー"
+        ]
     },
     {
         "name": "tasu",
         "trans": [
+            "足(た)す",
             "to add a number"
-        ],
-        "notation": "足(た)す"
+        ]
     },
     {
         "name": "shoukai",
         "trans": [
+            "紹介(しょうかい)",
             "introduction"
-        ],
-        "notation": "紹介(しょうかい)"
+        ]
     },
     {
         "name": "isshoukenmei",
         "trans": [
+            "一生懸命(いっしょうけんめい)",
             "with utmost effort"
-        ],
-        "notation": "一生懸命(いっしょうけんめい)"
+        ]
     },
     {
         "name": "harau",
         "trans": [
+            "払(はら)う",
             "to pay"
-        ],
-        "notation": "払(はら)う"
+        ]
     },
     {
         "name": "yureru",
         "trans": [
+            "揺(ゆ)れる",
             "to shake,to sway"
-        ],
-        "notation": "揺(ゆ)れる"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "都(と)",
             "metropolitan"
-        ],
-        "notation": "都(と)"
+        ]
     },
     {
         "name": "oto",
         "trans": [
+            "音(おと)",
             "sound,note"
-        ],
-        "notation": "音(おと)"
+        ]
     },
     {
         "name": "sorosoro",
         "trans": [
+            "そろそろ",
             "gradually,soon"
-        ],
-        "notation": "そろそろ"
+        ]
     },
     {
         "name": "mousu",
         "trans": [
+            "申(もう)す",
             "(humble) to be called,to say"
-        ],
-        "notation": "申(もう)す"
+        ]
     },
     {
         "name": "shakai",
         "trans": [
+            "社会(しゃかい)",
             "society,public"
-        ],
-        "notation": "社会(しゃかい)"
+        ]
     },
     {
         "name": "un",
         "trans": [
+            "うん",
             "(informal) yes"
-        ],
-        "notation": "うん"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "石(いし)",
             "stone"
-        ],
-        "notation": "石(いし)"
+        ]
     },
     {
         "name": "soreni",
         "trans": [
+            "それに",
             "moreover"
-        ],
-        "notation": "それに"
+        ]
     },
     {
         "name": "kaji",
         "trans": [
+            "火事(かじ)",
             "fire"
-        ],
-        "notation": "火事(かじ)"
+        ]
     },
     {
         "name": "keshigomu",
         "trans": [
+            "消(け)しゴム",
             "eraser"
-        ],
-        "notation": "消(け)しゴム"
+        ]
     },
     {
         "name": "hodo",
         "trans": [
+            "ほど",
             "extent"
-        ],
-        "notation": "ほど"
+        ]
     },
     {
         "name": "nikki",
         "trans": [
+            "日記(にっき)",
             "journal"
-        ],
-        "notation": "日記(にっき)"
+        ]
     },
     {
         "name": "bungaku",
         "trans": [
+            "文学(ぶんがく)",
             "literature"
-        ],
-        "notation": "文学(ぶんがく)"
+        ]
     },
     {
         "name": "sofuto",
         "trans": [
+            "ソフト",
             "soft"
-        ],
-        "notation": "ソフト"
+        ]
     },
     {
         "name": "minato",
         "trans": [
+            "港(みなと)",
             "harbour"
-        ],
-        "notation": "港(みなと)"
+        ]
     },
     {
         "name": "shinbunsha",
         "trans": [
+            "新聞(しんぶん)社(しゃ)",
             "newspaper company"
-        ],
-        "notation": "新聞(しんぶん)社(しゃ)"
+        ]
     },
     {
         "name": "sarada",
         "trans": [
+            "サラダ",
             "salad"
-        ],
-        "notation": "サラダ"
+        ]
     },
     {
         "name": "mannaka",
         "trans": [
+            "真中(まんなか)",
             "middle"
-        ],
-        "notation": "真中(まんなか)"
+        ]
     },
     {
         "name": "mairu",
         "trans": [
+            "参(まい)る",
             "(humble) to go,to come"
-        ],
-        "notation": "参(まい)る"
+        ]
     },
     {
         "name": "koshou",
         "trans": [
+            "故障(こしょう)",
             "to break-down"
-        ],
-        "notation": "故障(こしょう)"
+        ]
     },
     {
         "name": "uso",
         "trans": [
+            "うそ",
             "a lie"
-        ],
-        "notation": "うそ"
+        ]
     },
     {
         "name": "subarashii",
         "trans": [
+            "すばらしい",
             "wonderful"
-        ],
-        "notation": "すばらしい"
+        ]
     },
     {
         "name": "katsu",
         "trans": [
+            "勝(か)つ",
             "to win"
-        ],
-        "notation": "勝(か)つ"
+        ]
     },
     {
         "name": "wariai",
         "trans": [
+            "割合(わりあい)",
             "rate,ratio,percentage"
-        ],
-        "notation": "割合(わりあい)"
+        ]
     },
     {
         "name": "kowasu",
         "trans": [
+            "壊(こわ)す",
             "to break"
-        ],
-        "notation": "壊(こわ)す"
+        ]
     },
     {
         "name": "sukuriin",
         "trans": [
+            "スクリーン",
             "screen"
-        ],
-        "notation": "スクリーン"
+        ]
     },
     {
         "name": "jiyuu",
         "trans": [
+            "自由(じゆう)",
             "freedom"
-        ],
-        "notation": "自由(じゆう)"
+        ]
     },
     {
         "name": "daiji",
         "trans": [
+            "大事(だいじ)",
             "important,valuable,serious matter"
-        ],
-        "notation": "大事(だいじ)"
+        ]
     },
     {
         "name": "tsugou",
         "trans": [
+            "都合(つごう)",
             "circumstances,convenience"
-        ],
-        "notation": "都合(つごう)"
+        ]
     },
     {
         "name": "kyouiku",
         "trans": [
+            "教育(きょういく)",
             "education"
-        ],
-        "notation": "教育(きょういく)"
+        ]
     },
     {
         "name": "chuui",
         "trans": [
+            "注意(ちゅうい)",
             "caution"
-        ],
-        "notation": "注意(ちゅうい)"
+        ]
     },
     {
         "name": "sagasu",
         "trans": [
+            "探(さが)す",
             "to look for"
-        ],
-        "notation": "探(さが)す"
+        ]
     },
     {
         "name": "shusseki",
         "trans": [
+            "出席(しゅっせき)",
             "to attend"
-        ],
-        "notation": "出席(しゅっせき)"
+        ]
     },
     {
         "name": "gijutsu",
         "trans": [
+            "技術(ぎじゅつ)",
             "art,technology,skill"
-        ],
-        "notation": "技術(ぎじゅつ)"
+        ]
     },
     {
         "name": "kimono",
         "trans": [
+            "着物(きもの)",
             "kimono"
-        ],
-        "notation": "着物(きもの)"
+        ]
     },
     {
         "name": "jiko",
         "trans": [
+            "事故(じこ)",
             "accident"
-        ],
-        "notation": "事故(じこ)"
+        ]
     },
     {
         "name": "oideninaru",
         "trans": [
+            "おいでになる",
             "(respectful) to be"
-        ],
-        "notation": "おいでになる"
+        ]
     },
     {
         "name": "uriba",
         "trans": [
+            "売(う)り場(ば)",
             "place where things are sold"
-        ],
-        "notation": "売(う)り場(ば)"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "機会(きかい)",
             "opportunity"
-        ],
-        "notation": "機会(きかい)"
+        ]
     },
     {
         "name": "futsuu",
         "trans": [
+            "普通(ふつう)",
             "usually, or a train that stops at every station"
-        ],
-        "notation": "普通(ふつう)"
+        ]
     },
     {
         "name": "moshi",
         "trans": [
+            "もし",
             "if"
-        ],
-        "notation": "もし"
+        ]
     },
     {
         "name": "riyuu",
         "trans": [
+            "理由(りゆう)",
             "reason"
-        ],
-        "notation": "理由(りゆう)"
+        ]
     },
     {
         "name": "arukouru",
         "trans": [
+            "アルコール",
             "alcohol"
-        ],
-        "notation": "アルコール"
+        ]
     },
     {
         "name": "inai",
         "trans": [
+            "以内(いない)",
             "within"
-        ],
-        "notation": "以内(いない)"
+        ]
     },
     {
         "name": "yotei",
         "trans": [
+            "予定(よてい)",
             "arrangement"
-        ],
-        "notation": "予定(よてい)"
+        ]
     },
     {
         "name": "housou",
         "trans": [
+            "放送(ほうそう)",
             "to broadcast"
-        ],
-        "notation": "放送(ほうそう)"
+        ]
     },
     {
         "name": "tashika",
         "trans": [
+            "確(たし)か",
             "definite"
-        ],
-        "notation": "確(たし)か"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "急(きゅう)",
             "urgent, steep"
-        ],
-        "notation": "急(きゅう)"
+        ]
     },
     {
         "name": "kesshite",
         "trans": [
+            "決(けっ)して",
             "never"
-        ],
-        "notation": "決(けっ)して"
+        ]
     },
     {
         "name": "yorokobu",
         "trans": [
+            "喜(よろこ)ぶ",
             "to be delighted"
-        ],
-        "notation": "喜(よろこ)ぶ"
+        ]
     },
     {
         "name": "shuukan",
         "trans": [
+            "習慣(しゅうかん)",
             "custom,manners"
-        ],
-        "notation": "習慣(しゅうかん)"
+        ]
     },
     {
         "name": "chuugakkou",
         "trans": [
+            "中学校(ちゅうがっこう)",
             "junior high school,middle school"
-        ],
-        "notation": "中学校(ちゅうがっこう)"
+        ]
     },
     {
         "name": "tana",
         "trans": [
+            "棚(たな)",
             "shelves"
-        ],
-        "notation": "棚(たな)"
+        ]
     },
     {
         "name": "kubi",
         "trans": [
+            "首(くび)",
             "neck"
-        ],
-        "notation": "首(くび)"
+        ]
     },
     {
         "name": "oshiire",
         "trans": [
+            "押(お)し入(い)れ",
             "closet"
-        ],
-        "notation": "押(お)し入(い)れ"
+        ]
     },
     {
         "name": "koukou",
         "trans": [
+            "高校(こうこう)",
             "high school"
-        ],
-        "notation": "高校(こうこう)"
+        ]
     },
     {
         "name": "sou",
         "trans": [
+            "そう",
             "really"
-        ],
-        "notation": "そう"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "掛(か)ける",
             "to hang something"
-        ],
-        "notation": "掛(か)ける"
+        ]
     },
     {
         "name": "shimin",
         "trans": [
+            "市民(しみん)",
             "citizen"
-        ],
-        "notation": "市民(しみん)"
+        ]
     },
     {
         "name": "manga",
         "trans": [
+            "漫画(まんが)",
             "comic"
-        ],
-        "notation": "漫画(まんが)"
+        ]
     },
     {
         "name": "kotae",
         "trans": [
+            "答(こたえ)",
             "response"
-        ],
-        "notation": "答(こたえ)"
+        ]
     },
     {
         "name": "futoru",
         "trans": [
+            "太(ふと)る",
             "to become fat"
-        ],
-        "notation": "太(ふと)る"
+        ]
     },
     {
         "name": "okonau",
         "trans": [
+            "行(おこな)う",
             "to do"
-        ],
-        "notation": "行(おこな)う"
+        ]
     },
     {
         "name": "kumo",
         "trans": [
+            "雲(くも)",
             "cloud"
-        ],
-        "notation": "雲(くも)"
+        ]
     },
     {
         "name": "basho",
         "trans": [
+            "場所(ばしょ)",
             "location"
-        ],
-        "notation": "場所(ばしょ)"
+        ]
     },
     {
         "name": "ryouhou",
         "trans": [
+            "両方(りょうほう)",
             "both sides"
-        ],
-        "notation": "両方(りょうほう)"
+        ]
     },
     {
         "name": "youji",
         "trans": [
+            "用事(ようじ)",
             "things to do"
-        ],
-        "notation": "用事(ようじ)"
+        ]
     },
     {
         "name": "kachou",
         "trans": [
+            "課長(かちょう)",
             "section manager"
-        ],
-        "notation": "課長(かちょう)"
+        ]
     },
     {
         "name": "sashiageru",
         "trans": [
+            "差(さ)し上(あ)げる",
             "(polite) to give"
-        ],
-        "notation": "差(さ)し上(あ)げる"
+        ]
     },
     {
         "name": "konpyuuta/konpyuutaa",
         "trans": [
+            "コンピュータ/コンピューター",
             "computer"
-        ],
-        "notation": "コンピュータ/コンピューター"
+        ]
     },
     {
         "name": "kokoro",
         "trans": [
+            "心(こころ)",
             "core,heart"
-        ],
-        "notation": "心(こころ)"
+        ]
     },
     {
         "name": "piano",
         "trans": [
+            "ピアノ",
             "piano"
-        ],
-        "notation": "ピアノ"
+        ]
     },
     {
         "name": "oya",
         "trans": [
+            "親(おや)",
             "parents"
-        ],
-        "notation": "親(おや)"
+        ]
     },
     {
         "name": "muri",
         "trans": [
+            "無理(むり)",
             "impossible"
-        ],
-        "notation": "無理(むり)"
+        ]
     },
     {
         "name": "shiraberu",
         "trans": [
+            "調(しら)べる",
             "to investigate"
-        ],
-        "notation": "調(しら)べる"
+        ]
     },
     {
         "name": "gasu",
         "trans": [
+            "ガス",
             "petrol"
-        ],
-        "notation": "ガス"
+        ]
     },
     {
         "name": "reibou",
         "trans": [
+            "冷房(れいぼう)",
             "air conditioning"
-        ],
-        "notation": "冷房(れいぼう)"
+        ]
     },
     {
         "name": "nedan",
         "trans": [
+            "ねだん",
             "price"
-        ],
-        "notation": "ねだん"
+        ]
     },
     {
         "name": "nakunaru",
         "trans": [
+            "亡(な)くなる",
             "to die"
-        ],
-        "notation": "亡(な)くなる"
+        ]
     },
     {
         "name": "sorehodo",
         "trans": [
+            "それほど",
             "to that extent"
-        ],
-        "notation": "それほど"
+        ]
     },
     {
         "name": "naoru",
         "trans": [
+            "治(なお)る",
             "to be cured,to heal"
-        ],
-        "notation": "治(なお)る"
+        ]
     },
     {
         "name": "kenkyuushitsu",
         "trans": [
+            "研究(けんきゅう)室(しつ)",
             "study room,laboratory"
-        ],
-        "notation": "研究(けんきゅう)室(しつ)"
+        ]
     },
     {
         "name": "wake",
         "trans": [
+            "訳(わけ)",
             "meaning,reason"
-        ],
-        "notation": "訳(わけ)"
+        ]
     },
     {
         "name": "sandoicchi",
         "trans": [
+            "サンドイッチ",
             "sandwich"
-        ],
-        "notation": "サンドイッチ"
+        ]
     },
     {
         "name": "fueru",
         "trans": [
+            "増(ふ)える",
             "to increase"
-        ],
-        "notation": "増(ふ)える"
+        ]
     },
     {
         "name": "nemui",
         "trans": [
+            "眠(ねむ)い",
             "sleepy"
-        ],
-        "notation": "眠(ねむ)い"
+        ]
     },
     {
         "name": "hikaru",
         "trans": [
+            "光(ひか)る",
             "to shine,to glitter"
-        ],
-        "notation": "光(ひか)る"
+        ]
     },
     {
         "name": "arubaito",
         "trans": [
+            "アルバイト",
             "part-time job"
-        ],
-        "notation": "アルバイト"
+        ]
     },
     {
         "name": "kusa",
         "trans": [
+            "草(くさ)",
             "grass"
-        ],
-        "notation": "草(くさ)"
+        ]
     },
     {
         "name": "henji",
         "trans": [
+            "返事(へんじ)",
             "reply"
-        ],
-        "notation": "返事(へんじ)"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "線(せん)",
             "line"
-        ],
-        "notation": "線(せん)"
+        ]
     },
     {
         "name": "yogiru",
         "trans": [
+            "過(よ)ぎる",
             "to exceed"
-        ],
-        "notation": "過(よ)ぎる"
+        ]
     },
     {
         "name": "ken/kata/katai",
         "trans": [
+            "堅(けん)/硬(かた)/固(かた)い",
             "hard"
-        ],
-        "notation": "堅(けん)/硬(かた)/固(かた)い"
+        ]
     },
     {
         "name": "kuuki",
         "trans": [
+            "空気(くうき)",
             "air,atmosphere"
-        ],
-        "notation": "空気(くうき)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "生産(せいさん)",
             "to produce"
-        ],
-        "notation": "生産(せいさん)"
+        ]
     },
     {
         "name": "kanarazu",
         "trans": [
+            "必(かなら)ず",
             "certainly,necessarily"
-        ],
-        "notation": "必(かなら)ず"
+        ]
     },
     {
         "name": "mataha",
         "trans": [
+            "または",
             "or,otherwise"
-        ],
-        "notation": "または"
+        ]
     },
     {
         "name": "dentou",
         "trans": [
+            "電灯(でんとう)",
             "electric light"
-        ],
-        "notation": "電灯(でんとう)"
+        ]
     },
     {
         "name": "hanami",
         "trans": [
+            "花見(はなみ)",
             "cherry-blossom viewing"
-        ],
-        "notation": "花見(はなみ)"
+        ]
     },
     {
         "name": "senaka",
         "trans": [
+            "背中(せなか)",
             "back of the body"
-        ],
-        "notation": "背中(せなか)"
+        ]
     },
     {
         "name": "inaka",
         "trans": [
+            "田舎(いなか)",
             "countryside"
-        ],
-        "notation": "田舎(いなか)"
+        ]
     },
     {
         "name": "oreru",
         "trans": [
+            "折(お)れる",
             "to break or be folded"
-        ],
-        "notation": "折(お)れる"
+        ]
     },
     {
         "name": "okujou",
         "trans": [
+            "屋上(おくじょう)",
             "rooftop"
-        ],
-        "notation": "屋上(おくじょう)"
+        ]
     },
     {
         "name": "suku",
         "trans": [
+            "空(す)く",
             "to open, to become empty"
-        ],
-        "notation": "空(す)く"
+        ]
     },
     {
         "name": "kondo",
         "trans": [
+            "今度(こんど)",
             "now,next time"
-        ],
-        "notation": "今度(こんど)"
+        ]
     },
     {
         "name": "biru",
         "trans": [
+            "ビル",
             "building or bill"
-        ],
-        "notation": "ビル"
+        ]
     },
     {
         "name": "uchi",
         "trans": [
+            "うち",
             "within"
-        ],
-        "notation": "うち"
+        ]
     },
     {
         "name": "haisha",
         "trans": [
+            "歯医者(はいしゃ)",
             "dentist"
-        ],
-        "notation": "歯医者(はいしゃ)"
+        ]
     },
     {
         "name": "suteru",
         "trans": [
+            "捨(す)てる",
             "to throw away"
-        ],
-        "notation": "捨(す)てる"
+        ]
     },
     {
         "name": "yasashii",
         "trans": [
+            "優(やさ)しい",
             "kind"
-        ],
-        "notation": "優(やさ)しい"
+        ]
     },
     {
         "name": "ijimeru",
         "trans": [
+            "いじめる",
             "to tease"
-        ],
-        "notation": "いじめる"
+        ]
     },
     {
         "name": "sabishii",
         "trans": [
+            "寂(さび)しい",
             "lonely"
-        ],
-        "notation": "寂(さび)しい"
+        ]
     },
     {
         "name": "taifuu",
         "trans": [
+            "台風(たいふう)",
             "typhoon"
-        ],
-        "notation": "台風(たいふう)"
+        ]
     },
     {
         "name": "hakobu",
         "trans": [
+            "運(はこ)ぶ",
             "to transport"
-        ],
-        "notation": "運(はこ)ぶ"
+        ]
     },
     {
         "name": "taoreru",
         "trans": [
+            "倒(たお)れる",
             "to break down"
-        ],
-        "notation": "倒(たお)れる"
+        ]
     },
     {
         "name": "yahari/yappari",
         "trans": [
+            "やはり/やっぱり",
             "as I thought,absolutely"
-        ],
-        "notation": "やはり/やっぱり"
+        ]
     },
     {
         "name": "budou",
         "trans": [
+            "ぶどう",
             "grapes"
-        ],
-        "notation": "ぶどう"
+        ]
     },
     {
         "name": "omocha",
         "trans": [
+            "おもちゃ",
             "toy"
-        ],
-        "notation": "おもちゃ"
+        ]
     },
     {
         "name": "youi",
         "trans": [
+            "用意(ようい)",
             "preparation"
-        ],
-        "notation": "用意(ようい)"
+        ]
     },
     {
         "name": "jinkou",
         "trans": [
+            "人口(じんこう)",
             "population"
-        ],
-        "notation": "人口(じんこう)"
+        ]
     },
     {
         "name": "suugaku",
         "trans": [
+            "数学(すうがく)",
             "mathematics,arithmetic"
-        ],
-        "notation": "数学(すうがく)"
+        ]
     },
     {
         "name": "gasorin",
         "trans": [
+            "ガソリン",
             "petrol"
-        ],
-        "notation": "ガソリン"
+        ]
     },
     {
         "name": "kotori",
         "trans": [
+            "小鳥(ことり)",
             "small bird"
-        ],
-        "notation": "小鳥(ことり)"
+        ]
     },
     {
         "name": "sutto",
         "trans": [
+            "すっと",
             "straight,all of a sudden"
-        ],
-        "notation": "すっと"
+        ]
     },
     {
         "name": "norikaeru",
         "trans": [
+            "乗(の)り換(か)える",
             "to change between buses or trains"
-        ],
-        "notation": "乗(の)り換(か)える"
+        ]
     },
     {
         "name": "riyou",
         "trans": [
+            "利用(りよう)",
             "utilization"
-        ],
-        "notation": "利用(りよう)"
+        ]
     },
     {
         "name": "atsumeru",
         "trans": [
+            "集(あつ)める",
             "to collect something"
-        ],
-        "notation": "集(あつ)める"
+        ]
     },
     {
         "name": "nyuugaku",
         "trans": [
+            "入学(にゅうがく)",
             "to enter school or university"
-        ],
-        "notation": "入学(にゅうがく)"
+        ]
     },
     {
         "name": "shibaraku",
         "trans": [
+            "しばらく",
             "little while"
-        ],
-        "notation": "しばらく"
+        ]
     },
     {
         "name": "ossharu",
         "trans": [
+            "おっしゃる",
             "(respectful) to say"
-        ],
-        "notation": "おっしゃる"
+        ]
     },
     {
         "name": "yoroshii",
         "trans": [
+            "よろしい",
             "(respectful) OK,all right"
-        ],
-        "notation": "よろしい"
+        ]
     },
     {
         "name": "majime",
         "trans": [
+            "まじめ",
             "serious"
-        ],
-        "notation": "まじめ"
+        ]
     },
     {
         "name": "suidou",
         "trans": [
+            "水道(すいどう)",
             "water supply"
-        ],
-        "notation": "水道(すいどう)"
+        ]
     },
     {
         "name": "tatami",
         "trans": [
+            "畳(たたみ)",
             "Japanese straw mat"
-        ],
-        "notation": "畳(たたみ)"
+        ]
     },
     {
         "name": "sakki",
         "trans": [
+            "さっき",
             "some time ago"
-        ],
-        "notation": "さっき"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "日(ひ)",
             "day, sun"
-        ],
-        "notation": "日(ひ)"
+        ]
     },
     {
         "name": "hatsuon",
         "trans": [
+            "発音(はつおん)",
             "pronunciation"
-        ],
-        "notation": "発音(はつおん)"
+        ]
     },
     {
         "name": "honyaku",
         "trans": [
+            "翻訳(ほんやく)",
             "translation"
-        ],
-        "notation": "翻訳(ほんやく)"
+        ]
     },
     {
         "name": "ito",
         "trans": [
+            "糸(いと)",
             "thread"
-        ],
-        "notation": "糸(いと)"
+        ]
     },
     {
         "name": "kiken",
         "trans": [
+            "危険(きけん)",
             "danger"
-        ],
-        "notation": "危険(きけん)"
+        ]
     },
     {
         "name": "narubeku",
         "trans": [
+            "なるべく",
             "as much as possible"
-        ],
-        "notation": "なるべく"
+        ]
     },
     {
         "name": "ura",
         "trans": [
+            "裏(うら)",
             "reverse side"
-        ],
-        "notation": "裏(うら)"
+        ]
     },
     {
         "name": "tochuu",
         "trans": [
+            "途中(とちゅう)",
             "on the way"
-        ],
-        "notation": "途中(とちゅう)"
+        ]
     },
     {
         "name": "okashii",
         "trans": [
+            "おかしい",
             "strange or funny"
-        ],
-        "notation": "おかしい"
+        ]
     },
     {
         "name": "asai",
         "trans": [
+            "浅(あさ)い",
             "shallow,superficial"
-        ],
-        "notation": "浅(あさ)い"
+        ]
     },
     {
         "name": "hen",
         "trans": [
+            "変(へん)",
             "strange"
-        ],
-        "notation": "変(へん)"
+        ]
     },
     {
         "name": "saisho",
         "trans": [
+            "最初(さいしょ)",
             "beginning,first"
-        ],
-        "notation": "最初(さいしょ)"
+        ]
     },
     {
         "name": "haiken",
         "trans": [
+            "拝見(はいけん)",
             "(humble) to look at"
-        ],
-        "notation": "拝見(はいけん)"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "用(よう)",
             "use"
-        ],
-        "notation": "用(よう)"
+        ]
     },
     {
         "name": "tsutaeru",
         "trans": [
+            "伝(つた)える",
             "to report"
-        ],
-        "notation": "伝(つた)える"
+        ]
     },
     {
         "name": "sorede",
         "trans": [
+            "それで",
             "because of that"
-        ],
-        "notation": "それで"
+        ]
     },
     {
         "name": "mieru",
         "trans": [
+            "見(み)える",
             "to be in sight"
-        ],
-        "notation": "見(み)える"
+        ]
     },
     {
         "name": "otaku",
         "trans": [
+            "お宅(たく)",
             "(polite) your house"
-        ],
-        "notation": "お宅(たく)"
+        ]
     },
     {
         "name": "tariru",
         "trans": [
+            "足(た)りる",
             "to be enough"
-        ],
-        "notation": "足(た)りる"
+        ]
     },
     {
         "name": "nioi",
         "trans": [
+            "におい",
             "a smell"
-        ],
-        "notation": "におい"
+        ]
     },
     {
         "name": "otsuri",
         "trans": [
+            "おつり",
             "change from purchase, balance"
-        ],
-        "notation": "おつり"
+        ]
     },
     {
         "name": "shiken",
         "trans": [
+            "試験(しけん)",
             "examination"
-        ],
-        "notation": "試験(しけん)"
+        ]
     },
     {
         "name": "moushiageru",
         "trans": [
+            "申(もう)し上(あ)げる",
             "(humble) to say,to tell"
-        ],
-        "notation": "申(もう)し上(あ)げる"
+        ]
     },
     {
         "name": "saraishuu",
         "trans": [
+            "さ来週(らいしゅう)",
             "the week after next"
-        ],
-        "notation": "さ来週(らいしゅう)"
+        ]
     },
     {
         "name": "kudaru",
         "trans": [
+            "下(くだ)る",
             "to get down,to descend"
-        ],
-        "notation": "下(くだ)る"
+        ]
     },
     {
         "name": "hikoujou",
         "trans": [
+            "飛行場(ひこうじょう)",
             "airport"
-        ],
-        "notation": "飛行場(ひこうじょう)"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "工業(こうぎょう)",
             "the manufacturing industry"
-        ],
-        "notation": "工業(こうぎょう)"
+        ]
     },
     {
         "name": "tera",
         "trans": [
+            "寺(てら)",
             "temple"
-        ],
-        "notation": "寺(てら)"
+        ]
     },
     {
         "name": "fune",
         "trans": [
+            "舟(ふね)",
             "ship"
-        ],
-        "notation": "舟(ふね)"
+        ]
     },
     {
         "name": "nuru",
         "trans": [
+            "塗(ぬ)る",
             "to paint,to plaster"
-        ],
-        "notation": "塗(ぬ)る"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "打(う)つ",
             "to hit"
-        ],
-        "notation": "打(う)つ"
+        ]
     },
     {
         "name": "chikara",
         "trans": [
+            "力(ちから)",
             "strength,power"
-        ],
-        "notation": "力(ちから)"
+        ]
     },
     {
         "name": "tokuni",
         "trans": [
+            "特(とく)に",
             "particularly,especially"
-        ],
-        "notation": "特(とく)に"
+        ]
     },
     {
         "name": "ji",
         "trans": [
+            "字(じ)",
             "character"
-        ],
-        "notation": "字(じ)"
+        ]
     },
     {
         "name": "iken",
         "trans": [
+            "意見(いけん)",
             "opinion"
-        ],
-        "notation": "意見(いけん)"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "鳴(な)る",
             "to sound"
-        ],
-        "notation": "鳴(な)る"
+        ]
     },
     {
         "name": "komu",
         "trans": [
+            "込(こ)む",
             "to be crowded"
-        ],
-        "notation": "込(こ)む"
+        ]
     },
     {
         "name": "katachi",
         "trans": [
+            "形(かたち)",
             "shape"
-        ],
-        "notation": "形(かたち)"
+        ]
     },
     {
         "name": "hayashi",
         "trans": [
+            "林(はやし)",
             "woods,forester"
-        ],
-        "notation": "林(はやし)"
+        ]
     },
     {
         "name": "owari",
         "trans": [
+            "終(お)わり",
             "the end"
-        ],
-        "notation": "終(お)わり"
+        ]
     },
     {
         "name": "nemuru",
         "trans": [
+            "眠(ねむ)る",
             "to sleep"
-        ],
-        "notation": "眠(ねむ)る"
+        ]
     },
     {
         "name": "futon",
         "trans": [
+            "布団(ふとん)",
             "Japanese bedding, futon"
-        ],
-        "notation": "布団(ふとん)"
+        ]
     },
     {
         "name": "konogoro",
         "trans": [
+            "このごろ",
             "these days,nowadays"
-        ],
-        "notation": "このごろ"
+        ]
     },
     {
         "name": "yunyuu",
         "trans": [
+            "輸入(ゆにゅう)",
             "to import"
-        ],
-        "notation": "輸入(ゆにゅう)"
+        ]
     },
     {
         "name": "yogoreru",
         "trans": [
+            "汚(よご)れる",
             "to get dirty"
-        ],
-        "notation": "汚(よご)れる"
+        ]
     },
     {
         "name": "garasu",
         "trans": [
+            "ガラス",
             "a glass pane"
-        ],
-        "notation": "ガラス"
+        ]
     },
     {
         "name": "nasaru",
         "trans": [
+            "なさる",
             "(respectful) to do"
-        ],
-        "notation": "なさる"
+        ]
     },
     {
         "name": "kisetsu",
         "trans": [
+            "季節(きせつ)",
             "season"
-        ],
-        "notation": "季節(きせつ)"
+        ]
     },
     {
         "name": "tateru",
         "trans": [
+            "立(た)てる",
             "to stand something up"
-        ],
-        "notation": "立(た)てる"
+        ]
     },
     {
         "name": "hisashiburi",
         "trans": [
+            "久(ひさ)しぶり",
             "after a long time"
-        ],
-        "notation": "久(ひさ)しぶり"
+        ]
     },
     {
         "name": "bei",
         "trans": [
+            "米(べい)",
             "uncooked rice"
-        ],
-        "notation": "米(べい)"
+        ]
     },
     {
         "name": "keeki",
         "trans": [
+            "ケーキ",
             "cake"
-        ],
-        "notation": "ケーキ"
+        ]
     },
     {
         "name": "seikatsu",
         "trans": [
+            "生活(せいかつ)",
             "to live"
-        ],
-        "notation": "生活(せいかつ)"
+        ]
     },
     {
         "name": "wakareru",
         "trans": [
+            "別(わか)れる",
             "to separate"
-        ],
-        "notation": "別(わか)れる"
+        ]
     },
     {
         "name": "wasuremono",
         "trans": [
+            "忘(わす)れ物(もの)",
             "lost article"
-        ],
-        "notation": "忘(わす)れ物(もの)"
+        ]
     },
     {
         "name": "kowai",
         "trans": [
+            "怖(こわ)い",
             "frightening"
-        ],
-        "notation": "怖(こわ)い"
+        ]
     },
     {
         "name": "nyuuin",
         "trans": [
+            "入院(にゅういん)",
             "to hospitalise"
-        ],
-        "notation": "入院(にゅういん)"
+        ]
     },
     {
         "name": "suri",
         "trans": [
+            "すり",
             "pickpocket"
-        ],
-        "notation": "すり"
+        ]
     },
     {
         "name": "shoutai",
         "trans": [
+            "招待(しょうたい)",
             "to invite"
-        ],
-        "notation": "招待(しょうたい)"
+        ]
     },
     {
         "name": "suutsukeesu",
         "trans": [
+            "スーツケース",
             "suitcase"
-        ],
-        "notation": "スーツケース"
+        ]
     },
     {
         "name": "nebou",
         "trans": [
+            "寝坊(ねぼう)",
             "sleeping in late"
-        ],
-        "notation": "寝坊(ねぼう)"
+        ]
     },
     {
         "name": "mochiron",
         "trans": [
+            "もちろん",
             "of course"
-        ],
-        "notation": "もちろん"
+        ]
     },
     {
         "name": "kimi",
         "trans": [
+            "君(きみ)",
             "suffix for familiar young male"
-        ],
-        "notation": "君(きみ)"
+        ]
     },
     {
         "name": "rusu",
         "trans": [
+            "留守(るす)",
             "absence"
-        ],
-        "notation": "留守(るす)"
+        ]
     },
     {
         "name": "suruto",
         "trans": [
+            "すると",
             "then"
-        ],
-        "notation": "すると"
+        ]
     },
     {
         "name": "shinamono",
         "trans": [
+            "品物(しなもの)",
             "goods"
-        ],
-        "notation": "品物(しなもの)"
+        ]
     },
     {
         "name": "nageru",
         "trans": [
+            "投(な)げる",
             "to throw or cast away"
-        ],
-        "notation": "投(な)げる"
+        ]
     },
     {
         "name": "tsuma",
         "trans": [
+            "妻(つま)",
             "(humble) wife"
-        ],
-        "notation": "妻(つま)"
+        ]
     },
     {
         "name": "fakkusu",
         "trans": [
+            "ファックス",
             "fax"
-        ],
-        "notation": "ファックス"
+        ]
     },
     {
         "name": "odoroku",
         "trans": [
+            "驚(おどろ)く",
             "to be surprised"
-        ],
-        "notation": "驚(おどろ)く"
+        ]
     },
     {
         "name": "kawaru",
         "trans": [
+            "変(か)わる",
             "to change"
-        ],
-        "notation": "変(か)わる"
+        ]
     },
     {
         "name": "tatoeba",
         "trans": [
+            "例(たと)えば",
             "for example"
-        ],
-        "notation": "例(たと)えば"
+        ]
     },
     {
         "name": "orei",
         "trans": [
+            "お礼(れい)",
             "expression of gratitude"
-        ],
-        "notation": "お礼(れい)"
+        ]
     },
     {
         "name": "tsureru",
         "trans": [
+            "連(つ)れる",
             "to lead"
-        ],
-        "notation": "連(つ)れる"
+        ]
     },
     {
         "name": "tokoya",
         "trans": [
+            "とこや",
             "barber"
-        ],
-        "notation": "とこや"
+        ]
     },
     {
         "name": "keizai",
         "trans": [
+            "経済(けいざい)",
             "finance,economy"
-        ],
-        "notation": "経済(けいざい)"
+        ]
     },
     {
         "name": "koudou",
         "trans": [
+            "講堂(こうどう)",
             "auditorium"
-        ],
-        "notation": "講堂(こうどう)"
+        ]
     },
     {
         "name": "seiji",
         "trans": [
+            "政治(せいじ)",
             "politics,government"
-        ],
-        "notation": "政治(せいじ)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "地震(じしん)",
             "earthquake"
-        ],
-        "notation": "地震(じしん)"
+        ]
     },
     {
         "name": "beru",
         "trans": [
+            "ベル",
             "bell"
-        ],
-        "notation": "ベル"
+        ]
     },
     {
         "name": "mousugu",
         "trans": [
+            "もうすぐ",
             "soon"
-        ],
-        "notation": "もうすぐ"
+        ]
     },
     {
         "name": "doubutsuen",
         "trans": [
+            "動物(どうぶつ)園(えん)",
             "zoo"
-        ],
-        "notation": "動物(どうぶつ)園(えん)"
+        ]
     },
     {
         "name": "wareru",
         "trans": [
+            "割(わ)れる",
             "to break"
-        ],
-        "notation": "割(わ)れる"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "寄(よ)る",
             "to visit"
-        ],
-        "notation": "寄(よ)る"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "あげる",
             "to give"
-        ],
-        "notation": "あげる"
+        ]
     },
     {
         "name": "paato",
         "trans": [
+            "パート",
             "part time"
-        ],
-        "notation": "パート"
+        ]
     },
     {
         "name": "tazuneru",
         "trans": [
+            "尋(たず)ねる",
             "to ask"
-        ],
-        "notation": "尋(たず)ねる"
+        ]
     },
     {
         "name": "mou",
         "trans": [
+            "毛(もう)",
             "hair or fur"
-        ],
-        "notation": "毛(もう)"
+        ]
     },
     {
         "name": "sukkari",
         "trans": [
+            "すっかり",
             "completely"
-        ],
-        "notation": "すっかり"
+        ]
     },
     {
         "name": "hijouni",
         "trans": [
+            "非常(ひじょう)に",
             "extremely"
-        ],
-        "notation": "非常(ひじょう)に"
+        ]
     },
     {
         "name": "tsuru",
         "trans": [
+            "釣(つ)る",
             "to fish"
-        ],
-        "notation": "釣(つ)る"
+        ]
     },
     {
         "name": "houritsu",
         "trans": [
+            "法律(ほうりつ)",
             "law"
-        ],
-        "notation": "法律(ほうりつ)"
+        ]
     },
     {
         "name": "shitaku",
         "trans": [
+            "支度(したく)",
             "to prepare"
-        ],
-        "notation": "支度(したく)"
+        ]
     },
     {
         "name": "soudan",
         "trans": [
+            "相談(そうだん)",
             "to discuss"
-        ],
-        "notation": "相談(そうだん)"
+        ]
     },
     {
         "name": "yakunitatsu",
         "trans": [
+            "役(やく)に立(た)つ",
             "to be helpful"
-        ],
-        "notation": "役(やく)に立(た)つ"
+        ]
     },
     {
         "name": "fumu",
         "trans": [
+            "踏(ふ)む",
             "to step on"
-        ],
-        "notation": "踏(ふ)む"
+        ]
     },
     {
         "name": "handobaggu",
         "trans": [
+            "ハンドバッグ",
             "handbag　"
-        ],
-        "notation": "ハンドバッグ"
+        ]
     },
     {
         "name": "daitai",
         "trans": [
+            "大体(だいたい)",
             "generally"
-        ],
-        "notation": "大体(だいたい)"
+        ]
     },
     {
         "name": "kangaeru",
         "trans": [
+            "考(かんが)える",
             "to consider"
-        ],
-        "notation": "考(かんが)える"
+        ]
     },
     {
         "name": "toutou",
         "trans": [
+            "とうとう",
             "finally, after all"
-        ],
-        "notation": "とうとう"
+        ]
     },
     {
         "name": "mukashi",
         "trans": [
+            "昔(むかし)",
             "olden days, former"
-        ],
-        "notation": "昔(むかし)"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "折(お)る",
             "to break or to fold"
-        ],
-        "notation": "折(お)る"
+        ]
     },
     {
         "name": "chittomo",
         "trans": [
+            "ちっとも",
             "not at all (used with a negative verb)"
-        ],
-        "notation": "ちっとも"
+        ]
     },
     {
         "name": "kabe",
         "trans": [
+            "壁(かべ)",
             "wall"
-        ],
-        "notation": "壁(かべ)"
+        ]
     },
     {
         "name": "tooku",
         "trans": [
+            "遠(とお)く",
             "distant"
-        ],
-        "notation": "遠(とお)く"
+        ]
     },
     {
         "name": "kagaku",
         "trans": [
+            "科学(かがく)",
             "science"
-        ],
-        "notation": "科学(かがく)"
+        ]
     },
     {
         "name": "sobo",
         "trans": [
+            "祖母(そぼ)",
             "grandmother"
-        ],
-        "notation": "祖母(そぼ)"
+        ]
     },
     {
         "name": "aisatsu-suru",
         "trans": [
+            "あいさつ-する",
             "to greet"
-        ],
-        "notation": "あいさつ-する"
+        ]
     },
     {
         "name": "akachan",
         "trans": [
+            "あかちゃん",
             "infant"
-        ],
-        "notation": "あかちゃん"
+        ]
     },
     {
         "name": "saigo",
         "trans": [
+            "最後(さいご)",
             "last,end"
-        ],
-        "notation": "最後(さいご)"
+        ]
     },
     {
         "name": "uketsuke",
         "trans": [
+            "受付(うけつけ)",
             "receipt"
-        ],
-        "notation": "受付(うけつけ)"
+        ]
     },
     {
         "name": "tsuzuku",
         "trans": [
+            "続(つづ)く",
             "to be continued"
-        ],
-        "notation": "続(つづ)く"
+        ]
     },
     {
         "name": "kyousou",
         "trans": [
+            "競争(きょうそう)",
             "competition"
-        ],
-        "notation": "競争(きょうそう)"
+        ]
     },
     {
         "name": "yubi",
         "trans": [
+            "指(ゆび)",
             "finger"
-        ],
-        "notation": "指(ゆび)"
+        ]
     },
     {
         "name": "todokeru",
         "trans": [
+            "届(とど)ける",
             "to reach"
-        ],
-        "notation": "届(とど)ける"
+        ]
     },
     {
         "name": "ijou",
         "trans": [
+            "以上(いじょう)",
             "more than,this is all"
-        ],
-        "notation": "以上(いじょう)"
+        ]
     },
     {
         "name": "geshuku",
         "trans": [
+            "下宿(げしゅく)",
             "lodging"
-        ],
-        "notation": "下宿(げしゅく)"
+        ]
     },
     {
         "name": "odoru",
         "trans": [
+            "踊(おど)る",
             "to dance"
-        ],
-        "notation": "踊(おど)る"
+        ]
     },
     {
         "name": "hikidasu",
         "trans": [
+            "引(ひ)き出(だ)す",
             "to withdraw"
-        ],
-        "notation": "引(ひ)き出(だ)す"
+        ]
     },
     {
         "name": "dorobou",
         "trans": [
+            "泥棒(どろぼう)",
             "thief"
-        ],
-        "notation": "泥棒(どろぼう)"
+        ]
     },
     {
         "name": "kuraberu",
         "trans": [
+            "比(くら)べる",
             "to compare"
-        ],
-        "notation": "比(くら)べる"
+        ]
     },
     {
         "name": "yaseru",
         "trans": [
+            "痩(や)せる",
             "to become thin"
-        ],
-        "notation": "痩(や)せる"
+        ]
     },
     {
         "name": "shourai",
         "trans": [
+            "将来(しょうらい)",
             "future,prospects"
-        ],
-        "notation": "将来(しょうらい)"
+        ]
     },
     {
         "name": "tenisu",
         "trans": [
+            "テニス",
             "tennis"
-        ],
-        "notation": "テニス"
+        ]
     },
     {
         "name": "nusumu",
         "trans": [
+            "盗(ぬす)む",
             "to steal"
-        ],
-        "notation": "盗(ぬす)む"
+        ]
     },
     {
         "name": "goranninaru",
         "trans": [
+            "ごらんになる",
             "(respectful) to see"
-        ],
-        "notation": "ごらんになる"
+        ]
     },
     {
         "name": "esukareetaa",
         "trans": [
+            "エスカレーター",
             "escalator"
-        ],
-        "notation": "エスカレーター"
+        ]
     },
     {
         "name": "kokusai",
         "trans": [
+            "国際(こくさい)",
             "international"
-        ],
-        "notation": "国際(こくさい)"
+        ]
     },
     {
         "name": "hiruyasumi",
         "trans": [
+            "昼休(ひるやす)み",
             "noon break"
-        ],
-        "notation": "昼休(ひるやす)み"
+        ]
     },
     {
         "name": "kyaku",
         "trans": [
+            "客(きゃく)",
             "guest,customer"
-        ],
-        "notation": "客(きゃく)"
+        ]
     },
     {
         "name": "chiri",
         "trans": [
+            "地理(ちり)",
             "geography"
-        ],
-        "notation": "地理(ちり)"
+        ]
     },
     {
         "name": "kowata",
         "trans": [
+            "木綿(こわた)",
             "cotton"
-        ],
-        "notation": "木綿(こわた)"
+        ]
     },
     {
         "name": "shiai",
         "trans": [
+            "試合(しあい)",
             "match,game"
-        ],
-        "notation": "試合(しあい)"
+        ]
     },
     {
         "name": "tenrankai",
         "trans": [
+            "展覧(てんらん)会(かい)",
             "exhibition"
-        ],
-        "notation": "展覧(てんらん)会(かい)"
+        ]
     },
     {
         "name": "boku",
         "trans": [
+            "僕(ぼく)",
             "I (used by males)"
-        ],
-        "notation": "僕(ぼく)"
+        ]
     },
     {
         "name": "kakkou",
         "trans": [
+            "かっこう",
             "appearance"
-        ],
-        "notation": "かっこう"
+        ]
     },
     {
         "name": "otto",
         "trans": [
+            "夫(おっと)",
             "husband"
-        ],
-        "notation": "夫(おっと)"
+        ]
     },
     {
         "name": "afurika",
         "trans": [
+            "アフリカ",
             "Africa"
-        ],
-        "notation": "アフリカ"
+        ]
     },
     {
         "name": "anzen",
         "trans": [
+            "安全(あんぜん)",
             "safety"
-        ],
-        "notation": "安全(あんぜん)"
+        ]
     },
     {
         "name": "kaaten",
         "trans": [
+            "カーテン",
             "curtain"
-        ],
-        "notation": "カーテン"
+        ]
     },
     {
         "name": "shinpai",
         "trans": [
+            "心配(しんぱい)",
             "to worry"
-        ],
-        "notation": "心配(しんぱい)"
+        ]
     },
     {
         "name": "nigeru",
         "trans": [
+            "逃(に)げる",
             "to escape"
-        ],
-        "notation": "逃(に)げる"
+        ]
     },
     {
         "name": "tanoshimi",
         "trans": [
+            "楽(たの)しみ",
             "joy"
-        ],
-        "notation": "楽(たの)しみ"
+        ]
     },
     {
         "name": "kimochi",
         "trans": [
+            "気持(きも)ち",
             "feeling,mood"
-        ],
-        "notation": "気持(きも)ち"
+        ]
     },
     {
         "name": "ojousan",
         "trans": [
+            "お嬢(じょう)さん",
             "young lady"
-        ],
-        "notation": "お嬢(じょう)さん"
+        ]
     },
     {
         "name": "rekishi",
         "trans": [
+            "歴史(れきし)",
             "history"
-        ],
-        "notation": "歴史(れきし)"
+        ]
     },
     {
         "name": "norimono",
         "trans": [
+            "乗(の)り物(もの)",
             "vehicle"
-        ],
-        "notation": "乗(の)り物(もの)"
+        ]
     },
     {
         "name": "nesshin",
         "trans": [
+            "ねっしん",
             "enthusiasm"
-        ],
-        "notation": "ねっしん"
+        ]
     },
     {
         "name": "hige",
         "trans": [
+            "ひげ",
             "beard"
-        ],
-        "notation": "ひげ"
+        ]
     },
     {
         "name": "taitei",
         "trans": [
+            "たいてい",
             "usually"
-        ],
-        "notation": "たいてい"
+        ]
     },
     {
         "name": "genin",
         "trans": [
+            "原因(げんいん)",
             "cause,source"
-        ],
-        "notation": "原因(げんいん)"
+        ]
     },
     {
         "name": "kudasaru",
         "trans": [
+            "くださる",
             "(respectful) to give"
-        ],
-        "notation": "くださる"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "髪(かみ)",
             "hair"
-        ],
-        "notation": "髪(かみ)"
+        ]
     },
     {
         "name": "sonna",
         "trans": [
+            "そんな",
             "that sort of"
-        ],
-        "notation": "そんな"
+        ]
     },
     {
         "name": "itasu",
         "trans": [
+            "致(いた)す",
             "(humble) to do"
-        ],
-        "notation": "致(いた)す"
+        ]
     },
     {
         "name": "kaiwa",
         "trans": [
+            "会話(かいわ)",
             "conversation"
-        ],
-        "notation": "会話(かいわ)"
+        ]
     },
     {
         "name": "kimaru",
         "trans": [
+            "決(きま)る",
             "to be decided"
-        ],
-        "notation": "決(きま)る"
+        ]
     },
     {
         "name": "okosu",
         "trans": [
+            "起(おこ)す",
             "to wake"
-        ],
-        "notation": "起(おこ)す"
+        ]
     },
     {
         "name": "zenzen",
         "trans": [
+            "ぜんぜん",
             "not entirely (used in a negative sentence)"
-        ],
-        "notation": "ぜんぜん"
+        ]
     },
     {
         "name": "kanai",
         "trans": [
+            "家内(かない)",
             "housewife"
-        ],
-        "notation": "家内(かない)"
+        ]
     },
     {
         "name": "ten",
         "trans": [
+            "点(てん)",
             "point,dot"
-        ],
-        "notation": "点(てん)"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "変(か)える",
             "to change"
-        ],
-        "notation": "変(か)える"
+        ]
     },
     {
         "name": "okurimono",
         "trans": [
+            "贈(おく)り物(もの)",
             "gift"
-        ],
-        "notation": "贈(おく)り物(もの)"
+        ]
     },
     {
         "name": "chan",
         "trans": [
+            "ちゃん",
             "suffix for familiar female person"
-        ],
-        "notation": "ちゃん"
+        ]
     },
     {
         "name": "kyoumi",
         "trans": [
+            "興味(きょうみ)",
             "an interest"
-        ],
-        "notation": "興味(きょうみ)"
+        ]
     },
     {
         "name": "chuushajou",
         "trans": [
+            "駐車(ちゅうしゃ)場(じょう)",
             "parking lot"
-        ],
-        "notation": "駐車(ちゅうしゃ)場(じょう)"
+        ]
     },
     {
         "name": "dougu",
         "trans": [
+            "道具(どうぐ)",
             "tool,means"
-        ],
-        "notation": "道具(どうぐ)"
+        ]
     },
     {
         "name": "nareru",
         "trans": [
+            "慣(な)れる",
             "to grow accustomed to"
-        ],
-        "notation": "慣(な)れる"
+        ]
     },
     {
         "name": "kega/suru",
         "trans": [
+            "けが・する",
             "to injure"
-        ],
-        "notation": "けが・する"
+        ]
     },
     {
         "name": "sawaru",
         "trans": [
+            "触(さわ)る",
             "to touch"
-        ],
-        "notation": "触(さわ)る"
+        ]
     },
     {
         "name": "yushutsu",
         "trans": [
+            "輸出(ゆしゅつ)",
             "to export"
-        ],
-        "notation": "輸出(ゆしゅつ)"
+        ]
     },
     {
         "name": "keisatsu",
         "trans": [
+            "警察(けいさつ)",
             "police"
-        ],
-        "notation": "警察(けいさつ)"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "写(うつ)す",
             "to copy or photograph"
-        ],
-        "notation": "写(うつ)す"
+        ]
     },
     {
         "name": "kankei",
         "trans": [
+            "関係(かんけい)",
             "relationship"
-        ],
-        "notation": "関係(かんけい)"
+        ]
     },
     {
         "name": "gozonji",
         "trans": [
+            "ご存(ぞん)じ",
             "knowing,acquaintance"
-        ],
-        "notation": "ご存(ぞん)じ"
+        ]
     },
     {
         "name": "hirou",
         "trans": [
+            "拾(ひろ)う",
             "to pick up,to gather"
-        ],
-        "notation": "拾(ひろ)う"
+        ]
     },
     {
         "name": "yakusoku",
         "trans": [
+            "約束(やくそく)",
             "promise"
-        ],
-        "notation": "約束(やくそく)"
+        ]
     },
     {
         "name": "kyuukou",
         "trans": [
+            "急行(きゅうこう)",
             "speedy, express"
-        ],
-        "notation": "急行(きゅうこう)"
+        ]
     },
     {
         "name": "kantan",
         "trans": [
+            "簡単(かんたん)",
             "simple"
-        ],
-        "notation": "簡単(かんたん)"
+        ]
     },
     {
         "name": "mazu",
         "trans": [
+            "まず",
             "first of all"
-        ],
-        "notation": "まず"
+        ]
     },
     {
         "name": "josei",
         "trans": [
+            "女性(じょせい)",
             "woman"
-        ],
-        "notation": "女性(じょせい)"
+        ]
     },
     {
         "name": "ukeru",
         "trans": [
+            "受(う)ける",
             "to take a lesson or test"
-        ],
-        "notation": "受(う)ける"
+        ]
     },
     {
         "name": "ajia",
         "trans": [
+            "アジア",
             "Asia"
-        ],
-        "notation": "アジア"
+        ]
     },
     {
         "name": "tame",
         "trans": [
+            "為(ため)",
             "in order to"
-        ],
-        "notation": "為(ため)"
+        ]
     },
     {
         "name": "buchou",
         "trans": [
+            "部長(ぶちょう)",
             "head of a section"
-        ],
-        "notation": "部長(ぶちょう)"
+        ]
     },
     {
         "name": "teinei",
         "trans": [
+            "丁寧(ていねい)",
             "polite"
-        ],
-        "notation": "丁寧(ていねい)"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "合(あ)う",
             "to match"
-        ],
-        "notation": "合(あ)う"
+        ]
     },
     {
         "name": "susumu",
         "trans": [
+            "進(すす)む",
             "to make progress"
-        ],
-        "notation": "進(すす)む"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "上(のぼ)る",
             "to rise"
-        ],
-        "notation": "上(のぼ)る"
+        ]
     },
     {
         "name": "makeru",
         "trans": [
+            "負(ま)ける",
             "to lose"
-        ],
-        "notation": "負(ま)ける"
+        ]
     },
     {
         "name": "saka",
         "trans": [
+            "坂(さか)",
             "slope,hill"
-        ],
-        "notation": "坂(さか)"
+        ]
     },
     {
         "name": "ureshii",
         "trans": [
+            "うれしい",
             "glad"
-        ],
-        "notation": "うれしい"
+        ]
     },
     {
         "name": "yoyaku",
         "trans": [
+            "予約(よやく)",
             "reservation"
-        ],
-        "notation": "予約(よやく)"
+        ]
     },
     {
         "name": "shitagi",
         "trans": [
+            "下着(したぎ)",
             "underwear"
-        ],
-        "notation": "下着(したぎ)"
+        ]
     },
     {
         "name": "chuusha",
         "trans": [
+            "注射(ちゅうしゃ)",
             "injection"
-        ],
-        "notation": "注射(ちゅうしゃ)"
+        ]
     },
     {
         "name": "maniau",
         "trans": [
+            "間(ま)に合(あ)う",
             "to be in time for"
-        ],
-        "notation": "間(ま)に合(あ)う"
+        ]
     },
     {
         "name": "saraigetsu",
         "trans": [
+            "さ来月(らいげつ)",
             "the month after next"
-        ],
-        "notation": "さ来月(らいげつ)"
+        ]
     },
     {
         "name": "suteeki",
         "trans": [
+            "ステーキ",
             "steak"
-        ],
-        "notation": "ステーキ"
+        ]
     },
     {
         "name": "mitsukaru",
         "trans": [
+            "見(み)つかる",
             "to be discovered"
-        ],
-        "notation": "見(み)つかる"
+        ]
     },
     {
         "name": "keikaku",
         "trans": [
+            "計画(けいかく)",
             "to plan"
-        ],
-        "notation": "計画(けいかく)"
+        ]
     },
     {
         "name": "mukaeru",
         "trans": [
+            "迎(むか)える",
             "to go out to meet"
-        ],
-        "notation": "迎(むか)える"
+        ]
     },
     {
         "name": "kanojo",
         "trans": [
+            "彼女(かのじょ)",
             "she,girlfriend"
-        ],
-        "notation": "彼女(かのじょ)"
+        ]
     },
     {
         "name": "igai",
         "trans": [
+            "以外(いがい)",
             "with the exception of"
-        ],
-        "notation": "以外(いがい)"
+        ]
     },
     {
         "name": "kamu",
         "trans": [
+            "噛(か)む",
             "to bite,to chew"
-        ],
-        "notation": "噛(か)む"
+        ]
     },
     {
         "name": "miso",
         "trans": [
+            "味噌(みそ)",
             "bean paste"
-        ],
-        "notation": "味噌(みそ)"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "葉(は)",
             "leaf"
-        ],
-        "notation": "葉(は)"
+        ]
     },
     {
         "name": "koujou",
         "trans": [
+            "工場(こうじょう)",
             "factory"
-        ],
-        "notation": "工場(こうじょう)"
+        ]
     },
     {
         "name": "kazaru",
         "trans": [
+            "飾(かざ)る",
             "to decorate"
-        ],
-        "notation": "飾(かざ)る"
+        ]
     },
     {
         "name": "tsuki",
         "trans": [
+            "つき",
             "moon"
-        ],
-        "notation": "つき"
+        ]
     },
     {
         "name": "koumuin",
         "trans": [
+            "公務員(こうむいん)",
             "government worker"
-        ],
-        "notation": "公務員(こうむいん)"
+        ]
     },
     {
         "name": "kikoeru",
         "trans": [
+            "聞(き)こえる",
             "to be heard"
-        ],
-        "notation": "聞(き)こえる"
+        ]
     },
     {
         "name": "naruhodo",
         "trans": [
+            "なるほど",
             "now I understand"
-        ],
-        "notation": "なるほど"
+        ]
     },
     {
         "name": "itadaku",
         "trans": [
+            "いただく",
             "(humble) to receive"
-        ],
-        "notation": "いただく"
+        ]
     },
     {
         "name": "chi",
         "trans": [
+            "血(ち)",
             "blood"
-        ],
-        "notation": "血(ち)"
+        ]
     },
     {
         "name": "tekitou",
         "trans": [
+            "適当(てきとう)",
             "suitability"
-        ],
-        "notation": "適当(てきとう)"
+        ]
     },
     {
         "name": "tsutsumu",
         "trans": [
+            "包(つつ)む",
             "to wrap"
-        ],
-        "notation": "包(つつ)む"
+        ]
     },
     {
         "name": "niru",
         "trans": [
+            "似(に)る",
             "to be similar"
-        ],
-        "notation": "似(に)る"
+        ]
     },
     {
         "name": "undou",
         "trans": [
+            "運動(うんどう)",
             "to exercise"
-        ],
-        "notation": "運動(うんどう)"
+        ]
     },
     {
         "name": "mori",
         "trans": [
+            "森(もり)",
             "forest"
-        ],
-        "notation": "森(もり)"
+        ]
     },
     {
         "name": "shinsetsu",
         "trans": [
+            "親切(しんせつ)",
             "kindness"
-        ],
-        "notation": "親切(しんせつ)"
+        ]
     },
     {
         "name": "tebukuro",
         "trans": [
+            "手袋(てぶくろ)",
             "glove"
-        ],
-        "notation": "手袋(てぶくろ)"
+        ]
     },
     {
         "name": "kougai",
         "trans": [
+            "郊外(こうがい)",
             "outskirts"
-        ],
-        "notation": "郊外(こうがい)"
+        ]
     },
     {
         "name": "nigai",
         "trans": [
+            "苦(にが)い",
             "bitter"
-        ],
-        "notation": "苦(にが)い"
+        ]
     },
     {
         "name": "hoshi",
         "trans": [
+            "星(ほし)",
             "star"
-        ],
-        "notation": "星(ほし)"
+        ]
     },
     {
         "name": "tsumori",
         "trans": [
+            "つもり",
             "intention"
-        ],
-        "notation": "つもり"
+        ]
     },
     {
         "name": "dakara",
         "trans": [
+            "だから",
             "so,therefore"
-        ],
-        "notation": "だから"
+        ]
     },
     {
         "name": "koukousei",
         "trans": [
+            "高校生(こうこうせい)",
             "high school student"
-        ],
-        "notation": "高校生(こうこうせい)"
+        ]
     },
     {
         "name": "mawaru",
         "trans": [
+            "回(まわ)る",
             "to go around"
-        ],
-        "notation": "回(まわ)る"
+        ]
     },
     {
         "name": "ukagau",
         "trans": [
+            "うかがう",
             "to visit"
-        ],
-        "notation": "うかがう"
+        ]
     },
     {
         "name": "anna",
         "trans": [
+            "あんな",
             "such"
-        ],
-        "notation": "あんな"
+        ]
     },
     {
         "name": "katazukeru",
         "trans": [
+            "片付(かたづ)ける",
             "to tidy up"
-        ],
-        "notation": "片付(かたづ)ける"
+        ]
     },
     {
         "name": "shiraseru",
         "trans": [
+            "知(し)らせる",
             "to notify"
-        ],
-        "notation": "知(し)らせる"
+        ]
     },
     {
         "name": "juusho",
         "trans": [
+            "住所(じゅうしょ)",
             "an address,a residence"
-        ],
-        "notation": "住所(じゅうしょ)"
+        ]
     },
     {
         "name": "kaigan",
         "trans": [
+            "海岸(かいがん)",
             "coast"
-        ],
-        "notation": "海岸(かいがん)"
+        ]
     },
     {
         "name": "sodateru",
         "trans": [
+            "育(そだ)てる",
             "to rear,to bring up"
-        ],
-        "notation": "育(そだ)てる"
+        ]
     },
     {
         "name": "shumi",
         "trans": [
+            "趣味(しゅみ)",
             "hobby"
-        ],
-        "notation": "趣味(しゅみ)"
+        ]
     },
     {
         "name": "tokubetsu",
         "trans": [
+            "特別(とくべつ)",
             "special"
-        ],
-        "notation": "特別(とくべつ)"
+        ]
     },
     {
         "name": "kou",
         "trans": [
+            "こう",
             "this way"
-        ],
-        "notation": "こう"
+        ]
     },
     {
         "name": "mitsukeru",
         "trans": [
+            "見(み)つける",
             "to discover"
-        ],
-        "notation": "見(み)つける"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "付(つ)く",
             "to be attached"
-        ],
-        "notation": "付(つ)く"
+        ]
     },
     {
         "name": "asobi",
         "trans": [
+            "遊(あそ)び",
             "play"
-        ],
-        "notation": "遊(あそ)び"
+        ]
     },
     {
         "name": "sakan",
         "trans": [
+            "盛(さか)ん",
             "popularity,prosperous"
-        ],
-        "notation": "盛(さか)ん"
+        ]
     },
     {
         "name": "shokuryouhin",
         "trans": [
+            "食料(しょくりょう)品(ひん)",
             "groceries"
-        ],
-        "notation": "食料(しょくりょう)品(ひん)"
+        ]
     },
     {
         "name": "hidoi",
         "trans": [
+            "ひどい",
             "awful"
-        ],
-        "notation": "ひどい"
+        ]
     },
     {
         "name": "morau",
         "trans": [
+            "もらう",
             "to receive"
-        ],
-        "notation": "もらう"
+        ]
     },
     {
         "name": "gasorinsutando",
         "trans": [
+            "ガソリンスタンド",
             "petrol station"
-        ],
-        "notation": "ガソリンスタンド"
+        ]
     },
     {
         "name": "nikaidate",
         "trans": [
+            "二(に)階(かい)建(だ)て",
             "two storied"
-        ],
-        "notation": "二(に)階(かい)建(だ)て"
+        ]
     },
     {
         "name": "yu",
         "trans": [
+            "湯(ゆ)",
             "hot water"
-        ],
-        "notation": "湯(ゆ)"
+        ]
     },
     {
         "name": "kureru",
         "trans": [
+            "暮(く)れる",
             "to get dark,to come to an end"
-        ],
-        "notation": "暮(く)れる"
+        ]
     },
     {
         "name": "torikaeru",
         "trans": [
+            "取(と)り替(か)える",
             "to exchange"
-        ],
-        "notation": "取(と)り替(か)える"
+        ]
     },
     {
         "name": "omimai",
         "trans": [
+            "お見舞(みま)い",
             "calling on someone who is ill,enquiry"
-        ],
-        "notation": "お見舞(みま)い"
+        ]
     },
     {
         "name": "shokuji",
         "trans": [
+            "食事(しょくじ)",
             "to have a meal"
-        ],
-        "notation": "食事(しょくじ)"
+        ]
     },
     {
         "name": "omiyage",
         "trans": [
+            "お土産(みやげ)",
             "souvenir"
-        ],
-        "notation": "お土産(みやげ)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "止(と)める",
             "to stop something"
-        ],
-        "notation": "止(と)める"
+        ]
     },
     {
         "name": "nakanaka",
         "trans": [
+            "中々(なかなか)",
             "considerably"
-        ],
-        "notation": "中々(なかなか)"
+        ]
     },
     {
         "name": "karera",
         "trans": [
+            "彼(かれ)ら",
             "they"
-        ],
-        "notation": "彼(かれ)ら"
+        ]
     },
     {
         "name": "wakasu",
         "trans": [
+            "沸(わ)かす",
             "to boil,to heat"
-        ],
-        "notation": "沸(わ)かす"
+        ]
     },
     {
         "name": "shippai",
         "trans": [
+            "失敗(しっぱい)",
             "failure,mistake"
-        ],
-        "notation": "失敗(しっぱい)"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "沸(わ)く",
             "to boil, to grow hot,to get excited"
-        ],
-        "notation": "沸(わ)く"
+        ]
     },
     {
         "name": "naku",
         "trans": [
+            "泣(な)く",
             "to weep"
-        ],
-        "notation": "泣(な)く"
+        ]
     },
     {
         "name": "junbi",
         "trans": [
+            "準備(じゅんび)",
             "to prepare"
-        ],
-        "notation": "準備(じゅんび)"
+        ]
     },
     {
         "name": "tazuneru",
         "trans": [
+            "訪(たず)ねる",
             "to visit"
-        ],
-        "notation": "訪(たず)ねる"
+        ]
     },
     {
         "name": "omoidasu",
         "trans": [
+            "思(おも)い出(だ)す",
             "to remember"
-        ],
-        "notation": "思(おも)い出(だ)す"
+        ]
     },
     {
         "name": "keiken",
         "trans": [
+            "経験(けいけん)",
             "to experience"
-        ],
-        "notation": "経験(けいけん)"
+        ]
     },
     {
         "name": "guai",
         "trans": [
+            "具合(ぐあい)",
             "condition,health"
-        ],
-        "notation": "具合(ぐあい)"
+        ]
     },
     {
         "name": "yawarakai",
         "trans": [
+            "柔(やわ)らかい",
             "soft"
-        ],
-        "notation": "柔(やわ)らかい"
+        ]
     },
     {
         "name": "ko",
         "trans": [
+            "子(こ)",
             "child"
-        ],
-        "notation": "子(こ)"
+        ]
     },
     {
         "name": "naoru",
         "trans": [
+            "直(なお)る",
             "to be fixed,to be repaired"
-        ],
-        "notation": "直(なお)る"
+        ]
     },
     {
         "name": "jidai",
         "trans": [
+            "時代(じだい)",
             "era"
-        ],
-        "notation": "時代(じだい)"
+        ]
     },
     {
         "name": "kowareru",
         "trans": [
+            "壊(こわ)れる",
             "to be broken"
-        ],
-        "notation": "壊(こわ)れる"
+        ]
     },
     {
         "name": "mina",
         "trans": [
+            "皆(みな)",
             "everybody"
-        ],
-        "notation": "皆(みな)"
+        ]
     },
     {
         "name": "oriru",
         "trans": [
+            "下(お)りる",
             "to get off"
-        ],
-        "notation": "下(お)りる"
+        ]
     },
     {
         "name": "ayamaru",
         "trans": [
+            "謝(あやま)る",
             "to apologize"
-        ],
-        "notation": "謝(あやま)る"
+        ]
     },
     {
         "name": "bijutsukan",
         "trans": [
+            "美術館(びじゅつかん)",
             "art gallery"
-        ],
-        "notation": "美術館(びじゅつかん)"
+        ]
     },
     {
         "name": "yakeru",
         "trans": [
+            "焼(や)ける",
             "to burn,to be roasted"
-        ],
-        "notation": "焼(や)ける"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "市(し)",
             "city"
-        ],
-        "notation": "市(し)"
+        ]
     },
     {
         "name": "waapuro",
         "trans": [
+            "ワープロ",
             "word processor"
-        ],
-        "notation": "ワープロ"
+        ]
     },
     {
         "name": "mushi",
         "trans": [
+            "虫(むし)",
             "insect"
-        ],
-        "notation": "虫(むし)"
+        ]
     },
     {
         "name": "tsuzukeru",
         "trans": [
+            "続(つづ)ける",
             "to continue"
-        ],
-        "notation": "続(つづ)ける"
+        ]
     },
     {
         "name": "koutsuu",
         "trans": [
+            "交通(こうつう)",
             "traffic,transportation"
-        ],
-        "notation": "交通(こうつう)"
+        ]
     },
     {
         "name": "tetsudau",
         "trans": [
+            "手伝(てつだ)う",
             "to assist"
-        ],
-        "notation": "手伝(てつだ)う"
+        ]
     },
     {
         "name": "bunka",
         "trans": [
+            "文化(ぶんか)",
             "culture"
-        ],
-        "notation": "文化(ぶんか)"
+        ]
     },
     {
         "name": "kaeri",
         "trans": [
+            "帰(かえ)り",
             "return"
-        ],
-        "notation": "帰(かえ)り"
+        ]
     },
     {
         "name": "isogu",
         "trans": [
+            "急(いそ)ぐ",
             "to hurry"
-        ],
-        "notation": "急(いそ)ぐ"
+        ]
     },
     {
         "name": "hotondo",
         "trans": [
+            "ほとんど",
             "mostly"
-        ],
-        "notation": "ほとんど"
+        ]
     },
     {
         "name": "hitsuyou",
         "trans": [
+            "必要(ひつよう)",
             "necessary"
-        ],
-        "notation": "必要(ひつよう)"
+        ]
     },
     {
         "name": "sofu",
         "trans": [
+            "祖父(そふ)",
             "grandfather"
-        ],
-        "notation": "祖父(そふ)"
+        ]
     },
     {
         "name": "jinja",
         "trans": [
+            "神社(じんじゃ)",
             "Shinto shrine"
-        ],
-        "notation": "神社(じんじゃ)"
+        ]
     },
     {
         "name": "boueki",
         "trans": [
+            "貿易(ぼうえき)",
             "trade"
-        ],
-        "notation": "貿易(ぼうえき)"
+        ]
     },
     {
         "name": "betsu",
         "trans": [
+            "別(べつ)",
             "different"
-        ],
-        "notation": "別(べつ)"
+        ]
     },
     {
         "name": "tenkiyohou",
         "trans": [
+            "天気(てんき)予報(よほう)",
             "weather forecast"
-        ],
-        "notation": "天気(てんき)予報(よほう)"
+        ]
     },
     {
         "name": "tokkyuu",
         "trans": [
+            "特急(とっきゅう)",
             "limited express train (faster than an express train)"
-        ],
-        "notation": "特急(とっきゅう)"
+        ]
     },
     {
         "name": "o/kanemochi",
         "trans": [
+            "お・金持(かねも)ち",
             "rich man"
-        ],
-        "notation": "お・金持(かねも)ち"
+        ]
     },
     {
         "name": "hiraku",
         "trans": [
+            "開(ひら)く",
             "to open an event"
-        ],
-        "notation": "開(ひら)く"
+        ]
     },
     {
         "name": "ichido",
         "trans": [
+            "一(いち)度(ど)",
             "once"
-        ],
-        "notation": "一(いち)度(ど)"
+        ]
     },
     {
         "name": "dekirudake",
         "trans": [
+            "できるだけ",
             "as much as possible"
-        ],
-        "notation": "できるだけ"
+        ]
     },
     {
         "name": "okureru",
         "trans": [
+            "遅(おく)れる",
             "to be late"
-        ],
-        "notation": "遅(おく)れる"
+        ]
     },
     {
         "name": "hajimeru",
         "trans": [
+            "始(はじ)める",
             "to begin"
-        ],
-        "notation": "始(はじ)める"
+        ]
     },
     {
         "name": "a",
         "trans": [
+            "あ",
             "Ah"
-        ],
-        "notation": "あ"
+        ]
     },
     {
         "name": "taipu",
         "trans": [
+            "タイプ",
             "type,style"
-        ],
-        "notation": "タイプ"
+        ]
     },
     {
         "name": "repouto/ripouto",
         "trans": [
+            "レポート/リポート",
             "report"
-        ],
-        "notation": "レポート/リポート"
+        ]
     },
     {
         "name": "konya",
         "trans": [
+            "今夜(こんや)",
             "tonight"
-        ],
-        "notation": "今夜(こんや)"
+        ]
     },
     {
         "name": "bai",
         "trans": [
+            "倍(ばい)",
             "double"
-        ],
-        "notation": "倍(ばい)"
+        ]
     },
     {
         "name": "furidasu",
         "trans": [
+            "降(ふ)り出(だ)す",
             "to start to rain"
-        ],
-        "notation": "降(ふ)り出(だ)す"
+        ]
     },
     {
         "name": "mawari",
         "trans": [
+            "周(まわ)り",
             "surroundings"
-        ],
-        "notation": "周(まわ)り"
+        ]
     },
     {
         "name": "suku",
         "trans": [
+            "すく",
             "to become empty"
-        ],
-        "notation": "すく"
+        ]
     },
     {
         "name": "setsumei",
         "trans": [
+            "説明(せつめい)",
             "explanation"
-        ],
-        "notation": "説明(せつめい)"
+        ]
     },
     {
         "name": "bangumi",
         "trans": [
+            "番組(ばんぐみ)",
             "television or radio program"
-        ],
-        "notation": "番組(ばんぐみ)"
+        ]
     },
     {
         "name": "kisoku",
         "trans": [
+            "規則(きそく)",
             "regulations"
-        ],
-        "notation": "規則(きそく)"
+        ]
     },
     {
         "name": "taiin",
         "trans": [
+            "退院(たいいん)",
             "to leave hospital"
-        ],
-        "notation": "退院(たいいん)"
+        ]
     },
     {
         "name": "suiei",
         "trans": [
+            "水泳(すいえい)",
             "swimming"
-        ],
-        "notation": "水泳(すいえい)"
+        ]
     },
     {
         "name": "kouchou",
         "trans": [
+            "校長(こうちょう)",
             "headmaster"
-        ],
-        "notation": "校長(こうちょう)"
+        ]
     },
     {
         "name": "hazukashii",
         "trans": [
+            "恥(は)ずかしい",
             "embarrassed"
-        ],
-        "notation": "恥(は)ずかしい"
+        ]
     },
     {
         "name": "jiten",
         "trans": [
+            "辞典(じてん)",
             "dictionary"
-        ],
-        "notation": "辞典(じてん)"
+        ]
     },
     {
         "name": "hikkosu",
         "trans": [
+            "引(ひ)っ越(こ)す",
             "to move house"
-        ],
-        "notation": "引(ひ)っ越(こ)す"
+        ]
     },
     {
         "name": "danbou",
         "trans": [
+            "暖房(だんぼう)",
             "heating"
-        ],
-        "notation": "暖房(だんぼう)"
+        ]
     },
     {
         "name": "fukushuu",
         "trans": [
+            "復習(ふくしゅう)",
             "revision"
-        ],
-        "notation": "復習(ふくしゅう)"
+        ]
     },
     {
         "name": "meshiagaru",
         "trans": [
+            "召(め)し上(あ)がる",
             "(polite) to eat"
-        ],
-        "notation": "召(め)し上(あ)がる"
+        ]
     },
     {
         "name": "kawaku",
         "trans": [
+            "乾(かわ)く",
             "to get dry"
-        ],
-        "notation": "乾(かわ)く"
+        ]
     },
     {
         "name": "sensou",
         "trans": [
+            "戦争(せんそう)",
             "war"
-        ],
-        "notation": "戦争(せんそう)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "泊(と)まる",
             "to lodge at"
-        ],
-        "notation": "泊(と)まる"
+        ]
     },
     {
         "name": "kenbutsu",
         "trans": [
+            "見物(けんぶつ)",
             "sightseeing"
-        ],
-        "notation": "見物(けんぶつ)"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "教会(きょうかい)",
             "church"
-        ],
-        "notation": "教会(きょうかい)"
+        ]
     },
     {
         "name": "sugoi",
         "trans": [
+            "凄(すご)い",
             "terrific"
-        ],
-        "notation": "凄(すご)い"
+        ]
     },
     {
         "name": "eda",
         "trans": [
+            "枝(えだ)",
             "branch, twig"
-        ],
-        "notation": "枝(えだ)"
+        ]
     },
     {
         "name": "mukau",
         "trans": [
+            "向(む)かう",
             "to face"
-        ],
-        "notation": "向(む)かう"
+        ]
     },
     {
         "name": "yamu",
         "trans": [
+            "止(や)む",
             "to stop"
-        ],
-        "notation": "止(や)む"
+        ]
     },
     {
         "name": "tateru",
         "trans": [
+            "建(た)てる",
             "to build"
-        ],
-        "notation": "建(た)てる"
+        ]
     },
     {
         "name": "yume",
         "trans": [
+            "夢(ゆめ)",
             "dream"
-        ],
-        "notation": "夢(ゆめ)"
+        ]
     },
     {
         "name": "shikata",
         "trans": [
+            "仕方(しかた)",
             "method"
-        ],
-        "notation": "仕方(しかた)"
+        ]
     },
     {
         "name": "shikkari",
         "trans": [
+            "しっかり",
             "firmly,steadily"
-        ],
-        "notation": "しっかり"
+        ]
     },
     {
         "name": "sewa",
         "trans": [
+            "世話(せわ)",
             "to look after"
-        ],
-        "notation": "世話(せわ)"
+        ]
     },
     {
         "name": "fukai",
         "trans": [
+            "深(ふか)い",
             "deep"
-        ],
-        "notation": "深(ふか)い"
+        ]
     },
     {
         "name": "mezurashii",
         "trans": [
+            "珍(めずら)しい",
             "rare"
-        ],
-        "notation": "珍(めずら)しい"
+        ]
     },
     {
         "name": "koto",
         "trans": [
+            "こと",
             "thing,matter"
-        ],
-        "notation": "こと"
+        ]
     },
     {
         "name": "suna",
         "trans": [
+            "砂(すな)",
             "sand"
-        ],
-        "notation": "砂(すな)"
+        ]
     },
     {
         "name": "hantai",
         "trans": [
+            "反対(はんたい)",
             "opposition"
-        ],
-        "notation": "反対(はんたい)"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "気(き)",
             "spirit,mood"
-        ],
-        "notation": "気(き)"
+        ]
     },
     {
         "name": "musume",
         "trans": [
+            "娘(むすめ)",
             "(humble) daughter"
-        ],
-        "notation": "娘(むすめ)"
+        ]
     },
     {
         "name": "kaigishitsu",
         "trans": [
+            "会議(かいぎ)室(しつ)",
             "meeting room"
-        ],
-        "notation": "会議(かいぎ)室(しつ)"
+        ]
     },
     {
         "name": "ooita",
         "trans": [
+            "大分(おおいた)",
             "greatly"
-        ],
-        "notation": "大分(おおいた)"
+        ]
     },
     {
         "name": "shougakkou",
         "trans": [
+            "小学校(しょうがっこう)",
             "elementary school"
-        ],
-        "notation": "小学校(しょうがっこう)"
+        ]
     },
     {
         "name": "nakunaru",
         "trans": [
+            "無(な)くなる",
             "to disappear,to get lost"
-        ],
-        "notation": "無(な)くなる"
+        ]
     },
     {
         "name": "inoru",
         "trans": [
+            "祈(いの)る",
             "to pray"
-        ],
-        "notation": "祈(いの)る"
+        ]
     },
     {
         "name": "erabu",
         "trans": [
+            "選(えら)ぶ",
             "to choose"
-        ],
-        "notation": "選(えら)ぶ"
+        ]
     },
     {
         "name": "aji",
         "trans": [
+            "味(あじ)",
             "flavour"
-        ],
-        "notation": "味(あじ)"
+        ]
     },
     {
         "name": "hazu",
         "trans": [
+            "はず",
             "it should be so"
-        ],
-        "notation": "はず"
+        ]
     },
     {
         "name": "dondon",
         "trans": [
+            "どんどん",
             "more and more"
-        ],
-        "notation": "どんどん"
+        ]
     },
     {
         "name": "machigaeru",
         "trans": [
+            "間違(まちが)える",
             "to make a mistake"
-        ],
-        "notation": "間違(まちが)える"
+        ]
     },
     {
         "name": "sageru",
         "trans": [
+            "下(さ)げる",
             "to hang,to lower,to move back"
-        ],
-        "notation": "下(さ)げる"
+        ]
     },
     {
         "name": "goshujin",
         "trans": [
+            "御(ご)主人(しゅじん)",
             "(honorable) your husband"
-        ],
-        "notation": "御(ご)主人(しゅじん)"
+        ]
     },
     {
         "name": "konoaida",
         "trans": [
+            "このあいだ",
             "the other day,recently"
-        ],
-        "notation": "このあいだ"
+        ]
     },
     {
         "name": "zehi",
         "trans": [
+            "ぜひ",
             "without fail"
-        ],
-        "notation": "ぜひ"
+        ]
     },
     {
         "name": "modoru",
         "trans": [
+            "戻(もど)る",
             "to turn back"
-        ],
-        "notation": "戻(もど)る"
+        ]
     }
 ]

--- a/assets/dicts/JapVocabList.N5.json
+++ b/assets/dicts/JapVocabList.N5.json
@@ -2,4684 +2,4684 @@
     {
         "name": "donata",
         "trans": [
+            "どなた",
             "who"
-        ],
-        "notation": "どなた"
+        ]
     },
     {
         "name": "otokonoko",
         "trans": [
+            "男(おとこ)の子(こ)",
             "Boy"
-        ],
-        "notation": "男(おとこ)の子(こ)"
+        ]
     },
     {
         "name": "nana",
         "trans": [
+            "七(なな)",
             "Seven"
-        ],
-        "notation": "七(なな)"
+        ]
     },
     {
         "name": "bangou",
         "trans": [
+            "番号(ばんごう)",
             "number"
-        ],
-        "notation": "番号(ばんごう)"
+        ]
     },
     {
         "name": "docchi",
         "trans": [
+            "どっち",
             "which"
-        ],
-        "notation": "どっち"
+        ]
     },
     {
         "name": "shio",
         "trans": [
+            "塩(しお)",
             "Salt"
-        ],
-        "notation": "塩(しお)"
+        ]
     },
     {
         "name": "nado",
         "trans": [
+            "など",
             "et cetera"
-        ],
-        "notation": "など"
+        ]
     },
     {
         "name": "furui",
         "trans": [
+            "古(ふる)い",
             "old (not used for people)"
-        ],
-        "notation": "古(ふる)い"
+        ]
     },
     {
         "name": "resutoran",
         "trans": [
+            "レストラン",
             "restaurant"
-        ],
-        "notation": "レストラン"
+        ]
     },
     {
         "name": "sukunai",
         "trans": [
+            "少(すく)ない",
             "a few"
-        ],
-        "notation": "少(すく)ない"
+        ]
     },
     {
         "name": "tsuyoi",
         "trans": [
+            "強(つよ)い",
             "powerful"
-        ],
-        "notation": "強(つよ)い"
+        ]
     },
     {
         "name": "yobu",
         "trans": [
+            "呼(よ)ぶ",
             "to call out,to invite"
-        ],
-        "notation": "呼(よ)ぶ"
+        ]
     },
     {
         "name": "kakekakaru",
         "trans": [
+            "掛(かけ)かかる",
             "to take time or money"
-        ],
-        "notation": "掛(かけ)かかる"
+        ]
     },
     {
         "name": "kouban",
         "trans": [
+            "交番(こうばん)",
             "police box"
-        ],
-        "notation": "交番(こうばん)"
+        ]
     },
     {
         "name": "atama",
         "trans": [
+            "頭(あたま)",
             "head"
-        ],
-        "notation": "頭(あたま)"
+        ]
     },
     {
         "name": "doko",
         "trans": [
+            "どこ",
             "where"
-        ],
-        "notation": "どこ"
+        ]
     },
     {
         "name": "jisho",
         "trans": [
+            "辞書(じしょ)",
             "Dictionary"
-        ],
-        "notation": "辞書(じしょ)"
+        ]
     },
     {
         "name": "ookina",
         "trans": [
+            "大(おお)きな",
             "big"
-        ],
-        "notation": "大(おお)きな"
+        ]
     },
     {
         "name": "maitsuki",
         "trans": [
+            "毎月(まいつき)",
             "every month"
-        ],
-        "notation": "毎月(まいつき)"
+        ]
     },
     {
         "name": "taisei",
         "trans": [
+            "大勢(たいせい)",
             "great number of people"
-        ],
-        "notation": "大勢(たいせい)"
+        ]
     },
     {
         "name": "marui/marui",
         "trans": [
+            "丸(まる)い/円(まる)い",
             "round,circular"
-        ],
-        "notation": "丸(まる)い/円(まる)い"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "角(かく)",
             "a corner"
-        ],
-        "notation": "角(かく)"
+        ]
     },
     {
         "name": "daisuki",
         "trans": [
+            "大好(だいす)き",
             "to be very likeable"
-        ],
-        "notation": "大好(だいす)き"
+        ]
     },
     {
         "name": "takusan",
         "trans": [
+            "たくさん",
             "many"
-        ],
-        "notation": "たくさん"
+        ]
     },
     {
         "name": "watashi",
         "trans": [
+            "私(わたし)",
             "(humble) I,myself"
-        ],
-        "notation": "私(わたし)"
+        ]
     },
     {
         "name": "mono",
         "trans": [
+            "物(もの)",
             "thing"
-        ],
-        "notation": "物(もの)"
+        ]
     },
     {
         "name": "yama",
         "trans": [
+            "山(やま)",
             "mountain"
-        ],
-        "notation": "山(やま)"
+        ]
     },
     {
         "name": "tori",
         "trans": [
+            "鳥(とり)",
             "bird"
-        ],
-        "notation": "鳥(とり)"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "上(あ)げる",
             "to give"
-        ],
-        "notation": "上(あ)げる"
+        ]
     },
     {
         "name": "taihen",
         "trans": [
+            "大変(たいへん)",
             "difficult situation"
-        ],
-        "notation": "大変(たいへん)"
+        ]
     },
     {
         "name": "oishii",
         "trans": [
+            "おいしい",
             "delicious"
-        ],
-        "notation": "おいしい"
+        ]
     },
     {
         "name": "gaikoku",
         "trans": [
+            "外国(がいこく)",
             "foreign country"
-        ],
-        "notation": "外国(がいこく)"
+        ]
     },
     {
         "name": "kaze",
         "trans": [
+            "風邪(かぜ)",
             "a cold"
-        ],
-        "notation": "風邪(かぜ)"
+        ]
     },
     {
         "name": "onnanoko",
         "trans": [
+            "女(おんな)の子(こ)",
             "Girl"
-        ],
-        "notation": "女(おんな)の子(こ)"
+        ]
     },
     {
         "name": "oriru",
         "trans": [
+            "降(お)りる",
             "to get off, to descend"
-        ],
-        "notation": "降(お)りる"
+        ]
     },
     {
         "name": "ushiro",
         "trans": [
+            "後(うし)ろ",
             "behind"
-        ],
-        "notation": "後(うし)ろ"
+        ]
     },
     {
         "name": "tanomu",
         "trans": [
+            "頼(たの)む",
             "to ask"
-        ],
-        "notation": "頼(たの)む"
+        ]
     },
     {
         "name": "atsui",
         "trans": [
+            "熱(あつ)い",
             "hot to the touch"
-        ],
-        "notation": "熱(あつ)い"
+        ]
     },
     {
         "name": "okiru",
         "trans": [
+            "起(お)きる",
             "to get up"
-        ],
-        "notation": "起(お)きる"
+        ]
     },
     {
         "name": "depaato",
         "trans": [
+            "デパート",
             "department store"
-        ],
-        "notation": "デパート"
+        ]
     },
     {
         "name": "nananichi",
         "trans": [
+            "七(なな)日(にち)",
             "seven days,the seventh day"
-        ],
-        "notation": "七(なな)日(にち)"
+        ]
     },
     {
         "name": "kiru",
         "trans": [
+            "切(き)る",
             "to cut"
-        ],
-        "notation": "切(き)る"
+        ]
     },
     {
         "name": "minami",
         "trans": [
+            "南(みなみ)",
             "south"
-        ],
-        "notation": "南(みなみ)"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "箸(はし)",
             "chopsticks"
-        ],
-        "notation": "箸(はし)"
+        ]
     },
     {
         "name": "takushii",
         "trans": [
+            "タクシー",
             "taxi"
-        ],
-        "notation": "タクシー"
+        ]
     },
     {
         "name": "yuubinkyoku",
         "trans": [
+            "郵便(ゆうびん)局(きょく)",
             "post office"
-        ],
-        "notation": "郵便(ゆうびん)局(きょく)"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "紙(かみ)",
             "paper"
-        ],
-        "notation": "紙(かみ)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "勤(つと)める",
             "to work for someone"
-        ],
-        "notation": "勤(つと)める"
+        ]
     },
     {
         "name": "hashiru",
         "trans": [
+            "走(はし)る",
             "to run"
-        ],
-        "notation": "走(はし)る"
+        ]
     },
     {
         "name": "teepu",
         "trans": [
+            "テープ",
             "tape"
-        ],
-        "notation": "テープ"
+        ]
     },
     {
         "name": "uwagi",
         "trans": [
+            "上着(うわぎ)",
             "jacket"
-        ],
-        "notation": "上着(うわぎ)"
+        ]
     },
     {
         "name": "miseru",
         "trans": [
+            "見(み)せる",
             "to show"
-        ],
-        "notation": "見(み)せる"
+        ]
     },
     {
         "name": "watasu",
         "trans": [
+            "渡(わた)す",
             "to hand over"
-        ],
-        "notation": "渡(わた)す"
+        ]
     },
     {
         "name": "zenbu",
         "trans": [
+            "全部(ぜんぶ)",
             "All"
-        ],
-        "notation": "全部(ぜんぶ)"
+        ]
     },
     {
         "name": "ototoi",
         "trans": [
+            "一昨日(おととい)",
             "day before yesterday"
-        ],
-        "notation": "一昨日(おととい)"
+        ]
     },
     {
         "name": "osara",
         "trans": [
+            "お皿(さら)",
             "plate, dish"
-        ],
-        "notation": "お皿(さら)"
+        ]
     },
     {
         "name": "maiasa",
         "trans": [
+            "毎朝(まいあさ)",
             "every morning"
-        ],
-        "notation": "毎朝(まいあさ)"
+        ]
     },
     {
         "name": "asatte",
         "trans": [
+            "あさって",
             "day after tomorrow"
-        ],
-        "notation": "あさって"
+        ]
     },
     {
         "name": "kagi",
         "trans": [
+            "鍵(かぎ)",
             "Key"
-        ],
-        "notation": "鍵(かぎ)"
+        ]
     },
     {
         "name": "ojunmawarisan",
         "trans": [
+            "お巡(じゅん)まわりさん",
             "friendly term for policeman"
-        ],
-        "notation": "お巡(じゅん)まわりさん"
+        ]
     },
     {
         "name": "jitensha",
         "trans": [
+            "自転車(じてんしゃ)",
             "Bicycle"
-        ],
-        "notation": "自転車(じてんしゃ)"
+        ]
     },
     {
         "name": "kumori",
         "trans": [
+            "曇(くも)り",
             "cloudy weather"
-        ],
-        "notation": "曇(くも)り"
+        ]
     },
     {
         "name": "kawaii",
         "trans": [
+            "可愛(かわい)い",
             "Cute"
-        ],
-        "notation": "可愛(かわい)い"
+        ]
     },
     {
         "name": "sore",
         "trans": [
+            "それ",
             "that"
-        ],
-        "notation": "それ"
+        ]
     },
     {
         "name": "kyoushitsu",
         "trans": [
+            "教室(きょうしつ)",
             "Classroom"
-        ],
-        "notation": "教室(きょうしつ)"
+        ]
     },
     {
         "name": "puuru",
         "trans": [
+            "プール",
             "swimming pool"
-        ],
-        "notation": "プール"
+        ]
     },
     {
         "name": "mimi",
         "trans": [
+            "耳(みみ)",
             "ear"
-        ],
-        "notation": "耳(みみ)"
+        ]
     },
     {
         "name": "dasu",
         "trans": [
+            "出(だ)す",
             "to put out"
-        ],
-        "notation": "出(だ)す"
+        ]
     },
     {
         "name": "konna",
         "trans": [
+            "こんな",
             "Such"
-        ],
-        "notation": "こんな"
+        ]
     },
     {
         "name": "hanbun",
         "trans": [
+            "半分(はんぶん)",
             "half minute"
-        ],
-        "notation": "半分(はんぶん)"
+        ]
     },
     {
         "name": "futoi",
         "trans": [
+            "太(ふと)い",
             "fat"
-        ],
-        "notation": "太(ふと)い"
+        ]
     },
     {
         "name": "mokuyoubi",
         "trans": [
+            "木曜日(もくようび)",
             "Thursday"
-        ],
-        "notation": "木曜日(もくようび)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "書(か)く",
             "to write"
-        ],
-        "notation": "書(か)く"
+        ]
     },
     {
         "name": "ryuugakusei",
         "trans": [
+            "留学生(りゅうがくせい)",
             "overseas student"
-        ],
-        "notation": "留学生(りゅうがくせい)"
+        ]
     },
     {
         "name": "suiyoubi",
         "trans": [
+            "水曜日(すいようび)",
             "Wednesday"
-        ],
-        "notation": "水曜日(すいようび)"
+        ]
     },
     {
         "name": "tsukuru",
         "trans": [
+            "作(つく)る",
             "to make"
-        ],
-        "notation": "作(つく)る"
+        ]
     },
     {
         "name": "bataa",
         "trans": [
+            "バター",
             "butter"
-        ],
-        "notation": "バター"
+        ]
     },
     {
         "name": "hagaki",
         "trans": [
+            "葉書(はがき)",
             "postcard"
-        ],
-        "notation": "葉書(はがき)"
+        ]
     },
     {
         "name": "ichinichi",
         "trans": [
+            "一(いち)日(にち)",
             "first of the month"
-        ],
-        "notation": "一(いち)日(にち)"
+        ]
     },
     {
         "name": "fouku",
         "trans": [
+            "フォーク",
             "fork"
-        ],
-        "notation": "フォーク"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "取(と)る",
             "to take something"
-        ],
-        "notation": "取(と)る"
+        ]
     },
     {
         "name": "saa",
         "trans": [
+            "さあ",
             "well…"
-        ],
-        "notation": "さあ"
+        ]
     },
     {
         "name": "niku",
         "trans": [
+            "肉(にく)",
             "meat"
-        ],
-        "notation": "肉(にく)"
+        ]
     },
     {
         "name": "toshokan",
         "trans": [
+            "図書館(としょかん)",
             "library"
-        ],
-        "notation": "図書館(としょかん)"
+        ]
     },
     {
         "name": "nichiyoubi",
         "trans": [
+            "日曜日(にちようび)",
             "Sunday"
-        ],
-        "notation": "日曜日(にちようび)"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "下(した)",
             "Below"
-        ],
-        "notation": "下(した)"
+        ]
     },
     {
         "name": "heta",
         "trans": [
+            "下手(へた)",
             "unskillful"
-        ],
-        "notation": "下手(へた)"
+        ]
     },
     {
         "name": "usui",
         "trans": [
+            "薄(うす)い",
             "thin,weak"
-        ],
-        "notation": "薄(うす)い"
+        ]
     },
     {
         "name": "kocchi",
         "trans": [
+            "こっち",
             "this person or way"
-        ],
-        "notation": "こっち"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "差(さ)す",
             "to stretch out hands, to raise an umbrella"
-        ],
-        "notation": "差(さ)す"
+        ]
     },
     {
         "name": "tamago",
         "trans": [
+            "卵(たまご)",
             "egg"
-        ],
-        "notation": "卵(たまご)"
+        ]
     },
     {
         "name": "choudo",
         "trans": [
+            "ちょうど",
             "exactly"
-        ],
-        "notation": "ちょうど"
+        ]
     },
     {
         "name": "yuuhan",
         "trans": [
+            "夕飯(ゆうはん)",
             "dinner"
-        ],
-        "notation": "夕飯(ゆうはん)"
+        ]
     },
     {
         "name": "shitsumon",
         "trans": [
+            "質問(しつもん)",
             "Question"
-        ],
-        "notation": "質問(しつもん)"
+        ]
     },
     {
         "name": "achira",
         "trans": [
+            "あちら",
             "there"
-        ],
-        "notation": "あちら"
+        ]
     },
     {
         "name": "ue",
         "trans": [
+            "上(うえ)",
             "on top of"
-        ],
-        "notation": "上(うえ)"
+        ]
     },
     {
         "name": "dekakeru",
         "trans": [
+            "出(で)かける",
             "to go out"
-        ],
-        "notation": "出(で)かける"
+        ]
     },
     {
         "name": "rainen",
         "trans": [
+            "来年(らいねん)",
             "next year"
-        ],
-        "notation": "来年(らいねん)"
+        ]
     },
     {
         "name": "naku",
         "trans": [
+            "鳴(な)く",
             "animal noise. to chirp, roar or croak etc."
-        ],
-        "notation": "鳴(な)く"
+        ]
     },
     {
         "name": "naifu",
         "trans": [
+            "ナイフ",
             "knife"
-        ],
-        "notation": "ナイフ"
+        ]
     },
     {
         "name": "yaru",
         "trans": [
+            "やる",
             "to do"
-        ],
-        "notation": "やる"
+        ]
     },
     {
         "name": "sekken",
         "trans": [
+            "せっけん",
             "Economy"
-        ],
-        "notation": "せっけん"
+        ]
     },
     {
         "name": "iro",
         "trans": [
+            "色(いろ)",
             "colour"
-        ],
-        "notation": "色(いろ)"
+        ]
     },
     {
         "name": "nyuusu",
         "trans": [
+            "ニュース",
             "news"
-        ],
-        "notation": "ニュース"
+        ]
     },
     {
         "name": "iya",
         "trans": [
+            "嫌(いや)",
             "unpleasant"
-        ],
-        "notation": "嫌(いや)"
+        ]
     },
     {
         "name": "benkyou",
         "trans": [
+            "勉強(べんきょう)",
             "to study"
-        ],
-        "notation": "勉強(べんきょう)"
+        ]
     },
     {
         "name": "doubutsu",
         "trans": [
+            "動物(どうぶつ)",
             "animal"
-        ],
-        "notation": "動物(どうぶつ)"
+        ]
     },
     {
         "name": "wasureru",
         "trans": [
+            "忘(わす)れる",
             "to forget"
-        ],
-        "notation": "忘(わす)れる"
+        ]
     },
     {
         "name": "chigau",
         "trans": [
+            "違(ちが)う",
             "to differ"
-        ],
-        "notation": "違(ちが)う"
+        ]
     },
     {
         "name": "koe",
         "trans": [
+            "声(こえ)",
             "Voice"
-        ],
-        "notation": "声(こえ)"
+        ]
     },
     {
         "name": "higashi",
         "trans": [
+            "東(ひがし)",
             "east"
-        ],
-        "notation": "東(ひがし)"
+        ]
     },
     {
         "name": "chizu",
         "trans": [
+            "地図(ちず)",
             "map"
-        ],
-        "notation": "地図(ちず)"
+        ]
     },
     {
         "name": "hako",
         "trans": [
+            "箱(はこ)",
             "box"
-        ],
-        "notation": "箱(はこ)"
+        ]
     },
     {
         "name": "mouichido",
         "trans": [
+            "もう一度(いちど)",
             "again"
-        ],
-        "notation": "もう一度(いちど)"
+        ]
     },
     {
         "name": "kiru",
         "trans": [
+            "着(き)る",
             "to put on from the shoulders down"
-        ],
-        "notation": "着(き)る"
+        ]
     },
     {
         "name": "ashita",
         "trans": [
+            "明日(あした)",
             "tomorrow"
-        ],
-        "notation": "明日(あした)"
+        ]
     },
     {
         "name": "ikaga",
         "trans": [
+            "いかが",
             "how"
-        ],
-        "notation": "いかが"
+        ]
     },
     {
         "name": "maitoshi",
         "trans": [
+            "毎年(まいとし)",
             "every year"
-        ],
-        "notation": "毎年(まいとし)"
+        ]
     },
     {
         "name": "tabako",
         "trans": [
+            "煙草(たばこ)",
             "tobacco,cigarettes"
-        ],
-        "notation": "煙草(たばこ)"
+        ]
     },
     {
         "name": "kabin",
         "trans": [
+            "花瓶(かびん)",
             "a vase"
-        ],
-        "notation": "花瓶(かびん)"
+        ]
     },
     {
         "name": "hana",
         "trans": [
+            "鼻(はな)",
             "nose"
-        ],
-        "notation": "鼻(はな)"
+        ]
     },
     {
         "name": "tsugi",
         "trans": [
+            "次(つぎ)",
             "next"
-        ],
-        "notation": "次(つぎ)"
+        ]
     },
     {
         "name": "daijoubu",
         "trans": [
+            "大丈夫(だいじょうぶ)",
             "all right"
-        ],
-        "notation": "大丈夫(だいじょうぶ)"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "晩(ばん)",
             "evening"
-        ],
-        "notation": "晩(ばん)"
+        ]
     },
     {
         "name": "eigo",
         "trans": [
+            "英語(えいご)",
             "English language"
-        ],
-        "notation": "英語(えいご)"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "居(お)る",
             "to be, to have (used for people and animals)"
-        ],
-        "notation": "居(お)る"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "木(き)",
             "tree, wood"
-        ],
-        "notation": "木(き)"
+        ]
     },
     {
         "name": "kiro/kiroguramu",
         "trans": [
+            "キロ/キログラム",
             "Kilogram"
-        ],
-        "notation": "キロ/キログラム"
+        ]
     },
     {
         "name": "motsu",
         "trans": [
+            "持(も)つ",
             "to hold"
-        ],
-        "notation": "持(も)つ"
+        ]
     },
     {
         "name": "nukui",
         "trans": [
+            "温(ぬく)い",
             "luke warm"
-        ],
-        "notation": "温(ぬく)い"
+        ]
     },
     {
         "name": "miru/miru",
         "trans": [
+            "見(み)る/観(み)る",
             "to see, to watch"
-        ],
-        "notation": "見(み)る/観(み)る"
+        ]
     },
     {
         "name": "kiiroi",
         "trans": [
+            "黄色(きいろ)い",
             "yellow"
-        ],
-        "notation": "黄色(きいろ)い"
+        ]
     },
     {
         "name": "denki",
         "trans": [
+            "電気(でんき)",
             "electricity,electric light"
-        ],
-        "notation": "電気(でんき)"
+        ]
     },
     {
         "name": "acchi",
         "trans": [
+            "あっち",
             "over there"
-        ],
-        "notation": "あっち"
+        ]
     },
     {
         "name": "kesa",
         "trans": [
+            "今朝(けさ)",
             "this morning"
-        ],
-        "notation": "今朝(けさ)"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "春(はる)",
             "spring"
-        ],
-        "notation": "春(はる)"
+        ]
     },
     {
         "name": "natsu",
         "trans": [
+            "夏(なつ)",
             "summer"
-        ],
-        "notation": "夏(なつ)"
+        ]
     },
     {
         "name": "hontou",
         "trans": [
+            "本当(ほんとう)",
             "truth"
-        ],
-        "notation": "本当(ほんとう)"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "一(いち)",
             "one"
-        ],
-        "notation": "一(いち)"
+        ]
     },
     {
         "name": "denwa",
         "trans": [
+            "電話(でんわ)",
             "telephone"
-        ],
-        "notation": "電話(でんわ)"
+        ]
     },
     {
         "name": "amai",
         "trans": [
+            "甘(あま)い",
             "sweet"
-        ],
-        "notation": "甘(あま)い"
+        ]
     },
     {
         "name": "mado",
         "trans": [
+            "窓(まど)",
             "window"
-        ],
-        "notation": "窓(まど)"
+        ]
     },
     {
         "name": "abunai",
         "trans": [
+            "危(あぶ)ない",
             "dangerous"
-        ],
-        "notation": "危(あぶ)ない"
+        ]
     },
     {
         "name": "ja/jaa",
         "trans": [
+            "じゃ/じゃあ",
             "well then…"
-        ],
-        "notation": "じゃ/じゃあ"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "吹(ふ)く",
             "to blow"
-        ],
-        "notation": "吹(ふ)く"
+        ]
     },
     {
         "name": "reizouko",
         "trans": [
+            "冷蔵庫(れいぞうこ)",
             "refrigerator"
-        ],
-        "notation": "冷蔵庫(れいぞうこ)"
+        ]
     },
     {
         "name": "jikan",
         "trans": [
+            "時間(じかん)",
             "Time"
-        ],
-        "notation": "時間(じかん)"
+        ]
     },
     {
         "name": "byouin",
         "trans": [
+            "病院(びょういん)",
             "hospital"
-        ],
-        "notation": "病院(びょういん)"
+        ]
     },
     {
         "name": "fuyu",
         "trans": [
+            "冬(ふゆ)",
             "winter"
-        ],
-        "notation": "冬(ふゆ)"
+        ]
     },
     {
         "name": "kopiisuru",
         "trans": [
+            "コピーする",
             "to copy"
-        ],
-        "notation": "コピーする"
+        ]
     },
     {
         "name": "rajio",
         "trans": [
+            "ラジオ",
             "radio"
-        ],
-        "notation": "ラジオ"
+        ]
     },
     {
         "name": "akai",
         "trans": [
+            "明(あか)い",
             "bright"
-        ],
-        "notation": "明(あか)い"
+        ]
     },
     {
         "name": "atsui",
         "trans": [
+            "暑(あつ)い",
             "hot"
-        ],
-        "notation": "暑(あつ)い"
+        ]
     },
     {
         "name": "mise",
         "trans": [
+            "店(みせ)",
             "shop"
-        ],
-        "notation": "店(みせ)"
+        ]
     },
     {
         "name": "gaikokujin",
         "trans": [
+            "外国(がいこく)人(じん)",
             "Foreigner"
-        ],
-        "notation": "外国(がいこく)人(じん)"
+        ]
     },
     {
         "name": "hidari",
         "trans": [
+            "左(ひだり)",
             "left hand side"
-        ],
-        "notation": "左(ひだり)"
+        ]
     },
     {
         "name": "hankachi",
         "trans": [
+            "ハンカチ",
             "handkerchief"
-        ],
-        "notation": "ハンカチ"
+        ]
     },
     {
         "name": "karendaa",
         "trans": [
+            "カレンダー",
             "calendar"
-        ],
-        "notation": "カレンダー"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "向(む)こう",
             "over there"
-        ],
-        "notation": "向(む)こう"
+        ]
     },
     {
         "name": "yuki",
         "trans": [
+            "雪(ゆき)",
             "snow"
-        ],
-        "notation": "雪(ゆき)"
+        ]
     },
     {
         "name": "shigoto",
         "trans": [
+            "仕事(しごと)",
             "Job"
-        ],
-        "notation": "仕事(しごと)"
+        ]
     },
     {
         "name": "okane",
         "trans": [
+            "お金(かね)",
             "money"
-        ],
-        "notation": "お金(かね)"
+        ]
     },
     {
         "name": "waishatsu",
         "trans": [
+            "ワイシャツ",
             "business shirt"
-        ],
-        "notation": "ワイシャツ"
+        ]
     },
     {
         "name": "chiisai",
         "trans": [
+            "小(ちい)さい",
             "little"
-        ],
-        "notation": "小(ちい)さい"
+        ]
     },
     {
         "name": "toriniku",
         "trans": [
+            "とり肉(にく)",
             "chicken meat"
-        ],
-        "notation": "とり肉(にく)"
+        ]
     },
     {
         "name": "gogo",
         "trans": [
+            "午後(ごご)",
             "afternoon"
-        ],
-        "notation": "午後(ごご)"
+        ]
     },
     {
         "name": "hare",
         "trans": [
+            "晴(は)れ",
             "clear weather"
-        ],
-        "notation": "晴(は)れ"
+        ]
     },
     {
         "name": "ikura",
         "trans": [
+            "いくら",
             "how much?"
-        ],
-        "notation": "いくら"
+        ]
     },
     {
         "name": "paatii",
         "trans": [
+            "パーティー",
             "party"
-        ],
-        "notation": "パーティー"
+        ]
     },
     {
         "name": "tanoshii",
         "trans": [
+            "楽(たの)しい",
             "enjoyable"
-        ],
-        "notation": "楽(たの)しい"
+        ]
     },
     {
         "name": "nouto",
         "trans": [
+            "ノート",
             "notebook,exercise book"
-        ],
-        "notation": "ノート"
+        ]
     },
     {
         "name": "aka",
         "trans": [
+            "赤(あか)",
             "red"
-        ],
-        "notation": "赤(あか)"
+        ]
     },
     {
         "name": "hajimaru",
         "trans": [
+            "始(はじ)まる",
             "to begin"
-        ],
-        "notation": "始(はじ)まる"
+        ]
     },
     {
         "name": "yasumi",
         "trans": [
+            "休(やす)み",
             "rest,holiday"
-        ],
-        "notation": "休(やす)み"
+        ]
     },
     {
         "name": "dochira",
         "trans": [
+            "どちら",
             "which of two"
-        ],
-        "notation": "どちら"
+        ]
     },
     {
         "name": "hiraku",
         "trans": [
+            "開(ひら)く",
             "to open, to become open"
-        ],
-        "notation": "開(ひら)く"
+        ]
     },
     {
         "name": "ie",
         "trans": [
+            "家(いえ)",
             "house"
-        ],
-        "notation": "家(いえ)"
+        ]
     },
     {
         "name": "neko",
         "trans": [
+            "猫(ねこ)",
             "cat"
-        ],
-        "notation": "猫(ねこ)"
+        ]
     },
     {
         "name": "hayai",
         "trans": [
+            "早(はや)い",
             "early"
-        ],
-        "notation": "早(はや)い"
+        ]
     },
     {
         "name": "mina",
         "trans": [
+            "皆(みな)",
             "everyone"
-        ],
-        "notation": "皆(みな)"
+        ]
     },
     {
         "name": "migaku",
         "trans": [
+            "磨(みが)く",
             "to brush teeth, to polish"
-        ],
-        "notation": "磨(みが)く"
+        ]
     },
     {
         "name": "oniisan",
         "trans": [
+            "お兄(にい)さん",
             "(honorable) older brother"
-        ],
-        "notation": "お兄(にい)さん"
+        ]
     },
     {
         "name": "suguni",
         "trans": [
+            "すぐに",
             "Instantly"
-        ],
-        "notation": "すぐに"
+        ]
     },
     {
         "name": "atsui",
         "trans": [
+            "厚(あつ)い",
             "kind, deep, thick"
-        ],
-        "notation": "厚(あつ)い"
+        ]
     },
     {
         "name": "bangohan",
         "trans": [
+            "晩(ばん)御飯(ごはん)",
             "evening meal"
-        ],
-        "notation": "晩(ばん)御飯(ごはん)"
+        ]
     },
     {
         "name": "asagohan",
         "trans": [
+            "朝(あさ)御飯(ごはん)",
             "breakfast"
-        ],
-        "notation": "朝(あさ)御飯(ごはん)"
+        ]
     },
     {
         "name": "tesuto",
         "trans": [
+            "テスト",
             "test"
-        ],
-        "notation": "テスト"
+        ]
     },
     {
         "name": "nani",
         "trans": [
+            "何(なに)",
             "what"
-        ],
-        "notation": "何(なに)"
+        ]
     },
     {
         "name": "totemo",
         "trans": [
+            "とても",
             "very"
-        ],
-        "notation": "とても"
+        ]
     },
     {
         "name": "ao",
         "trans": [
+            "青(あお)",
             "blue"
-        ],
-        "notation": "青(あお)"
+        ]
     },
     {
         "name": "oyogu",
         "trans": [
+            "泳(およ)ぐ",
             "to swim"
-        ],
-        "notation": "泳(およ)ぐ"
+        ]
     },
     {
         "name": "issho",
         "trans": [
+            "一緒(いっしょ)",
             "together"
-        ],
-        "notation": "一緒(いっしょ)"
+        ]
     },
     {
         "name": "naraberu",
         "trans": [
+            "並(なら)べる",
             "to line up,to set up"
-        ],
-        "notation": "並(なら)べる"
+        ]
     },
     {
         "name": "sebiro",
         "trans": [
+            "背広(せびろ)",
             "business suit"
-        ],
-        "notation": "背広(せびろ)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "はい",
             "yes"
-        ],
-        "notation": "はい"
+        ]
     },
     {
         "name": "koucha",
         "trans": [
+            "紅茶(こうちゃ)",
             "black tea"
-        ],
-        "notation": "紅茶(こうちゃ)"
+        ]
     },
     {
         "name": "ane",
         "trans": [
+            "姉(あね)",
             "(humble) older sister"
-        ],
-        "notation": "姉(あね)"
+        ]
     },
     {
         "name": "satou",
         "trans": [
+            "砂糖(さとう)",
             "Sugar"
-        ],
-        "notation": "砂糖(さとう)"
+        ]
     },
     {
         "name": "shiro",
         "trans": [
+            "白(しろ)",
             "White"
-        ],
-        "notation": "白(しろ)"
+        ]
     },
     {
         "name": "soushite/soshite",
         "trans": [
+            "そうして/そして",
             "And"
-        ],
-        "notation": "そうして/そして"
+        ]
     },
     {
         "name": "wakaru",
         "trans": [
+            "分(わ)かる",
             "to be understood"
-        ],
-        "notation": "分(わ)かる"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "はく",
             "to wear,to put on trousers"
-        ],
-        "notation": "はく"
+        ]
     },
     {
         "name": "ryoushin",
         "trans": [
+            "両親(りょうしん)",
             "both parents"
-        ],
-        "notation": "両親(りょうしん)"
+        ]
     },
     {
         "name": "asa",
         "trans": [
+            "朝(あさ)",
             "morning"
-        ],
-        "notation": "朝(あさ)"
+        ]
     },
     {
         "name": "doa",
         "trans": [
+            "ドア",
             "Western style door"
-        ],
-        "notation": "ドア"
+        ]
     },
     {
         "name": "sensei",
         "trans": [
+            "先生(せんせい)",
             "teacher, doctor"
-        ],
-        "notation": "先生(せんせい)"
+        ]
     },
     {
         "name": "ookii",
         "trans": [
+            "大(おお)きい",
             "big"
-        ],
-        "notation": "大(おお)きい"
+        ]
     },
     {
         "name": "gitaa",
         "trans": [
+            "ギター",
             "Guitar"
-        ],
-        "notation": "ギター"
+        ]
     },
     {
         "name": "shouyu",
         "trans": [
+            "醤油(しょうゆ)",
             "soy sauce"
-        ],
-        "notation": "醤油(しょうゆ)"
+        ]
     },
     {
         "name": "koppu",
         "trans": [
+            "コップ",
             "cop, police officer"
-        ],
-        "notation": "コップ"
+        ]
     },
     {
         "name": "keikan",
         "trans": [
+            "警官(けいかん)",
             "policeman"
-        ],
-        "notation": "警官(けいかん)"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "九(きゅう)",
             "Nine"
-        ],
-        "notation": "九(きゅう)"
+        ]
     },
     {
         "name": "kau",
         "trans": [
+            "買(か)う",
             "to buy"
-        ],
-        "notation": "買(か)う"
+        ]
     },
     {
         "name": "macchi",
         "trans": [
+            "マッチ",
             "match"
-        ],
-        "notation": "マッチ"
+        ]
     },
     {
         "name": "deru",
         "trans": [
+            "出(で)る",
             "to appear,to leave"
-        ],
-        "notation": "出(で)る"
+        ]
     },
     {
         "name": "narabu",
         "trans": [
+            "並(なら)ぶ",
             "to line up,to stand in a line"
-        ],
-        "notation": "並(なら)ぶ"
+        ]
     },
     {
         "name": "souji",
         "trans": [
+            "掃除(そうじ)",
             "to clean, to sweep"
-        ],
-        "notation": "掃除(そうじ)"
+        ]
     },
     {
         "name": "ongaku",
         "trans": [
+            "音楽(おんがく)",
             "Music"
-        ],
-        "notation": "音楽(おんがく)"
+        ]
     },
     {
         "name": "rajikase / rajiokasetto",
         "trans": [
+            "ラジカセ / ラジオカセット",
             "radio cassette player"
-        ],
-        "notation": "ラジカセ / ラジオカセット"
+        ]
     },
     {
         "name": "nomimono",
         "trans": [
+            "飲(の)み物(もの)",
             "a drink"
-        ],
-        "notation": "飲(の)み物(もの)"
+        ]
     },
     {
         "name": "itsumo",
         "trans": [
+            "いつも",
             "always"
-        ],
-        "notation": "いつも"
+        ]
     },
     {
         "name": "ike",
         "trans": [
+            "池(いけ)",
             "pond"
-        ],
-        "notation": "池(いけ)"
+        ]
     },
     {
         "name": "kaimono",
         "trans": [
+            "買(か)い物(もの)",
             "Shopping"
-        ],
-        "notation": "買(か)い物(もの)"
+        ]
     },
     {
         "name": "youfuku",
         "trans": [
+            "洋服(ようふく)",
             "western-style clothes"
-        ],
-        "notation": "洋服(ようふく)"
+        ]
     },
     {
         "name": "soko",
         "trans": [
+            "そこ",
             "that place"
-        ],
-        "notation": "そこ"
+        ]
     },
     {
         "name": "sutoubu",
         "trans": [
+            "ストーブ",
             "Heater"
-        ],
-        "notation": "ストーブ"
+        ]
     },
     {
         "name": "sakuya",
         "trans": [
+            "昨夜(さくや)",
             "last night"
-        ],
-        "notation": "昨夜(さくや)"
+        ]
     },
     {
         "name": "raigetsu",
         "trans": [
+            "来月(らいげつ)",
             "next month"
-        ],
-        "notation": "来月(らいげつ)"
+        ]
     },
     {
         "name": "umi",
         "trans": [
+            "海(うみ)",
             "sea"
-        ],
-        "notation": "海(うみ)"
+        ]
     },
     {
         "name": "kippu",
         "trans": [
+            "切符(きっぷ)",
             "Ticket"
-        ],
-        "notation": "切符(きっぷ)"
+        ]
     },
     {
         "name": "yonnichi",
         "trans": [
+            "四(よん)日(にち)",
             "four days, fouth day of the month"
-        ],
-        "notation": "四(よん)日(にち)"
+        ]
     },
     {
         "name": "tooi",
         "trans": [
+            "遠(とお)い",
             "far"
-        ],
-        "notation": "遠(とお)い"
+        ]
     },
     {
         "name": "sono",
         "trans": [
+            "その",
             "That"
-        ],
-        "notation": "その"
+        ]
     },
     {
         "name": "getsuyoubi",
         "trans": [
+            "月曜日(げつようび)",
             "Monday"
-        ],
-        "notation": "月曜日(げつようび)"
+        ]
     },
     {
         "name": "sanpo",
         "trans": [
+            "散歩(さんぽ)",
             "to stroll"
-        ],
-        "notation": "散歩(さんぽ)"
+        ]
     },
     {
         "name": "chikatetsu",
         "trans": [
+            "地下鉄(ちかてつ)",
             "underground train"
-        ],
-        "notation": "地下鉄(ちかてつ)"
+        ]
     },
     {
         "name": "oji/oji",
         "trans": [
+            "伯父(おじ)/叔父(おじ)",
             "uncle, middle aged gentleman"
-        ],
-        "notation": "伯父(おじ)/叔父(おじ)"
+        ]
     },
     {
         "name": "itai",
         "trans": [
+            "痛(いた)い",
             "painful"
-        ],
-        "notation": "痛(いた)い"
+        ]
     },
     {
         "name": "isu",
         "trans": [
+            "いす",
             "chair"
-        ],
-        "notation": "いす"
+        ]
     },
     {
         "name": "tobu",
         "trans": [
+            "飛(と)ぶ",
             "to fly,to hop"
-        ],
-        "notation": "飛(と)ぶ"
+        ]
     },
     {
         "name": "hachinichi",
         "trans": [
+            "八(はち)日(にち)",
             "eight days, eighth day of the month"
-        ],
-        "notation": "八(はち)日(にち)"
+        ]
     },
     {
         "name": "jibun",
         "trans": [
+            "自分(じぶん)",
             "Oneself"
-        ],
-        "notation": "自分(じぶん)"
+        ]
     },
     {
         "name": "narau",
         "trans": [
+            "習(なら)う",
             "to learn"
-        ],
-        "notation": "習(なら)う"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "千(せん)",
             "Thousand"
-        ],
-        "notation": "千(せん)"
+        ]
     },
     {
         "name": "samui",
         "trans": [
+            "寒(さむ)い",
             "Cold"
-        ],
-        "notation": "寒(さむ)い"
+        ]
     },
     {
         "name": "ii/yoi",
         "trans": [
+            "いい/よい",
             "good"
-        ],
-        "notation": "いい/よい"
+        ]
     },
     {
         "name": "tokei",
         "trans": [
+            "時計(とけい)",
             "watch,clock"
-        ],
-        "notation": "時計(とけい)"
+        ]
     },
     {
         "name": "kouto",
         "trans": [
+            "コート",
             "coat, tennis court"
-        ],
-        "notation": "コート"
+        ]
     },
     {
         "name": "ryokou",
         "trans": [
+            "旅行(りょこう)",
             "travel"
-        ],
-        "notation": "旅行(りょこう)"
+        ]
     },
     {
         "name": "konban",
         "trans": [
+            "今晩(こんばん)",
             "this evening"
-        ],
-        "notation": "今晩(こんばん)"
+        ]
     },
     {
         "name": "hareru",
         "trans": [
+            "晴(は)れる",
             "to be sunny"
-        ],
-        "notation": "晴(は)れる"
+        ]
     },
     {
         "name": "petto",
         "trans": [
+            "ペット",
             "pet"
-        ],
-        "notation": "ペット"
+        ]
     },
     {
         "name": "renshuu",
         "trans": [
+            "練習(れんしゅう)",
             "to practice"
-        ],
-        "notation": "練習(れんしゅう)"
+        ]
     },
     {
         "name": "sorekara",
         "trans": [
+            "それから",
             "after that"
-        ],
-        "notation": "それから"
+        ]
     },
     {
         "name": "oshieru",
         "trans": [
+            "教(おし)える",
             "to teach, to tell"
-        ],
-        "notation": "教(おし)える"
+        ]
     },
     {
         "name": "tokidoki",
         "trans": [
+            "時々(ときどき)",
             "sometimes"
-        ],
-        "notation": "時々(ときどき)"
+        ]
     },
     {
         "name": "poketto",
         "trans": [
+            "ポケット",
             "pocket"
-        ],
-        "notation": "ポケット"
+        ]
     },
     {
         "name": "watashi",
         "trans": [
+            "私(わたし)",
             "I,myself"
-        ],
-        "notation": "私(わたし)"
+        ]
     },
     {
         "name": "koko",
         "trans": [
+            "ここ",
             "Here"
-        ],
-        "notation": "ここ"
+        ]
     },
     {
         "name": "kiro/kiromeetoru",
         "trans": [
+            "キロ/キロメートル",
             "Kilometer"
-        ],
-        "notation": "キロ/キロメートル"
+        ]
     },
     {
         "name": "kongetsu",
         "trans": [
+            "今月(こんげつ)",
             "this month"
-        ],
-        "notation": "今月(こんげつ)"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "弾(ひ)く",
             "to play an instrument with strings, including piano"
-        ],
-        "notation": "弾(ひ)く"
+        ]
     },
     {
         "name": "hon",
         "trans": [
+            "本(ほん)",
             "book"
-        ],
-        "notation": "本(ほん)"
+        ]
     },
     {
         "name": "me",
         "trans": [
+            "目(め)",
             "eye"
-        ],
-        "notation": "目(め)"
+        ]
     },
     {
         "name": "ikutsu",
         "trans": [
+            "いくつ",
             "how many?,how old?"
-        ],
-        "notation": "いくつ"
+        ]
     },
     {
         "name": "yukkurito",
         "trans": [
+            "ゆっくりと",
             "slowly"
-        ],
-        "notation": "ゆっくりと"
+        ]
     },
     {
         "name": "ichigatsu",
         "trans": [
+            "一月(いちがつ)",
             "one month"
-        ],
-        "notation": "一月(いちがつ)"
+        ]
     },
     {
         "name": "kyonen",
         "trans": [
+            "去年(きょねん)",
             "last year"
-        ],
-        "notation": "去年(きょねん)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "たて",
             "length,height"
-        ],
-        "notation": "たて"
+        ]
     },
     {
         "name": "kappu",
         "trans": [
+            "カップ",
             "Cup"
-        ],
-        "notation": "カップ"
+        ]
     },
     {
         "name": "kochira",
         "trans": [
+            "こちら",
             "this person or way"
-        ],
-        "notation": "こちら"
+        ]
     },
     {
         "name": "natsuyasumi",
         "trans": [
+            "夏休(なつやす)み",
             "summer holiday"
-        ],
-        "notation": "夏休(なつやす)み"
+        ]
     },
     {
         "name": "iroiro",
         "trans": [
+            "いろいろ",
             "various"
-        ],
-        "notation": "いろいろ"
+        ]
     },
     {
         "name": "kuru",
         "trans": [
+            "来(く)る",
             "to come"
-        ],
-        "notation": "来(く)る"
+        ]
     },
     {
         "name": "sannichi",
         "trans": [
+            "三(さん)日(にち)",
             "three days, third day of the month"
-        ],
-        "notation": "三(さん)日(にち)"
+        ]
     },
     {
         "name": "osoi",
         "trans": [
+            "遅(おそ)い",
             "late, slow"
-        ],
-        "notation": "遅(おそ)い"
+        ]
     },
     {
         "name": "owaru",
         "trans": [
+            "終(おわ)る",
             "to finish"
-        ],
-        "notation": "終(おわ)る"
+        ]
     },
     {
         "name": "shawaa",
         "trans": [
+            "シャワー",
             "Shower"
-        ],
-        "notation": "シャワー"
+        ]
     },
     {
         "name": "ooi",
         "trans": [
+            "多(おお)い",
             "many"
-        ],
-        "notation": "多(おお)い"
+        ]
     },
     {
         "name": "otousan",
         "trans": [
+            "お父(とう)さん",
             "(honorable) father"
-        ],
-        "notation": "お父(とう)さん"
+        ]
     },
     {
         "name": "seito",
         "trans": [
+            "生徒(せいと)",
             "Pupil"
-        ],
-        "notation": "生徒(せいと)"
+        ]
     },
     {
         "name": "kariru",
         "trans": [
+            "借(か)りる",
             "to borrow"
-        ],
-        "notation": "借(か)りる"
+        ]
     },
     {
         "name": "daigaku",
         "trans": [
+            "大学(だいがく)",
             "university"
-        ],
-        "notation": "大学(だいがく)"
+        ]
     },
     {
         "name": "doyoubi",
         "trans": [
+            "土曜日(どようび)",
             "Saturday"
-        ],
-        "notation": "土曜日(どようび)"
+        ]
     },
     {
         "name": "nishi",
         "trans": [
+            "西(にし)",
             "west"
-        ],
-        "notation": "西(にし)"
+        ]
     },
     {
         "name": "kayoubi",
         "trans": [
+            "火曜日(かようび)",
             "Tuesday"
-        ],
-        "notation": "火曜日(かようび)"
+        ]
     },
     {
         "name": "joubu",
         "trans": [
+            "丈夫(じょうぶ)",
             "strong, durable"
-        ],
-        "notation": "丈夫(じょうぶ)"
+        ]
     },
     {
         "name": "doumo",
         "trans": [
+            "どうも",
             "thanks"
-        ],
-        "notation": "どうも"
+        ]
     },
     {
         "name": "yasai",
         "trans": [
+            "野菜(やさい)",
             "vegetable"
-        ],
-        "notation": "野菜(やさい)"
+        ]
     },
     {
         "name": "otearai",
         "trans": [
+            "お手洗(てあら)い",
             "bathroom"
-        ],
-        "notation": "お手洗(てあら)い"
+        ]
     },
     {
         "name": "kanji",
         "trans": [
+            "漢字(かんじ)",
             "Chinese character"
-        ],
-        "notation": "漢字(かんじ)"
+        ]
     },
     {
         "name": "nigiyaka",
         "trans": [
+            "賑(にぎ)やか",
             "bustling,busy"
-        ],
-        "notation": "賑(にぎ)やか"
+        ]
     },
     {
         "name": "hana",
         "trans": [
+            "花(はな)",
             "flower"
-        ],
-        "notation": "花(はな)"
+        ]
     },
     {
         "name": "otoko",
         "trans": [
+            "男(おとこ)",
             "Man"
-        ],
-        "notation": "男(おとこ)"
+        ]
     },
     {
         "name": "ryouri",
         "trans": [
+            "料理(りょうり)",
             "cuisine"
-        ],
-        "notation": "料理(りょうり)"
+        ]
     },
     {
         "name": "shimaru",
         "trans": [
+            "閉(し)まる",
             "to close, to be closed"
-        ],
-        "notation": "閉(し)まる"
+        ]
     },
     {
         "name": "muttsu",
         "trans": [
+            "六(むっ)つ",
             "six"
-        ],
-        "notation": "六(むっ)つ"
+        ]
     },
     {
         "name": "furo",
         "trans": [
+            "ふろ",
             "bath"
-        ],
-        "notation": "ふろ"
+        ]
     },
     {
         "name": "rippa",
         "trans": [
+            "立派(りっぱ)",
             "splendid"
-        ],
-        "notation": "立派(りっぱ)"
+        ]
     },
     {
         "name": "karui",
         "trans": [
+            "軽(かる)い",
             "Light"
-        ],
-        "notation": "軽(かる)い"
+        ]
     },
     {
         "name": "toire",
         "trans": [
+            "トイレ",
             "toilet"
-        ],
-        "notation": "トイレ"
+        ]
     },
     {
         "name": "hyaku",
         "trans": [
+            "百(ひゃく)",
             "hundred"
-        ],
-        "notation": "百(ひゃく)"
+        ]
     },
     {
         "name": "hou",
         "trans": [
+            "方(ほう)",
             "person, way of doing"
-        ],
-        "notation": "方(ほう)"
+        ]
     },
     {
         "name": "kutsu",
         "trans": [
+            "靴(くつ)",
             "Shoes"
-        ],
-        "notation": "靴(くつ)"
+        ]
     },
     {
         "name": "shizuka",
         "trans": [
+            "静(しず)か",
             "Quiet"
-        ],
-        "notation": "静(しず)か"
+        ]
     },
     {
         "name": "shatsu",
         "trans": [
+            "シャツ",
             "Shirt"
-        ],
-        "notation": "シャツ"
+        ]
     },
     {
         "name": "kusuri",
         "trans": [
+            "薬(くすり)",
             "medicine"
-        ],
-        "notation": "薬(くすり)"
+        ]
     },
     {
         "name": "omoshiroi",
         "trans": [
+            "面(おも)白(しろ)い",
             "Interesting"
-        ],
-        "notation": "面(おも)白(しろ)い"
+        ]
     },
     {
         "name": "itsu",
         "trans": [
+            "いつ",
             "when"
-        ],
-        "notation": "いつ"
+        ]
     },
     {
         "name": "komaru",
         "trans": [
+            "困(こま)る",
             "to be worried"
-        ],
-        "notation": "困(こま)る"
+        ]
     },
     {
         "name": "osake",
         "trans": [
+            "お酒(さけ)",
             "alcohol, rice wine"
-        ],
-        "notation": "お酒(さけ)"
+        ]
     },
     {
         "name": "okashi",
         "trans": [
+            "お菓子(かし)",
             "sweets, candy"
-        ],
-        "notation": "お菓子(かし)"
+        ]
     },
     {
         "name": "kurai",
         "trans": [
+            "暗(くら)い",
             "Gloomy"
-        ],
-        "notation": "暗(くら)い"
+        ]
     },
     {
         "name": "tenki",
         "trans": [
+            "天気(てんき)",
             "weather"
-        ],
-        "notation": "天気(てんき)"
+        ]
     },
     {
         "name": "tsukue",
         "trans": [
+            "机(つくえ)",
             "desk"
-        ],
-        "notation": "机(つくえ)"
+        ]
     },
     {
         "name": "surippa",
         "trans": [
+            "スリッパ",
             "Slippers"
-        ],
-        "notation": "スリッパ"
+        ]
     },
     {
         "name": "utau",
         "trans": [
+            "歌(うた)う",
             "to sing"
-        ],
-        "notation": "歌(うた)う"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "話(はな)す",
             "to speak"
-        ],
-        "notation": "話(はな)す"
+        ]
     },
     {
         "name": "e",
         "trans": [
+            "絵(え)",
             "picture"
-        ],
-        "notation": "絵(え)"
+        ]
     },
     {
         "name": "ee",
         "trans": [
+            "ええ",
             "yes"
-        ],
-        "notation": "ええ"
+        ]
     },
     {
         "name": "yattsu",
         "trans": [
+            "八(やっ)つ",
             "eight"
-        ],
-        "notation": "八(やっ)つ"
+        ]
     },
     {
         "name": "mazui",
         "trans": [
+            "不味(まず)い",
             "unpleasant"
-        ],
-        "notation": "不味(まず)い"
+        ]
     },
     {
         "name": "boushi",
         "trans": [
+            "帽子(ぼうし)",
             "hat"
-        ],
-        "notation": "帽子(ぼうし)"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "登(のぼ)る",
             "to climb"
-        ],
-        "notation": "登(のぼ)る"
+        ]
     },
     {
         "name": "roku",
         "trans": [
+            "六(ろく)",
             "six"
-        ],
-        "notation": "六(ろく)"
+        ]
     },
     {
         "name": "ni",
         "trans": [
+            "二(に)",
             "two"
-        ],
-        "notation": "二(に)"
+        ]
     },
     {
         "name": "chikaku",
         "trans": [
+            "近(ちか)く",
             "near"
-        ],
-        "notation": "近(ちか)く"
+        ]
     },
     {
         "name": "kuni",
         "trans": [
+            "国(くに)",
             "Country"
-        ],
-        "notation": "国(くに)"
+        ]
     },
     {
         "name": "kirei",
         "trans": [
+            "綺麗(きれい)",
             "pretty, clean"
-        ],
-        "notation": "綺麗(きれい)"
+        ]
     },
     {
         "name": "teepurekoudaa",
         "trans": [
+            "テープレコーダー",
             "tape recorder"
-        ],
-        "notation": "テープレコーダー"
+        ]
     },
     {
         "name": "hoteru",
         "trans": [
+            "ホテル",
             "hotel"
-        ],
-        "notation": "ホテル"
+        ]
     },
     {
         "name": "atatakai",
         "trans": [
+            "暖(あたた)かい",
             "warm"
-        ],
-        "notation": "暖(あたた)かい"
+        ]
     },
     {
         "name": "soredeha",
         "trans": [
+            "それでは",
             "in that situation"
-        ],
-        "notation": "それでは"
+        ]
     },
     {
         "name": "osu",
         "trans": [
+            "押(お)す",
             "to push, to stamp something"
-        ],
-        "notation": "押(お)す"
+        ]
     },
     {
         "name": "shokudou",
         "trans": [
+            "食堂(しょくどう)",
             "dining hall"
-        ],
-        "notation": "食堂(しょくどう)"
+        ]
     },
     {
         "name": "kiiro",
         "trans": [
+            "黄色(きいろ)",
             "yellow"
-        ],
-        "notation": "黄色(きいろ)"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "聞(き)く",
             "to hear, to listen to, to ask"
-        ],
-        "notation": "聞(き)く"
+        ]
     },
     {
         "name": "suki",
         "trans": [
+            "好(す)き",
             "Likeable"
-        ],
-        "notation": "好(す)き"
+        ]
     },
     {
         "name": "oji/oji",
         "trans": [
+            "伯父(おじ)/叔父(おじ)",
             "grandfather, male senior citizen"
-        ],
-        "notation": "伯父(おじ)/叔父(おじ)"
+        ]
     },
     {
         "name": "gonichi",
         "trans": [
+            "五(ご)日(にち)",
             "five days, fifth day"
-        ],
-        "notation": "五(ご)日(にち)"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "咲(さ)く",
             "to bloom"
-        ],
-        "notation": "咲(さ)く"
+        ]
     },
     {
         "name": "kesu",
         "trans": [
+            "消(け)す",
             "to erase, to turn off power"
-        ],
-        "notation": "消(け)す"
+        ]
     },
     {
         "name": "nimotsu",
         "trans": [
+            "荷物(にもつ)",
             "luggage"
-        ],
-        "notation": "荷物(にもつ)"
+        ]
     },
     {
         "name": "mainichi",
         "trans": [
+            "毎日(まいにち)",
             "every day"
-        ],
-        "notation": "毎日(まいにち)"
+        ]
     },
     {
         "name": "isha",
         "trans": [
+            "医者(いしゃ)",
             "medical doctor"
-        ],
-        "notation": "医者(いしゃ)"
+        ]
     },
     {
         "name": "nagai",
         "trans": [
+            "長(なが)い",
             "long"
-        ],
-        "notation": "長(なが)い"
+        ]
     },
     {
         "name": "gyuunyuu",
         "trans": [
+            "牛乳(ぎゅうにゅう)",
             "Milk"
-        ],
-        "notation": "牛乳(ぎゅうにゅう)"
+        ]
     },
     {
         "name": "ocha",
         "trans": [
+            "お茶(ちゃ)",
             "green tea"
-        ],
-        "notation": "お茶(ちゃ)"
+        ]
     },
     {
         "name": "takai",
         "trans": [
+            "高(たか)い",
             "tall, expensive"
-        ],
-        "notation": "高(たか)い"
+        ]
     },
     {
         "name": "issakunen",
         "trans": [
+            "一昨年(いっさくねん)",
             "year before last"
-        ],
-        "notation": "一昨年(いっさくねん)"
+        ]
     },
     {
         "name": "shukudai",
         "trans": [
+            "宿題(しゅくだい)",
             "homework"
-        ],
-        "notation": "宿題(しゅくだい)"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "ある",
             "to be,to have (used for inanimate objects)"
-        ],
-        "notation": "ある"
+        ]
     },
     {
         "name": "ideguchi",
         "trans": [
+            "出口(いでぐち)",
             "exit"
-        ],
-        "notation": "出口(いでぐち)"
+        ]
     },
     {
         "name": "saki",
         "trans": [
+            "先(さき)",
             "the future, previous"
-        ],
-        "notation": "先(さき)"
+        ]
     },
     {
         "name": "ame",
         "trans": [
+            "雨(あめ)",
             "rain"
-        ],
-        "notation": "雨(あめ)"
+        ]
     },
     {
         "name": "noru",
         "trans": [
+            "乗(の)る",
             "to get on,to ride"
-        ],
-        "notation": "乗(の)る"
+        ]
     },
     {
         "name": "byouki",
         "trans": [
+            "病気(びょうき)",
             "illness"
-        ],
-        "notation": "病気(びょうき)"
+        ]
     },
     {
         "name": "tokoro",
         "trans": [
+            "所(ところ)",
             "place"
-        ],
-        "notation": "所(ところ)"
+        ]
     },
     {
         "name": "aruku",
         "trans": [
+            "歩(ある)く",
             "to walk"
-        ],
-        "notation": "歩(ある)く"
+        ]
     },
     {
         "name": "tsumetai",
         "trans": [
+            "冷(つめ)たい",
             "cold to the touch"
-        ],
-        "notation": "冷(つめ)たい"
+        ]
     },
     {
         "name": "kitanai",
         "trans": [
+            "汚(きたな)い",
             "Dirty"
-        ],
-        "notation": "汚(きたな)い"
+        ]
     },
     {
         "name": "hayai",
         "trans": [
+            "速(はや)い",
             "quick"
-        ],
-        "notation": "速(はや)い"
+        ]
     },
     {
         "name": "kouen",
         "trans": [
+            "公園(こうえん)",
             "Park"
-        ],
-        "notation": "公園(こうえん)"
+        ]
     },
     {
         "name": "kumoru",
         "trans": [
+            "曇(くも)る",
             "to become cloudy, to become dim"
-        ],
-        "notation": "曇(くも)る"
+        ]
     },
     {
         "name": "shiru",
         "trans": [
+            "知(し)る",
             "to know"
-        ],
-        "notation": "知(し)る"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "歯(は)",
             "tooth"
-        ],
-        "notation": "歯(は)"
+        ]
     },
     {
         "name": "onna",
         "trans": [
+            "女(おんな)",
             "Woman"
-        ],
-        "notation": "女(おんな)"
+        ]
     },
     {
         "name": "taishikan",
         "trans": [
+            "大使館(たいしかん)",
             "embassy"
-        ],
-        "notation": "大使館(たいしかん)"
+        ]
     },
     {
         "name": "supuun",
         "trans": [
+            "スプーン",
             "Spoon"
-        ],
-        "notation": "スプーン"
+        ]
     },
     {
         "name": "hondana",
         "trans": [
+            "本棚(ほんだな)",
             "bookshelves"
-        ],
-        "notation": "本棚(ほんだな)"
+        ]
     },
     {
         "name": "zero",
         "trans": [
+            "ゼロ",
             "Zero"
-        ],
-        "notation": "ゼロ"
+        ]
     },
     {
         "name": "terebi",
         "trans": [
+            "テレビ",
             "television"
-        ],
-        "notation": "テレビ"
+        ]
     },
     {
         "name": "warui",
         "trans": [
+            "悪(わる)い",
             "bad"
-        ],
-        "notation": "悪(わる)い"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "つける",
             "to turn on"
-        ],
-        "notation": "つける"
+        ]
     },
     {
         "name": "isogashii",
         "trans": [
+            "忙(いそが)しい",
             "busy, irritated"
-        ],
-        "notation": "忙(いそが)しい"
+        ]
     },
     {
         "name": "anata",
         "trans": [
+            "あなた",
             "you"
-        ],
-        "notation": "あなた"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "戸(と)",
             "Japanese style door"
-        ],
-        "notation": "戸(と)"
+        ]
     },
     {
         "name": "doushite",
         "trans": [
+            "どうして",
             "for what reason"
-        ],
-        "notation": "どうして"
+        ]
     },
     {
         "name": "okaasan",
         "trans": [
+            "お母(かあ)さん",
             "(honorable) mother"
-        ],
-        "notation": "お母(かあ)さん"
+        ]
     },
     {
         "name": "kamera",
         "trans": [
+            "カメラ",
             "camera"
-        ],
-        "notation": "カメラ"
+        ]
     },
     {
         "name": "kodomo",
         "trans": [
+            "子供(こども)",
             "Child"
-        ],
-        "notation": "子供(こども)"
+        ]
     },
     {
         "name": "sora",
         "trans": [
+            "空(そら)",
             "Sky"
-        ],
-        "notation": "空(そら)"
+        ]
     },
     {
         "name": "tegami",
         "trans": [
+            "手紙(てがみ)",
             "letter"
-        ],
-        "notation": "手紙(てがみ)"
+        ]
     },
     {
         "name": "uta",
         "trans": [
+            "歌(うた)",
             "song"
-        ],
-        "notation": "歌(うた)"
+        ]
     },
     {
         "name": "kekkon",
         "trans": [
+            "結婚(けっこん)",
             "Marriage"
-        ],
-        "notation": "結婚(けっこん)"
+        ]
     },
     {
         "name": "kirai",
         "trans": [
+            "嫌(きら)い",
             "Hate"
-        ],
-        "notation": "嫌(きら)い"
+        ]
     },
     {
         "name": "mou",
         "trans": [
+            "もう",
             "already"
-        ],
-        "notation": "もう"
+        ]
     },
     {
         "name": "rekoudo",
         "trans": [
+            "レコード",
             "record"
-        ],
-        "notation": "レコード"
+        ]
     },
     {
         "name": "taberu",
         "trans": [
+            "食(た)べる",
             "to eat"
-        ],
-        "notation": "食(た)べる"
+        ]
     },
     {
         "name": "dare",
         "trans": [
+            "誰(だれ)",
             "somebody"
-        ],
-        "notation": "誰(だれ)"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "帰(かえ)る",
             "to go back"
-        ],
-        "notation": "帰(かえ)る"
+        ]
     },
     {
         "name": "kaisha",
         "trans": [
+            "会社(かいしゃ)",
             "Company"
-        ],
-        "notation": "会社(かいしゃ)"
+        ]
     },
     {
         "name": "chotto",
         "trans": [
+            "ちょっと",
             "somewhat"
-        ],
-        "notation": "ちょっと"
+        ]
     },
     {
         "name": "yuugata",
         "trans": [
+            "夕方(ゆうがた)",
             "evening"
-        ],
-        "notation": "夕方(ゆうがた)"
+        ]
     },
     {
         "name": "are",
         "trans": [
+            "あれ",
             "that"
-        ],
-        "notation": "あれ"
+        ]
     },
     {
         "name": "nugu",
         "trans": [
+            "脱(ぬ)ぐ",
             "to take off clothes"
-        ],
-        "notation": "脱(ぬ)ぐ"
+        ]
     },
     {
         "name": "hikouki",
         "trans": [
+            "飛行機(ひこうき)",
             "aeroplane"
-        ],
-        "notation": "飛行機(ひこうき)"
+        ]
     },
     {
         "name": "wakai",
         "trans": [
+            "若(わか)い",
             "young"
-        ],
-        "notation": "若(わか)い"
+        ]
     },
     {
         "name": "hosoi",
         "trans": [
+            "細(ほそ)い",
             "thin"
-        ],
-        "notation": "細(ほそ)い"
+        ]
     },
     {
         "name": "sukaato",
         "trans": [
+            "スカート",
             "Skirt"
-        ],
-        "notation": "スカート"
+        ]
     },
     {
         "name": "yottsu",
         "trans": [
+            "四(よっ)つ",
             "four"
-        ],
-        "notation": "四(よっ)つ"
+        ]
     },
     {
         "name": "hataraku",
         "trans": [
+            "働(はたら)く",
             "to work"
-        ],
-        "notation": "働(はたら)く"
+        ]
     },
     {
         "name": "kawa/kawa",
         "trans": [
+            "川(かわ)/河(かわ)",
             "River"
-        ],
-        "notation": "川(かわ)/河(かわ)"
+        ]
     },
     {
         "name": "guramu",
         "trans": [
+            "グラム",
             "Gram"
-        ],
-        "notation": "グラム"
+        ]
     },
     {
         "name": "hikui",
         "trans": [
+            "低(ひく)い",
             "short,low"
-        ],
-        "notation": "低(ひく)い"
+        ]
     },
     {
         "name": "kaidan",
         "trans": [
+            "階段(かいだん)",
             "Stairs"
-        ],
-        "notation": "階段(かいだん)"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "辺(あたり)",
             "area"
-        ],
-        "notation": "辺(あたり)"
+        ]
     },
     {
         "name": "mon",
         "trans": [
+            "門(もん)",
             "gate"
-        ],
-        "notation": "門(もん)"
+        ]
     },
     {
         "name": "kinyoubi",
         "trans": [
+            "金曜日(きんようび)",
             "Friday"
-        ],
-        "notation": "金曜日(きんようび)"
+        ]
     },
     {
         "name": "basu",
         "trans": [
+            "バス",
             "bus"
-        ],
-        "notation": "バス"
+        ]
     },
     {
         "name": "jibiki",
         "trans": [
+            "字引(じびき)",
             "Dictionary"
-        ],
-        "notation": "字引(じびき)"
+        ]
     },
     {
         "name": "hachi",
         "trans": [
+            "八(はち)",
             "eight"
-        ],
-        "notation": "八(はち)"
+        ]
     },
     {
         "name": "ban",
         "trans": [
+            "万(ばん)",
             "ten thousand"
-        ],
-        "notation": "万(ばん)"
+        ]
     },
     {
         "name": "tatemono",
         "trans": [
+            "建物(たてもの)",
             "building"
-        ],
-        "notation": "建物(たてもの)"
+        ]
     },
     {
         "name": "obasan/obasan",
         "trans": [
+            "伯母(おば)さん/叔母(おば)さん",
             "Aunt"
-        ],
-        "notation": "伯母(おば)さん/叔母(おば)さん"
+        ]
     },
     {
         "name": "jugyou",
         "trans": [
+            "授業(じゅぎょう)",
             "lesson, class work"
-        ],
-        "notation": "授業(じゅぎょう)"
+        ]
     },
     {
         "name": "oku",
         "trans": [
+            "置(お)く",
             "to put"
-        ],
-        "notation": "置(お)く"
+        ]
     },
     {
         "name": "eki",
         "trans": [
+            "駅(えき)",
             "station"
-        ],
-        "notation": "駅(えき)"
+        ]
     },
     {
         "name": "ginkou",
         "trans": [
+            "銀行(ぎんこう)",
             "Bank"
-        ],
-        "notation": "銀行(ぎんこう)"
+        ]
     },
     {
         "name": "kyuunichi",
         "trans": [
+            "九(きゅう)日(にち)",
             "nine days, ninth day"
-        ],
-        "notation": "九(きゅう)日(にち)"
+        ]
     },
     {
         "name": "magaru",
         "trans": [
+            "曲(まが)る",
             "to turn,to bend"
-        ],
-        "notation": "曲(まが)る"
+        ]
     },
     {
         "name": "yoko",
         "trans": [
+            "横(よこ)",
             "beside,side,width"
-        ],
-        "notation": "横(よこ)"
+        ]
     },
     {
         "name": "bunshou",
         "trans": [
+            "文章(ぶんしょう)",
             "sentence,text"
-        ],
-        "notation": "文章(ぶんしょう)"
+        ]
     },
     {
         "name": "beddo",
         "trans": [
+            "ベッド",
             "bed"
-        ],
-        "notation": "ベッド"
+        ]
     },
     {
         "name": "kita",
         "trans": [
+            "北(きた)",
             "North"
-        ],
-        "notation": "北(きた)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "かける",
             "to call by phone"
-        ],
-        "notation": "かける"
+        ]
     },
     {
         "name": "suwaru",
         "trans": [
+            "座(すわ)る",
             "to sit"
-        ],
-        "notation": "座(すわ)る"
+        ]
     },
     {
         "name": "ninichi",
         "trans": [
+            "二(に)日(にち)",
             "two days, second day of the month"
-        ],
-        "notation": "二(に)日(にち)"
+        ]
     },
     {
         "name": "gohan",
         "trans": [
+            "御飯(ごはん)",
             "cooked rice, meal"
-        ],
-        "notation": "御飯(ごはん)"
+        ]
     },
     {
         "name": "obentou",
         "trans": [
+            "お弁当(べんとう)",
             "boxed lunch"
-        ],
-        "notation": "お弁当(べんとう)"
+        ]
     },
     {
         "name": "kuruma",
         "trans": [
+            "車(くるま)",
             "car, vehicle"
-        ],
-        "notation": "車(くるま)"
+        ]
     },
     {
         "name": "yori,hou",
         "trans": [
+            "より、ほう",
             "Used for comparison."
-        ],
-        "notation": "より、ほう"
+        ]
     },
     {
         "name": "maiban",
         "trans": [
+            "毎晩(まいばん)",
             "every night"
-        ],
-        "notation": "毎晩(まいばん)"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "着(つ)く",
             "to arrive at"
-        ],
-        "notation": "着(つ)く"
+        ]
     },
     {
         "name": "wataru",
         "trans": [
+            "渡(わた)る",
             "to go across"
-        ],
-        "notation": "渡(わた)る"
+        ]
     },
     {
         "name": "sakubun",
         "trans": [
+            "作文(さくぶん)",
             "composition, writing"
-        ],
-        "notation": "作文(さくぶん)"
+        ]
     },
     {
         "name": "chikai",
         "trans": [
+            "近(ちか)い",
             "near"
-        ],
-        "notation": "近(ちか)い"
+        ]
     },
     {
         "name": "michi",
         "trans": [
+            "道(みち)",
             "street"
-        ],
-        "notation": "道(みち)"
+        ]
     },
     {
         "name": "itsutsu",
         "trans": [
+            "五(いつ)つ",
             "five"
-        ],
-        "notation": "五(いつ)つ"
+        ]
     },
     {
         "name": "dore",
         "trans": [
+            "どれ",
             "which (of three or more)"
-        ],
-        "notation": "どれ"
+        ]
     },
     {
         "name": "genkan",
         "trans": [
+            "玄関(げんかん)",
             "entry hall"
-        ],
-        "notation": "玄関(げんかん)"
+        ]
     },
     {
         "name": "kieru",
         "trans": [
+            "消(き)える",
             "to disappear"
-        ],
-        "notation": "消(き)える"
+        ]
     },
     {
         "name": "daidokoro",
         "trans": [
+            "台所(だいどころ)",
             "kitchen"
-        ],
-        "notation": "台所(だいどころ)"
+        ]
     },
     {
         "name": "massugu",
         "trans": [
+            "真(ま)っ直(す)ぐ",
             "straight ahead,direct"
-        ],
-        "notation": "真(ま)っ直(す)ぐ"
+        ]
     },
     {
         "name": "jidousha",
         "trans": [
+            "自動車(じどうしゃ)",
             "Automobile"
-        ],
-        "notation": "自動車(じどうしゃ)"
+        ]
     },
     {
         "name": "peeji",
         "trans": [
+            "ページ",
             "page"
-        ],
-        "notation": "ページ"
+        ]
     },
     {
         "name": "raishuu",
         "trans": [
+            "来週(らいしゅう)",
             "next week"
-        ],
-        "notation": "来週(らいしゅう)"
+        ]
     },
     {
         "name": "te",
         "trans": [
+            "手(て)",
             "hand"
-        ],
-        "notation": "手(て)"
+        ]
     },
     {
         "name": "hirugohan",
         "trans": [
+            "昼(ひる)御飯(ごはん)",
             "midday meal"
-        ],
-        "notation": "昼(ひる)御飯(ごはん)"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "服(ふく)",
             "clothes"
-        ],
-        "notation": "服(ふく)"
+        ]
     },
     {
         "name": "suru",
         "trans": [
+            "する",
             "to do"
-        ],
-        "notation": "する"
+        ]
     },
     {
         "name": "rouka",
         "trans": [
+            "廊下(ろうか)",
             "corridor"
-        ],
-        "notation": "廊下(ろうか)"
+        ]
     },
     {
         "name": "kuro",
         "trans": [
+            "黒(くろ)",
             "Black"
-        ],
-        "notation": "黒(くろ)"
+        ]
     },
     {
         "name": "ima",
         "trans": [
+            "今(いま)",
             "now"
-        ],
-        "notation": "今(いま)"
+        ]
     },
     {
         "name": "sochira",
         "trans": [
+            "そちら",
             "over there"
-        ],
-        "notation": "そちら"
+        ]
     },
     {
         "name": "mata",
         "trans": [
+            "また",
             "again,and"
-        ],
-        "notation": "また"
+        ]
     },
     {
         "name": "taihen",
         "trans": [
+            "たいへん",
             "very"
-        ],
-        "notation": "たいへん"
+        ]
     },
     {
         "name": "dou",
         "trans": [
+            "どう",
             "how,in what way"
-        ],
-        "notation": "どう"
+        ]
     },
     {
         "name": "botan",
         "trans": [
+            "ボタン",
             "button"
-        ],
-        "notation": "ボタン"
+        ]
     },
     {
         "name": "gakusei",
         "trans": [
+            "学生(がくせい)",
             "Student"
-        ],
-        "notation": "学生(がくせい)"
+        ]
     },
     {
         "name": "kurasu",
         "trans": [
+            "クラス",
             "Class"
-        ],
-        "notation": "クラス"
+        ]
     },
     {
         "name": "shikashi",
         "trans": [
+            "しかし",
             "However"
-        ],
-        "notation": "しかし"
+        ]
     },
     {
         "name": "dare",
         "trans": [
+            "誰(だれ)",
             "who"
-        ],
-        "notation": "誰(だれ)"
+        ]
     },
     {
         "name": "yoku",
         "trans": [
+            "よく",
             "often, well"
-        ],
-        "notation": "よく"
+        ]
     },
     {
         "name": "ofuro",
         "trans": [
+            "お風呂(ふろ)",
             "Bath"
-        ],
-        "notation": "お風呂(ふろ)"
+        ]
     },
     {
         "name": "nakusu",
         "trans": [
+            "無(な)くす",
             "to lose something"
-        ],
-        "notation": "無(な)くす"
+        ]
     },
     {
         "name": "asobu",
         "trans": [
+            "遊(あそ)ぶ",
             "to play, to make a visit"
-        ],
-        "notation": "遊(あそ)ぶ"
+        ]
     },
     {
         "name": "yuumei",
         "trans": [
+            "有名(ゆうめい)",
             "famous"
-        ],
-        "notation": "有名(ゆうめい)"
+        ]
     },
     {
         "name": "hito",
         "trans": [
+            "人(ひと)",
             "person"
-        ],
-        "notation": "人(ひと)"
+        ]
     },
     {
         "name": "kutsushita",
         "trans": [
+            "靴下(くつした)",
             "Socks"
-        ],
-        "notation": "靴下(くつした)"
+        ]
     },
     {
         "name": "iie",
         "trans": [
+            "いいえ",
             "no"
-        ],
-        "notation": "いいえ"
+        ]
     },
     {
         "name": "genki",
         "trans": [
+            "元気(げんき)",
             "health, vitality"
-        ],
-        "notation": "元気(げんき)"
+        ]
     },
     {
         "name": "hitotsu",
         "trans": [
+            "一(ひと)つ",
             "one"
-        ],
-        "notation": "一(ひと)つ"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "家庭(かてい)",
             "Household"
-        ],
-        "notation": "家庭(かてい)"
+        ]
     },
     {
         "name": "mittsu",
         "trans": [
+            "三(みっ)つ",
             "three"
-        ],
-        "notation": "三(みっ)つ"
+        ]
     },
     {
         "name": "yasumu",
         "trans": [
+            "休(やす)む",
             "to rest"
-        ],
-        "notation": "休(やす)む"
+        ]
     },
     {
         "name": "kuchi",
         "trans": [
+            "口(くち)",
             "mouth, opening"
-        ],
-        "notation": "口(くち)"
+        ]
     },
     {
         "name": "benri",
         "trans": [
+            "便利(べんり)",
             "useful, convenient"
-        ],
-        "notation": "便利(べんり)"
+        ]
     },
     {
         "name": "kotoba",
         "trans": [
+            "言葉(ことば)",
             "word, language"
-        ],
-        "notation": "言葉(ことば)"
+        ]
     },
     {
         "name": "chawan",
         "trans": [
+            "茶碗(ちゃわん)",
             "rice bowl"
-        ],
-        "notation": "茶碗(ちゃわん)"
+        ]
     },
     {
         "name": "toshi",
         "trans": [
+            "年(とし)",
             "year"
-        ],
-        "notation": "年(とし)"
+        ]
     },
     {
         "name": "hairu",
         "trans": [
+            "入(はい)る",
             "to enter,to contain"
-        ],
-        "notation": "入(はい)る"
+        ]
     },
     {
         "name": "kasu",
         "trans": [
+            "貸(か)す",
             "to lend"
-        ],
-        "notation": "貸(か)す"
+        ]
     },
     {
         "name": "juunichi",
         "trans": [
+            "十(じゅう)日(にち)",
             "ten days,the tenth day"
-        ],
-        "notation": "十(じゅう)日(にち)"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "閉(し)める",
             "to close something"
-        ],
-        "notation": "閉(し)める"
+        ]
     },
     {
         "name": "hajimete",
         "trans": [
+            "初(はじ)めて",
             "for the first time"
-        ],
-        "notation": "初(はじ)めて"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "締(し)める",
             "to tie"
-        ],
-        "notation": "締(し)める"
+        ]
     },
     {
         "name": "futatsu",
         "trans": [
+            "二(ふた)つ",
             "two"
-        ],
-        "notation": "二(ふた)つ"
+        ]
     },
     {
         "name": "okusan",
         "trans": [
+            "奥(おく)さん",
             "(honorable) wife"
-        ],
-        "notation": "奥(おく)さん"
+        ]
     },
     {
         "name": "rokunichi",
         "trans": [
+            "六(ろく)日(にち)",
             "six days, sixth day of the month"
-        ],
-        "notation": "六(ろく)日(にち)"
+        ]
     },
     {
         "name": "kousaten",
         "trans": [
+            "交差点(こうさてん)",
             "intersection"
-        ],
-        "notation": "交差点(こうさてん)"
+        ]
     },
     {
         "name": "inu",
         "trans": [
+            "犬(いぬ)",
             "dog"
-        ],
-        "notation": "犬(いぬ)"
+        ]
     },
     {
         "name": "kinou",
         "trans": [
+            "昨日(きのう)",
             "Yesterday"
-        ],
-        "notation": "昨日(きのう)"
+        ]
     },
     {
         "name": "yaoya",
         "trans": [
+            "八百屋(やおや)",
             "greengrocer"
-        ],
-        "notation": "八百屋(やおや)"
+        ]
     },
     {
         "name": "dandan",
         "trans": [
+            "だんだん",
             "gradually"
-        ],
-        "notation": "だんだん"
+        ]
     },
     {
         "name": "hiru",
         "trans": [
+            "昼(ひる)",
             "noon, daytime"
-        ],
-        "notation": "昼(ひる)"
+        ]
     },
     {
         "name": "amari",
         "trans": [
+            "あまり",
             "not very"
-        ],
-        "notation": "あまり"
+        ]
     },
     {
         "name": "omoi",
         "trans": [
+            "重(おも)い",
             "Heavy"
-        ],
-        "notation": "重(おも)い"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "貼(は)る",
             "to stick"
-        ],
-        "notation": "貼(は)る"
+        ]
     },
     {
         "name": "taisetsu",
         "trans": [
+            "大切(たいせつ)",
             "important"
-        ],
-        "notation": "大切(たいせつ)"
+        ]
     },
     {
         "name": "naka",
         "trans": [
+            "中(なか)",
             "middle"
-        ],
-        "notation": "中(なか)"
+        ]
     },
     {
         "name": "iku",
         "trans": [
+            "行(い)く",
             "to go"
-        ],
-        "notation": "行(い)く"
+        ]
     },
     {
         "name": "migi",
         "trans": [
+            "右(みぎ)",
             "right side"
-        ],
-        "notation": "右(みぎ)"
+        ]
     },
     {
         "name": "pan",
         "trans": [
+            "パン",
             "bread"
-        ],
-        "notation": "パン"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "橋(はし)",
             "bridge"
-        ],
-        "notation": "橋(はし)"
+        ]
     },
     {
         "name": "ani",
         "trans": [
+            "兄(あに)",
             "(humble) older brother"
-        ],
-        "notation": "兄(あに)"
+        ]
     },
     {
         "name": "asoko",
         "trans": [
+            "あそこ",
             "over there"
-        ],
-        "notation": "あそこ"
+        ]
     },
     {
         "name": "suu",
         "trans": [
+            "吸(す)う",
             "to smoke, to suck"
-        ],
-        "notation": "吸(す)う"
+        ]
     },
     {
         "name": "mijikai",
         "trans": [
+            "短(みじか)い",
             "short"
-        ],
-        "notation": "短(みじか)い"
+        ]
     },
     {
         "name": "nomu",
         "trans": [
+            "飲(の)む",
             "to drink"
-        ],
-        "notation": "飲(の)む"
+        ]
     },
     {
         "name": "imouto",
         "trans": [
+            "妹(いもうと)",
             "(humble) younger sister"
-        ],
-        "notation": "妹(いもうと)"
+        ]
     },
     {
         "name": "hiroi",
         "trans": [
+            "広(ひろ)い",
             "spacious,wide"
-        ],
-        "notation": "広(ひろ)い"
+        ]
     },
     {
         "name": "yowai",
         "trans": [
+            "弱(よわ)い",
             "weak"
-        ],
-        "notation": "弱(よわ)い"
+        ]
     },
     {
         "name": "hoshii",
         "trans": [
+            "欲(ほ)しい",
             "want"
-        ],
-        "notation": "欲(ほ)しい"
+        ]
     },
     {
         "name": "tonari",
         "trans": [
+            "隣(となり)",
             "next door to"
-        ],
-        "notation": "隣(となり)"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "なる",
             "to become"
-        ],
-        "notation": "なる"
+        ]
     },
     {
         "name": "arau",
         "trans": [
+            "洗(あら)う",
             "to wash"
-        ],
-        "notation": "洗(あら)う"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "零(れい)",
             "zero"
-        ],
-        "notation": "零(れい)"
+        ]
     },
     {
         "name": "kaban",
         "trans": [
+            "鞄(かばん)",
             "bag, basket"
-        ],
-        "notation": "鞄(かばん)"
+        ]
     },
     {
         "name": "erebeetaa",
         "trans": [
+            "エレベーター",
             "elevator"
-        ],
-        "notation": "エレベーター"
+        ]
     },
     {
         "name": "gozen",
         "trans": [
+            "午前(ごぜん)",
             "morning"
-        ],
-        "notation": "午前(ごぜん)"
+        ]
     },
     {
         "name": "uru",
         "trans": [
+            "売(う)る",
             "to sell"
-        ],
-        "notation": "売(う)る"
+        ]
     },
     {
         "name": "seetaa",
         "trans": [
+            "セーター",
             "sweater, jumper"
-        ],
-        "notation": "セーター"
+        ]
     },
     {
         "name": "hanashi",
         "trans": [
+            "話(はなし)",
             "talk,story"
-        ],
-        "notation": "話(はなし)"
+        ]
     },
     {
         "name": "aki",
         "trans": [
+            "秋(あき)",
             "autumn"
-        ],
-        "notation": "秋(あき)"
+        ]
     },
     {
         "name": "senshuu",
         "trans": [
+            "先週(せんしゅう)",
             "last week"
-        ],
-        "notation": "先週(せんしゅう)"
+        ]
     },
     {
         "name": "akeru",
         "trans": [
+            "開(あ)ける",
             "to open"
-        ],
-        "notation": "開(あ)ける"
+        ]
     },
     {
         "name": "ano",
         "trans": [
+            "あの",
             "that over there"
-        ],
-        "notation": "あの"
+        ]
     },
     {
         "name": "se",
         "trans": [
+            "背(せ)",
             "height, stature"
-        ],
-        "notation": "背(せ)"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "降(ふ)る",
             "to fall, e.g. rain or snow"
-        ],
-        "notation": "降(ふ)る"
+        ]
     },
     {
         "name": "muzukashii",
         "trans": [
+            "難(むずか)しい",
             "difficult"
-        ],
-        "notation": "難(むずか)しい"
+        ]
     },
     {
         "name": "otona",
         "trans": [
+            "大人(おとな)",
             "Adult"
-        ],
-        "notation": "大人(おとな)"
+        ]
     },
     {
         "name": "machi",
         "trans": [
+            "町(まち)",
             "town,city"
-        ],
-        "notation": "町(まち)"
+        ]
     },
     {
         "name": "kuroi",
         "trans": [
+            "黒(くろ)い",
             "black"
-        ],
-        "notation": "黒(くろ)い"
+        ]
     },
     {
         "name": "minasan",
         "trans": [
+            "皆(みな)さん",
             "everyone"
-        ],
-        "notation": "皆(みな)さん"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "三(さん)",
             "Three"
-        ],
-        "notation": "三(さん)"
+        ]
     },
     {
         "name": "kore",
         "trans": [
+            "これ",
             "This"
-        ],
-        "notation": "これ"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "答(こた)える",
             "to answer"
-        ],
-        "notation": "答(こた)える"
+        ]
     },
     {
         "name": "kissaten",
         "trans": [
+            "喫茶店(きっさてん)",
             "coffee lounge"
-        ],
-        "notation": "喫茶店(きっさてん)"
+        ]
     },
     {
         "name": "sukoshi",
         "trans": [
+            "少(すこ)し",
             "Few"
-        ],
-        "notation": "少(すこ)し"
+        ]
     },
     {
         "name": "soba",
         "trans": [
+            "そば",
             "near, beside"
-        ],
-        "notation": "そば"
+        ]
     },
     {
         "name": "mannenhitsu",
         "trans": [
+            "万年筆(まんねんひつ)",
             "fountain pen"
-        ],
-        "notation": "万年筆(まんねんひつ)"
+        ]
     },
     {
         "name": "onaka",
         "trans": [
+            "おなか",
             "stomach"
-        ],
-        "notation": "おなか"
+        ]
     },
     {
         "name": "eigakan",
         "trans": [
+            "映画(えいが)館(かん)",
             "cinema"
-        ],
-        "notation": "映画(えいが)館(かん)"
+        ]
     },
     {
         "name": "kyoudai",
         "trans": [
+            "兄弟(きょうだい)",
             "(humble) siblings"
-        ],
-        "notation": "兄弟(きょうだい)"
+        ]
     },
     {
         "name": "ireru",
         "trans": [
+            "入(い)れる",
             "to put in"
-        ],
-        "notation": "入(い)れる"
+        ]
     },
     {
         "name": "mada",
         "trans": [
+            "まだ",
             "yet,still"
-        ],
-        "notation": "まだ"
+        ]
     },
     {
         "name": "densha",
         "trans": [
+            "電車(でんしゃ)",
             "electric train"
-        ],
-        "notation": "電車(でんしゃ)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "立(た)つ",
             "to stand"
-        ],
-        "notation": "立(た)つ"
+        ]
     },
     {
         "name": "posuto",
         "trans": [
+            "ポスト",
             "post"
-        ],
-        "notation": "ポスト"
+        ]
     },
     {
         "name": "naze",
         "trans": [
+            "なぜ",
             "why"
-        ],
-        "notation": "なぜ"
+        ]
     },
     {
         "name": "dekiru",
         "trans": [
+            "できる",
             "to be able to"
-        ],
-        "notation": "できる"
+        ]
     },
     {
         "name": "zubon",
         "trans": [
+            "ズボン",
             "Trousers"
-        ],
-        "notation": "ズボン"
+        ]
     },
     {
         "name": "nekutai",
         "trans": [
+            "ネクタイ",
             "tie,necktie"
-        ],
-        "notation": "ネクタイ"
+        ]
     },
     {
         "name": "sakana",
         "trans": [
+            "魚(さかな)",
             "Fish"
-        ],
-        "notation": "魚(さかな)"
+        ]
     },
     {
         "name": "teeburu",
         "trans": [
+            "テーブル",
             "table"
-        ],
-        "notation": "テーブル"
+        ]
     },
     {
         "name": "kokonotsu",
         "trans": [
+            "九(ここの)つ",
             "Nine"
-        ],
-        "notation": "九(ここの)つ"
+        ]
     },
     {
         "name": "kasa",
         "trans": [
+            "傘(かさ)",
             "Umbrella"
-        ],
-        "notation": "傘(かさ)"
+        ]
     },
     {
         "name": "maishuu",
         "trans": [
+            "毎週(まいしゅう)",
             "every week"
-        ],
-        "notation": "毎週(まいしゅう)"
+        ]
     },
     {
         "name": "yasui",
         "trans": [
+            "安(やす)い",
             "cheap"
-        ],
-        "notation": "安(やす)い"
+        ]
     },
     {
         "name": "megane",
         "trans": [
+            "眼鏡(めがね)",
             "glasses"
-        ],
-        "notation": "眼鏡(めがね)"
+        ]
     },
     {
         "name": "shiroi",
         "trans": [
+            "白(しろ)い",
             "White"
-        ],
-        "notation": "白(しろ)い"
+        ]
     },
     {
         "name": "enpitsu",
         "trans": [
+            "鉛筆(えんぴつ)",
             "pencil"
-        ],
-        "notation": "鉛筆(えんぴつ)"
+        ]
     },
     {
         "name": "kaesu",
         "trans": [
+            "返(かえ)す",
             "to return something"
-        ],
-        "notation": "返(かえ)す"
+        ]
     },
     {
         "name": "soto",
         "trans": [
+            "外(そと)",
             "Outside"
-        ],
-        "notation": "外(そと)"
+        ]
     },
     {
         "name": "hajime/hajime",
         "trans": [
+            "初(はじ)め/始(はじ)め",
             "beginning"
-        ],
-        "notation": "初(はじ)め/始(はじ)め"
+        ]
     },
     {
         "name": "tabemono",
         "trans": [
+            "食(た)べ物(もの)",
             "food"
-        ],
-        "notation": "食(た)べ物(もの)"
+        ]
     },
     {
         "name": "douzo",
         "trans": [
+            "どうぞ",
             "please"
-        ],
-        "notation": "どうぞ"
+        ]
     },
     {
         "name": "aoi",
         "trans": [
+            "青(あお)い",
             "blue"
-        ],
-        "notation": "青(あお)い"
+        ]
     },
     {
         "name": "kono",
         "trans": [
+            "この",
             "This"
-        ],
-        "notation": "この"
+        ]
     },
     {
         "name": "nijuunichi",
         "trans": [
+            "二(に)十(じゅう)日(にち)",
             "twenty days,twentieth"
-        ],
-        "notation": "二(に)十(じゅう)日(にち)"
+        ]
     },
     {
         "name": "saifu",
         "trans": [
+            "財布(さいふ)",
             "Wallet"
-        ],
-        "notation": "財布(さいふ)"
+        ]
     },
     {
         "name": "gakkou",
         "trans": [
+            "学校(がっこう)",
             "School"
-        ],
-        "notation": "学校(がっこう)"
+        ]
     },
     {
         "name": "tsukareru",
         "trans": [
+            "疲(つか)れる",
             "to get tired"
-        ],
-        "notation": "疲(つか)れる"
+        ]
     },
     {
         "name": "sengetsu",
         "trans": [
+            "先月(せんげつ)",
             "last month"
-        ],
-        "notation": "先月(せんげつ)"
+        ]
     },
     {
         "name": "ichinichi",
         "trans": [
+            "一(いち)日(にち)",
             "first of month"
-        ],
-        "notation": "一(いち)日(にち)"
+        ]
     },
     {
         "name": "bourupen",
         "trans": [
+            "ボールペン",
             "ball-point pen"
-        ],
-        "notation": "ボールペン"
+        ]
     },
     {
         "name": "oneesan",
         "trans": [
+            "お姉(ねえ)さん",
             "(honorable) older sister"
-        ],
-        "notation": "お姉(ねえ)さん"
+        ]
     },
     {
         "name": "suzushii",
         "trans": [
+            "涼(すず)しい",
             "Refreshing"
-        ],
-        "notation": "涼(すず)しい"
+        ]
     },
     {
         "name": "atarashii",
         "trans": [
+            "新(あたら)しい",
             "new"
-        ],
-        "notation": "新(あたら)しい"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "撮(と)る",
             "to take a photo or record a film"
-        ],
-        "notation": "撮(と)る"
+        ]
     },
     {
         "name": "meetoru",
         "trans": [
+            "メートル",
             "metre"
-        ],
-        "notation": "メートル"
+        ]
     },
     {
         "name": "kouhii",
         "trans": [
+            "コーヒー",
             "Coffee"
-        ],
-        "notation": "コーヒー"
+        ]
     },
     {
         "name": "yon",
         "trans": [
+            "四(よん)",
             "Four"
-        ],
-        "notation": "四(よん)"
+        ]
     },
     {
         "name": "hima",
         "trans": [
+            "暇(ひま)",
             "free time"
-        ],
-        "notation": "暇(ひま)"
+        ]
     },
     {
         "name": "demo",
         "trans": [
+            "でも",
             "but"
-        ],
-        "notation": "でも"
+        ]
     },
     {
         "name": "ichinin",
         "trans": [
+            "一(いち)人(にん)",
             "one person"
-        ],
-        "notation": "一(いち)人(にん)"
+        ]
     },
     {
         "name": "yomu",
         "trans": [
+            "読(よ)む",
             "to read"
-        ],
-        "notation": "読(よ)む"
+        ]
     },
     {
         "name": "apaato",
         "trans": [
+            "アパート",
             "apartment"
-        ],
-        "notation": "アパート"
+        ]
     },
     {
         "name": "iu",
         "trans": [
+            "言(い)う",
             "to say"
-        ],
-        "notation": "言(い)う"
+        ]
     },
     {
         "name": "mae",
         "trans": [
+            "前(まえ)",
             "before"
-        ],
-        "notation": "前(まえ)"
+        ]
     },
     {
         "name": "butaniku",
         "trans": [
+            "豚肉(ぶたにく)",
             "pork"
-        ],
-        "notation": "豚肉(ぶたにく)"
+        ]
     },
     {
         "name": "kudasai",
         "trans": [
+            "ください",
             "Please"
-        ],
-        "notation": "ください"
+        ]
     },
     {
         "name": "sentaku",
         "trans": [
+            "洗濯(せんたく)",
             "Washing"
-        ],
-        "notation": "洗濯(せんたく)"
+        ]
     },
     {
         "name": "niwa",
         "trans": [
+            "庭(にわ)",
             "garden"
-        ],
-        "notation": "庭(にわ)"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "住(す)む",
             "to live in"
-        ],
-        "notation": "住(す)む"
+        ]
     },
     {
         "name": "imi",
         "trans": [
+            "意味(いみ)",
             "meaning"
-        ],
-        "notation": "意味(いみ)"
+        ]
     },
     {
         "name": "hoka",
         "trans": [
+            "ほか",
             "other, the rest"
-        ],
-        "notation": "ほか"
+        ]
     },
     {
         "name": "semai",
         "trans": [
+            "狭(せま)い",
             "Narrow"
-        ],
-        "notation": "狭(せま)い"
+        ]
     },
     {
         "name": "kyou",
         "trans": [
+            "今日(きょう)",
             "Today"
-        ],
-        "notation": "今日(きょう)"
+        ]
     },
     {
         "name": "matsu",
         "trans": [
+            "待(ま)つ",
             "to wait"
-        ],
-        "notation": "待(ま)つ"
+        ]
     },
     {
         "name": "namae",
         "trans": [
+            "名前(なまえ)",
             "name"
-        ],
-        "notation": "名前(なまえ)"
+        ]
     },
     {
         "name": "ano",
         "trans": [
+            "あの",
             "um..."
-        ],
-        "notation": "あの"
+        ]
     },
     {
         "name": "go",
         "trans": [
+            "五(ご)",
             "Five"
-        ],
-        "notation": "五(ご)"
+        ]
     },
     {
         "name": "deha",
         "trans": [
+            "では",
             "with that..."
-        ],
-        "notation": "では"
+        ]
     },
     {
         "name": "konshuu",
         "trans": [
+            "今週(こんしゅう)",
             "this week"
-        ],
-        "notation": "今週(こんしゅう)"
+        ]
     },
     {
         "name": "tabun",
         "trans": [
+            "多分(たぶん)",
             "probably"
-        ],
-        "notation": "多分(たぶん)"
+        ]
     },
     {
         "name": "iku",
         "trans": [
+            "行(い)く",
             "to go"
-        ],
-        "notation": "行(い)く"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "止(と)まる",
             "to come to a halt"
-        ],
-        "notation": "止(と)まる"
+        ]
     },
     {
         "name": "sarainen",
         "trans": [
+            "さ来年(らいねん)",
             "year after next"
-        ],
-        "notation": "さ来年(らいねん)"
+        ]
     },
     {
         "name": "supoutsu",
         "trans": [
+            "スポーツ",
             "Sport"
-        ],
-        "notation": "スポーツ"
+        ]
     },
     {
         "name": "mizu",
         "trans": [
+            "水(みず)",
             "water"
-        ],
-        "notation": "水(みず)"
+        ]
     },
     {
         "name": "kaze",
         "trans": [
+            "風(かぜ)",
             "Wind"
-        ],
-        "notation": "風(かぜ)"
+        ]
     },
     {
         "name": "han",
         "trans": [
+            "半(はん)",
             "half"
-        ],
-        "notation": "半(はん)"
+        ]
     },
     {
         "name": "tanjoubi",
         "trans": [
+            "誕生(たんじょう)日(び)",
             "birthday"
-        ],
-        "notation": "誕生(たんじょう)日(び)"
+        ]
     },
     {
         "name": "karee",
         "trans": [
+            "カレー",
             "Curry"
-        ],
-        "notation": "カレー"
+        ]
     },
     {
         "name": "firumu",
         "trans": [
+            "フィルム",
             "roll of film"
-        ],
-        "notation": "フィルム"
+        ]
     },
     {
         "name": "tsukau",
         "trans": [
+            "使(つか)う",
             "to use"
-        ],
-        "notation": "使(つか)う"
+        ]
     },
     {
         "name": "pen",
         "trans": [
+            "ペン",
             "pen"
-        ],
-        "notation": "ペン"
+        ]
     },
     {
         "name": "heya",
         "trans": [
+            "部屋(へや)",
             "room"
-        ],
-        "notation": "部屋(へや)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "十(じゅう)",
             "Ten"
-        ],
-        "notation": "十(じゅう)"
+        ]
     },
     {
         "name": "otouto",
         "trans": [
+            "弟(おとうと)",
             "younger brother"
-        ],
-        "notation": "弟(おとうと)"
+        ]
     },
     {
         "name": "iriguchi",
         "trans": [
+            "入口(いりぐち)",
             "entrance"
-        ],
-        "notation": "入口(いりぐち)"
+        ]
     },
     {
         "name": "socchi",
         "trans": [
+            "そっち",
             "over there"
-        ],
-        "notation": "そっち"
+        ]
     },
     {
         "name": "gyuuniku",
         "trans": [
+            "牛肉(ぎゅうにく)",
             "Beef"
-        ],
-        "notation": "牛肉(ぎゅうにく)"
+        ]
     },
     {
         "name": "jouzu",
         "trans": [
+            "上手(じょうず)",
             "Skillful"
-        ],
-        "notation": "上手(じょうず)"
+        ]
     },
     {
         "name": "kekkou",
         "trans": [
+            "結構(けっこう)",
             "splendid, enough"
-        ],
-        "notation": "結構(けっこう)"
+        ]
     },
     {
         "name": "oboeru",
         "trans": [
+            "覚(おぼ)える",
             "to remember"
-        ],
-        "notation": "覚(おぼ)える"
+        ]
     },
     {
         "name": "chiisana",
         "trans": [
+            "小(ちい)さな",
             "little"
-        ],
-        "notation": "小(ちい)さな"
+        ]
     },
     {
         "name": "umareru",
         "trans": [
+            "生(う)まれる",
             "to be born"
-        ],
-        "notation": "生(う)まれる"
+        ]
     },
     {
         "name": "karada",
         "trans": [
+            "体(からだ)",
             "Body"
-        ],
-        "notation": "体(からだ)"
+        ]
     },
     {
         "name": "dono",
         "trans": [
+            "どの",
             "which"
-        ],
-        "notation": "どの"
+        ]
     },
     {
         "name": "akai",
         "trans": [
+            "赤(あか)い",
             "red"
-        ],
-        "notation": "赤(あか)い"
+        ]
     },
     {
         "name": "mondai",
         "trans": [
+            "問題(もんだい)",
             "problem"
-        ],
-        "notation": "問題(もんだい)"
+        ]
     },
     {
         "name": "ninin",
         "trans": [
+            "二(に)人(にん)",
             "two people"
-        ],
-        "notation": "二(に)人(にん)"
+        ]
     },
     {
         "name": "tomodachi",
         "trans": [
+            "友達(ともだち)",
             "friend"
-        ],
-        "notation": "友達(ともだち)"
+        ]
     },
     {
         "name": "kazoku",
         "trans": [
+            "家族(かぞく)",
             "Family"
-        ],
-        "notation": "家族(かぞく)"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "夜(よる)",
             "evening,night"
-        ],
-        "notation": "夜(よる)"
+        ]
     },
     {
         "name": "ashi",
         "trans": [
+            "足(あし)",
             "foot, leg"
-        ],
-        "notation": "足(あし)"
+        ]
     },
     {
         "name": "kudamono",
         "trans": [
+            "果物(くだもの)",
             "Fruit"
-        ],
-        "notation": "果物(くだもの)"
+        ]
     },
     {
         "name": "kitte",
         "trans": [
+            "切手(きって)",
             "postage stamp"
-        ],
-        "notation": "切手(きって)"
+        ]
     },
     {
         "name": "fuutou",
         "trans": [
+            "封筒(ふうとう)",
             "envelope"
-        ],
-        "notation": "封筒(ふうとう)"
+        ]
     },
     {
         "name": "ichiban",
         "trans": [
+            "いちばん",
             "best, first"
-        ],
-        "notation": "いちばん"
+        ]
     },
     {
         "name": "najiranai",
         "trans": [
+            "詰(なじ)らない",
             "boring"
-        ],
-        "notation": "詰(なじ)らない"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "引(ひ)く",
             "to pull"
-        ],
-        "notation": "引(ひ)く"
+        ]
     },
     {
         "name": "shinu",
         "trans": [
+            "死(し)ぬ",
             "to die"
-        ],
-        "notation": "死(し)ぬ"
+        ]
     },
     {
         "name": "nochi",
         "trans": [
+            "後(のち)",
             "afterwards"
-        ],
-        "notation": "後(のち)"
+        ]
     },
     {
         "name": "chairo",
         "trans": [
+            "茶色(ちゃいろ)",
             "brown"
-        ],
-        "notation": "茶色(ちゃいろ)"
+        ]
     },
     {
         "name": "nanatsu",
         "trans": [
+            "七(なな)つ",
             "seven"
-        ],
-        "notation": "七(なな)つ"
+        ]
     },
     {
         "name": "shinbun",
         "trans": [
+            "新聞(しんぶん)",
             "newspaper"
-        ],
-        "notation": "新聞(しんぶん)"
+        ]
     },
     {
         "name": "yasashii",
         "trans": [
+            "易(やさ)しい",
             "easy, simple"
-        ],
-        "notation": "易(やさ)しい"
+        ]
     },
     {
         "name": "eiga",
         "trans": [
+            "映画(えいが)",
             "movie"
-        ],
-        "notation": "映画(えいが)"
+        ]
     },
     {
         "name": "urusai",
         "trans": [
+            "煩(うるさ)い",
             "noisy, annoying"
-        ],
-        "notation": "煩(うるさ)い"
+        ]
     },
     {
         "name": "mura",
         "trans": [
+            "村(むら)",
             "village"
-        ],
-        "notation": "村(むら)"
+        ]
     },
     {
         "name": "abiru",
         "trans": [
+            "あびる",
             "to bathe, to shower"
-        ],
-        "notation": "あびる"
+        ]
     },
     {
         "name": "ame",
         "trans": [
+            "飴(あめ)",
             "candy"
-        ],
-        "notation": "飴(あめ)"
+        ]
     },
     {
         "name": "tsurai",
         "trans": [
+            "辛(つら)い",
             "Spicy"
-        ],
-        "notation": "辛(つら)い"
+        ]
     },
     {
         "name": "obaasan",
         "trans": [
+            "おばあさん",
             "grandmother, female senior-citizen"
-        ],
-        "notation": "おばあさん"
+        ]
     },
     {
         "name": "onaji",
         "trans": [
+            "同(おな)じ",
             "same"
-        ],
-        "notation": "同(おな)じ"
+        ]
     },
     {
         "name": "neru",
         "trans": [
+            "寝(ね)る",
             "to go to bed,to sleep"
-        ],
-        "notation": "寝(ね)る"
+        ]
     },
     {
         "name": "motto",
         "trans": [
+            "もっと",
             "more"
-        ],
-        "notation": "もっと"
+        ]
     },
     {
         "name": "zasshi",
         "trans": [
+            "雑誌(ざっし)",
             "Magazine"
-        ],
-        "notation": "雑誌(ざっし)"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "会(あ)う",
             "to meet"
-        ],
-        "notation": "会(あ)う"
+        ]
     },
     {
         "name": "iru",
         "trans": [
+            "要(い)る",
             "to need"
-        ],
-        "notation": "要(い)る"
+        ]
     },
     {
         "name": "midori",
         "trans": [
+            "緑(みどり)",
             "green"
-        ],
-        "notation": "緑(みどり)"
+        ]
     },
     {
         "name": "shashin",
         "trans": [
+            "写真(しゃしん)",
             "photograph"
-        ],
-        "notation": "写真(しゃしん)"
+        ]
     },
     {
         "name": "kotoshi",
         "trans": [
+            "今年(ことし)",
             "this year"
-        ],
-        "notation": "今年(ことし)"
+        ]
     },
     {
         "name": "haizara",
         "trans": [
+            "灰皿(はいざら)",
             "ashtray"
-        ],
-        "notation": "灰皿(はいざら)"
+        ]
     },
     {
         "name": "nijuusai",
         "trans": [
+            "二(に)十(じゅう)歳(さい)",
             "20 years old,20th year"
-        ],
-        "notation": "二(に)十(じゅう)歳(さい)"
+        ]
     }
 ]

--- a/assets/dicts/Jap_High-Frequency_N1.json
+++ b/assets/dicts/Jap_High-Frequency_N1.json
@@ -2,21001 +2,21001 @@
     {
         "name": "aiirenai",
         "trans": [
+            "相容(あいい)れない",
             "① 连语  互相矛盾，不相容"
-        ],
-        "notation": "相容(あいい)れない"
+        ]
     },
     {
         "name": "saegiru",
         "trans": [
+            "遮(さえぎ)る",
             "③ 他动1  遮挡；阻拦，阻挡"
-        ],
-        "notation": "遮(さえぎ)る"
+        ]
     },
     {
         "name": "kyuuryou",
         "trans": [
+            "丘陵(きゅうりょう)",
             "⓪ 名  丘陵"
-        ],
-        "notation": "丘陵(きゅうりょう)"
+        ]
     },
     {
         "name": "ryoken",
         "trans": [
+            "旅券(りょけん)",
             "⓪ 名  护照"
-        ],
-        "notation": "旅券(りょけん)"
+        ]
     },
     {
         "name": "netamu",
         "trans": [
+            "妬(ねた)む",
             "② 他动1  嫉妒，眼红；嫉恨"
-        ],
-        "notation": "妬(ねた)む"
+        ]
     },
     {
         "name": "aikata",
         "trans": [
+            "相方(あいかた)",
             "⓪ 名  伙伴；对方"
-        ],
-        "notation": "相方(あいかた)"
+        ]
     },
     {
         "name": "koukan",
         "trans": [
+            "好感(こうかん)",
             "⓪ 名  好感"
-        ],
-        "notation": "好感(こうかん)"
+        ]
     },
     {
         "name": "omonjiru",
         "trans": [
+            "重(おも)んじる",
             "⓪ 他动2  重视，注重；尊重"
-        ],
-        "notation": "重(おも)んじる"
+        ]
     },
     {
         "name": "supesharu",
         "trans": [
+            "スペシャル",
             "② 名·ナ形  特别，特殊；专门"
-        ],
-        "notation": "スペシャル"
+        ]
     },
     {
         "name": "fusai",
         "trans": [
+            "負債(ふさい)",
             "⓪ 名  负债，欠债"
-        ],
-        "notation": "負債(ふさい)"
+        ]
     },
     {
         "name": "hanabanashii",
         "trans": [
+            "華々しい(はなばなしい)",
             "⑤ イ形  华丽的，豪华的；壮烈的"
-        ],
-        "notation": "華々しい(はなばなしい)"
+        ]
     },
     {
         "name": "teiji",
         "trans": [
+            "提示(ていじ)",
             "⓪ 名·他动3  出示"
-        ],
-        "notation": "提示(ていじ)"
+        ]
     },
     {
         "name": "aikyou",
         "trans": [
+            "愛嬌(あいきょう)",
             "③ 名  言行举止可爱；殷勤，讨好"
-        ],
-        "notation": "愛嬌(あいきょう)"
+        ]
     },
     {
         "name": "tadachini",
         "trans": [
+            "直(ただ)ちに",
             "① 副  立刻，马上；直接"
-        ],
-        "notation": "直(ただ)ちに"
+        ]
     },
     {
         "name": "sao",
         "trans": [
+            "竿(さお)",
             "② 名  竿子；船篙"
-        ],
-        "notation": "竿(さお)"
+        ]
     },
     {
         "name": "uchiwake",
         "trans": [
+            "内訳(うちわけ)",
             "⓪ 名  明细，详细内容"
-        ],
-        "notation": "内訳(うちわけ)"
+        ]
     },
     {
         "name": "aikurushii",
         "trans": [
+            "愛(あい)くるしい",
             "⑤ イ形  天真可爱的"
-        ],
-        "notation": "愛(あい)くるしい"
+        ]
     },
     {
         "name": "goban",
         "trans": [
+            "碁盤(ごばん)",
             "⓪ 名  围棋盘"
-        ],
-        "notation": "碁盤(ごばん)"
+        ]
     },
     {
         "name": "tejina",
         "trans": [
+            "手品(てじな)",
             "① 名  戏法，魔术；骗术，奸计"
-        ],
-        "notation": "手品(てじな)"
+        ]
     },
     {
         "name": "megurasu",
         "trans": [
+            "巡(めぐ)らす",
             "⓪ 他动1  围上，绕上；思考，筹划"
-        ],
-        "notation": "巡(めぐ)らす"
+        ]
     },
     {
         "name": "yabu",
         "trans": [
+            "藪(やぶ)",
             "⓪ 名  灌木丛，草丛"
-        ],
-        "notation": "藪(やぶ)"
+        ]
     },
     {
         "name": "panikku",
         "trans": [
+            "パニック",
             "① 名  恐慌，慌乱，混乱"
-        ],
-        "notation": "パニック"
+        ]
     },
     {
         "name": "gomakasu",
         "trans": [
+            "ごまかす",
             "③ 他动1  欺骗；掩盖，敷衍；弄虚作假"
-        ],
-        "notation": "ごまかす"
+        ]
     },
     {
         "name": "kyakuhon",
         "trans": [
+            "脚本(きゃくほん)",
             "⓪ 名  脚本，剧本"
-        ],
-        "notation": "脚本(きゃくほん)"
+        ]
     },
     {
         "name": "aiko",
         "trans": [
+            "愛顧(あいこ)",
             "① 名·他动3  惠顾，光顾"
-        ],
-        "notation": "愛顧(あいこ)"
+        ]
     },
     {
         "name": "katakuna",
         "trans": [
+            "頑(かたく)な",
             "⓪ ナ形  顽固的，固执的"
-        ],
-        "notation": "頑(かたく)な"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "振興(しんこう)",
             "⓪ 名·自他动3  振兴"
-        ],
-        "notation": "振興(しんこう)"
+        ]
     },
     {
         "name": "chuusuu",
         "trans": [
+            "中枢(ちゅうすう)",
             "⓪ 名  中枢；关键"
-        ],
-        "notation": "中枢(ちゅうすう)"
+        ]
     },
     {
         "name": "tomu",
         "trans": [
+            "富(と)む",
             "① 自动1  （金钱）富有；丰富"
-        ],
-        "notation": "富(と)む"
+        ]
     },
     {
         "name": "hijoukin",
         "trans": [
+            "非常勤(ひじょうきん)",
             "② 名  兼职，兼任"
-        ],
-        "notation": "非常勤(ひじょうきん)"
+        ]
     },
     {
         "name": "heisha",
         "trans": [
+            "弊社(へいしゃ)",
             "① 名  敝公司"
-        ],
-        "notation": "弊社(へいしゃ)"
+        ]
     },
     {
         "name": "sashikaeru",
         "trans": [
+            "差(さ)し替(か)える",
             "⓪ 他动2  更换，调换"
-        ],
-        "notation": "差(さ)し替(か)える"
+        ]
     },
     {
         "name": "aishou",
         "trans": [
+            "相性(あいしょう)",
             "③ 名  缘分；性格相合"
-        ],
-        "notation": "相性(あいしょう)"
+        ]
     },
     {
         "name": "kakushin",
         "trans": [
+            "革新(かくしん)",
             "⓪ 名·他动3  革新"
-        ],
-        "notation": "革新(かくしん)"
+        ]
     },
     {
         "name": "ukeau",
         "trans": [
+            "請(う)け合(あ)う",
             "③ 他动1  承担，负责；保证"
-        ],
-        "notation": "請(う)け合(あ)う"
+        ]
     },
     {
         "name": "kureyon",
         "trans": [
+            "クレヨン",
             "② 名  蜡笔"
-        ],
-        "notation": "クレヨン"
+        ]
     },
     {
         "name": "shohyou",
         "trans": [
+            "書評(しょひょう)",
             "⓪ 名  书评"
-        ],
-        "notation": "書評(しょひょう)"
+        ]
     },
     {
         "name": "tachisukumu",
         "trans": [
+            "立(た)ちすくむ",
             "⓪ 自动1  （因吃惊、害怕等）呆立不动"
-        ],
-        "notation": "立(た)ちすくむ"
+        ]
     },
     {
         "name": "aiseki",
         "trans": [
+            "相席(あいせき)",
             "⓪ 名·自动3  （在餐厅）拼桌"
-        ],
-        "notation": "相席(あいせき)"
+        ]
     },
     {
         "name": "toge",
         "trans": [
+            "棘(とげ)",
             "② 名  刺；（说话）尖酸，（话里）带刺"
-        ],
-        "notation": "棘(とげ)"
+        ]
     },
     {
         "name": "horobosu",
         "trans": [
+            "滅(ほろ)ぼす",
             "③ 他动1  毁灭，使⋯⋯灭亡"
-        ],
-        "notation": "滅(ほろ)ぼす"
+        ]
     },
     {
         "name": "kozue",
         "trans": [
+            "梢(こずえ)",
             "⓪ 名  树梢"
-        ],
-        "notation": "梢(こずえ)"
+        ]
     },
     {
         "name": "genkyuu",
         "trans": [
+            "言及(げんきゅう)",
             "⓪ 名·自动3  提及，说到"
-        ],
-        "notation": "言及(げんきゅう)"
+        ]
     },
     {
         "name": "tsunoru",
         "trans": [
+            "募(つの)る",
             "② 自他动1  招募，募集；（某种情况、倾向）越来越厉害"
-        ],
-        "notation": "募(つの)る"
+        ]
     },
     {
         "name": "nanshoku",
         "trans": [
+            "難色(なんしょく)",
             "⓪ 名  为难的神色"
-        ],
-        "notation": "難色(なんしょく)"
+        ]
     },
     {
         "name": "bankai",
         "trans": [
+            "挽回(ばんかい)",
             "⓪ 名·他动3  挽回"
-        ],
-        "notation": "挽回(ばんかい)"
+        ]
     },
     {
         "name": "yasuppoi",
         "trans": [
+            "安(やす)っぽい",
             "④ イ形  廉价的；庸俗的，卑鄙的"
-        ],
-        "notation": "安(やす)っぽい"
+        ]
     },
     {
         "name": "rinri",
         "trans": [
+            "倫理(りんり)",
             "① 名  伦理，人伦"
-        ],
-        "notation": "倫理(りんり)"
+        ]
     },
     {
         "name": "namari",
         "trans": [
+            "訛(なま)り",
             "③ 名  乡音，地方口音"
-        ],
-        "notation": "訛(なま)り"
+        ]
     },
     {
         "name": "oyobu",
         "trans": [
+            "及(およ)ぶ",
             "⓪ 自动1  达到；波及；匹敌"
-        ],
-        "notation": "及(およ)ぶ"
+        ]
     },
     {
         "name": "sharin",
         "trans": [
+            "車輪(しゃりん)",
             "⓪ 名  车轮"
-        ],
-        "notation": "車輪(しゃりん)"
+        ]
     },
     {
         "name": "aiso/aisou",
         "trans": [
+            "愛想(あいそ/あいそう)",
             "③ 名  亲切，和蔼；招待"
-        ],
-        "notation": "愛想(あいそ/あいそう)"
+        ]
     },
     {
         "name": "hagemu",
         "trans": [
+            "励(はげ)む",
             "② 自动1  努力，刻苦"
-        ],
-        "notation": "励(はげ)む"
+        ]
     },
     {
         "name": "taima-",
         "trans": [
+            "タイマー",
             "① 名  秒表，定时器；计时员"
-        ],
-        "notation": "タイマー"
+        ]
     },
     {
         "name": "shukketsu",
         "trans": [
+            "出血(しゅっけつ)",
             "⓪ 名·自动3  出血；亏本"
-        ],
-        "notation": "出血(しゅっけつ)"
+        ]
     },
     {
         "name": "oboreru",
         "trans": [
+            "溺(おぼ)れる",
             "⓪ 自动2  溺水；沉溺于"
-        ],
-        "notation": "溺(おぼ)れる"
+        ]
     },
     {
         "name": "utsubyou",
         "trans": [
+            "うつ病(びょう)",
             "⓪ 名  抑郁症"
-        ],
-        "notation": "うつ病(びょう)"
+        ]
     },
     {
         "name": "zuhyou",
         "trans": [
+            "図表(ずひょう)",
             "⓪ 名  图表"
-        ],
-        "notation": "図表(ずひょう)"
+        ]
     },
     {
         "name": "ninau",
         "trans": [
+            "担(にな)う",
             "② 他动1  担，挑；承担，担负"
-        ],
-        "notation": "担(にな)う"
+        ]
     },
     {
         "name": "aidagara",
         "trans": [
+            "間柄(あいだがら)",
             "⓪ 名  血缘关系；社交关系"
-        ],
-        "notation": "間柄(あいだがら)"
+        ]
     },
     {
         "name": "senmu",
         "trans": [
+            "専務(せんむ)",
             "① 名  专职；专务董事"
-        ],
-        "notation": "専務(せんむ)"
+        ]
     },
     {
         "name": "kareru",
         "trans": [
+            "涸(か)れる",
             "⓪ 自动2  干涸；（能力、感情等）枯竭"
-        ],
-        "notation": "涸(か)れる"
+        ]
     },
     {
         "name": "genten",
         "trans": [
+            "原点(げんてん)",
             "① 名  出发点；原点，基准点"
-        ],
-        "notation": "原点(げんてん)"
+        ]
     },
     {
         "name": "sutajiamu",
         "trans": [
+            "スタジアム",
             "② 名  运动场，比赛场"
-        ],
-        "notation": "スタジアム"
+        ]
     },
     {
         "name": "aitsugu",
         "trans": [
+            "相次(あいつ)ぐ",
             "① 自动1  相继发生，接连不断"
-        ],
-        "notation": "相次(あいつ)ぐ"
+        ]
     },
     {
         "name": "shikkyaku",
         "trans": [
+            "失脚(しっきゃく)",
             "⓪ 名·自动3  下台；垮台"
-        ],
-        "notation": "失脚(しっきゃく)"
+        ]
     },
     {
         "name": "taishitsu",
         "trans": [
+            "体質(たいしつ)",
             "⓪ 名  体质；（组织、机构等的）素质"
-        ],
-        "notation": "体質(たいしつ)"
+        ]
     },
     {
         "name": "nukinderu",
         "trans": [
+            "抜(ぬ)きん出(で)る",
             "④ 自他动2  出类拔萃；选出"
-        ],
-        "notation": "抜(ぬ)きん出(で)る"
+        ]
     },
     {
         "name": "hitogara",
         "trans": [
+            "人柄(ひとがら)",
             "⓪ 名  人品"
-        ],
-        "notation": "人柄(ひとがら)"
+        ]
     },
     {
         "name": "aiduchi",
         "trans": [
+            "相槌(あいづち)",
             "⓪ 名  帮腔，随声附和"
-        ],
-        "notation": "相槌(あいづち)"
+        ]
     },
     {
         "name": "zotto",
         "trans": [
+            "ぞっと",
             "⓪ 副·自动3  打寒战；毛骨悚然"
-        ],
-        "notation": "ぞっと"
+        ]
     },
     {
         "name": "omowaku",
         "trans": [
+            "思惑(おもわく)",
             "⓪ 名  想法，念头；看法，评价"
-        ],
-        "notation": "思惑(おもわく)"
+        ]
     },
     {
         "name": "kuchou",
         "trans": [
+            "口調(くちょう)",
             "⓪ 名  声调，语调；腔调"
-        ],
-        "notation": "口調(くちょう)"
+        ]
     },
     {
         "name": "aitedoru",
         "trans": [
+            "相手取(あいてど)る",
             "④ 名·他动1  以⋯⋯为对手"
-        ],
-        "notation": "相手取(あいてど)る"
+        ]
     },
     {
         "name": "shin'nen",
         "trans": [
+            "信念(しんねん)",
             "① 名  信念"
-        ],
-        "notation": "信念(しんねん)"
+        ]
     },
     {
         "name": "hoshaku",
         "trans": [
+            "保釈(ほしゃく)",
             "⓪ 名·他动3  保释"
-        ],
-        "notation": "保釈(ほしゃく)"
+        ]
     },
     {
         "name": "nasakenai",
         "trans": [
+            "情(なさ)けない",
             "④ イ形  无情的；可怜的；可耻的"
-        ],
-        "notation": "情(なさ)けない"
+        ]
     },
     {
         "name": "takurami",
         "trans": [
+            "企(たくら)み",
             "⓪ 名  企图，阴谋"
-        ],
-        "notation": "企(たくら)み"
+        ]
     },
     {
         "name": "aomuke",
         "trans": [
+            "仰向(あおむ)け",
             "⓪ 名  仰面朝天"
-        ],
-        "notation": "仰向(あおむ)け"
+        ]
     },
     {
         "name": "shibashi",
         "trans": [
+            "しばし",
             "① 副  暂时，不久"
-        ],
-        "notation": "しばし"
+        ]
     },
     {
         "name": "koudan",
         "trans": [
+            "講壇(こうだん)",
             "⓪ 名  讲台，讲坛"
-        ],
-        "notation": "講壇(こうだん)"
+        ]
     },
     {
         "name": "kategori-",
         "trans": [
+            "カテゴリー",
             "② 名  范畴，种类"
-        ],
-        "notation": "カテゴリー"
+        ]
     },
     {
         "name": "aete",
         "trans": [
+            "あえて",
             "① 副  敢于，硬要；（后接否定）并（不）"
-        ],
-        "notation": "あえて"
+        ]
     },
     {
         "name": "shoudan",
         "trans": [
+            "商談(しょうだん)",
             "⓪ 名·自动3  商业谈判，贸易谈判"
-        ],
-        "notation": "商談(しょうだん)"
+        ]
     },
     {
         "name": "kiryou",
         "trans": [
+            "器量(きりょう)",
             "① 名  才能，才干；容貌"
-        ],
-        "notation": "器量(きりょう)"
+        ]
     },
     {
         "name": "dabudabu",
         "trans": [
+            "だぶだぶ",
             "① 副·自动3  肥大；肥胖；（液体）满，盈"
-        ],
-        "notation": "だぶだぶ"
+        ]
     },
     {
         "name": "aidoru",
         "trans": [
+            "アイドル",
             "① 名  偶像"
-        ],
-        "notation": "アイドル"
+        ]
     },
     {
         "name": "fugou",
         "trans": [
+            "富豪(ふごう)",
             "⓪ 名  富豪，富翁"
-        ],
-        "notation": "富豪(ふごう)"
+        ]
     },
     {
         "name": "mensuru",
         "trans": [
+            "面(めん)する",
             "③ 自动3  面对，朝向；面临"
-        ],
-        "notation": "面(めん)する"
+        ]
     },
     {
         "name": "teigi",
         "trans": [
+            "定義(ていぎ)",
             "① 名·他动3  定义，下定义"
-        ],
-        "notation": "定義(ていぎ)"
+        ]
     },
     {
         "name": "kanki",
         "trans": [
+            "寒気(かんき)",
             "① 名  寒气，寒冷的气候"
-        ],
-        "notation": "寒気(かんき)"
+        ]
     },
     {
         "name": "aogu",
         "trans": [
+            "仰(あお)ぐ",
             "② 他动1  仰起；尊为，推为；仰仗；请求"
-        ],
-        "notation": "仰(あお)ぐ"
+        ]
     },
     {
         "name": "taiboku",
         "trans": [
+            "大木(たいぼく)",
             "⓪ 名  大树"
-        ],
-        "notation": "大木(たいぼく)"
+        ]
     },
     {
         "name": "aima",
         "trans": [
+            "合間(あいま)",
             "⓪ 名  空闲时间，间歇"
-        ],
-        "notation": "合間(あいま)"
+        ]
     },
     {
         "name": "nozomashii",
         "trans": [
+            "望(のぞ)ましい",
             "④ イ形  最理想的，最好的"
-        ],
-        "notation": "望(のぞ)ましい"
+        ]
     },
     {
         "name": "keisei",
         "trans": [
+            "形勢(けいせい)",
             "⓪ 名  形势，局势"
-        ],
-        "notation": "形勢(けいせい)"
+        ]
     },
     {
         "name": "aonisai",
         "trans": [
+            "青二才(あおにさい)",
             "③ 名  小毛孩儿（比喻经验不足者）"
-        ],
-        "notation": "青二才(あおにさい)"
+        ]
     },
     {
         "name": "tsukaikonasu",
         "trans": [
+            "使(つか)いこなす",
             "⑤ 他动1  熟练掌握，运用自如"
-        ],
-        "notation": "使(つか)いこなす"
+        ]
     },
     {
         "name": "keihin",
         "trans": [
+            "景品(けいひん)",
             "⓪ 名  赠品；纪念品，礼品"
-        ],
-        "notation": "景品(けいひん)"
+        ]
     },
     {
         "name": "mesaki",
         "trans": [
+            "目先(めさき)",
             "③ 名  眼前；当前；预见"
-        ],
-        "notation": "目先(めさき)"
+        ]
     },
     {
         "name": "uchikiru",
         "trans": [
+            "打(う)ち切(き)る",
             "③ 他动1  停止，中止；结束"
-        ],
-        "notation": "打(う)ち切(き)る"
+        ]
     },
     {
         "name": "aojashin",
         "trans": [
+            "青写真(あおじゃしん)",
             "③ 名  蓝图；初步计划"
-        ],
-        "notation": "青写真(あおじゃしん)"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "完工(かんこう)",
             "⓪ 名·自动3  完工"
-        ],
-        "notation": "完工(かんこう)"
+        ]
     },
     {
         "name": "kobamu",
         "trans": [
+            "拒(こば)む",
             "② 他动1  拒绝；阻挡，阻止"
-        ],
-        "notation": "拒(こば)む"
+        ]
     },
     {
         "name": "chian",
         "trans": [
+            "治安(ちあん)",
             "⓪ 名  治安"
-        ],
-        "notation": "治安(ちあん)"
+        ]
     },
     {
         "name": "hanga-",
         "trans": [
+            "ハンガー",
             "① 名  衣架"
-        ],
-        "notation": "ハンガー"
+        ]
     },
     {
         "name": "sakaeru",
         "trans": [
+            "栄(さか)える",
             "③ 自动2  兴盛，繁荣；显赫"
-        ],
-        "notation": "栄(さか)える"
+        ]
     },
     {
         "name": "ikou",
         "trans": [
+            "意向(いこう)",
             "⓪ 名  意向，打算"
-        ],
-        "notation": "意向(いこう)"
+        ]
     },
     {
         "name": "keiba",
         "trans": [
+            "競馬(けいば)",
             "⓪ 名  赛马"
-        ],
-        "notation": "競馬(けいば)"
+        ]
     },
     {
         "name": "bokeru",
         "trans": [
+            "呆(ぼ)ける",
             "② 自动2  头脑迟钝，糊涂"
-        ],
-        "notation": "呆(ぼ)ける"
+        ]
     },
     {
         "name": "dabingu",
         "trans": [
+            "ダビング",
             "⓪ 名·他动3  复制，拷贝（磁盘、唱片等）"
-        ],
-        "notation": "ダビング"
+        ]
     },
     {
         "name": "kutouten",
         "trans": [
+            "句読点(くとうてん)",
             "② 名  句号和顿号；标点符号"
-        ],
-        "notation": "句読点(くとうてん)"
+        ]
     },
     {
         "name": "aojiroi",
         "trans": [
+            "青白(あおじろ)い",
             "④ イ形  青白色的；苍白的"
-        ],
-        "notation": "青白(あおじろ)い"
+        ]
     },
     {
         "name": "kawara",
         "trans": [
+            "瓦(かわら)",
             "⓪ 名  瓦"
-        ],
-        "notation": "瓦(かわら)"
+        ]
     },
     {
         "name": "tsuihou",
         "trans": [
+            "追放(ついほう)",
             "⓪ 名·他动3  驱逐；驱除；开除"
-        ],
-        "notation": "追放(ついほう)"
+        ]
     },
     {
         "name": "shimiru",
         "trans": [
+            "染(し)みる",
             "⓪ 自动2  染上，沾染；刺，刺痛；浸透"
-        ],
-        "notation": "染(し)みる"
+        ]
     },
     {
         "name": "taika",
         "trans": [
+            "大家(たいか)",
             "① 名  权威，专家；名门，大户人家"
-        ],
-        "notation": "大家(たいか)"
+        ]
     },
     {
         "name": "tegata",
         "trans": [
+            "手形(てがた)",
             "⓪ 名  手印；票据"
-        ],
-        "notation": "手形(てがた)"
+        ]
     },
     {
         "name": "pinto",
         "trans": [
+            "ぴんと",
             "⓪ 副  突然；绷紧；马上明白"
-        ],
-        "notation": "ぴんと"
+        ]
     },
     {
         "name": "hanpa",
         "trans": [
+            "半端(はんぱ)",
             "⓪ 名·ナ形  零头；不彻底；无用的人"
-        ],
-        "notation": "半端(はんぱ)"
+        ]
     },
     {
         "name": "sozai",
         "trans": [
+            "素材(そざい)",
             "⓪ 名  素材；原材料"
-        ],
-        "notation": "素材(そざい)"
+        ]
     },
     {
         "name": "kakotsukeru",
         "trans": [
+            "託(かこつ)ける",
             "⓪ 自动2  借口，托故"
-        ],
-        "notation": "託(かこつ)ける"
+        ]
     },
     {
         "name": "eiji",
         "trans": [
+            "英字(えいじ)",
             "⓪ 名  英文"
-        ],
-        "notation": "英字(えいじ)"
+        ]
     },
     {
         "name": "sanmyaku",
         "trans": [
+            "山脈(さんみゃく)",
             "⓪ 名  山脉"
-        ],
-        "notation": "山脈(さんみゃく)"
+        ]
     },
     {
         "name": "idomu",
         "trans": [
+            "挑(いど)む",
             "② 自他动1  挑衅，挑战；征服"
-        ],
-        "notation": "挑(いど)む"
+        ]
     },
     {
         "name": "kusari",
         "trans": [
+            "鎖(くさり)",
             "⓪ 名  锁链；联系，关系"
-        ],
-        "notation": "鎖(くさり)"
+        ]
     },
     {
         "name": "tsutsumi",
         "trans": [
+            "堤(つつみ)",
             "③ 名  堤坝"
-        ],
-        "notation": "堤(つつみ)"
+        ]
     },
     {
         "name": "kanau",
         "trans": [
+            "叶(かな)う",
             "② 自动1  能实现，能如愿以偿"
-        ],
-        "notation": "叶(かな)う"
+        ]
     },
     {
         "name": "firuta-",
         "trans": [
+            "フィルター",
             "⓪ 名  过滤嘴，过滤器"
-        ],
-        "notation": "フィルター"
+        ]
     },
     {
         "name": "yuuboku",
         "trans": [
+            "遊牧(ゆうぼく)",
             "⓪ 名·自动3  游牧"
-        ],
-        "notation": "遊牧(ゆうぼく)"
+        ]
     },
     {
         "name": "miataru",
         "trans": [
+            "見当(みあ)たる",
             "⓪ 自动1  找到；看到"
-        ],
-        "notation": "見当(みあ)たる"
+        ]
     },
     {
         "name": "tokonatsu",
         "trans": [
+            "常夏(とこなつ)",
             "⓪ 名  四季常夏"
-        ],
-        "notation": "常夏(とこなつ)"
+        ]
     },
     {
         "name": "kogara",
         "trans": [
+            "小柄(こがら)",
             "⓪ 名·ナ形  小花纹，碎花；身材矮小"
-        ],
-        "notation": "小柄(こがら)"
+        ]
     },
     {
         "name": "sashikakaru",
         "trans": [
+            "差(さ)し掛(か)かる",
             "④ 自动1  靠近，路过；逼近，临近；垂悬"
-        ],
-        "notation": "差(さ)し掛(か)かる"
+        ]
     },
     {
         "name": "tsujitsuma",
         "trans": [
+            "つじつま",
             "⓪ 名  条理，道理；前后，首尾"
-        ],
-        "notation": "つじつま"
+        ]
     },
     {
         "name": "mujitsu",
         "trans": [
+            "無実(むじつ)",
             "① 名  没有根据，凭空捏造；冤枉"
-        ],
-        "notation": "無実(むじつ)"
+        ]
     },
     {
         "name": "wazurau",
         "trans": [
+            "患(わずら)う",
             "③ 自他动1  患病；苦恼，烦恼"
-        ],
-        "notation": "患(わずら)う"
+        ]
     },
     {
         "name": "isan",
         "trans": [
+            "遺産(いさん)",
             "⓪ 名  遗产"
-        ],
-        "notation": "遺産(いさん)"
+        ]
     },
     {
         "name": "oshikko",
         "trans": [
+            "おしっこ",
             "② 名  撒尿，小便"
-        ],
-        "notation": "おしっこ"
+        ]
     },
     {
         "name": "tachiau",
         "trans": [
+            "立(た)ち会(あ)う",
             "③ 自动1  遇见；在场，到场"
-        ],
-        "notation": "立(た)ち会(あ)う"
+        ]
     },
     {
         "name": "kikin",
         "trans": [
+            "飢饉(ききん)",
             "② 名  粮荒，饥荒；不足，缺乏"
-        ],
-        "notation": "飢饉(ききん)"
+        ]
     },
     {
         "name": "houchi",
         "trans": [
+            "放置(ほうち)",
             "⓪ 名·他动3  置之不理，搁置"
-        ],
-        "notation": "放置(ほうち)"
+        ]
     },
     {
         "name": "tokotonmade",
         "trans": [
+            "とことんまで",
             "③ 副  直到最后，一直到底"
-        ],
-        "notation": "とことんまで"
+        ]
     },
     {
         "name": "sokkusu",
         "trans": [
+            "ソックス",
             "① 名  短袜"
-        ],
-        "notation": "ソックス"
+        ]
     },
     {
         "name": "kinzoku",
         "trans": [
+            "勤続(きんぞく)",
             "⓪ 名·自动3  工龄，持续工作"
-        ],
-        "notation": "勤続(きんぞく)"
+        ]
     },
     {
         "name": "kemutai",
         "trans": [
+            "煙(けむ)たい",
             "⓪ イ形  烟雾弥漫的，呛人的；难相处的"
-        ],
-        "notation": "煙(けむ)たい"
+        ]
     },
     {
         "name": "taiatari",
         "trans": [
+            "体当(たいあ)たり",
             "③ 名·自动3  冲撞；拼命干，全力以赴"
-        ],
-        "notation": "体当(たいあ)たり"
+        ]
     },
     {
         "name": "nikushin",
         "trans": [
+            "肉親(にくしん)",
             "⓪ 名  亲人，骨肉至亲"
-        ],
-        "notation": "肉親(にくしん)"
+        ]
     },
     {
         "name": "komiageru",
         "trans": [
+            "込(こ)み上(あ)げる",
             "④ 自动2  往上涌；作呕；（感情）油然而生"
-        ],
-        "notation": "込(こ)み上(あ)げる"
+        ]
     },
     {
         "name": "katahou",
         "trans": [
+            "片方(かたほう)",
             "② 名  （两方中的）一方，（两个中的）一个"
-        ],
-        "notation": "片方(かたほう)"
+        ]
     },
     {
         "name": "e",
         "trans": [
+            "柄(え)",
             "⓪ 名  手柄，把手"
-        ],
-        "notation": "柄(え)"
+        ]
     },
     {
         "name": "hakadoru",
         "trans": [
+            "捗(はかど)る",
             "③ 自动1  （工作、工程等的）进展"
-        ],
-        "notation": "捗(はかど)る"
+        ]
     },
     {
         "name": "shugyou",
         "trans": [
+            "修業(しゅぎょう)",
             "⓪ 名·自他动3  学习（技术、学业）"
-        ],
-        "notation": "修業(しゅぎょう)"
+        ]
     },
     {
         "name": "kuichigai",
         "trans": [
+            "食(く)い違(ちが)い",
             "⓪ 名  分歧，不一致；交叉"
-        ],
-        "notation": "食(く)い違(ちが)い"
+        ]
     },
     {
         "name": "orosoka",
         "trans": [
+            "疎(おろそ)か",
             "② ナ形  马虎的，疏忽的"
-        ],
-        "notation": "疎(おろそ)か"
+        ]
     },
     {
         "name": "ikuta",
         "trans": [
+            "幾多(いくた)",
             "① 副  许多，几多"
-        ],
-        "notation": "幾多(いくた)"
+        ]
     },
     {
         "name": "goui",
         "trans": [
+            "合意(ごうい)",
             "① 名·自动3  同意，达成协议"
-        ],
-        "notation": "合意(ごうい)"
+        ]
     },
     {
         "name": "saeru",
         "trans": [
+            "冴(さ)える",
             "② 自动2  （光、声音等）鲜明，清晰；清醒；纯熟，精湛"
-        ],
-        "notation": "冴(さ)える"
+        ]
     },
     {
         "name": "utsubuse",
         "trans": [
+            "うつ伏(ぶ)せ",
             "⓪ 名  脸朝下俯卧；东西倒扣"
-        ],
-        "notation": "うつ伏(ぶ)せ"
+        ]
     },
     {
         "name": "jihaku",
         "trans": [
+            "自白(じはく)",
             "⓪ 名·他动3  坦白；招供"
-        ],
-        "notation": "自白(じはく)"
+        ]
     },
     {
         "name": "mekuru",
         "trans": [
+            "捲(めく)る",
             "⓪ 他动1  翻起；揭开；撕下"
-        ],
-        "notation": "捲(めく)る"
+        ]
     },
     {
         "name": "ru-zu",
         "trans": [
+            "ルーズ",
             "① ナ形  松懈的；散漫的"
-        ],
-        "notation": "ルーズ"
+        ]
     },
     {
         "name": "netsui",
         "trans": [
+            "熱意(ねつい)",
             "① 名  热忱，热情"
-        ],
-        "notation": "熱意(ねつい)"
+        ]
     },
     {
         "name": "soreyue",
         "trans": [
+            "それゆえ",
             "⓪ 接续  所以，因此"
-        ],
-        "notation": "それゆえ"
+        ]
     },
     {
         "name": "suiri",
         "trans": [
+            "推理(すいり)",
             "① 名·他动3  推理，推断"
-        ],
-        "notation": "推理(すいり)"
+        ]
     },
     {
         "name": "kairyuu",
         "trans": [
+            "海流(かいりゅう)",
             "⓪ 名  海流"
-        ],
-        "notation": "海流(かいりゅう)"
+        ]
     },
     {
         "name": "okasu",
         "trans": [
+            "冒(おか)す",
             "② 他动1  冒着；侵袭，患病；冒充"
-        ],
-        "notation": "冒(おか)す"
+        ]
     },
     {
         "name": "kyouchou",
         "trans": [
+            "協調(きょうちょう)",
             "⓪ 名·自动3  协调，合作"
-        ],
-        "notation": "協調(きょうちょう)"
+        ]
     },
     {
         "name": "hikan",
         "trans": [
+            "悲観(ひかん)",
             "⓪ 名·自他动3  悲观，失望"
-        ],
-        "notation": "悲観(ひかん)"
+        ]
     },
     {
         "name": "sanagara",
         "trans": [
+            "宛(さなが)ら",
             "⓪ 副  宛如，好像"
-        ],
-        "notation": "宛(さなが)ら"
+        ]
     },
     {
         "name": "teisai",
         "trans": [
+            "体裁(ていさい)",
             "⓪ 名  门面，外表；体面；奉承话"
-        ],
-        "notation": "体裁(ていさい)"
+        ]
     },
     {
         "name": "bakansu",
         "trans": [
+            "バカンス",
             "① 名  休假，假期"
-        ],
-        "notation": "バカンス"
+        ]
     },
     {
         "name": "misuborashii",
         "trans": [
+            "みすぼらしい",
             "⑤ イ形  难看的，寒碜的"
-        ],
-        "notation": "みすぼらしい"
+        ]
     },
     {
         "name": "shussan",
         "trans": [
+            "出産(しゅっさん)",
             "⓪ 名·自他动3  分娩"
-        ],
-        "notation": "出産(しゅっさん)"
+        ]
     },
     {
         "name": "kogitte",
         "trans": [
+            "小切手(こぎって)",
             "② 名  支票"
-        ],
-        "notation": "小切手(こぎって)"
+        ]
     },
     {
         "name": "odosu",
         "trans": [
+            "脅(おど)す",
             "⓪ 他动1  威胁，恐吓"
-        ],
-        "notation": "脅(おど)す"
+        ]
     },
     {
         "name": "hidarikiki",
         "trans": [
+            "左利(ひだりき)き",
             "⓪ 名  左撇子，左手灵活的人"
-        ],
-        "notation": "左利(ひだりき)き"
+        ]
     },
     {
         "name": "tenji",
         "trans": [
+            "展示(てんじ)",
             "⓪ 名·他动3  展示，陈列"
-        ],
-        "notation": "展示(てんじ)"
+        ]
     },
     {
         "name": "shibomu",
         "trans": [
+            "萎(しぼ)む",
             "⓪ 自动1  枯萎，凋谢；瘪"
-        ],
-        "notation": "萎(しぼ)む"
+        ]
     },
     {
         "name": "gyoukai",
         "trans": [
+            "業界(ぎょうかい)",
             "⓪ 名  业界"
-        ],
-        "notation": "業界(ぎょうかい)"
+        ]
     },
     {
         "name": "omoiyari",
         "trans": [
+            "思(おも)いやり",
             "⓪ 名  同情心，体贴"
-        ],
-        "notation": "思(おも)いやり"
+        ]
     },
     {
         "name": "ikari",
         "trans": [
+            "怒(いか)り",
             "③ 名  愤怒，生气"
-        ],
-        "notation": "怒(いか)り"
+        ]
     },
     {
         "name": "sugasugashii",
         "trans": [
+            "清清(すがすが)しい",
             "⑤ イ形  神清气爽的"
-        ],
-        "notation": "清清(すがすが)しい"
+        ]
     },
     {
         "name": "haijakku",
         "trans": [
+            "ハイジャック",
             "③ 名·他动3  劫持飞机"
-        ],
-        "notation": "ハイジャック"
+        ]
     },
     {
         "name": "mikon",
         "trans": [
+            "未婚(みこん)",
             "⓪ 名  未婚"
-        ],
-        "notation": "未婚(みこん)"
+        ]
     },
     {
         "name": "akasu",
         "trans": [
+            "明(あ)かす",
             "⓪ 他动1  说出；揭露，揭晓；过夜"
-        ],
-        "notation": "明(あ)かす"
+        ]
     },
     {
         "name": "kouchou",
         "trans": [
+            "好調(こうちょう)",
             "⓪ 名·ナ形  顺利，情况良好"
-        ],
-        "notation": "好調(こうちょう)"
+        ]
     },
     {
         "name": "shuwa",
         "trans": [
+            "手話(しゅわ)",
             "① 名  手语"
-        ],
-        "notation": "手話(しゅわ)"
+        ]
     },
     {
         "name": "yousuru",
         "trans": [
+            "要(よう)する",
             "③ 他动3  需要；归纳，摘要"
-        ],
-        "notation": "要(よう)する"
+        ]
     },
     {
         "name": "hojuu",
         "trans": [
+            "補充(ほじゅう)",
             "⓪ 名·他动3  补充"
-        ],
-        "notation": "補充(ほじゅう)"
+        ]
     },
     {
         "name": "namami",
         "trans": [
+            "生身(なまみ)",
             "② 名  肉体，活人"
-        ],
-        "notation": "生身(なまみ)"
+        ]
     },
     {
         "name": "tayumu",
         "trans": [
+            "弛(たゆ)む",
             "② 自动1  松弛，松懈"
-        ],
-        "notation": "弛(たゆ)む"
+        ]
     },
     {
         "name": "kakehashi",
         "trans": [
+            "架(か)け橋(はし)",
             "② 名  桥梁"
-        ],
-        "notation": "架(か)け橋(はし)"
+        ]
     },
     {
         "name": "mansei",
         "trans": [
+            "慢性(まんせい)",
             "⓪ 名  慢性"
-        ],
-        "notation": "慢性(まんせい)"
+        ]
     },
     {
         "name": "niekiranai",
         "trans": [
+            "煮(に)え切(き)らない",
             "④ 连语·イ形  暧昧不清，犹豫不定，不干脆"
-        ],
-        "notation": "煮(に)え切(き)らない"
+        ]
     },
     {
         "name": "tsuiraku",
         "trans": [
+            "墜落(ついらく)",
             "⓪ 名·自动3  坠落，掉下"
-        ],
-        "notation": "墜落(ついらく)"
+        ]
     },
     {
         "name": "shigaisen",
         "trans": [
+            "紫外線(しがいせん)",
             "⓪ 名  紫外线"
-        ],
-        "notation": "紫外線(しがいせん)"
+        ]
     },
     {
         "name": "masaru",
         "trans": [
+            "勝(まさ)る",
             "② 自动1  胜过，强过"
-        ],
-        "notation": "勝(まさ)る"
+        ]
     },
     {
         "name": "fea",
         "trans": [
+            "フェア",
             "① ナ形  公平的"
-        ],
-        "notation": "フェア"
+        ]
     },
     {
         "name": "kenji",
         "trans": [
+            "検事(けんじ)",
             "① 名  检察官"
-        ],
-        "notation": "検事(けんじ)"
+        ]
     },
     {
         "name": "akireru",
         "trans": [
+            "呆(あき)れる",
             "⓪ 自动2  吃惊；吓呆，发愣"
-        ],
-        "notation": "呆(あき)れる"
+        ]
     },
     {
         "name": "endaka",
         "trans": [
+            "円高(えんだか)",
             "⓪ 名  日元升值"
-        ],
-        "notation": "円高(えんだか)"
+        ]
     },
     {
         "name": "kizoku",
         "trans": [
+            "貴族(きぞく)",
             "① 名  贵族"
-        ],
-        "notation": "貴族(きぞく)"
+        ]
     },
     {
         "name": "sosoru",
         "trans": [
+            "そそる",
             "⓪ 他动1  引起，勾起（感情、欲望等）"
-        ],
-        "notation": "そそる"
+        ]
     },
     {
         "name": "kurouto",
         "trans": [
+            "玄人(くろうと)",
             "① 名  内行，行家"
-        ],
-        "notation": "玄人(くろうと)"
+        ]
     },
     {
         "name": "donzoko",
         "trans": [
+            "どん底(ぞこ)",
             "⓪ 名  最底层，最穷困的状态"
-        ],
-        "notation": "どん底(ぞこ)"
+        ]
     },
     {
         "name": "hisuru",
         "trans": [
+            "比(ひ)する",
             "② 他动3  比较"
-        ],
-        "notation": "比(ひ)する"
+        ]
     },
     {
         "name": "hosutesu",
         "trans": [
+            "ホステス",
             "① 名  （宴会的）女主人；（酒吧的）女招待"
-        ],
-        "notation": "ホステス"
+        ]
     },
     {
         "name": "rikujou",
         "trans": [
+            "陸上(りくじょう)",
             "⓪ 名  陆地上"
-        ],
-        "notation": "陸上(りくじょう)"
+        ]
     },
     {
         "name": "iyashii",
         "trans": [
+            "卑(いや)しい",
             "③ イ形  卑鄙的；低贱的；破旧的"
-        ],
-        "notation": "卑(いや)しい"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "階層(かいそう)",
             "⓪ 名  （社会）阶层；楼层"
-        ],
-        "notation": "階層(かいそう)"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "磁器(じき)",
             "① 名  瓷器"
-        ],
-        "notation": "磁器(じき)"
+        ]
     },
     {
         "name": "sokuzani",
         "trans": [
+            "即座(そくざ)に",
             "① 副  立即，马上"
-        ],
-        "notation": "即座(そくざ)に"
+        ]
     },
     {
         "name": "keireki",
         "trans": [
+            "経歴(けいれき)",
             "⓪ 名·自动3  经历；履历；来历"
-        ],
-        "notation": "経歴(けいれき)"
+        ]
     },
     {
         "name": "honkan",
         "trans": [
+            "本館(ほんかん)",
             "⓪ 名  主楼，正楼"
-        ],
-        "notation": "本館(ほんかん)"
+        ]
     },
     {
         "name": "yokotawaru",
         "trans": [
+            "横(よこ)たわる",
             "④ 自动1  躺卧；横亘；迫在眼前"
-        ],
-        "notation": "横(よこ)たわる"
+        ]
     },
     {
         "name": "shiraga",
         "trans": [
+            "白髪(しらが)",
             "③ 名  白头发"
-        ],
-        "notation": "白髪(しらが)"
+        ]
     },
     {
         "name": "onrain",
         "trans": [
+            "オンライン",
             "③ 名  联机，在线"
-        ],
-        "notation": "オンライン"
+        ]
     },
     {
         "name": "isasaka",
         "trans": [
+            "いささか",
             "② 副  稍微，有些，一点儿"
-        ],
-        "notation": "いささか"
+        ]
     },
     {
         "name": "senshuu",
         "trans": [
+            "専修(せんしゅう)",
             "⓪ 名·他动3  专修，专攻"
-        ],
-        "notation": "専修(せんしゅう)"
+        ]
     },
     {
         "name": "maue",
         "trans": [
+            "真上(まうえ)",
             "③ 名  正上方，头顶上"
-        ],
-        "notation": "真上(まうえ)"
+        ]
     },
     {
         "name": "wakiagaru",
         "trans": [
+            "沸(わ)き上(あ)がる",
             "④ 自动1  煮开，沸腾；涌现；兴奋"
-        ],
-        "notation": "沸(わ)き上(あ)がる"
+        ]
     },
     {
         "name": "bansou",
         "trans": [
+            "伴奏(ばんそう)",
             "⓪ 名·自动3  伴奏"
-        ],
-        "notation": "伴奏(ばんそう)"
+        ]
     },
     {
         "name": "keibu",
         "trans": [
+            "警部(けいぶ)",
             "① 名  警部（日本警察职称）"
-        ],
-        "notation": "警部(けいぶ)"
+        ]
     },
     {
         "name": "ogoru",
         "trans": [
+            "驕(おご)る",
             "⓪ 自动1  骄傲，傲慢"
-        ],
-        "notation": "驕(おご)る"
+        ]
     },
     {
         "name": "imin",
         "trans": [
+            "移民(いみん)",
             "⓪ 名·自动3  移民"
-        ],
-        "notation": "移民(いみん)"
+        ]
     },
     {
         "name": "daenkei",
         "trans": [
+            "楕円形(だえんけい)",
             "⓪ 名  椭圆形"
-        ],
-        "notation": "楕円形(だえんけい)"
+        ]
     },
     {
         "name": "mezamashii",
         "trans": [
+            "目覚(めざ)ましい",
             "④ イ形  惊人的，异常显著的"
-        ],
-        "notation": "目覚(めざ)ましい"
+        ]
     },
     {
         "name": "hideri",
         "trans": [
+            "日照(ひで)り",
             "⓪ 名  干旱；缺乏"
-        ],
-        "notation": "日照(ひで)り"
+        ]
     },
     {
         "name": "shiitake",
         "trans": [
+            "椎茸(しいたけ)",
             "① 名  香菇"
-        ],
-        "notation": "椎茸(しいたけ)"
+        ]
     },
     {
         "name": "dokasu",
         "trans": [
+            "退(ど)かす",
             "⓪ 他动1  让⋯⋯躲开；挪走，搬走"
-        ],
-        "notation": "退(ど)かす"
+        ]
     },
     {
         "name": "gyappu",
         "trans": [
+            "ギャップ",
             "⓪ 名  裂缝；分歧，隔阂"
-        ],
-        "notation": "ギャップ"
+        ]
     },
     {
         "name": "kyozetsu",
         "trans": [
+            "拒絶(きょぜつ)",
             "⓪ 名·他动3  拒绝"
-        ],
-        "notation": "拒絶(きょぜつ)"
+        ]
     },
     {
         "name": "uwamawaru",
         "trans": [
+            "上回(うわまわ)る",
             "④ 自动1  超过，超出"
-        ],
-        "notation": "上回(うわまわ)る"
+        ]
     },
     {
         "name": "kanshoku",
         "trans": [
+            "感触(かんしょく)",
             "⓪ 名  触觉，触感；感觉"
-        ],
-        "notation": "感触(かんしょく)"
+        ]
     },
     {
         "name": "yusuru",
         "trans": [
+            "強請(ゆす)る",
             "⓪ 他动1  敲诈，勒索"
-        ],
-        "notation": "強請(ゆす)る"
+        ]
     },
     {
         "name": "minagiru",
         "trans": [
+            "漲(みなぎ)る",
             "③ 自动1  涨满；充满，洋溢"
-        ],
-        "notation": "漲(みなぎ)る"
+        ]
     },
     {
         "name": "yuubou",
         "trans": [
+            "有望(ゆうぼう)",
             "⓪ 名·ナ形  （前途）有希望"
-        ],
-        "notation": "有望(ゆうぼう)"
+        ]
     },
     {
         "name": "jisonshin",
         "trans": [
+            "自尊心(じそんしん)",
             "② 名  自尊心"
-        ],
-        "notation": "自尊心(じそんしん)"
+        ]
     },
     {
         "name": "arappoi",
         "trans": [
+            "荒(あら)っぽい",
             "④ イ形  粗野的，粗暴的"
-        ],
-        "notation": "荒(あら)っぽい"
+        ]
     },
     {
         "name": "chakushu",
         "trans": [
+            "着手(ちゃくしゅ)",
             "① 名·自动3  着手，开始"
-        ],
-        "notation": "着手(ちゃくしゅ)"
+        ]
     },
     {
         "name": "genkyuu",
         "trans": [
+            "減給(げんきゅう)",
             "⓪ 名·自他动3  减薪，降薪"
-        ],
-        "notation": "減給(げんきゅう)"
+        ]
     },
     {
         "name": "sabaku",
         "trans": [
+            "裁(さば)く",
             "② 他动1  审判；从中调停"
-        ],
-        "notation": "裁(さば)く"
+        ]
     },
     {
         "name": "kaunsera-",
         "trans": [
+            "カウンセラー",
             "② 名  （心理）咨询师；生活指导员"
-        ],
-        "notation": "カウンセラー"
+        ]
     },
     {
         "name": "chouhen",
         "trans": [
+            "長編(ちょうへん)",
             "⓪ 名  长篇"
-        ],
-        "notation": "長編(ちょうへん)"
+        ]
     },
     {
         "name": "hitokiwa",
         "trans": [
+            "ひときわ",
             "② 副  格外，尤其"
-        ],
-        "notation": "ひときわ"
+        ]
     },
     {
         "name": "taka",
         "trans": [
+            "鷹(たか)",
             "⓪ 名  鹰"
-        ],
-        "notation": "鷹(たか)"
+        ]
     },
     {
         "name": "gunshuu",
         "trans": [
+            "群衆(ぐんしゅう)",
             "⓪ 名  群众"
-        ],
-        "notation": "群衆(ぐんしゅう)"
+        ]
     },
     {
         "name": "atsuraeru",
         "trans": [
+            "誂(あつら)える",
             "③ 他动2  定做"
-        ],
-        "notation": "誂(あつら)える"
+        ]
     },
     {
         "name": "sashiire",
         "trans": [
+            "差(さ)し入(い)れ",
             "⓪ 名·他动3  插入，投入；送慰问品"
-        ],
-        "notation": "差(さ)し入(い)れ"
+        ]
     },
     {
         "name": "tsukanoma",
         "trans": [
+            "束(つか)の間(ま)",
             "⓪ 名  刹那间，转瞬"
-        ],
-        "notation": "束(つか)の間(ま)"
+        ]
     },
     {
         "name": "nogasu",
         "trans": [
+            "逃(のが)す",
             "② 他动1  错过；放过"
-        ],
-        "notation": "逃(のが)す"
+        ]
     },
     {
         "name": "bunshi",
         "trans": [
+            "分子(ぶんし)",
             "① 名  分子"
-        ],
-        "notation": "分子(ぶんし)"
+        ]
     },
     {
         "name": "oki",
         "trans": [
+            "沖(おき)",
             "⓪ 名  海上，洋面；湖心"
-        ],
-        "notation": "沖(おき)"
+        ]
     },
     {
         "name": "inamenai",
         "trans": [
+            "否(いな)めない",
             "③ 连语  不可否认；不能拒绝"
-        ],
-        "notation": "否(いな)めない"
+        ]
     },
     {
         "name": "kikyou",
         "trans": [
+            "帰京(ききょう)",
             "⓪ 名·自动3  回（东）京，回首都"
-        ],
-        "notation": "帰京(ききょう)"
+        ]
     },
     {
         "name": "dekiai",
         "trans": [
+            "溺愛(できあい)",
             "⓪ 名·他动3  溺爱"
-        ],
-        "notation": "溺愛(できあい)"
+        ]
     },
     {
         "name": "hassuru",
         "trans": [
+            "発(はっ)する",
             "⓪ 自他动3  发出；发端；派遣"
-        ],
-        "notation": "発(はっ)する"
+        ]
     },
     {
         "name": "tenji",
         "trans": [
+            "点字(てんじ)",
             "⓪ 名  盲文"
-        ],
-        "notation": "点字(てんじ)"
+        ]
     },
     {
         "name": "kichoumen",
         "trans": [
+            "几帳面(きちょうめん)",
             "④ ナ形  一丝不苟的，严谨的"
-        ],
-        "notation": "几帳面(きちょうめん)"
+        ]
     },
     {
         "name": "shitau",
         "trans": [
+            "慕(した)う",
             "⓪ 他动1  爱慕，思慕；敬仰；追随"
-        ],
-        "notation": "慕(した)う"
+        ]
     },
     {
         "name": "misairu",
         "trans": [
+            "ミサイル",
             "② 名  导弹"
-        ],
-        "notation": "ミサイル"
+        ]
     },
     {
         "name": "akashi",
         "trans": [
+            "証(あかし)",
             "⓪ 名  证据，证明"
-        ],
-        "notation": "証(あかし)"
+        ]
     },
     {
         "name": "onozukara",
         "trans": [
+            "自(おの)ずから",
             "⓪ 副  自然而然地"
-        ],
-        "notation": "自(おの)ずから"
+        ]
     },
     {
         "name": "suii",
         "trans": [
+            "推移(すいい)",
             "① 名·自动3  推移；变迁；演变"
-        ],
-        "notation": "推移(すいい)"
+        ]
     },
     {
         "name": "fukitsu",
         "trans": [
+            "不吉(ふきつ)",
             "⓪ 名·ナ形  不吉利，不祥"
-        ],
-        "notation": "不吉(ふきつ)"
+        ]
     },
     {
         "name": "yabureru",
         "trans": [
+            "敗(やぶ)れる",
             "③ 自动2  失败，败北"
-        ],
-        "notation": "敗(やぶ)れる"
+        ]
     },
     {
         "name": "ton'ya",
         "trans": [
+            "問屋(とんや)",
             "⓪ 名  批发商"
-        ],
-        "notation": "問屋(とんや)"
+        ]
     },
     {
         "name": "emono",
         "trans": [
+            "獲物(えもの)",
             "⓪ 名  猎物，战利品"
-        ],
-        "notation": "獲物(えもの)"
+        ]
     },
     {
         "name": "akinai",
         "trans": [
+            "商(あきな)い",
             "② 名  买卖，生意"
-        ],
-        "notation": "商(あきな)い"
+        ]
     },
     {
         "name": "kanaduchi",
         "trans": [
+            "金槌(かなづち)",
             "③ 名  锤子，铁锤；不会游泳的人"
-        ],
-        "notation": "金槌(かなづち)"
+        ]
     },
     {
         "name": "heigai",
         "trans": [
+            "弊害(へいがい)",
             "⓪ 名  弊病；恶劣影响"
-        ],
-        "notation": "弊害(へいがい)"
+        ]
     },
     {
         "name": "manmarui",
         "trans": [
+            "真(ま)ん丸(まる)い",
             "④ イ形  圆溜溜的，圆滚滚的"
-        ],
-        "notation": "真(ま)ん丸(まる)い"
+        ]
     },
     {
         "name": "mo-teru",
         "trans": [
+            "モーテル",
             "① 名  汽车旅馆"
-        ],
-        "notation": "モーテル"
+        ]
     },
     {
         "name": "konpon",
         "trans": [
+            "根本(こんぽん)",
             "⓪ 名  根本，根源"
-        ],
-        "notation": "根本(こんぽん)"
+        ]
     },
     {
         "name": "karonjiru",
         "trans": [
+            "軽(かろ)んじる",
             "④ 他动2  轻视；忽视"
-        ],
-        "notation": "軽(かろ)んじる"
+        ]
     },
     {
         "name": "eiyuu",
         "trans": [
+            "英雄(えいゆう)",
             "⓪ 名  英雄"
-        ],
-        "notation": "英雄(えいゆう)"
+        ]
     },
     {
         "name": "nohara",
         "trans": [
+            "野原(のはら)",
             "① 名  原野，野地"
-        ],
-        "notation": "野原(のはら)"
+        ]
     },
     {
         "name": "misugosu",
         "trans": [
+            "見過(みす)ごす",
             "⓪ 他动1  看漏，没看到；饶恕，放过"
-        ],
-        "notation": "見過(みす)ごす"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "補償(ほしょう)",
             "⓪ 名·他动3  补偿，赔偿"
-        ],
-        "notation": "補償(ほしょう)"
+        ]
     },
     {
         "name": "yokkyuu",
         "trans": [
+            "欲求(よっきゅう)",
             "⓪ 名·他动3  欲望，欲求"
-        ],
-        "notation": "欲求(よっきゅう)"
+        ]
     },
     {
         "name": "nikayou",
         "trans": [
+            "似通(にかよ)う",
             "③ 自动1  相似，类似"
-        ],
-        "notation": "似通(にかよ)う"
+        ]
     },
     {
         "name": "kure-mu",
         "trans": [
+            "クレーム",
             "⓪ 名  不平，不满；索赔"
-        ],
-        "notation": "クレーム"
+        ]
     },
     {
         "name": "kaizokuban",
         "trans": [
+            "海賊版(かいぞくばん)",
             "⓪ 名  盗版"
-        ],
-        "notation": "海賊版(かいぞくばん)"
+        ]
     },
     {
         "name": "subashikoi",
         "trans": [
+            "すばしこい",
             "④ イ形  敏捷的，灵活的"
-        ],
-        "notation": "すばしこい"
+        ]
     },
     {
         "name": "kinri",
         "trans": [
+            "金利(きんり)",
             "⓪ 名  利息，利率"
-        ],
-        "notation": "金利(きんり)"
+        ]
     },
     {
         "name": "imadoki",
         "trans": [
+            "今時(いまどき)",
             "⓪ 名  现今，当代；这时候"
-        ],
-        "notation": "今時(いまどき)"
+        ]
     },
     {
         "name": "obiyakasu",
         "trans": [
+            "脅(おびや)かす",
             "④ 他动1  威胁，恫吓，胁迫；威逼，强迫"
-        ],
-        "notation": "脅(おびや)かす"
+        ]
     },
     {
         "name": "goku",
         "trans": [
+            "語句(ごく)",
             "① 名  语句；词"
-        ],
-        "notation": "語句(ごく)"
+        ]
     },
     {
         "name": "nikkou",
         "trans": [
+            "日光(にっこう)",
             "① 名  日光，阳光"
-        ],
-        "notation": "日光(にっこう)"
+        ]
     },
     {
         "name": "sakanoboru",
         "trans": [
+            "遡(さかのぼ)る",
             "④ 自动1  逆流而上；追溯"
-        ],
-        "notation": "遡(さかのぼ)る"
+        ]
     },
     {
         "name": "dageki",
         "trans": [
+            "打撃(だげき)",
             "⓪ 名  打击；损失"
-        ],
-        "notation": "打撃(だげき)"
+        ]
     },
     {
         "name": "tounyuu",
         "trans": [
+            "投入(とうにゅう)",
             "⓪ 名·他动3  投进去；投入（资本）"
-        ],
-        "notation": "投入(とうにゅう)"
+        ]
     },
     {
         "name": "keisandakai",
         "trans": [
+            "計算高(けいさんだか)い",
             "⑥ イ形  会算计的；打小算盘的，精打细算的"
-        ],
-        "notation": "計算高(けいさんだか)い"
+        ]
     },
     {
         "name": "uchiwa",
         "trans": [
+            "団扇(うちわ)",
             "② 名  团扇，蒲扇"
-        ],
-        "notation": "団扇(うちわ)"
+        ]
     },
     {
         "name": "maebure",
         "trans": [
+            "前触(まえぶ)れ",
             "⓪ 名  预告；先兆，前兆"
-        ],
-        "notation": "前触(まえぶ)れ"
+        ]
     },
     {
         "name": "hizumu",
         "trans": [
+            "歪(ひず)む",
             "⓪ 自动1  变形，走样"
-        ],
-        "notation": "歪(ひず)む"
+        ]
     },
     {
         "name": "surakkusu",
         "trans": [
+            "スラックス",
             "② 名  裤子，女士西裤"
-        ],
-        "notation": "スラックス"
+        ]
     },
     {
         "name": "namari",
         "trans": [
+            "鉛(なまり)",
             "⓪ 名  铅"
-        ],
-        "notation": "鉛(なまり)"
+        ]
     },
     {
         "name": "kogasu",
         "trans": [
+            "焦(こ)がす",
             "② 他动1  烧焦；（心情）焦急"
-        ],
-        "notation": "焦(こ)がす"
+        ]
     },
     {
         "name": "aka",
         "trans": [
+            "垢(あか)",
             "② 名  污垢；水垢"
-        ],
-        "notation": "垢(あか)"
+        ]
     },
     {
         "name": "toushi",
         "trans": [
+            "投資(とうし)",
             "⓪ 名·自他动3  投资"
-        ],
-        "notation": "投資(とうし)"
+        ]
     },
     {
         "name": "yomigaeru",
         "trans": [
+            "蘇(よみがえ)る",
             "③ 自动1  苏醒，复活；复苏"
-        ],
-        "notation": "蘇(よみがえ)る"
+        ]
     },
     {
         "name": "insupire-shon",
         "trans": [
+            "インスピレーション",
             "⑤ 名  灵感"
-        ],
-        "notation": "インスピレーション"
+        ]
     },
     {
         "name": "tadoritsuku",
         "trans": [
+            "辿(たど)り着(つ)く",
             "④ 自动1  好不容易走到"
-        ],
-        "notation": "辿(たど)り着(つ)く"
+        ]
     },
     {
         "name": "hageru",
         "trans": [
+            "剥(は)げる",
             "② 自动2  剥落；褪色"
-        ],
-        "notation": "剥(は)げる"
+        ]
     },
     {
         "name": "makki",
         "trans": [
+            "末期(まっき)",
             "① 名  晚期，末期"
-        ],
-        "notation": "末期(まっき)"
+        ]
     },
     {
         "name": "kussetsu",
         "trans": [
+            "屈折(くっせつ)",
             "⓪ 名·自动3  弯曲，曲折；歪曲，不正常"
-        ],
-        "notation": "屈折(くっせつ)"
+        ]
     },
     {
         "name": "hokorobiru",
         "trans": [
+            "綻(ほころ)びる",
             "④ 自动2  （衣服）开绽；稍微张开"
-        ],
-        "notation": "綻(ほころ)びる"
+        ]
     },
     {
         "name": "shinpan",
         "trans": [
+            "審判(しんぱん)",
             "⓪ 名·他动3  审判，裁判"
-        ],
-        "notation": "審判(しんぱん)"
+        ]
     },
     {
         "name": "ikan",
         "trans": [
+            "遺憾(いかん)",
             "⓪ 名·ナ形  遗憾"
-        ],
-        "notation": "遺憾(いかん)"
+        ]
     },
     {
         "name": "kiyoraka",
         "trans": [
+            "清(きよ)らか",
             "② ナ形  清澈的；纯洁的；清爽的"
-        ],
-        "notation": "清(きよ)らか"
+        ]
     },
     {
         "name": "saido",
         "trans": [
+            "再度(さいど)",
             "① 副  再次，第二次"
-        ],
-        "notation": "再度(さいど)"
+        ]
     },
     {
         "name": "chiri",
         "trans": [
+            "塵(ちり)",
             "⓪ 名  灰尘；少许，丝毫"
-        ],
-        "notation": "塵(ちり)"
+        ]
     },
     {
         "name": "migurushii",
         "trans": [
+            "見苦(みぐる)しい",
             "④ イ形  难看的，寒碜的；丢脸的"
-        ],
-        "notation": "見苦(みぐる)しい"
+        ]
     },
     {
         "name": "yatou",
         "trans": [
+            "野党(やとう)",
             "① 名  在野党"
-        ],
-        "notation": "野党(やとう)"
+        ]
     },
     {
         "name": "sesshu",
         "trans": [
+            "摂取(せっしゅ)",
             "① 名·他动3  摄取(营养)；吸收（文化）"
-        ],
-        "notation": "摂取(せっしゅ)"
+        ]
     },
     {
         "name": "okasu",
         "trans": [
+            "侵(おか)す",
             "② 他动1  侵犯，侵害；侵占"
-        ],
-        "notation": "侵(おか)す"
+        ]
     },
     {
         "name": "inabikari",
         "trans": [
+            "稲光(いなびかり)",
             "③ 名  闪电"
-        ],
-        "notation": "稲光(いなびかり)"
+        ]
     },
     {
         "name": "sakan",
         "trans": [
+            "左官(さかん)",
             "⓪ 名  泥瓦匠"
-        ],
-        "notation": "左官(さかん)"
+        ]
     },
     {
         "name": "kimetsukeru",
         "trans": [
+            "決(き)め付(つ)ける",
             "④ 他动2  （不容分说地）指责，申斥"
-        ],
-        "notation": "決(き)め付(つ)ける"
+        ]
     },
     {
         "name": "akaji",
         "trans": [
+            "赤字(あかじ)",
             "⓪ 名  赤字，亏空"
-        ],
-        "notation": "赤字(あかじ)"
+        ]
     },
     {
         "name": "fukoku",
         "trans": [
+            "布告(ふこく)",
             "⓪ 名·他动3  公告，宣布"
-        ],
-        "notation": "布告(ふこく)"
+        ]
     },
     {
         "name": "todaeru",
         "trans": [
+            "途絶(とだ)える",
             "③ 自动2  断绝，中断"
-        ],
-        "notation": "途絶(とだ)える"
+        ]
     },
     {
         "name": "azuki",
         "trans": [
+            "小豆(あずき)",
             "③ 名  红豆  "
-        ],
-        "notation": "小豆(あずき)"
+        ]
     },
     {
         "name": "buenryo",
         "trans": [
+            "無遠慮(ぶえんりょ)",
             "② 名·ナ形  不客气，直率"
-        ],
-        "notation": "無遠慮(ぶえんりょ)"
+        ]
     },
     {
         "name": "majieru",
         "trans": [
+            "交(まじ)える",
             "③ 他动2  夹杂，掺杂；交叉，互相"
-        ],
-        "notation": "交(まじ)える"
+        ]
     },
     {
         "name": "yuui",
         "trans": [
+            "優位(ゆうい)",
             "① 名·ナ形  优势，有利地位"
-        ],
-        "notation": "優位(ゆうい)"
+        ]
     },
     {
         "name": "hakyoku",
         "trans": [
+            "破局(はきょく)",
             "⓪ 名  不可收拾的局面；悲惨的结局"
-        ],
-        "notation": "破局(はきょく)"
+        ]
     },
     {
         "name": "samo",
         "trans": [
+            "さも",
             "① 副  非常，很；好像"
-        ],
-        "notation": "さも"
+        ]
     },
     {
         "name": "uchimaku",
         "trans": [
+            "内幕(うちまく)",
             "⓪ 名  内幕，内情"
-        ],
-        "notation": "内幕(うちまく)"
+        ]
     },
     {
         "name": "sutajio",
         "trans": [
+            "スタジオ",
             "⓪ 名  摄影棚；工作室"
-        ],
-        "notation": "スタジオ"
+        ]
     },
     {
         "name": "tsukaeru",
         "trans": [
+            "仕(つか)える",
             "③ 自动2  伺候，服侍；做官"
-        ],
-        "notation": "仕(つか)える"
+        ]
     },
     {
         "name": "nissuu",
         "trans": [
+            "日数(にっすう)",
             "③ 名  日数，天数"
-        ],
-        "notation": "日数(にっすう)"
+        ]
     },
     {
         "name": "harigane",
         "trans": [
+            "針金(はりがね)",
             "⓪ 名  铁丝；钢丝"
-        ],
-        "notation": "針金(はりがね)"
+        ]
     },
     {
         "name": "moukeru",
         "trans": [
+            "設(もう)ける",
             "③ 他动2  设立，设置；准备"
-        ],
-        "notation": "設(もう)ける"
+        ]
     },
     {
         "name": "raijou",
         "trans": [
+            "来場(らいじょう)",
             "⓪ 名·自动3  到场，出席"
-        ],
-        "notation": "来場(らいじょう)"
+        ]
     },
     {
         "name": "gangu",
         "trans": [
+            "玩具(がんぐ)",
             "① 名  玩具"
-        ],
-        "notation": "玩具(がんぐ)"
+        ]
     },
     {
         "name": "imaichi",
         "trans": [
+            "今一(いまいち)",
             "② 副  差一点儿，再加把劲"
-        ],
-        "notation": "今一(いまいち)"
+        ]
     },
     {
         "name": "bira",
         "trans": [
+            "びら",
             "⓪ 名  传单，广告"
-        ],
-        "notation": "びら"
+        ]
     },
     {
         "name": "mokuroku",
         "trans": [
+            "目録(もくろく)",
             "⓪ 名  目录；清单"
-        ],
-        "notation": "目録(もくろく)"
+        ]
     },
     {
         "name": "wazatorashii",
         "trans": [
+            "わざとらしい",
             "⑤ イ形  故意似的，不自然的"
-        ],
-        "notation": "わざとらしい"
+        ]
     },
     {
         "name": "misemono",
         "trans": [
+            "見世物(みせもの)",
             "③ 名  杂耍，小节目；出洋相"
-        ],
-        "notation": "見世物(みせもの)"
+        ]
     },
     {
         "name": "nadare",
         "trans": [
+            "雪崩(なだれ)",
             "⓪ 名  雪崩"
-        ],
-        "notation": "雪崩(なだれ)"
+        ]
     },
     {
         "name": "sabaku",
         "trans": [
+            "捌(さば)く",
             "② 他动1  销售，推销；妥善处理，弄清楚"
-        ],
-        "notation": "捌(さば)く"
+        ]
     },
     {
         "name": "guri-nsha",
         "trans": [
+            "グリーン車(しゃ)",
             "② 名  一等车，软席车厢"
-        ],
-        "notation": "グリーン車(しゃ)"
+        ]
     },
     {
         "name": "o",
         "trans": [
+            "尾(お)",
             "① 名  尾巴；尾部"
-        ],
-        "notation": "尾(お)"
+        ]
     },
     {
         "name": "itamashii",
         "trans": [
+            "痛(いた)ましい",
             "④ イ形  可怜的，凄惨的，令人痛心的"
-        ],
-        "notation": "痛(いた)ましい"
+        ]
     },
     {
         "name": "nagai",
         "trans": [
+            "長居(ながい)",
             "⓪ 名·自动3  久坐"
-        ],
-        "notation": "長居(ながい)"
+        ]
     },
     {
         "name": "hitokage",
         "trans": [
+            "人影(ひとかげ)",
             "⓪ 名  人影"
-        ],
-        "notation": "人影(ひとかげ)"
+        ]
     },
     {
         "name": "sobieru",
         "trans": [
+            "聳(そび)える",
             "③ 自动2  耸立，矗立"
-        ],
-        "notation": "聳(そび)える"
+        ]
     },
     {
         "name": "gengaku",
         "trans": [
+            "減額(げんがく)",
             "⓪ 名·他动3  减少数额"
-        ],
-        "notation": "減額(げんがく)"
+        ]
     },
     {
         "name": "eisha",
         "trans": [
+            "映写(えいしゃ)",
             "⓪ 名·他动3  放映"
-        ],
-        "notation": "映写(えいしゃ)"
+        ]
     },
     {
         "name": "tadayou",
         "trans": [
+            "漂(ただよ)う",
             "③ 自动1  漂浮；洋溢，充满"
-        ],
-        "notation": "漂(ただよ)う"
+        ]
     },
     {
         "name": "nimaime",
         "trans": [
+            "二枚目(にまいめ)",
             "④ 名  美男子"
-        ],
-        "notation": "二枚目(にまいめ)"
+        ]
     },
     {
         "name": "hanran",
         "trans": [
+            "反乱(はんらん)",
             "⓪ 名·自动3  叛乱"
-        ],
-        "notation": "反乱(はんらん)"
+        ]
     },
     {
         "name": "uketsugu",
         "trans": [
+            "受(う)け継(つ)ぐ",
             "③ 他动1  继承，传承"
-        ],
-        "notation": "受(う)け継(つ)ぐ"
+        ]
     },
     {
         "name": "kakuseizai",
         "trans": [
+            "覚醒剤(かくせいざい)",
             "③ 名  兴奋剂"
-        ],
-        "notation": "覚醒剤(かくせいざい)"
+        ]
     },
     {
         "name": "tsuyu",
         "trans": [
+            "露(つゆ)",
             "① 名·副  露水；短暂，微小；一点也"
-        ],
-        "notation": "露(つゆ)"
+        ]
     },
     {
         "name": "konasu",
         "trans": [
+            "熟(こな)す",
             "⓪ 他动1  处理，做完；运用自如，掌握"
-        ],
-        "notation": "熟(こな)す"
+        ]
     },
     {
         "name": "shouchi",
         "trans": [
+            "承知(しょうち)",
             "⓪ 名·他动3  同意，许可；知道"
-        ],
-        "notation": "承知(しょうち)"
+        ]
     },
     {
         "name": "dakai",
         "trans": [
+            "打開(だかい)",
             "⓪ 名·他动3  开辟（途径），解决（问题）"
-        ],
-        "notation": "打開(だかい)"
+        ]
     },
     {
         "name": "hakanai",
         "trans": [
+            "はかない",
             "③ イ形  短暂的，无常的；虚幻的"
-        ],
-        "notation": "はかない"
+        ]
     },
     {
         "name": "hougaku",
         "trans": [
+            "法学(ほうがく)",
             "⓪ 名  法学"
-        ],
-        "notation": "法学(ほうがく)"
+        ]
     },
     {
         "name": "yosomi",
         "trans": [
+            "余所見(よそみ)",
             "② 名·自动3  往旁边看；别人看着"
-        ],
-        "notation": "余所見(よそみ)"
+        ]
     },
     {
         "name": "ruisuru",
         "trans": [
+            "類(るい)する",
             "③ 自动3  相似，类似"
-        ],
-        "notation": "類(るい)する"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "刊行(かんこう)",
             "⓪ 名·他动3  出版；发行"
-        ],
-        "notation": "刊行(かんこう)"
+        ]
     },
     {
         "name": "endan",
         "trans": [
+            "縁談(えんだん)",
             "⓪ 名  亲事，婚事"
-        ],
-        "notation": "縁談(えんだん)"
+        ]
     },
     {
         "name": "ikidumaru/yukidumaru",
         "trans": [
+            "行(いきづまる/ゆ)き詰(づま)る",
             "④ 自动1  走到尽头；陷入僵局"
-        ],
-        "notation": "行(いきづまる/ゆ)き詰(づま)る"
+        ]
     },
     {
         "name": "gikyoku",
         "trans": [
+            "戯曲(ぎきょく)",
             "⓪ 名  剧本；戏剧"
-        ],
-        "notation": "戯曲(ぎきょく)"
+        ]
     },
     {
         "name": "janpa-",
         "trans": [
+            "ジャンパー",
             "① 名  夹克衫，运动服"
-        ],
-        "notation": "ジャンパー"
+        ]
     },
     {
         "name": "gessori",
         "trans": [
+            "げっそり",
             "③ 副·自动3  急剧消瘦；灰心，失望"
-        ],
-        "notation": "げっそり"
+        ]
     },
     {
         "name": "zetsumetsu",
         "trans": [
+            "絶滅(ぜつめつ)",
             "⓪ 名·自他动3  灭绝，根绝"
-        ],
-        "notation": "絶滅(ぜつめつ)"
+        ]
     },
     {
         "name": "nyuukyo",
         "trans": [
+            "入居(にゅうきょ)",
             "⓪ 名·自动3  迁入，搬进"
-        ],
-        "notation": "入居(にゅうきょ)"
+        ]
     },
     {
         "name": "machidooshii",
         "trans": [
+            "待(ま)ち遠(どお)しい",
             "⑤ イ形  急切等待的，盼望已久的"
-        ],
-        "notation": "待(ま)ち遠(どお)しい"
+        ]
     },
     {
         "name": "yousou",
         "trans": [
+            "様相(ようそう)",
             "⓪ 名  样子，情况"
-        ],
-        "notation": "様相(ようそう)"
+        ]
     },
     {
         "name": "ryakugo",
         "trans": [
+            "略語(りゃくご)",
             "⓪ 名  缩略语"
-        ],
-        "notation": "略語(りゃくご)"
+        ]
     },
     {
         "name": "akaramu",
         "trans": [
+            "赤(あか)らむ",
             "③ 自动1  变红，发红"
-        ],
-        "notation": "赤(あか)らむ"
+        ]
     },
     {
         "name": "kanpouyaku",
         "trans": [
+            "漢方薬(かんぽうやく)",
             "③ 名  中药"
-        ],
-        "notation": "漢方薬(かんぽうやく)"
+        ]
     },
     {
         "name": "zumen",
         "trans": [
+            "図面(ずめん)",
             "⓪ 名  图纸，设计图"
-        ],
-        "notation": "図面(ずめん)"
+        ]
     },
     {
         "name": "takuwaeru",
         "trans": [
+            "蓄(たくわ)える",
             "④ 他动2  储存，储备；留，蓄"
-        ],
-        "notation": "蓄(たくわ)える"
+        ]
     },
     {
         "name": "haguruma",
         "trans": [
+            "歯車(はぐるま)",
             "② 名  齿轮"
-        ],
-        "notation": "歯車(はぐるま)"
+        ]
     },
     {
         "name": "yuuyake",
         "trans": [
+            "夕焼(ゆうや)け",
             "⓪ 名  晚霞"
-        ],
-        "notation": "夕焼(ゆうや)け"
+        ]
     },
     {
         "name": "kitaeru",
         "trans": [
+            "鍛(きた)える",
             "③ 他动2  锤炼；锻炼"
-        ],
-        "notation": "鍛(きた)える"
+        ]
     },
     {
         "name": "iwakan",
         "trans": [
+            "違和感(いわかん)",
             "② 名  别扭，违和感"
-        ],
-        "notation": "違和感(いわかん)"
+        ]
     },
     {
         "name": "hinata",
         "trans": [
+            "日向(ひなた)",
             "⓪ 名  向阳处，太阳地儿"
-        ],
-        "notation": "日向(ひなた)"
+        ]
     },
     {
         "name": "mawarikudoi",
         "trans": [
+            "回(まわ)りくどい",
             "⑤ イ形  拐弯抹角的，兜圈子的"
-        ],
-        "notation": "回(まわ)りくどい"
+        ]
     },
     {
         "name": "ta-minaru",
         "trans": [
+            "ターミナル",
             "① 名  终点站；航站楼"
-        ],
-        "notation": "ターミナル"
+        ]
     },
     {
         "name": "keisei",
         "trans": [
+            "形成(けいせい)",
             "⓪ 名·他动3  形成"
-        ],
-        "notation": "形成(けいせい)"
+        ]
     },
     {
         "name": "obiru",
         "trans": [
+            "帯(お)びる",
             "② 他动2  佩带；担负，承担；带有"
-        ],
-        "notation": "帯(お)びる"
+        ]
     },
     {
         "name": "goma",
         "trans": [
+            "胡麻(ごま)",
             "⓪ 名  芝麻"
-        ],
-        "notation": "胡麻(ごま)"
+        ]
     },
     {
         "name": "shihan",
         "trans": [
+            "市販(しはん)",
             "⓪ 名·他动3  在市面上出售"
-        ],
-        "notation": "市販(しはん)"
+        ]
     },
     {
         "name": "hayaikoto",
         "trans": [
+            "早(はや)いこと",
             "② 副  赶快，迅速"
-        ],
-        "notation": "早(はや)いこと"
+        ]
     },
     {
         "name": "kamihanki",
         "trans": [
+            "上半期(かみはんき)",
             "③ 名  上半期，上半年度"
-        ],
-        "notation": "上半期(かみはんき)"
+        ]
     },
     {
         "name": "mokuromi",
         "trans": [
+            "目論見(もくろみ)",
             "⓪ 名  计划，策划"
-        ],
-        "notation": "目論見(もくろみ)"
+        ]
     },
     {
         "name": "uchikomu",
         "trans": [
+            "打(う)ち込(こ)む",
             "⓪ 自他动1  热衷，专心致志；打进，砸进"
-        ],
-        "notation": "打(う)ち込(こ)む"
+        ]
     },
     {
         "name": "choubo",
         "trans": [
+            "帳簿(ちょうぼ)",
             "⓪ 名  账本，账簿"
-        ],
-        "notation": "帳簿(ちょうぼ)"
+        ]
     },
     {
         "name": "hitokukuri",
         "trans": [
+            "一括(ひとくく)り",
             "② 名  一捆，一扎"
-        ],
-        "notation": "一括(ひとくく)り"
+        ]
     },
     {
         "name": "yadoru",
         "trans": [
+            "宿(やど)る",
             "② 自动1  住宿；寄生；怀孕；存在"
-        ],
-        "notation": "宿(やど)る"
+        ]
     },
     {
         "name": "roji",
         "trans": [
+            "路地(ろじ)",
             "① 名  胡同，小巷"
-        ],
-        "notation": "路地(ろじ)"
+        ]
     },
     {
         "name": "akatsuki",
         "trans": [
+            "暁(あかつき)",
             "⓪ 名  拂晓；⋯⋯之时，⋯⋯之际"
-        ],
-        "notation": "暁(あかつき)"
+        ]
     },
     {
         "name": "gunshuu",
         "trans": [
+            "群集(ぐんしゅう)",
             "⓪ 名·自动3  人群；聚集，群集"
-        ],
-        "notation": "群集(ぐんしゅう)"
+        ]
     },
     {
         "name": "daisuru",
         "trans": [
+            "題(だい)する",
             "③ 他动3  题名，标题；题字，题词"
-        ],
-        "notation": "題(だい)する"
+        ]
     },
     {
         "name": "dekigokoro",
         "trans": [
+            "出来心(できごころ)",
             "③ 名  一时的邪念，歹心"
-        ],
-        "notation": "出来心(できごころ)"
+        ]
     },
     {
         "name": "hakuryoku",
         "trans": [
+            "迫力(はくりょく)",
             "② 名  感染力"
-        ],
-        "notation": "迫力(はくりょく)"
+        ]
     },
     {
         "name": "fuseru",
         "trans": [
+            "伏(ふ)せる",
             "② 他动2  隐藏，保密；趴下；扣；躺下"
-        ],
-        "notation": "伏(ふ)せる"
+        ]
     },
     {
         "name": "mineraruwho-ta-",
         "trans": [
+            "ミネラルウォーター",
             "⑤ 名  矿泉水"
-        ],
-        "notation": "ミネラルウォーター"
+        ]
     },
     {
         "name": "yuuutsu",
         "trans": [
+            "憂鬱(ゆううつ)",
             "⓪ 名·ナ形  忧郁，郁闷"
-        ],
-        "notation": "憂鬱(ゆううつ)"
+        ]
     },
     {
         "name": "rikutsuppoi",
         "trans": [
+            "理屈(りくつ)っぽい",
             "⑤ イ形  好讲理的，爱诡辩的，爱抠死理的"
-        ],
-        "notation": "理屈(りくつ)っぽい"
+        ]
     },
     {
         "name": "wairo",
         "trans": [
+            "賄賂(わいろ)",
             "① 名  贿赂"
-        ],
-        "notation": "賄賂(わいろ)"
+        ]
     },
     {
         "name": "iibun",
         "trans": [
+            "言(い)い分(ぶん)",
             "⓪ 名  主张；不满，意见"
-        ],
-        "notation": "言(い)い分(ぶん)"
+        ]
     },
     {
         "name": "gaisuru",
         "trans": [
+            "害(がい)する",
             "③ 他动3  伤害；损害；妨碍；危害"
-        ],
-        "notation": "害(がい)する"
+        ]
     },
     {
         "name": "saikutsu",
         "trans": [
+            "採掘(さいくつ)",
             "⓪ 名·他动3  开采，采矿"
-        ],
-        "notation": "採掘(さいくつ)"
+        ]
     },
     {
         "name": "chuufuku",
         "trans": [
+            "中腹(ちゅうふく)",
             "⓪ 名  半山腰"
-        ],
-        "notation": "中腹(ちゅうふく)"
+        ]
     },
     {
         "name": "nagabiku",
         "trans": [
+            "長引(ながび)く",
             "③ 自动1  拖长，拖延"
-        ],
-        "notation": "長引(ながび)く"
+        ]
     },
     {
         "name": "hikanteki",
         "trans": [
+            "悲観的(ひかんてき)",
             "⓪ ナ形  悲观的"
-        ],
-        "notation": "悲観的(ひかんてき)"
+        ]
     },
     {
         "name": "maemotte",
         "trans": [
+            "前(まえ)もって",
             "③ 副  预先，事先"
-        ],
-        "notation": "前(まえ)もって"
+        ]
     },
     {
         "name": "yagai",
         "trans": [
+            "野外(やがい)",
             "① 名  野外，郊外；户外"
-        ],
-        "notation": "野外(やがい)"
+        ]
     },
     {
         "name": "raisensu",
         "trans": [
+            "ライセンス",
             "① 名  许可；执照，许可证"
-        ],
-        "notation": "ライセンス"
+        ]
     },
     {
         "name": "wazurawashii",
         "trans": [
+            "煩(わずら)わしい",
             "⑤ イ形  烦琐的，麻烦的"
-        ],
-        "notation": "煩(わずら)わしい"
+        ]
     },
     {
         "name": "ueki",
         "trans": [
+            "植木(うえき)",
             "⓪ 名  栽种的树木"
-        ],
-        "notation": "植木(うえき)"
+        ]
     },
     {
         "name": "gian",
         "trans": [
+            "議案(ぎあん)",
             "⓪ 名  议案"
-        ],
-        "notation": "議案(ぎあん)"
+        ]
     },
     {
         "name": "shikujiru",
         "trans": [
+            "しくじる",
             "③ 他动1  失败；被解雇"
-        ],
-        "notation": "しくじる"
+        ]
     },
     {
         "name": "tsuunen",
         "trans": [
+            "通念(つうねん)",
             "① 名  普遍的想法，共同观念"
-        ],
-        "notation": "通念(つうねん)"
+        ]
     },
     {
         "name": "nukarumi",
         "trans": [
+            "泥濘(ぬかるみ)",
             "⓪ 名  泥泞；（比喻）泥潭"
-        ],
-        "notation": "泥濘(ぬかるみ)"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "耽(ふけ)る",
             "② 自动1  沉溺，入迷；埋头，专心致志"
-        ],
-        "notation": "耽(ふけ)る"
+        ]
     },
     {
         "name": "meate",
         "trans": [
+            "目当(めあ)て",
             "① 名  目标；目的"
-        ],
-        "notation": "目当(めあ)て"
+        ]
     },
     {
         "name": "youin",
         "trans": [
+            "要因(よういん)",
             "⓪ 名  主要原因"
-        ],
-        "notation": "要因(よういん)"
+        ]
     },
     {
         "name": "oikomu",
         "trans": [
+            "追(お)い込(こ)む",
             "③ 他动1  赶进，撵进去；逼入，使陷入"
-        ],
-        "notation": "追(お)い込(こ)む"
+        ]
     },
     {
         "name": "keikai",
         "trans": [
+            "軽快(けいかい)",
             "⓪ ナ形  （动作）轻快的；（心情）舒畅的"
-        ],
-        "notation": "軽快(けいかい)"
+        ]
     },
     {
         "name": "suke-ru",
         "trans": [
+            "スケール",
             "② 名  尺寸；规模；能力"
-        ],
-        "notation": "スケール"
+        ]
     },
     {
         "name": "tayasui",
         "trans": [
+            "容易(たやす)い",
             "③ イ形  容易的，不难的"
-        ],
-        "notation": "容易(たやす)い"
+        ]
     },
     {
         "name": "neiro",
         "trans": [
+            "音色(ねいろ)",
             "⓪ 名  音色"
-        ],
-        "notation": "音色(ねいろ)"
+        ]
     },
     {
         "name": "buaisou",
         "trans": [
+            "無愛想(ぶあいそう)",
             "② 名·ナ形  冷淡，不和蔼"
-        ],
-        "notation": "無愛想(ぶあいそう)"
+        ]
     },
     {
         "name": "mijinmo",
         "trans": [
+            "微塵(みじん)も",
             "⓪ 副  （后接否定）丝毫也⋯⋯"
-        ],
-        "notation": "微塵(みじん)も"
+        ]
     },
     {
         "name": "yagu",
         "trans": [
+            "夜具(やぐ)",
             "① 名  寝具（被褥的总称）"
-        ],
-        "notation": "夜具(やぐ)"
+        ]
     },
     {
         "name": "rikuesuto",
         "trans": [
+            "リクエスト",
             "③ 名·他动3  要求，希望；点播（节目）"
-        ],
-        "notation": "リクエスト"
+        ]
     },
     {
         "name": "eguru",
         "trans": [
+            "抉(えぐ)る",
             "② 他动1  挖，剜；挖掘，追究；挖苦"
-        ],
-        "notation": "抉(えぐ)る"
+        ]
     },
     {
         "name": "koukyou",
         "trans": [
+            "好況(こうきょう)",
             "⓪ 名  景气，繁荣"
-        ],
-        "notation": "好況(こうきょう)"
+        ]
     },
     {
         "name": "seii",
         "trans": [
+            "誠意(せいい)",
             "① 名  诚意；诚恳"
-        ],
-        "notation": "誠意(せいい)"
+        ]
     },
     {
         "name": "chirachira",
         "trans": [
+            "ちらちら",
             "① 副·自动3  纷纷扬扬；时隐时现；一闪一闪；眼睛发花"
-        ],
-        "notation": "ちらちら"
+        ]
     },
     {
         "name": "noiro-ze",
         "trans": [
+            "ノイローゼ",
             "③ 名  神经过敏"
-        ],
-        "notation": "ノイローゼ"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "平衡(へいこう)",
             "⓪ 名  平衡，均衡"
-        ],
-        "notation": "平衡(へいこう)"
+        ]
     },
     {
         "name": "mogaku",
         "trans": [
+            "もがく",
             "② 自动1  挣扎；着急"
-        ],
-        "notation": "もがく"
+        ]
     },
     {
         "name": "wakusei",
         "trans": [
+            "惑星(わくせい)",
             "⓪ 名  行星；有前途的人"
-        ],
-        "notation": "惑星(わくせい)"
+        ]
     },
     {
         "name": "shishuu",
         "trans": [
+            "刺繍(ししゅう)",
             "⓪ 名·他动3  刺绣"
-        ],
-        "notation": "刺繍(ししゅう)"
+        ]
     },
     {
         "name": "yokubukai",
         "trans": [
+            "欲深(よくぶか)い",
             "④ イ形  贪得无厌的"
-        ],
-        "notation": "欲深(よくぶか)い"
+        ]
     },
     {
         "name": "akibare",
         "trans": [
+            "秋晴(あきば)れ",
             "⓪ 名  秋天的晴天"
-        ],
-        "notation": "秋晴(あきば)れ"
+        ]
     },
     {
         "name": "kaigara",
         "trans": [
+            "貝殻(かいがら)",
             "③ 名  贝壳"
-        ],
-        "notation": "貝殻(かいがら)"
+        ]
     },
     {
         "name": "nagusameru",
         "trans": [
+            "慰(なぐさ)める",
             "④ 他动2  安慰，慰问；使舒畅"
-        ],
-        "notation": "慰(なぐさ)める"
+        ]
     },
     {
         "name": "ieji",
         "trans": [
+            "家路(いえじ)",
             "⓪ 名  回家的路"
-        ],
-        "notation": "家路(いえじ)"
+        ]
     },
     {
         "name": "kyouryoku",
         "trans": [
+            "強力(きょうりょく)",
             "⓪ 名·ナ形  强有力，强大"
-        ],
-        "notation": "強力(きょうりょく)"
+        ]
     },
     {
         "name": "shirizoku",
         "trans": [
+            "退(しりぞ)く",
             "③ 自动1  后退；辞职；退出"
-        ],
-        "notation": "退(しりぞ)く"
+        ]
     },
     {
         "name": "tounin",
         "trans": [
+            "当人(とうにん)",
             "① 名  当事人，本人"
-        ],
-        "notation": "当人(とうにん)"
+        ]
     },
     {
         "name": "nyuansu",
         "trans": [
+            "ニュアンス",
             "① 名  语气，语感；微妙的差别"
-        ],
-        "notation": "ニュアンス"
+        ]
     },
     {
         "name": "hateru",
         "trans": [
+            "果(は)てる",
             "② 自动2  完毕，结束；死亡"
-        ],
-        "notation": "果(は)てる"
+        ]
     },
     {
         "name": "muki",
         "trans": [
+            "無機(むき)",
             "① 名  （化学用语）无机"
-        ],
-        "notation": "無機(むき)"
+        ]
     },
     {
         "name": "yuueki",
         "trans": [
+            "有益(ゆうえき)",
             "⓪ 名·ナ形  有意义，有好处"
-        ],
-        "notation": "有益(ゆうえき)"
+        ]
     },
     {
         "name": "wariateru",
         "trans": [
+            "割(わ)り当(あ)てる",
             "④ 他动2  分配，分摊"
-        ],
-        "notation": "割(わ)り当(あ)てる"
+        ]
     },
     {
         "name": "ekika",
         "trans": [
+            "液化(えきか)",
             "⓪ 名·自他动1  （物理用语）液化"
-        ],
-        "notation": "液化(えきか)"
+        ]
     },
     {
         "name": "gasshou",
         "trans": [
+            "合唱(がっしょう)",
             "⓪ 名·他动3  合唱"
-        ],
-        "notation": "合唱(がっしょう)"
+        ]
     },
     {
         "name": "tsukasadoru",
         "trans": [
+            "司(つかさど)る",
             "④ 他动1  掌管，管理；担任"
-        ],
-        "notation": "司(つかさど)る"
+        ]
     },
     {
         "name": "soui",
         "trans": [
+            "相違(そうい)",
             "⓪ 名·自动3  差异，悬殊"
-        ],
-        "notation": "相違(そうい)"
+        ]
     },
     {
         "name": "nokinami",
         "trans": [
+            "軒並(のきな)み",
             "⓪ 名·副  屋檐鳞次栉比；家家户户；挨个儿，一律"
-        ],
-        "notation": "軒並(のきな)み"
+        ]
     },
     {
         "name": "muron",
         "trans": [
+            "無論(むろん)",
             "⓪ 副  不用说，当然"
-        ],
-        "notation": "無論(むろん)"
+        ]
     },
     {
         "name": "fikushon",
         "trans": [
+            "フィクション",
             "① 名  小说；虚构，杜撰"
-        ],
-        "notation": "フィクション"
+        ]
     },
     {
         "name": "iden",
         "trans": [
+            "遺伝(いでん)",
             "⓪ 名·自动3  遗传"
-        ],
-        "notation": "遺伝(いでん)"
+        ]
     },
     {
         "name": "akekureru",
         "trans": [
+            "明(あ)け暮(く)れる",
             "④ 自动2  时光流逝；致力于，埋头于"
-        ],
-        "notation": "明(あ)け暮(く)れる"
+        ]
     },
     {
         "name": "ga-ze",
         "trans": [
+            "ガーゼ",
             "① 名  纱布"
-        ],
-        "notation": "ガーゼ"
+        ]
     },
     {
         "name": "saiaku",
         "trans": [
+            "最悪(さいあく)",
             "⓪ 名·ナ形  最坏，最糟糕"
-        ],
-        "notation": "最悪(さいあく)"
+        ]
     },
     {
         "name": "tagayasu",
         "trans": [
+            "耕(たがや)す",
             "③ 他动1  耕，耕作"
-        ],
-        "notation": "耕(たがや)す"
+        ]
     },
     {
         "name": "naiju",
         "trans": [
+            "内需(ないじゅ)",
             "① 名  国内需要，内需"
-        ],
-        "notation": "内需(ないじゅ)"
+        ]
     },
     {
         "name": "haaku",
         "trans": [
+            "把握(はあく)",
             "⓪ 名·他动3  理解，掌握"
-        ],
-        "notation": "把握(はあく)"
+        ]
     },
     {
         "name": "maiagaru",
         "trans": [
+            "舞(ま)い上(あ)がる",
             "④ 自动1  飞舞，飞扬；忘乎所以"
-        ],
-        "notation": "舞(ま)い上(あ)がる"
+        ]
     },
     {
         "name": "yakuba",
         "trans": [
+            "役場(やくば)",
             "③ 名  （乡、村）办事处"
-        ],
-        "notation": "役場(やくば)"
+        ]
     },
     {
         "name": "raifusutairu",
         "trans": [
+            "ライフスタイル",
             "⑤ 名  生活方式"
-        ],
-        "notation": "ライフスタイル"
+        ]
     },
     {
         "name": "iisobireru",
         "trans": [
+            "言(い)いそびれる",
             "⑤ 他动2  没能说出"
-        ],
-        "notation": "言(い)いそびれる"
+        ]
     },
     {
         "name": "kigai",
         "trans": [
+            "危害(きがい)",
             "① 名  危害；灾祸，灾害"
-        ],
-        "notation": "危害(きがい)"
+        ]
     },
     {
         "name": "shian",
         "trans": [
+            "試案(しあん)",
             "⓪ 名  试行方案"
-        ],
-        "notation": "試案(しあん)"
+        ]
     },
     {
         "name": "chikau",
         "trans": [
+            "誓(ちか)う",
             "② 自动1  发誓，立誓"
-        ],
-        "notation": "誓(ちか)う"
+        ]
     },
     {
         "name": "nikushimi",
         "trans": [
+            "憎(にく)しみ",
             "⓪ 名  憎恶，憎恨"
-        ],
-        "notation": "憎(にく)しみ"
+        ]
     },
     {
         "name": "pi-nattsu",
         "trans": [
+            "ピーナッツ",
             "① 名  花生"
-        ],
-        "notation": "ピーナッツ"
+        ]
     },
     {
         "name": "miotori",
         "trans": [
+            "見劣(みおと)り",
             "⓪ 名·自动3  逊色，相形见绌"
-        ],
-        "notation": "見劣(みおと)り"
+        ]
     },
     {
         "name": "yukitodoku",
         "trans": [
+            "行(ゆ)き届(とど)く",
             "④ 自动1  周到，无微不至"
-        ],
-        "notation": "行(ゆ)き届(とど)く"
+        ]
     },
     {
         "name": "usetsu",
         "trans": [
+            "右折(うせつ)",
             "⓪ 名·自动3  右转弯"
-        ],
-        "notation": "右折(うせつ)"
+        ]
     },
     {
         "name": "keii",
         "trans": [
+            "経緯(けいい)",
             "① 名  经度和纬度；事情的经过，原委"
-        ],
-        "notation": "経緯(けいい)"
+        ]
     },
     {
         "name": "susamajii",
         "trans": [
+            "凄(すさ)まじい",
             "④ イ形  惊人的；厉害的，猛烈的"
-        ],
-        "notation": "凄(すさ)まじい"
+        ]
     },
     {
         "name": "tsuika",
         "trans": [
+            "追加(ついか)",
             "⓪ 名·他动3  追加"
-        ],
-        "notation": "追加(ついか)"
+        ]
     },
     {
         "name": "numa",
         "trans": [
+            "沼(ぬま)",
             "② 名  沼泽"
-        ],
-        "notation": "沼(ぬま)"
+        ]
     },
     {
         "name": "fukusuru",
         "trans": [
+            "服(ふく)する",
             "③ 自他动3  服从；从事；使服从；服用"
-        ],
-        "notation": "服(ふく)する"
+        ]
     },
     {
         "name": "mukiryoku",
         "trans": [
+            "無気力(むきりょく)",
             "② 名·ナ形  没精神，缺乏朝气"
-        ],
-        "notation": "無気力(むきりょく)"
+        ]
     },
     {
         "name": "youeki",
         "trans": [
+            "溶液(ようえき)",
             "① 名  （物理、化学用语）溶液"
-        ],
-        "notation": "溶液(ようえき)"
+        ]
     },
     {
         "name": "oiru",
         "trans": [
+            "老(お)いる",
             "② 自动2  上年纪；衰老"
-        ],
-        "notation": "老(お)いる"
+        ]
     },
     {
         "name": "kou",
         "trans": [
+            "甲(こう)",
             "① 名  甲壳；表面；第一位"
-        ],
-        "notation": "甲(こう)"
+        ]
     },
     {
         "name": "seiu",
         "trans": [
+            "晴雨(せいう)",
             "① 名  晴天和雨天"
-        ],
-        "notation": "晴雨(せいう)"
+        ]
     },
     {
         "name": "neiru",
         "trans": [
+            "寝入(ねい)る",
             "② 自动1  睡着；熟睡"
-        ],
-        "notation": "寝入(ねい)る"
+        ]
     },
     {
         "name": "pearukku",
         "trans": [
+            "ペアルック",
             " ③ 名  情侣装"
-        ],
-        "notation": "ペアルック"
+        ]
     },
     {
         "name": "meisai",
         "trans": [
+            "明細(めいさい)",
             "⓪ 名  明细"
-        ],
-        "notation": "明細(めいさい)"
+        ]
     },
     {
         "name": "yakeni",
         "trans": [
+            "やけに",
             "① 副  特别，非常"
-        ],
-        "notation": "やけに"
+        ]
     },
     {
         "name": "reigai",
         "trans": [
+            "冷害(れいがい)",
             "⓪ 名  冷冻灾害"
-        ],
-        "notation": "冷害(れいがい)"
+        ]
     },
     {
         "name": "akademikku",
         "trans": [
+            "アカデミック",
             "④ ナ形  学术的；墨守成规的"
-        ],
-        "notation": "アカデミック"
+        ]
     },
     {
         "name": "kaiaku",
         "trans": [
+            "改悪(かいあく)",
             "⓪ 名·他动3  越改越坏，改坏"
-        ],
-        "notation": "改悪(かいあく)"
+        ]
     },
     {
         "name": "sakarau",
         "trans": [
+            "逆(さか)らう",
             "③ 自动1  逆着，相反；违抗，违背"
-        ],
-        "notation": "逆(さか)らう"
+        ]
     },
     {
         "name": "taiou",
         "trans": [
+            "対応(たいおう)",
             "⓪ 名·自动3  对应；调和，协调；应付"
-        ],
-        "notation": "対応(たいおう)"
+        ]
     },
     {
         "name": "naisho",
         "trans": [
+            "内緒(ないしょ)",
             "③ 名  秘密，不公开"
-        ],
-        "notation": "内緒(ないしょ)"
+        ]
     },
     {
         "name": "hagukumu",
         "trans": [
+            "育(はぐく)む",
             "③ 他动1  孵化；培养，培育"
-        ],
-        "notation": "育(はぐく)む"
+        ]
     },
     {
         "name": "maizou",
         "trans": [
+            "埋蔵(まいぞう)",
             "⓪ 名·自他动3  埋藏，蕴藏（资源）"
-        ],
-        "notation": "埋蔵(まいぞう)"
+        ]
     },
     {
         "name": "yakedo",
         "trans": [
+            "火傷(やけど)",
             "⓪ 名·自动3  烫伤；吃亏，遭殃"
-        ],
-        "notation": "火傷(やけど)"
+        ]
     },
     {
         "name": "warikomu",
         "trans": [
+            "割(わ)り込(こ)む",
             "③ 自动1  插队；插嘴"
-        ],
-        "notation": "割(わ)り込(こ)む"
+        ]
     },
     {
         "name": "yamakuzure",
         "trans": [
+            "山崩(やまくず)れ",
             "③ 名  山崩，山体滑坡"
-        ],
-        "notation": "山崩(やまくず)れ"
+        ]
     },
     {
         "name": "iede",
         "trans": [
+            "家出(いえで)",
             "⓪ 名·自动3  离家出走"
-        ],
-        "notation": "家出(いえで)"
+        ]
     },
     {
         "name": "kikazaru",
         "trans": [
+            "着飾(きかざ)る",
             "③ 自他动1  盛装；打扮"
-        ],
-        "notation": "着飾(きかざ)る"
+        ]
     },
     {
         "name": "sa-kasu",
         "trans": [
+            "サーカス",
             "① 名  杂技团，马戏团"
-        ],
-        "notation": "サーカス"
+        ]
     },
     {
         "name": "taika",
         "trans": [
+            "退化(たいか)",
             "① 名·自动3  退化；倒退"
-        ],
-        "notation": "退化(たいか)"
+        ]
     },
     {
         "name": "nagekawashii",
         "trans": [
+            "嘆(なげ)かわしい",
             "⑤ イ形  可叹的，可悲的"
-        ],
-        "notation": "嘆(なげ)かわしい"
+        ]
     },
     {
         "name": "baatari",
         "trans": [
+            "場当(ばあ)たり",
             "② 名·ナ形  即兴（表演）；权宜，临时"
-        ],
-        "notation": "場当(ばあ)たり"
+        ]
     },
     {
         "name": "maeuri",
         "trans": [
+            "前売(まえう)り",
             "⓪ 名·他动3  预售"
-        ],
-        "notation": "前売(まえう)り"
+        ]
     },
     {
         "name": "yusaburu",
         "trans": [
+            "揺(ゆ)さぶる",
             "⓪ 他动1  摇动，晃动；震撼，震惊"
-        ],
-        "notation": "揺(ゆ)さぶる"
+        ]
     },
     {
         "name": "rikishi",
         "trans": [
+            "力士(りきし)",
             "① 名  大力士；相扑运动员"
-        ],
-        "notation": "力士(りきし)"
+        ]
     },
     {
         "name": "uitto",
         "trans": [
+            "ウイット",
             "② 名  机智；妙语，打趣的话"
-        ],
-        "notation": "ウイット"
+        ]
     },
     {
         "name": "kuitomeru",
         "trans": [
+            "食(く)い止(と)める",
             "④ 他动2  控制住，阻止住，拦住"
-        ],
-        "notation": "食(く)い止(と)める"
+        ]
     },
     {
         "name": "suigen",
         "trans": [
+            "水源(すいげん)",
             "⓪ 名  水源"
-        ],
-        "notation": "水源(すいげん)"
+        ]
     },
     {
         "name": "tsuikyuu",
         "trans": [
+            "追及(ついきゅう)",
             "⓪ 名·他动3  追究，追问；追赶"
-        ],
-        "notation": "追及(ついきゅう)"
+        ]
     },
     {
         "name": "nukedasu",
         "trans": [
+            "抜(ぬ)け出(だ)す",
             "③ 自动1  悄悄溜走；开始脱落"
-        ],
-        "notation": "抜(ぬ)け出(だ)す"
+        ]
     },
     {
         "name": "faito",
         "trans": [
+            "ファイト",
             "① 名  战斗，斗争；斗志"
-        ],
-        "notation": "ファイト"
+        ]
     },
     {
         "name": "mukuchi",
         "trans": [
+            "無口(むくち)",
             "① 名·ナ形  沉默寡言"
-        ],
-        "notation": "無口(むくち)"
+        ]
     },
     {
         "name": "yojinoboru",
         "trans": [
+            "攀(よ)じ登(のぼ)る",
             "④ 自动1  攀登，爬上"
-        ],
-        "notation": "攀(よ)じ登(のぼ)る"
+        ]
     },
     {
         "name": "ruika",
         "trans": [
+            "累加(るいか)",
             "⓪ 名·自他动3  递增；累积"
-        ],
-        "notation": "累加(るいか)"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "枠(わく)",
             "② 名  边框；范围，界限"
-        ],
-        "notation": "枠(わく)"
+        ]
     },
     {
         "name": "utoi",
         "trans": [
+            "疎(うと)い",
             "② イ形  疏远的；不了解的"
-        ],
-        "notation": "疎(うと)い"
+        ]
     },
     {
         "name": "keien",
         "trans": [
+            "敬遠(けいえん)",
             "⓪ 名·他动3  敬而远之，回避"
-        ],
-        "notation": "敬遠(けいえん)"
+        ]
     },
     {
         "name": "setogiwa",
         "trans": [
+            "瀬戸際(せとぎわ)",
             "⓪ 名  紧要关头，关键时刻"
-        ],
-        "notation": "瀬戸際(せとぎわ)"
+        ]
     },
     {
         "name": "tegakeru",
         "trans": [
+            "手(て)がける",
             "③ 他动2  亲自动手；亲自培养"
-        ],
-        "notation": "手(て)がける"
+        ]
     },
     {
         "name": "neuchi",
         "trans": [
+            "値打(ねう)ち",
             "⓪ 名  价格；价值"
-        ],
-        "notation": "値打(ねう)ち"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "閉口(へいこう)",
             "⓪ 名·自动3  闭口不言；受不了，为难"
-        ],
-        "notation": "閉口(へいこう)"
+        ]
     },
     {
         "name": "mekimeki",
         "trans": [
+            "めきめき",
             "① 副  （能力、水平等）显著提高"
-        ],
-        "notation": "めきめき"
+        ]
     },
     {
         "name": "yougisha",
         "trans": [
+            "容疑者(ようぎしゃ)",
             "③ 名  嫌疑人"
-        ],
-        "notation": "容疑者(ようぎしゃ)"
+        ]
     },
     {
         "name": "re-za-",
         "trans": [
+            "レーザー",
             "① 名  激光"
-        ],
-        "notation": "レーザー"
+        ]
     },
     {
         "name": "oginau",
         "trans": [
+            "補(おぎな)う",
             "③ 他动1  补充；补偿，弥补"
-        ],
-        "notation": "補(おぎな)う"
+        ]
     },
     {
         "name": "koseki",
         "trans": [
+            "戸籍(こせき)",
             "⓪ 名  户籍"
-        ],
-        "notation": "戸籍(こせき)"
+        ]
     },
     {
         "name": "souba",
         "trans": [
+            "相場(そうば)",
             "⓪ 名  行情，行市"
-        ],
-        "notation": "相場(そうば)"
+        ]
     },
     {
         "name": "toitadasu",
         "trans": [
+            "問(と)いただす",
             "④ 他动1  询问，质疑；盘问"
-        ],
-        "notation": "問(と)いただす"
+        ]
     },
     {
         "name": "nouki",
         "trans": [
+            "納期(のうき)",
             "① 名  交货期"
-        ],
-        "notation": "納期(のうき)"
+        ]
     },
     {
         "name": "hoiku",
         "trans": [
+            "保育(ほいく)",
             "⓪ 名·他动3  保护养育（幼儿）"
-        ],
-        "notation": "保育(ほいく)"
+        ]
     },
     {
         "name": "motareru",
         "trans": [
+            "凭(もた)れる",
             "③ 自动2  倚靠；积食，不消化"
-        ],
-        "notation": "凭(もた)れる"
+        ]
     },
     {
         "name": "yukue",
         "trans": [
+            "行方(ゆくえ)",
             "⓪ 名  去向；前景"
-        ],
-        "notation": "行方(ゆくえ)"
+        ]
     },
     {
         "name": "rounyakunan'nyo",
         "trans": [
+            "老若男女(ろうにゃくなんにょ)",
             "⑤ 名  男女老少"
-        ],
-        "notation": "老若男女(ろうにゃくなんにょ)"
+        ]
     },
     {
         "name": "akogareru",
         "trans": [
+            "憧(あこが)れる",
             "⓪ 自动2  向往，憧憬"
-        ],
-        "notation": "憧(あこが)れる"
+        ]
     },
     {
         "name": "kiza",
         "trans": [
+            "気障(きざ)",
             "① ナ形  装模作样的；华丽刺眼的"
-        ],
-        "notation": "気障(きざ)"
+        ]
     },
     {
         "name": "jibika",
         "trans": [
+            "耳鼻科(じびか)",
             "⓪ 名  耳鼻科"
-        ],
-        "notation": "耳鼻科(じびか)"
+        ]
     },
     {
         "name": "chokuchoku",
         "trans": [
+            "ちょくちょく",
             "① 副  时常，往往"
-        ],
-        "notation": "ちょくちょく"
+        ]
     },
     {
         "name": "napukin",
         "trans": [
+            "ナプキン",
             "① 名  餐巾"
-        ],
-        "notation": "ナプキン"
+        ]
     },
     {
         "name": "fudangi",
         "trans": [
+            "普段着(ふだんぎ)",
             "② 名  日常穿的衣服，便装"
-        ],
-        "notation": "普段着(ふだんぎ)"
+        ]
     },
     {
         "name": "miawaseru",
         "trans": [
+            "見合(みあ)わせる",
             "④ 他动2  互相看；比较，考量；暂缓，推迟"
-        ],
-        "notation": "見合(みあ)わせる"
+        ]
     },
     {
         "name": "yokyou",
         "trans": [
+            "余興(よきょう)",
             "⓪ 名  余兴，助兴的表演"
-        ],
-        "notation": "余興(よきょう)"
+        ]
     },
     {
         "name": "rifujin",
         "trans": [
+            "理不尽(りふじん)",
             "② 名·ナ形  不讲理，蛮横无理"
-        ],
-        "notation": "理不尽(りふじん)"
+        ]
     },
     {
         "name": "azamuku",
         "trans": [
+            "欺(あざむ)く",
             "③ 他动1  欺骗；胜过，赛过"
-        ],
-        "notation": "欺(あざむ)く"
+        ]
     },
     {
         "name": "kataomoi",
         "trans": [
+            "片思(かたおも)い",
             "③ 名  单相思"
-        ],
-        "notation": "片思(かたおも)い"
+        ]
     },
     {
         "name": "sashizu",
         "trans": [
+            "指図(さしず)",
             "① 名·他动3  指示，吩咐；指使，命令"
-        ],
-        "notation": "指図(さしず)"
+        ]
     },
     {
         "name": "tawainai",
         "trans": [
+            "たわいない",
             "④ イ形  不省人事的；轻而易举的，一下子就⋯⋯；无聊的；天真的"
-        ],
-        "notation": "たわいない"
+        ]
     },
     {
         "name": "ninchishou",
         "trans": [
+            "認知症(にんちしょう)",
             "⓪ 名  痴呆症"
-        ],
-        "notation": "認知症(にんちしょう)"
+        ]
     },
     {
         "name": "hazumu",
         "trans": [
+            "弾(はず)む",
             "⓪ 自动1  反弹；起劲儿，（情绪）高涨；（呼吸）急促"
-        ],
-        "notation": "弾(はず)む"
+        ]
     },
     {
         "name": "maeoki",
         "trans": [
+            "前置(まえお)き",
             "⓪ 名·自动3  开场白，引子"
-        ],
-        "notation": "前置(まえお)き"
+        ]
     },
     {
         "name": "yatai",
         "trans": [
+            "屋台(やたい)",
             "① 名  小摊，流动货摊"
-        ],
-        "notation": "屋台(やたい)"
+        ]
     },
     {
         "name": "rafu",
         "trans": [
+            "ラフ",
             "① ナ形  粗糙的；粗略的；不加修饰的"
-        ],
-        "notation": "ラフ"
+        ]
     },
     {
         "name": "iou",
         "trans": [
+            "硫黄(いおう)",
             "⓪ 名  （化学用语）硫黄"
-        ],
-        "notation": "硫黄(いおう)"
+        ]
     },
     {
         "name": "kimajime",
         "trans": [
+            "生真面目(きまじめ)",
             "② 名·ナ形  一本正经，死心眼儿"
-        ],
-        "notation": "生真面目(きまじめ)"
+        ]
     },
     {
         "name": "shibutoi",
         "trans": [
+            "しぶとい",
             "③ イ形  顽固的；顽强的"
-        ],
-        "notation": "しぶとい"
+        ]
     },
     {
         "name": "cha-mingu",
         "trans": [
+            "チャーミング",
             "① ナ形  有魅力的，迷人的"
-        ],
-        "notation": "チャーミング"
+        ]
     },
     {
         "name": "nitariyottari",
         "trans": [
+            "似(に)たり寄(よ)ったり",
             "② 名·イ形  大同小异，半斤八两"
-        ],
-        "notation": "似(に)たり寄(よ)ったり"
+        ]
     },
     {
         "name": "hiiteha",
         "trans": [
+            "ひいては",
             "① 副  进而，不但⋯⋯而且⋯⋯"
-        ],
-        "notation": "ひいては"
+        ]
     },
     {
         "name": "migonashi",
         "trans": [
+            "身(み)ごなし",
             "⓪ 名  举止，动作"
-        ],
-        "notation": "身(み)ごなし"
+        ]
     },
     {
         "name": "yuuetsu",
         "trans": [
+            "優越(ゆうえつ)",
             "⓪ 名·自动3  优越"
-        ],
-        "notation": "優越(ゆうえつ)"
+        ]
     },
     {
         "name": "ukeou",
         "trans": [
+            "請(う)け負(お)う",
             "③ 他动1  承包，承办"
-        ],
-        "notation": "請(う)け負(お)う"
+        ]
     },
     {
         "name": "ku-pon",
         "trans": [
+            "クーポン",
             " ① 名  优惠券；联票，通票"
-        ],
-        "notation": "クーポン"
+        ]
     },
     {
         "name": "suikou",
         "trans": [
+            "遂行(すいこう)",
             "⓪ 名·他动3  完成，贯彻；执行"
-        ],
-        "notation": "遂行(すいこう)"
+        ]
     },
     {
         "name": "tsukisou",
         "trans": [
+            "付(つ)き添(そ)う",
             "③ 自动1  跟随左右；照顾；陪伴"
-        ],
-        "notation": "付(つ)き添(そ)う"
+        ]
     },
     {
         "name": "nezou",
         "trans": [
+            "寝相(ねぞう)",
             "⓪ 名  睡相"
-        ],
-        "notation": "寝相(ねぞう)"
+        ]
     },
     {
         "name": "fuan'nai",
         "trans": [
+            "不案内(ふあんない)",
             "② 名·ナ形  不熟悉，生疏"
-        ],
-        "notation": "不案内(ふあんない)"
+        ]
     },
     {
         "name": "musubitsuku",
         "trans": [
+            "結(むす)び付(つ)く",
             "④ 自动1  有关联，有联系；结合在一起"
-        ],
-        "notation": "結(むす)び付(つ)く"
+        ]
     },
     {
         "name": "yougo",
         "trans": [
+            "養護(ようご)",
             "① 名·他动3  护养，保健"
-        ],
-        "notation": "養護(ようご)"
+        ]
     },
     {
         "name": "ruikei",
         "trans": [
+            "類型(るいけい)",
             "⓪ 名  类型"
-        ],
-        "notation": "類型(るいけい)"
+        ]
     },
     {
         "name": "enjiru",
         "trans": [
+            "演(えん)じる",
             "③ 他动2  扮演；造成"
-        ],
-        "notation": "演(えん)じる"
+        ]
     },
     {
         "name": "keika",
         "trans": [
+            "経過(けいか)",
             "⓪ 名·自动3  （事情的）经过，过程；时间流逝，过去"
-        ],
-        "notation": "経過(けいか)"
+        ]
     },
     {
         "name": "seika",
         "trans": [
+            "成果(せいか)",
             "① 名  成果，成就"
-        ],
-        "notation": "成果(せいか)"
+        ]
     },
     {
         "name": "dekuwasu",
         "trans": [
+            "出(で)くわす",
             "⓪ 自动1  偶遇，碰到"
-        ],
-        "notation": "出(で)くわす"
+        ]
     },
     {
         "name": "ne-mingu",
         "trans": [
+            "ネーミング",
             "⓪ 名  命名"
-        ],
-        "notation": "ネーミング"
+        ]
     },
     {
         "name": "heijou",
         "trans": [
+            "平常(へいじょう)",
             "⓪ 名  平常，平素"
-        ],
-        "notation": "平常(へいじょう)"
+        ]
     },
     {
         "name": "memagurushii",
         "trans": [
+            "目(め)まぐるしい",
             "⑤ イ形  眼花缭乱的，瞬息万变的"
-        ],
-        "notation": "目(め)まぐるしい"
+        ]
     },
     {
         "name": "yamadumi",
         "trans": [
+            "山積(やまづ)み",
             "⓪ 名  堆积如山，大量积压"
-        ],
-        "notation": "山積(やまづ)み"
+        ]
     },
     {
         "name": "reikoku",
         "trans": [
+            "冷酷(れいこく)",
             "⓪ 名·ナ形  冷酷无情"
-        ],
-        "notation": "冷酷(れいこく)"
+        ]
     },
     {
         "name": "oomaka",
         "trans": [
+            "おおまか",
             "⓪ ナ形  粗枝大叶的；粗略的，马马虎虎的"
-        ],
-        "notation": "おおまか"
+        ]
     },
     {
         "name": "kotodute",
         "trans": [
+            "言伝(ことづて)",
             "⓪ 名  传闻；口信"
-        ],
-        "notation": "言伝(ことづて)"
+        ]
     },
     {
         "name": "zoukyuu",
         "trans": [
+            "増給(ぞうきゅう)",
             "⓪ 名·自他动3  加薪，涨薪"
-        ],
-        "notation": "増給(ぞうきゅう)"
+        ]
     },
     {
         "name": "doukasuruto",
         "trans": [
+            "どうかすると",
             "① 副  有时，偶尔；动辄，常常"
-        ],
-        "notation": "どうかすると"
+        ]
     },
     {
         "name": "noukou",
         "trans": [
+            "農耕(のうこう)",
             "⓪ 名  农耕，耕作"
-        ],
-        "notation": "農耕(のうこう)"
+        ]
     },
     {
         "name": "boikotto",
         "trans": [
+            "ボイコット",
             "③ 名·他动3  联合抵制"
-        ],
-        "notation": "ボイコット"
+        ]
     },
     {
         "name": "mogitoru",
         "trans": [
+            "もぎ取(と)る",
             "③ 他动1  摘，拧；夺取"
-        ],
-        "notation": "もぎ取(と)る"
+        ]
     },
     {
         "name": "yuukai",
         "trans": [
+            "誘拐(ゆうかい)",
             "⓪ 名·他动3  拐骗，诱拐"
-        ],
-        "notation": "誘拐(ゆうかい)"
+        ]
     },
     {
         "name": "roushi",
         "trans": [
+            "労使(ろうし)",
             "① 名  工人与雇主，劳资（双方）"
-        ],
-        "notation": "労使(ろうし)"
+        ]
     },
     {
         "name": "agari",
         "trans": [
+            "上(あ)がり",
             "⓪ 名  往上；完成；收益，收获；结束"
-        ],
-        "notation": "上(あ)がり"
+        ]
     },
     {
         "name": "ka-soru",
         "trans": [
+            "カーソル",
             "⓪ 名  光标，指针"
-        ],
-        "notation": "カーソル"
+        ]
     },
     {
         "name": "sakeru",
         "trans": [
+            "裂(さ)ける",
             "② 自动2  裂开；破裂"
-        ],
-        "notation": "裂(さ)ける"
+        ]
     },
     {
         "name": "taigai",
         "trans": [
+            "大概(たいがい)",
             "⓪ 名·副  大概，大致；适度"
-        ],
-        "notation": "大概(たいがい)"
+        ]
     },
     {
         "name": "naishi",
         "trans": [
+            "乃至(ないし)",
             "① 接续  至，乃至；或者"
-        ],
-        "notation": "乃至(ないし)"
+        ]
     },
     {
         "name": "haeru",
         "trans": [
+            "映(は)える",
             "② 自动2  映照；显得好看，显眼"
-        ],
-        "notation": "映(は)える"
+        ]
     },
     {
         "name": "maegaki",
         "trans": [
+            "前書(まえが)き",
             "⓪ 名  序言，前言"
-        ],
-        "notation": "前書(まえが)き"
+        ]
     },
     {
         "name": "yashiki",
         "trans": [
+            "屋敷(やしき)",
             "③ 名  宅邸，住宅；房屋和地产"
-        ],
-        "notation": "屋敷(やしき)"
+        ]
     },
     {
         "name": "wakuwaku",
         "trans": [
+            "わくわく",
             "① 副  （兴奋或期待时）心扑通扑通地跳"
-        ],
-        "notation": "わくわく"
+        ]
     },
     {
         "name": "igi",
         "trans": [
+            "異議(いぎ)",
             "① 名  异议，反对意见"
-        ],
-        "notation": "異議(いぎ)"
+        ]
     },
     {
         "name": "giri",
         "trans": [
+            "義理(ぎり)",
             "② 名  情面，人情；道理；亲戚关系"
-        ],
-        "notation": "義理(ぎり)"
+        ]
     },
     {
         "name": "shidekasu",
         "trans": [
+            "しでかす",
             "③ 他动1  做出，干出（不像话的事）"
-        ],
-        "notation": "しでかす"
+        ]
     },
     {
         "name": "che-n",
         "trans": [
+            "チェーン",
             "① 名  链子，链条；连锁组织"
-        ],
-        "notation": "チェーン"
+        ]
     },
     {
         "name": "nikka",
         "trans": [
+            "日課(にっか)",
             "⓪ 名  每天的习惯活动"
-        ],
-        "notation": "日課(にっか)"
+        ]
     },
     {
         "name": "hikizuru",
         "trans": [
+            "引(ひ)きずる",
             "⓪ 自他动1  拖拽；拖延；硬拽"
-        ],
-        "notation": "引(ひ)きずる"
+        ]
     },
     {
         "name": "misaki",
         "trans": [
+            "岬(みさき)",
             "⓪ 名  海角，岬"
-        ],
-        "notation": "岬(みさき)"
+        ]
     },
     {
         "name": "yarikuri",
         "trans": [
+            "遣(や)り繰(く)り",
             "② 名·他动3  设法安排，筹措"
-        ],
-        "notation": "遣(や)り繰(く)り"
+        ]
     },
     {
         "name": "rikoteki",
         "trans": [
+            "利己的(りこてき)",
             "⓪ ナ形  利己的，自私自利的"
-        ],
-        "notation": "利己的(りこてき)"
+        ]
     },
     {
         "name": "ushirodate",
         "trans": [
+            "後(うし)ろ盾(だて)",
             "⓪ 名  后盾，靠山"
-        ],
-        "notation": "後(うし)ろ盾(だて)"
+        ]
     },
     {
         "name": "kujo",
         "trans": [
+            "駆除(くじょ)",
             "① 名·他动3  （用药剂等）驱除，消灭"
-        ],
-        "notation": "駆除(くじょ)"
+        ]
     },
     {
         "name": "sekasu",
         "trans": [
+            "急(せ)かす",
             "② 他动1  催促"
-        ],
-        "notation": "急(せ)かす"
+        ]
     },
     {
         "name": "nekkyou",
         "trans": [
+            "熱狂(ねっきょう)",
             "⓪ 名·自动3  狂热"
-        ],
-        "notation": "熱狂(ねっきょう)"
+        ]
     },
     {
         "name": "puraibashi-",
         "trans": [
+            "プライバシー",
             "② 名  隐私，私生活"
-        ],
-        "notation": "プライバシー"
+        ]
     },
     {
         "name": "mukatsuku",
         "trans": [
+            "むかつく",
             "⓪ 自动1  恶心，想吐；生气，发怒"
-        ],
-        "notation": "むかつく"
+        ]
     },
     {
         "name": "yuukan",
         "trans": [
+            "勇敢(ゆうかん)",
             "⓪ ナ形  勇敢的"
-        ],
-        "notation": "勇敢(ゆうかん)"
+        ]
     },
     {
         "name": "ruiji",
         "trans": [
+            "類似(るいじ)",
             "⓪ 名·自动3  类似"
-        ],
-        "notation": "類似(るいじ)"
+        ]
     },
     {
         "name": "okotaru",
         "trans": [
+            "怠(おこた)る",
             "⓪ 自他动1  懈怠，偷懒；疏忽，大意"
-        ],
-        "notation": "怠(おこた)る"
+        ]
     },
     {
         "name": "keikai",
         "trans": [
+            "警戒(けいかい)",
             "⓪ 名·他动3  警戒，防范；警惕，提防"
-        ],
-        "notation": "警戒(けいかい)"
+        ]
     },
     {
         "name": "seigyo",
         "trans": [
+            "制御(せいぎょ)",
             "① 名·他动3  控制，驾驭"
-        ],
-        "notation": "制御(せいぎょ)"
+        ]
     },
     {
         "name": "tekkiri",
         "trans": [
+            "てっきり",
             "③ 副  以为一定（其实并不）"
-        ],
-        "notation": "てっきり"
+        ]
     },
     {
         "name": "nounyuu",
         "trans": [
+            "納入(のうにゅう)",
             "⓪ 名·他动3  缴纳，交纳"
-        ],
-        "notation": "納入(のうにゅう)"
+        ]
     },
     {
         "name": "bekkyo",
         "trans": [
+            "別居(べっきょ)",
             "⓪ 名·自动3  分居，分开居住"
-        ],
-        "notation": "別居(べっきょ)"
+        ]
     },
     {
         "name": "menjiru",
         "trans": [
+            "免(めん)じる",
             "⓪ 他动2  免除，免去；免职；看在⋯⋯的面子上"
-        ],
-        "notation": "免(めん)じる"
+        ]
     },
     {
         "name": "yousha",
         "trans": [
+            "容赦(ようしゃ)",
             "① 名·他动3  宽恕，原谅；姑息"
-        ],
-        "notation": "容赦(ようしゃ)"
+        ]
     },
     {
         "name": "regyura-",
         "trans": [
+            "レギュラー",
             "① 名  正式成员；正规"
-        ],
-        "notation": "レギュラー"
+        ]
     },
     {
         "name": "akinau",
         "trans": [
+            "商(あきな)う",
             "③ 他动1  买卖，经商"
-        ],
-        "notation": "商(あきな)う"
+        ]
     },
     {
         "name": "ka-petto",
         "trans": [
+            "カーペット",
             "① 名  地毯"
-        ],
-        "notation": "カーペット"
+        ]
     },
     {
         "name": "saihatsu",
         "trans": [
+            "再発(さいはつ)",
             "⓪ 名·自动3  （疾病、事故等）再次发生，复发"
-        ],
-        "notation": "再発(さいはつ)"
+        ]
     },
     {
         "name": "takaga",
         "trans": [
+            "高(たか)が",
             "① 副  充其量，最多"
-        ],
-        "notation": "高(たか)が"
+        ]
     },
     {
         "name": "nafuda",
         "trans": [
+            "名札(なふだ)",
             "⓪ 名  姓名牌"
-        ],
-        "notation": "名札(なふだ)"
+        ]
     },
     {
         "name": "haiki",
         "trans": [
+            "廃棄(はいき)",
             "① 名·他动3  废弃，废除（合同）"
-        ],
-        "notation": "廃棄(はいき)"
+        ]
     },
     {
         "name": "mizumizushii",
         "trans": [
+            "みずみずしい",
             "⑤ イ形  水灵灵的，娇嫩的"
-        ],
-        "notation": "みずみずしい"
+        ]
     },
     {
         "name": "yofuke",
         "trans": [
+            "夜更(よふ)け",
             "③ 名  深夜"
-        ],
-        "notation": "夜更(よふ)け"
+        ]
     },
     {
         "name": "rakugaki",
         "trans": [
+            "落書(らくが)き",
             "⓪ 名·自动3  涂鸦，乱写乱画"
-        ],
-        "notation": "落書(らくが)き"
+        ]
     },
     {
         "name": "iitsukeru",
         "trans": [
+            "言(い)いつける",
             "④ 他动2  吩咐；告状"
-        ],
-        "notation": "言(い)いつける"
+        ]
     },
     {
         "name": "kigane",
         "trans": [
+            "気兼(きが)ね",
             "⓪ 名·自动3  顾虑，拘谨，客气"
-        ],
-        "notation": "気兼(きが)ね"
+        ]
     },
     {
         "name": "jibyou",
         "trans": [
+            "持病(じびょう)",
             "⓪ 名  慢性病；老毛病"
-        ],
-        "notation": "持病(じびょう)"
+        ]
     },
     {
         "name": "chiratto",
         "trans": [
+            "ちらっと",
             "② 副  一晃，一闪；隐约（听到）"
-        ],
-        "notation": "ちらっと"
+        ]
     },
     {
         "name": "nidukuri",
         "trans": [
+            "荷造(にづく)り",
             "② 名·自他动3  打包，包装"
-        ],
-        "notation": "荷造(にづく)り"
+        ]
     },
     {
         "name": "hikyou",
         "trans": [
+            "卑怯(ひきょう)",
             "② 名·ナ形  卑鄙，无耻；胆怯，懦弱"
-        ],
-        "notation": "卑怯(ひきょう)"
+        ]
     },
     {
         "name": "makanau",
         "trans": [
+            "賄(まかな)う",
             "③ 他动1  供给伙食；勉强维持"
-        ],
-        "notation": "賄(まかな)う"
+        ]
     },
     {
         "name": "yuukyou",
         "trans": [
+            "遊興(ゆうきょう)",
             "⓪ 名·自动3  游玩，作乐"
-        ],
-        "notation": "遊興(ゆうきょう)"
+        ]
     },
     {
         "name": "rikutsu",
         "trans": [
+            "理屈(りくつ)",
             "⓪ 名  道理；歪理，借口"
-        ],
-        "notation": "理屈(りくつ)"
+        ]
     },
     {
         "name": "uyauyashii",
         "trans": [
+            "恭(うやうや)しい",
             "⑤ イ形  恭敬的，有礼貌的"
-        ],
-        "notation": "恭(うやうや)しい"
+        ]
     },
     {
         "name": "guchi",
         "trans": [
+            "愚痴(ぐち)",
             "⓪ 名  抱怨，牢骚"
-        ],
-        "notation": "愚痴(ぐち)"
+        ]
     },
     {
         "name": "jakkan",
         "trans": [
+            "若干(じゃっかん)",
             "⓪ 名·副  若干，一些"
-        ],
-        "notation": "若干(じゃっかん)"
+        ]
     },
     {
         "name": "nasakebukai",
         "trans": [
+            "情(なさ)け深(ぶか)い",
             "⑤ イ形  仁慈的，有同情心的"
-        ],
-        "notation": "情(なさ)け深(ぶか)い"
+        ]
     },
     {
         "name": "hankan",
         "trans": [
+            "反感(はんかん)",
             "⓪ 名  反感"
-        ],
-        "notation": "反感(はんかん)"
+        ]
     },
     {
         "name": "michidure",
         "trans": [
+            "道連(みちづ)れ",
             "⓪ 名  旅伴，同行者"
-        ],
-        "notation": "道連(みちづ)れ"
+        ]
     },
     {
         "name": "yashinau",
         "trans": [
+            "養(やしな)う",
             "③ 他动1  养育；培养；疗养"
-        ],
-        "notation": "養(やしな)う"
+        ]
     },
     {
         "name": "wazawai",
         "trans": [
+            "災(わざわ)い",
             "⓪ 名  灾难，灾害，灾祸"
-        ],
-        "notation": "災(わざわ)い"
+        ]
     },
     {
         "name": "jishuku",
         "trans": [
+            "自粛(じしゅく)",
             "⓪ 名·他动3  自我约束，自我克制"
-        ],
-        "notation": "自粛(じしゅく)"
+        ]
     },
     {
         "name": "akudoi",
         "trans": [
+            "あくどい",
             "③ イ形  （颜色）过艳的；（味道）腻的；（手法）恶毒的"
-        ],
-        "notation": "あくどい"
+        ]
     },
     {
         "name": "kangen",
         "trans": [
+            "還元(かんげん)",
             "⓪ 名·自他动3  还原，恢复原状"
-        ],
-        "notation": "還元(かんげん)"
+        ]
     },
     {
         "name": "sashou",
         "trans": [
+            "査証(さしょう)",
             "⓪ 名·他动3  签证；调查证明"
-        ],
-        "notation": "査証(さしょう)"
+        ]
     },
     {
         "name": "tachikiru",
         "trans": [
+            "断(た)ち切(き)る",
             "③ 他动1  切断；断绝（关系）"
-        ],
-        "notation": "断(た)ち切(き)る"
+        ]
     },
     {
         "name": "naishoku",
         "trans": [
+            "内職(ないしょく)",
             "⓪ 名·自动3  副业；（上课）做别的事"
-        ],
-        "notation": "内職(ないしょく)"
+        ]
     },
     {
         "name": "hagire",
         "trans": [
+            "歯切(はぎ)れ",
             "③ 名  （食物）脆；口齿，发音；（态度）干脆，爽快"
-        ],
-        "notation": "歯切(はぎ)れ"
+        ]
     },
     {
         "name": "magotsuku",
         "trans": [
+            "まごつく",
             "⓪ 自动1  惊慌失措；徘徊，彷徨"
-        ],
-        "notation": "まごつく"
+        ]
     },
     {
         "name": "yuuyami",
         "trans": [
+            "夕闇(ゆうやみ)",
             "⓪ 名  暮色，黄昏"
-        ],
-        "notation": "夕闇(ゆうやみ)"
+        ]
     },
     {
         "name": "raihou",
         "trans": [
+            "来訪(らいほう)",
             "⓪ 名·自动3  来访"
-        ],
-        "notation": "来訪(らいほう)"
+        ]
     },
     {
         "name": "iiharu",
         "trans": [
+            "言(い)い張(は)る",
             "③ 他动1  固执己见，坚持"
-        ],
-        "notation": "言(い)い張(は)る"
+        ]
     },
     {
         "name": "kikijouzu",
         "trans": [
+            "聞(き)き上手(じょうず)",
             "③ 名·ナ形  善于倾听"
-        ],
-        "notation": "聞(き)き上手(じょうず)"
+        ]
     },
     {
         "name": "shisa",
         "trans": [
+            "示唆(しさ)",
             "① 名·他动3  暗示，启发"
-        ],
-        "notation": "示唆(しさ)"
+        ]
     },
     {
         "name": "nedaru",
         "trans": [
+            "強請(ねだ)る",
             "② 他动1  死乞白赖地要求"
-        ],
-        "notation": "強請(ねだ)る"
+        ]
     },
     {
         "name": "hitteki",
         "trans": [
+            "匹敵(ひってき)",
             "⓪ 名·自动3  匹敌，比得上"
-        ],
-        "notation": "匹敵(ひってき)"
+        ]
     },
     {
         "name": "mijuku",
         "trans": [
+            "未熟(みじゅく)",
             "⓪ 名·ナ形  未成熟；不熟练"
-        ],
-        "notation": "未熟(みじゅく)"
+        ]
     },
     {
         "name": "yosoou",
         "trans": [
+            "装(よそお)う",
             "③ 他动1  穿戴，打扮；伪装，假装"
-        ],
-        "notation": "装(よそお)う"
+        ]
     },
     {
         "name": "ryakudatsu",
         "trans": [
+            "略奪(りゃくだつ)",
             "⓪ 名·他动3  掠夺，抢夺"
-        ],
-        "notation": "略奪(りゃくだつ)"
+        ]
     },
     {
         "name": "wanpata-n",
         "trans": [
+            "ワンパターン",
             "④ 名·ナ形  千篇一律，一个模子"
-        ],
-        "notation": "ワンパターン"
+        ]
     },
     {
         "name": "ukeireru",
         "trans": [
+            "受(う)け入(い)れる",
             "④ 他动2  收；接纳；承认，采纳"
-        ],
-        "notation": "受(う)け入(い)れる"
+        ]
     },
     {
         "name": "assen",
         "trans": [
+            "斡旋(あっせん)",
             "⓪ 名·他动3  斡旋；帮助；介绍"
-        ],
-        "notation": "斡旋(あっせん)"
+        ]
     },
     {
         "name": "kanshou",
         "trans": [
+            "完勝(かんしょう)",
             "⓪ 名·自动3  完全胜利，完胜"
-        ],
-        "notation": "完勝(かんしょう)"
+        ]
     },
     {
         "name": "sashitsukaeru",
         "trans": [
+            "差(さ)し支(つか)える",
             "⑤ 自动2  妨碍，有影响；不方便"
-        ],
-        "notation": "差(さ)し支(つか)える"
+        ]
     },
     {
         "name": "tatemae",
         "trans": [
+            "建前(たてまえ)",
             "③ 名  原则，方针；场面话"
-        ],
-        "notation": "建前(たてまえ)"
+        ]
     },
     {
         "name": "nakoudo",
         "trans": [
+            "仲人(なこうど)",
             "② 名  媒人"
-        ],
-        "notation": "仲人(なこうど)"
+        ]
     },
     {
         "name": "bateru",
         "trans": [
+            "ばてる",
             "② 自动2  精疲力竭，累得要命"
-        ],
-        "notation": "ばてる"
+        ]
     },
     {
         "name": "magiwa",
         "trans": [
+            "間際(まぎわ)",
             "① 名  正要⋯⋯的时候；快要⋯⋯的时候"
-        ],
-        "notation": "間際(まぎわ)"
+        ]
     },
     {
         "name": "yashin",
         "trans": [
+            "野心(やしん)",
             "① 名  野心"
-        ],
-        "notation": "野心(やしん)"
+        ]
     },
     {
         "name": "azawarau",
         "trans": [
+            "嘲笑(あざわら)う",
             "④ 他动1  嘲笑"
-        ],
-        "notation": "嘲笑(あざわら)う"
+        ]
     },
     {
         "name": "okubyou",
         "trans": [
+            "臆病(おくびょう)",
             "③ 名·ナ形  胆怯，胆小，懦弱"
-        ],
-        "notation": "臆病(おくびょう)"
+        ]
     },
     {
         "name": "gyara",
         "trans": [
+            "ギャラ",
             "⓪ 名  出场费，演出费"
-        ],
-        "notation": "ギャラ"
+        ]
     },
     {
         "name": "shanimuni",
         "trans": [
+            "遮二無二(しゃにむに)",
             "⓪ 副  胡乱，盲目；一个劲儿"
-        ],
-        "notation": "遮二無二(しゃにむに)"
+        ]
     },
     {
         "name": "kugiru",
         "trans": [
+            "区切(くぎ)る",
             "② 他动1  划分；（文章）划分段落"
-        ],
-        "notation": "区切(くぎ)る"
+        ]
     },
     {
         "name": "shiren",
         "trans": [
+            "試練(しれん)",
             "① 名  考验，锻炼"
-        ],
-        "notation": "試練(しれん)"
+        ]
     },
     {
         "name": "takibi",
         "trans": [
+            "焚(た)き火(び)",
             "⓪ 名  篝火"
-        ],
-        "notation": "焚(た)き火(び)"
+        ]
     },
     {
         "name": "namanamashii",
         "trans": [
+            "生々しい(なまなましい)",
             "⑤ イ形  生动的，活生生的，栩栩如生的"
-        ],
-        "notation": "生々しい(なまなましい)"
+        ]
     },
     {
         "name": "hitoke",
         "trans": [
+            "人気(ひとけ)",
             "⓪ 名  人的气息"
-        ],
-        "notation": "人気(ひとけ)"
+        ]
     },
     {
         "name": "honoo",
         "trans": [
+            "炎(ほのお)",
             "① 名  火焰；（内心的）火苗"
-        ],
-        "notation": "炎(ほのお)"
+        ]
     },
     {
         "name": "mitsumoru",
         "trans": [
+            "見積(みつ)もる",
             "⓪ 他动1  粗略计算，估计"
-        ],
-        "notation": "見積(みつ)もる"
+        ]
     },
     {
         "name": "akisu",
         "trans": [
+            "空(あ)き巣(す)",
             "⓪ 名  空房"
-        ],
-        "notation": "空(あ)き巣(す)"
+        ]
     },
     {
         "name": "kaso",
         "trans": [
+            "過疎(かそ)",
             "① 名·ナ形  人口过少"
-        ],
-        "notation": "過疎(かそ)"
+        ]
     },
     {
         "name": "komoru",
         "trans": [
+            "籠(こ)もる",
             "② 自动1  闭门不出；充满；包含"
-        ],
-        "notation": "籠(こ)もる"
+        ]
     },
     {
         "name": "joucho/jousho",
         "trans": [
+            "情緒(じょうちょ/じょうしょ)",
             "① 名  情趣；情绪"
-        ],
-        "notation": "情緒(じょうちょ/じょうしょ)"
+        ]
     },
     {
         "name": "taimingu",
         "trans": [
+            "タイミング",
             "⓪ 名  时机"
-        ],
-        "notation": "タイミング"
+        ]
     },
     {
         "name": "terekusai",
         "trans": [
+            "照(て)れくさい",
             "④ イ形  害羞的，不好意思的"
-        ],
-        "notation": "照(て)れくさい"
+        ]
     },
     {
         "name": "netsuben",
         "trans": [
+            "熱弁(ねつべん)",
             "⓪ 名  热情洋溢的讲话"
-        ],
-        "notation": "熱弁(ねつべん)"
+        ]
     },
     {
         "name": "hiketsu",
         "trans": [
+            "否決(ひけつ)",
             "⓪ 名·他动3  否决"
-        ],
-        "notation": "否決(ひけつ)"
+        ]
     },
     {
         "name": "uwamuku",
         "trans": [
+            "上向(うわむ)く",
             "⓪ 自动1  向上；行情看涨"
-        ],
-        "notation": "上向(うわむ)く"
+        ]
     },
     {
         "name": "gaikan",
         "trans": [
+            "外観(がいかん)",
             "⓪ 名  外观，外表"
-        ],
-        "notation": "外観(がいかん)"
+        ]
     },
     {
         "name": "sabaibaru",
         "trans": [
+            "サバイバル",
             "② 名  幸存，残存"
-        ],
-        "notation": "サバイバル"
+        ]
     },
     {
         "name": "tachinoku",
         "trans": [
+            "立(た)ち退(の)く",
             "③ 自动1  走开，离开；搬走"
-        ],
-        "notation": "立(た)ち退(の)く"
+        ]
     },
     {
         "name": "tegoro",
         "trans": [
+            "手頃(てごろ)",
             "⓪ 名·ナ形  （大小、粗细）合手；适中，合适"
-        ],
-        "notation": "手頃(てごろ)"
+        ]
     },
     {
         "name": "naishin",
         "trans": [
+            "内心(ないしん)",
             "⓪ 名·副  内心，心中"
-        ],
-        "notation": "内心(ないしん)"
+        ]
     },
     {
         "name": "hirameku",
         "trans": [
+            "閃(ひらめ)く",
             "③ 自动1  闪耀；（旗子等）飘扬；突然想到（主意）"
-        ],
-        "notation": "閃(ひらめ)く"
+        ]
     },
     {
         "name": "hosoku",
         "trans": [
+            "補足(ほそく)",
             "⓪ 名·他动3  补充，补足"
-        ],
-        "notation": "補足(ほそく)"
+        ]
     },
     {
         "name": "magureatari",
         "trans": [
+            "紛(まぐ)れ当(あ)たり",
             "④ 名  歪打正着，碰巧打中"
-        ],
-        "notation": "紛(まぐ)れ当(あ)たり"
+        ]
     },
     {
         "name": "yattenokeru",
         "trans": [
+            "やってのける",
             "⓪ 他动2  （出色地）做完"
-        ],
-        "notation": "やってのける"
+        ]
     },
     {
         "name": "rakunou",
         "trans": [
+            "酪農(らくのう)",
             "⓪ 名  乳畜业（以生产奶制品为主）"
-        ],
-        "notation": "酪農(らくのう)"
+        ]
     },
     {
         "name": "watakushigoto",
         "trans": [
+            "私事(わたくしごと)",
             "⓪ 名  私事"
-        ],
-        "notation": "私事(わたくしごと)"
+        ]
     },
     {
         "name": "itsuwaru",
         "trans": [
+            "偽(いつわ)る",
             "③ 他动1  说谎；欺骗；冒充"
-        ],
-        "notation": "偽(いつわ)る"
+        ]
     },
     {
         "name": "kusshi",
         "trans": [
+            "屈指(くっし)",
             "① 名·自动3  屈指可数，数一数二"
-        ],
-        "notation": "屈指(くっし)"
+        ]
     },
     {
         "name": "juritsu",
         "trans": [
+            "樹立(じゅりつ)",
             "⓪ 名·自他动3  树立，建立"
-        ],
-        "notation": "樹立(じゅりつ)"
+        ]
     },
     {
         "name": "decchiageru",
         "trans": [
+            "でっち上(あ)げる",
             "⑤ 他动2  捏造，编造；拼凑出"
-        ],
-        "notation": "でっち上(あ)げる"
+        ]
     },
     {
         "name": "hakai",
         "trans": [
+            "破壊(はかい)",
             "⓪ 名·自他动3  破坏"
-        ],
-        "notation": "破壊(はかい)"
+        ]
     },
     {
         "name": "fuete",
         "trans": [
+            "不得手(ふえて)",
             "② ナ形  不擅长的；不爱好的"
-        ],
-        "notation": "不得手(ふえて)"
+        ]
     },
     {
         "name": "magirawashii",
         "trans": [
+            "紛(まぎ)らわしい",
             "⑤ イ形  容易混淆的，不易分辨的"
-        ],
-        "notation": "紛(まぎ)らわしい"
+        ]
     },
     {
         "name": "riko-ru",
         "trans": [
+            "リコール",
             "② 名·他动3  罢免；召回（有缺陷产品）"
-        ],
-        "notation": "リコール"
+        ]
     },
     {
         "name": "idou",
         "trans": [
+            "異動(いどう)",
             "⓪ 名·自他动3  调动，变动"
-        ],
-        "notation": "異動(いどう)"
+        ]
     },
     {
         "name": "shikakeru",
         "trans": [
+            "仕掛(しか)ける",
             "③ 他动2  开始做；做到中途；挑衅；布置，设置"
-        ],
-        "notation": "仕掛(しか)ける"
+        ]
     },
     {
         "name": "eshaku",
         "trans": [
+            "会釈(えしゃく)",
             "① 名·自动3  点头致意，打招呼"
-        ],
-        "notation": "会釈(えしゃく)"
+        ]
     },
     {
         "name": "sensu",
         "trans": [
+            "扇子(せんす)",
             "⓪ 名  扇子"
-        ],
-        "notation": "扇子(せんす)"
+        ]
     },
     {
         "name": "torishiraberu",
         "trans": [
+            "取(と)り調(しら)べる",
             "⑤ 他动2  调查；审讯，审问"
-        ],
-        "notation": "取(と)り調(しら)べる"
+        ]
     },
     {
         "name": "batsugun",
         "trans": [
+            "抜群(ばつぐん)",
             "⓪ 名·ナ形  超群，突出，出众"
-        ],
-        "notation": "抜群(ばつぐん)"
+        ]
     },
     {
         "name": "makezuotorazu",
         "trans": [
+            "負(ま)けず劣(おと)らず",
             "⑤ 连语  势均力敌，不相上下"
-        ],
-        "notation": "負(ま)けず劣(おと)らず"
+        ]
     },
     {
         "name": "monotarinai",
         "trans": [
+            "物足(ものた)りない",
             "⓪ イ形  感到有欠缺的，不十分满意的；不够充分的，美中不足的"
-        ],
-        "notation": "物足(ものた)りない"
+        ]
     },
     {
         "name": "yuuzai",
         "trans": [
+            "有罪(ゆうざい)",
             "⓪ 名  有罪"
-        ],
-        "notation": "有罪(ゆうざい)"
+        ]
     },
     {
         "name": "ryoudo",
         "trans": [
+            "領土(りょうど)",
             "① 名  领土"
-        ],
-        "notation": "領土(りょうど)"
+        ]
     },
     {
         "name": "azukaru",
         "trans": [
+            "与(あずか)る",
             "③ 自动1  参与；蒙，受（夸奖、邀请）"
-        ],
-        "notation": "与(あずか)る"
+        ]
     },
     {
         "name": "opushon",
         "trans": [
+            "オプション",
             "① 名  选择"
-        ],
-        "notation": "オプション"
+        ]
     },
     {
         "name": "gunbi",
         "trans": [
+            "軍備(ぐんび)",
             "① 名  军备"
-        ],
-        "notation": "軍備(ぐんび)"
+        ]
     },
     {
         "name": "samatageru",
         "trans": [
+            "妨(さまた)げる",
             "④ 他动2  妨碍，阻挠"
-        ],
-        "notation": "妨(さまた)げる"
+        ]
     },
     {
         "name": "sochi",
         "trans": [
+            "措置(そち)",
             "① 名·他动3  措施，处理"
-        ],
-        "notation": "措置(そち)"
+        ]
     },
     {
         "name": "chouhon'nin",
         "trans": [
+            "張本人(ちょうほんにん)",
             "③ 名  罪魁祸首，肇事者"
-        ],
-        "notation": "張本人(ちょうほんにん)"
+        ]
     },
     {
         "name": "nagedasu",
         "trans": [
+            "投(な)げ出(だ)す",
             "③ 他动1  扔出去；放弃，抛弃；豁出去"
-        ],
-        "notation": "投(な)げ出(だ)す"
+        ]
     },
     {
         "name": "biri",
         "trans": [
+            "びり",
             "① 名  最后，倒数第一"
-        ],
-        "notation": "びり"
+        ]
     },
     {
         "name": "meishou",
         "trans": [
+            "名称(めいしょう)",
             "⓪ 名  名称"
-        ],
-        "notation": "名称(めいしょう)"
+        ]
     },
     {
         "name": "yudaneru",
         "trans": [
+            "委(ゆだ)ねる",
             "③ 他动2  委托；献身，委身"
-        ],
-        "notation": "委(ゆだ)ねる"
+        ]
     },
     {
         "name": "rakkan",
         "trans": [
+            "楽観(らっかん)",
             "⓪ 名·他动3  乐观"
-        ],
-        "notation": "楽観(らっかん)"
+        ]
     },
     {
         "name": "akirame",
         "trans": [
+            "諦(あきら)め",
             "⓪ 名  断念，死心，想开"
-        ],
-        "notation": "諦(あきら)め"
+        ]
     },
     {
         "name": "kitaru",
         "trans": [
+            "来(きた)る",
             "② 连体·自动1  到来；下次的"
-        ],
-        "notation": "来(きた)る"
+        ]
     },
     {
         "name": "shougeki",
         "trans": [
+            "衝撃(しょうげき)",
             "⓪ 名  冲击，打击"
-        ],
-        "notation": "衝撃(しょうげき)"
+        ]
     },
     {
         "name": "osananajimi",
         "trans": [
+            "幼馴染(おさななじみ)",
             "④ 名  青梅竹马"
-        ],
-        "notation": "幼馴染(おさななじみ)"
+        ]
     },
     {
         "name": "tsutsushimu",
         "trans": [
+            "慎(つつし)む",
             "③ 他动1  谨慎，慎重；节制"
-        ],
-        "notation": "慎(つつし)む"
+        ]
     },
     {
         "name": "ichidaiji",
         "trans": [
+            "一大事(いちだいじ)",
             "③ 名  一件大事"
-        ],
-        "notation": "一大事(いちだいじ)"
+        ]
     },
     {
         "name": "shikke",
         "trans": [
+            "湿気(しっけ)",
             "⓪ 名  湿气，潮气"
-        ],
-        "notation": "湿気(しっけ)"
+        ]
     },
     {
         "name": "tadadesae",
         "trans": [
+            "ただでさえ",
             "① 副  平时就，本来就"
-        ],
-        "notation": "ただでさえ"
+        ]
     },
     {
         "name": "tero",
         "trans": [
+            "テロ",
             "① 名  恐怖主义"
-        ],
-        "notation": "テロ"
+        ]
     },
     {
         "name": "hekieki",
         "trans": [
+            "辟易(へきえき)",
             "⓪ 名·自动3  退缩，畏缩；束手无策"
-        ],
-        "notation": "辟易(へきえき)"
+        ]
     },
     {
         "name": "miiru",
         "trans": [
+            "見入(みい)る",
             "② 自他动1  看得入迷；注视"
-        ],
-        "notation": "見入(みい)る"
+        ]
     },
     {
         "name": "yuuyo",
         "trans": [
+            "猶予(ゆうよ)",
             "① 名·自动3  犹豫；缓期，延期"
-        ],
-        "notation": "猶予(ゆうよ)"
+        ]
     },
     {
         "name": "rijun",
         "trans": [
+            "利潤(りじゅん)",
             "⓪ 名  利润"
-        ],
-        "notation": "利潤(りじゅん)"
+        ]
     },
     {
         "name": "iiyodomu",
         "trans": [
+            "言(い)いよどむ",
             "④ 他动1  欲言又止，吞吞吐吐"
-        ],
-        "notation": "言(い)いよどむ"
+        ]
     },
     {
         "name": "kaiun",
         "trans": [
+            "海運(かいうん)",
             "⓪ 名  海运"
-        ],
-        "notation": "海運(かいうん)"
+        ]
     },
     {
         "name": "koyuu",
         "trans": [
+            "固有(こゆう)",
             "⓪ 名·ナ形  固有；特有"
-        ],
-        "notation": "固有(こゆう)"
+        ]
     },
     {
         "name": "junjiru",
         "trans": [
+            "準(じゅん)じる",
             "⓪ 自动2  以⋯⋯为标准；按照⋯⋯看待"
-        ],
-        "notation": "準(じゅん)じる"
+        ]
     },
     {
         "name": "tanaage",
         "trans": [
+            "棚上(たなあ)げ",
             "⓪ 名·他动3  搁置；（商品）囤积不卖"
-        ],
-        "notation": "棚上(たなあ)げ"
+        ]
     },
     {
         "name": "ashidori",
         "trans": [
+            "足取(あしど)り",
             "⓪ 名  脚步，步伐；踪迹"
-        ],
-        "notation": "足取(あしど)り"
+        ]
     },
     {
         "name": "haradatashii",
         "trans": [
+            "腹立(はらだ)たしい",
             "⑤ イ形  令人气愤的"
-        ],
-        "notation": "腹立(はらだ)たしい"
+        ]
     },
     {
         "name": "tsugime",
         "trans": [
+            "継(つ)ぎ目(め)",
             "⓪ 名  接口，接缝"
-        ],
-        "notation": "継(つ)ぎ目(め)"
+        ]
     },
     {
         "name": "iroai",
         "trans": [
+            "色合(いろあ)い",
             "⓪ 名  色调，配色；倾向"
-        ],
-        "notation": "色合(いろあ)い"
+        ]
     },
     {
         "name": "odoodo",
         "trans": [
+            "おどおど",
             "① 副·自动3  提心吊胆，战战兢兢"
-        ],
-        "notation": "おどおど"
+        ]
     },
     {
         "name": "kyoutei",
         "trans": [
+            "協定(きょうてい)",
             "⓪ 名·他动3  协定"
-        ],
-        "notation": "協定(きょうてい)"
+        ]
     },
     {
         "name": "janbo",
         "trans": [
+            "ジャンボ",
             "① 名·ナ形  巨大，特大"
-        ],
-        "notation": "ジャンボ"
+        ]
     },
     {
         "name": "tsuranuku",
         "trans": [
+            "貫(つらぬ)く",
             "③ 他动1  贯通，穿过；贯彻，坚持"
-        ],
-        "notation": "貫(つらぬ)く"
+        ]
     },
     {
         "name": "keigen",
         "trans": [
+            "軽減(けいげん)",
             "⓪ 名·他动3  减轻"
-        ],
-        "notation": "軽減(けいげん)"
+        ]
     },
     {
         "name": "ikaku",
         "trans": [
+            "威嚇(いかく)",
             "⓪ 名·他动3  威胁，恫吓"
-        ],
-        "notation": "威嚇(いかく)"
+        ]
     },
     {
         "name": "okuraseru",
         "trans": [
+            "遅(おく)らせる",
             "⓪ 他动2  推迟，延迟"
-        ],
-        "notation": "遅(おく)らせる"
+        ]
     },
     {
         "name": "kokuchi",
         "trans": [
+            "告知(こくち)",
             "⓪ 名·他动3  告知，通报"
-        ],
-        "notation": "告知(こくち)"
+        ]
     },
     {
         "name": "juutai",
         "trans": [
+            "重体(じゅうたい)",
             "⓪ 名  病危"
-        ],
-        "notation": "重体(じゅうたい)"
+        ]
     },
     {
         "name": "baramaku",
         "trans": [
+            "ばらまく",
             "③ 他动1  散播，散发；散财，到处花钱"
-        ],
-        "notation": "ばらまく"
+        ]
     },
     {
         "name": "maikuro~",
         "trans": [
+            "マイクロ～",
             " 接头  微；百万分之一"
-        ],
-        "notation": "マイクロ～"
+        ]
     },
     {
         "name": "yuushi",
         "trans": [
+            "融資(ゆうし)",
             "① 名·自动3  融资，贷款"
-        ],
-        "notation": "融資(ゆうし)"
+        ]
     },
     {
         "name": "uketomeru",
         "trans": [
+            "受(う)け止(と)める",
             "④ 他动2  接住；阻击；理解，接受"
-        ],
-        "notation": "受(う)け止(と)める"
+        ]
     },
     {
         "name": "kyakka",
         "trans": [
+            "却下(きゃっか)",
             "① 名·他动3  驳回，不受理"
-        ],
-        "notation": "却下(きゃっか)"
+        ]
     },
     {
         "name": "akushitsu",
         "trans": [
+            "悪質(あくしつ)",
             "⓪ 名·ナ形  质量差；性质恶劣"
-        ],
-        "notation": "悪質(あくしつ)"
+        ]
     },
     {
         "name": "sasageru",
         "trans": [
+            "捧(ささ)げる",
             "⓪ 他动2  捧举；献，供奉；贡献"
-        ],
-        "notation": "捧(ささ)げる"
+        ]
     },
     {
         "name": "maemuki",
         "trans": [
+            "前向(まえむ)き",
             "⓪ 名·ナ形  面向前方；（态度）积极"
-        ],
-        "notation": "前向(まえむ)き"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "粋(いき)",
             "⓪ 名·ナ形  时髦，漂亮；通情达理"
-        ],
-        "notation": "粋(いき)"
+        ]
     },
     {
         "name": "hageru",
         "trans": [
+            "禿(は)げる",
             "② 自动2  脱发；变秃"
-        ],
-        "notation": "禿(は)げる"
+        ]
     },
     {
         "name": "henjou",
         "trans": [
+            "返上(へんじょう)",
             "⓪ 名·他动3  归还，奉还"
-        ],
-        "notation": "返上(へんじょう)"
+        ]
     },
     {
         "name": "resepushon",
         "trans": [
+            "レセプション",
             "② 名  招待会，欢迎会，宴会"
-        ],
-        "notation": "レセプション"
+        ]
     },
     {
         "name": "okubukai/okufukai",
         "trans": [
+            "奥深(おくぶかい/おくふか)い",
             "④ イ形  幽深的；深奥的，深远的"
-        ],
-        "notation": "奥深(おくぶかい/おくふか)い"
+        ]
     },
     {
         "name": "atoshimatsu",
         "trans": [
+            "後始末(あとしまつ)",
             "③ 名  善后，收拾"
-        ],
-        "notation": "後始末(あとしまつ)"
+        ]
     },
     {
         "name": "kaitaku",
         "trans": [
+            "開拓(かいたく)",
             "⓪ 名·他动3  开垦（土地）；开辟（新领域）"
-        ],
-        "notation": "開拓(かいたく)"
+        ]
     },
     {
         "name": "sashite",
         "trans": [
+            "然(さ)して",
             "① 副  （后接否定）那么，那样"
-        ],
-        "notation": "然(さ)して"
+        ]
     },
     {
         "name": "kyuutou",
         "trans": [
+            "急騰(きゅうとう)",
             "⓪ 名·自动3  暴涨，急剧增长"
-        ],
-        "notation": "急騰(きゅうとう)"
+        ]
     },
     {
         "name": "shukuga",
         "trans": [
+            "祝賀(しゅくが)",
             "② 名·他动3  祝贺，庆贺"
-        ],
-        "notation": "祝賀(しゅくが)"
+        ]
     },
     {
         "name": "tabaneru",
         "trans": [
+            "束(たば)ねる",
             "③ 他动2  捆，扎；管理，整顿"
-        ],
-        "notation": "束(たば)ねる"
+        ]
     },
     {
         "name": "mizutamari",
         "trans": [
+            "水溜(みずたま)り",
             "⓪ 名  水洼，水坑"
-        ],
-        "notation": "水溜(みずたま)り"
+        ]
     },
     {
         "name": "akutoku",
         "trans": [
+            "悪徳(あくとく)",
             "⓪ 名  缺德，不道德"
-        ],
-        "notation": "悪徳(あくとく)"
+        ]
     },
     {
         "name": "kaika",
         "trans": [
+            "開花(かいか)",
             "① 名·自动3  （植物）开花；有成果"
-        ],
-        "notation": "開花(かいか)"
+        ]
     },
     {
         "name": "sazukeru",
         "trans": [
+            "授(さず)ける",
             "③ 他动2  授予，赋予；教授，传授"
-        ],
-        "notation": "授(さず)ける"
+        ]
     },
     {
         "name": "taikin",
         "trans": [
+            "大金(たいきん)",
             "⓪ 名  巨款"
-        ],
-        "notation": "大金(たいきん)"
+        ]
     },
     {
         "name": "shuugeki",
         "trans": [
+            "襲撃(しゅうげき)",
             "⓪ 名·他动3  袭击"
-        ],
-        "notation": "襲撃(しゅうげき)"
+        ]
     },
     {
         "name": "hagasu",
         "trans": [
+            "剥(は)がす",
             "② 他动1  揭下，剥下"
-        ],
-        "notation": "剥(は)がす"
+        ]
     },
     {
         "name": "ikinuki",
         "trans": [
+            "息抜(いきぬ)き",
             "⓪ 名·自动3  歇口气，休息一会儿"
-        ],
-        "notation": "息抜(いきぬ)き"
+        ]
     },
     {
         "name": "kimarimonku",
         "trans": [
+            "決(き)まり文句(もんく)",
             "④ 名  口头禅，老一套的话"
-        ],
-        "notation": "決(き)まり文句(もんく)"
+        ]
     },
     {
         "name": "houkeru",
         "trans": [
+            "惚(ほう)ける",
             "③ 自动2  装傻，装糊涂；出洋相"
-        ],
-        "notation": "惚(ほう)ける"
+        ]
     },
     {
         "name": "shiire",
         "trans": [
+            "仕入(しい)れ",
             "⓪ 名  进货，采购"
-        ],
-        "notation": "仕入(しい)れ"
+        ]
     },
     {
         "name": "chuujitsu",
         "trans": [
+            "忠実(ちゅうじつ)",
             "⓪ 名·ナ形  忠实，忠诚；照原样"
-        ],
-        "notation": "忠実(ちゅうじつ)"
+        ]
     },
     {
         "name": "nadakai",
         "trans": [
+            "名高(なだか)い",
             "③ イ形  有名的，著名的"
-        ],
-        "notation": "名高(なだか)い"
+        ]
     },
     {
         "name": "hitokoro",
         "trans": [
+            "ひところ",
             "② 名  前些日子，曾经有段时间"
-        ],
-        "notation": "ひところ"
+        ]
     },
     {
         "name": "matanithi-",
         "trans": [
+            "マタニティー",
             "② 名  孕妇；怀孕期间"
-        ],
-        "notation": "マタニティー"
+        ]
     },
     {
         "name": "yarikonasu",
         "trans": [
+            "やりこなす",
             "④ 他动1  出色完成，妥善处理"
-        ],
-        "notation": "やりこなす"
+        ]
     },
     {
         "name": "rousui",
         "trans": [
+            "老衰(ろうすい)",
             "⓪ 名·自动3  衰老"
-        ],
-        "notation": "老衰(ろうすい)"
+        ]
     },
     {
         "name": "ete",
         "trans": [
+            "得手(えて)",
             "② ナ形  擅长的，拿手的"
-        ],
-        "notation": "得手(えて)"
+        ]
     },
     {
         "name": "kuichigau",
         "trans": [
+            "食(く)い違(ちが)う",
             "④ 自动1  有分歧，不一致；错位"
-        ],
-        "notation": "食(く)い違(ちが)う"
+        ]
     },
     {
         "name": "shusshi",
         "trans": [
+            "出資(しゅっし)",
             "⓪ 名·自动3  出资，投资"
-        ],
-        "notation": "出資(しゅっし)"
+        ]
     },
     {
         "name": "douin",
         "trans": [
+            "動員(どういん)",
             "⓪ 名·他动3  动员；调动（积极性）"
-        ],
-        "notation": "動員(どういん)"
+        ]
     },
     {
         "name": "negiru",
         "trans": [
+            "値切(ねぎ)る",
             "② 他动1  还价，讲价"
-        ],
-        "notation": "値切(ねぎ)る"
+        ]
     },
     {
         "name": "osarai",
         "trans": [
+            "おさらい",
             "⓪ 名·他动3  复习，温习；排练"
-        ],
-        "notation": "おさらい"
+        ]
     },
     {
         "name": "shishoku",
         "trans": [
+            "試食(ししょく)",
             "⓪ 名·他动3  试吃，品尝"
-        ],
-        "notation": "試食(ししょく)"
+        ]
     },
     {
         "name": "hikiiru",
         "trans": [
+            "率(ひき)いる",
             "③ 他动2  率领，统率"
-        ],
-        "notation": "率(ひき)いる"
+        ]
     },
     {
         "name": "mujaki",
         "trans": [
+            "無邪気(むじゃき)",
             "① ナ形  天真烂漫的；思想单纯的"
-        ],
-        "notation": "無邪気(むじゃき)"
+        ]
     },
     {
         "name": "uetto",
         "trans": [
+            "ウエット",
             "② ナ形  湿的；多愁善感的"
-        ],
-        "notation": "ウエット"
+        ]
     },
     {
         "name": "kanau",
         "trans": [
+            "敵(かな)う",
             "② 自动1  比得上，敌得过"
-        ],
-        "notation": "敵(かな)う"
+        ]
     },
     {
         "name": "shitsuke",
         "trans": [
+            "躾(しつけ)",
             "⓪ 名  教养，教育；管教"
-        ],
-        "notation": "躾(しつけ)"
+        ]
     },
     {
         "name": "dakyou",
         "trans": [
+            "妥協(だきょう)",
             "⓪ 名·自动3  妥协，和解"
-        ],
-        "notation": "妥協(だきょう)"
+        ]
     },
     {
         "name": "nandakanda",
         "trans": [
+            "なんだかんだ",
             "④ 连语  这样那样，这个那个"
-        ],
-        "notation": "なんだかんだ"
+        ]
     },
     {
         "name": "buryoku",
         "trans": [
+            "武力(ぶりょく)",
             "① 名  武力"
-        ],
-        "notation": "武力(ぶりょく)"
+        ]
     },
     {
         "name": "ikioi",
         "trans": [
+            "勢(いきお)い",
             "③ 名  气势；势力；趋势，形势"
-        ],
-        "notation": "勢(いきお)い"
+        ]
     },
     {
         "name": "omokurushii",
         "trans": [
+            "重苦(おもくる)しい",
             "⑤ イ形  沉闷的，郁闷的，不舒畅的"
-        ],
-        "notation": "重苦(おもくる)しい"
+        ]
     },
     {
         "name": "genkou",
         "trans": [
+            "現行(げんこう)",
             "⓪ 名  现行，正在实行"
-        ],
-        "notation": "現行(げんこう)"
+        ]
     },
     {
         "name": "sesshoku",
         "trans": [
+            "接触(せっしょく)",
             "⓪ 名·自动3  接触；来往，交往"
-        ],
-        "notation": "接触(せっしょく)"
+        ]
     },
     {
         "name": "toozakaru",
         "trans": [
+            "遠(とお)ざかる",
             "④ 自动1  远离，疏远"
-        ],
-        "notation": "遠(とお)ざかる"
+        ]
     },
     {
         "name": "buthikku",
         "trans": [
+            "ブティック",
             "① 名  精品店，时装店"
-        ],
-        "notation": "ブティック"
+        ]
     },
     {
         "name": "attou",
         "trans": [
+            "圧倒(あっとう)",
             "⓪ 名·他动3  压倒；胜过"
-        ],
-        "notation": "圧倒(あっとう)"
+        ]
     },
     {
         "name": "kirameku",
         "trans": [
+            "煌(きらめ)く",
             "③ 自动1  闪耀，闪烁"
-        ],
-        "notation": "煌(きらめ)く"
+        ]
     },
     {
         "name": "soshi",
         "trans": [
+            "阻止(そし)",
             "① 名·他动3  阻止"
-        ],
-        "notation": "阻止(そし)"
+        ]
     },
     {
         "name": "tewake",
         "trans": [
+            "手分(てわ)け",
             "③ 名·自动3  分头做；分工"
-        ],
-        "notation": "手分(てわ)け"
+        ]
     },
     {
         "name": "hataku",
         "trans": [
+            "叩(はた)く",
             "② 他动1  掸；拍打；全部拿出，倾囊"
-        ],
-        "notation": "叩(はた)く"
+        ]
     },
     {
         "name": "magokoro",
         "trans": [
+            "真心(まごころ)",
             "② 名  真心"
-        ],
-        "notation": "真心(まごころ)"
+        ]
     },
     {
         "name": "youshou",
         "trans": [
+            "幼少(ようしょう)",
             "⓪ 名  年幼，童年时代"
-        ],
-        "notation": "幼少(ようしょう)"
+        ]
     },
     {
         "name": "itamu",
         "trans": [
+            "悼(いた)む",
             "② 他动1  哀悼，悼念"
-        ],
-        "notation": "悼(いた)む"
+        ]
     },
     {
         "name": "kuubaku",
         "trans": [
+            "空爆(くうばく)",
             "⓪ 名·他动3  空袭"
-        ],
-        "notation": "空爆(くうばく)"
+        ]
     },
     {
         "name": "shinpi",
         "trans": [
+            "神秘(しんぴ)",
             "① 名·ナ形  神秘"
-        ],
-        "notation": "神秘(しんぴ)"
+        ]
     },
     {
         "name": "nan'narito",
         "trans": [
+            "なんなりと",
             "① 副  无论什么，不管什么"
-        ],
-        "notation": "なんなりと"
+        ]
     },
     {
         "name": "hakujaku",
         "trans": [
+            "薄弱(はくじゃく)",
             "⓪ 名·ナ形  （意志）薄弱，不坚定；（证据）不充足"
-        ],
-        "notation": "薄弱(はくじゃく)"
+        ]
     },
     {
         "name": "meichuu",
         "trans": [
+            "命中(めいちゅう)",
             "⓪ 名·自动3  命中（目标）"
-        ],
-        "notation": "命中(めいちゅう)"
+        ]
     },
     {
         "name": "yubisasu",
         "trans": [
+            "指差(ゆびさ)す",
             "③ 他动1  用手指；受人指责"
-        ],
-        "notation": "指差(ゆびさ)す"
+        ]
     },
     {
         "name": "akusesu",
         "trans": [
+            "アクセス",
             "① 名·自动3  计算机存取数据；连接机场等地的公路或铁路；网站登录"
-        ],
-        "notation": "アクセス"
+        ]
     },
     {
         "name": "katamari",
         "trans": [
+            "塊(かたまり)",
             "⓪ 名  块儿；群体；极端⋯⋯的人"
-        ],
-        "notation": "塊(かたまり)"
+        ]
     },
     {
         "name": "konomashii",
         "trans": [
+            "好(この)ましい",
             "④ イ形  可喜的，令人满意的"
-        ],
-        "notation": "好(この)ましい"
+        ]
     },
     {
         "name": "taikou",
         "trans": [
+            "対抗(たいこう)",
             "⓪ 名·自动3  对抗，抗衡"
-        ],
-        "notation": "対抗(たいこう)"
+        ]
     },
     {
         "name": "nemawashi",
         "trans": [
+            "根回(ねまわ)し",
             "② 名·他动3  事先疏通，做事前工作"
-        ],
-        "notation": "根回(ねまわ)し"
+        ]
     },
     {
         "name": "hikaeru",
         "trans": [
+            "控(ひか)える",
             "③ 自他动2  等候；控制，节制；暂不；面临，迫近"
-        ],
-        "notation": "控(ひか)える"
+        ]
     },
     {
         "name": "michi",
         "trans": [
+            "未知(みち)",
             "① 名  未知"
-        ],
-        "notation": "未知(みち)"
+        ]
     },
     {
         "name": "ryuuchou",
         "trans": [
+            "流暢(りゅうちょう)",
             "① ナ形  流畅的，流利的"
-        ],
-        "notation": "流暢(りゅうちょう)"
+        ]
     },
     {
         "name": "uchiyaburu",
         "trans": [
+            "打(う)ち破(やぶ)る",
             "④ 他动1  打破，破坏；打败，击败"
-        ],
-        "notation": "打(う)ち破(やぶ)る"
+        ]
     },
     {
         "name": "kaodachi",
         "trans": [
+            "顔立(かおだ)ち",
             "⓪ 名  容貌，五官"
-        ],
-        "notation": "顔立(かおだ)ち"
+        ]
     },
     {
         "name": "saihou",
         "trans": [
+            "裁縫(さいほう)",
             "⓪ 名·自动3  缝纫；做针线活儿"
-        ],
-        "notation": "裁縫(さいほう)"
+        ]
     },
     {
         "name": "shocchuu",
         "trans": [
+            "しょっちゅう",
             "① 副  经常，总是"
-        ],
-        "notation": "しょっちゅう"
+        ]
     },
     {
         "name": "dhisupure-",
         "trans": [
+            "ディスプレー",
             "① 名·他动3  陈列，展示，展览"
-        ],
-        "notation": "ディスプレー"
+        ]
     },
     {
         "name": "hitojichi",
         "trans": [
+            "人質(ひとじち)",
             "⓪ 名  人质"
-        ],
-        "notation": "人質(ひとじち)"
+        ]
     },
     {
         "name": "misebirakasu",
         "trans": [
+            "見(み)せびらかす",
             "⑤ 他动1  炫耀，卖弄"
-        ],
-        "notation": "見(み)せびらかす"
+        ]
     },
     {
         "name": "kikurage",
         "trans": [
+            "木耳(きくらげ)",
             "② 名  木耳"
-        ],
-        "notation": "木耳(きくらげ)"
+        ]
     },
     {
         "name": "shibutsu",
         "trans": [
+            "私物(しぶつ)",
             "⓪ 名  私人物品"
-        ],
-        "notation": "私物(しぶつ)"
+        ]
     },
     {
         "name": "ikkyoni",
         "trans": [
+            "一挙(いっきょ)に",
             "① 副  一举，一下子"
-        ],
-        "notation": "一挙(いっきょ)に"
+        ]
     },
     {
         "name": "oshoku",
         "trans": [
+            "汚職(おしょく)",
             "⓪ 名  贪污，渎职"
-        ],
-        "notation": "汚職(おしょく)"
+        ]
     },
     {
         "name": "shugyou",
         "trans": [
+            "修行(しゅぎょう)",
             "⓪ 名·自他动3  （佛教用语）修行；学习(学问、技艺)"
-        ],
-        "notation": "修行(しゅぎょう)"
+        ]
     },
     {
         "name": "tatekaeru",
         "trans": [
+            "立(た)て替(か)える",
             "⓪ 他动2  垫付，代付"
-        ],
-        "notation": "立(た)て替(か)える"
+        ]
     },
     {
         "name": "batontacchi",
         "trans": [
+            "バトンタッチ",
             "④ 名·他动3  递交接力棒；交接（工作）"
-        ],
-        "notation": "バトンタッチ"
+        ]
     },
     {
         "name": "midokoro",
         "trans": [
+            "見所(みどころ)",
             "⓪ 名  看点；前途；可取之处"
-        ],
-        "notation": "見所(みどころ)"
+        ]
     },
     {
         "name": "yayakoshii",
         "trans": [
+            "ややこしい",
             "④ イ形  麻烦的；复杂的；难办的"
-        ],
-        "notation": "ややこしい"
+        ]
     },
     {
         "name": "unomi",
         "trans": [
+            "鵜呑(うの)み",
             "③ 名  囫囵吞枣"
-        ],
-        "notation": "鵜呑(うの)み"
+        ]
     },
     {
         "name": "atotsugi",
         "trans": [
+            "跡継(あとつ)ぎ",
             "② 名  接班人，继承者；后嗣"
-        ],
-        "notation": "跡継(あとつ)ぎ"
+        ]
     },
     {
         "name": "sueru",
         "trans": [
+            "据(す)える",
             "⓪ 他动2  放置；让⋯⋯坐在⋯⋯位置；让⋯⋯就⋯⋯职位；沉着"
-        ],
-        "notation": "据(す)える"
+        ]
     },
     {
         "name": "denshou",
         "trans": [
+            "伝承(でんしょう)",
             "⓪ 名·他动3  代代相传，传承"
-        ],
-        "notation": "伝承(でんしょう)"
+        ]
     },
     {
         "name": "himei",
         "trans": [
+            "悲鳴(ひめい)",
             "⓪ 名  悲鸣，惨叫；叫苦声"
-        ],
-        "notation": "悲鳴(ひめい)"
+        ]
     },
     {
         "name": "magireru",
         "trans": [
+            "紛(まぎ)れる",
             "③ 自动2  混淆；混杂，混进；（因忙碌）忘怀"
-        ],
-        "notation": "紛(まぎ)れる"
+        ]
     },
     {
         "name": "yuuzuu",
         "trans": [
+            "融通(ゆうずう)",
             "⓪ 名·他动3  筹款，借贷；随机应变"
-        ],
-        "notation": "融通(ゆうずう)"
+        ]
     },
     {
         "name": "ragubi-",
         "trans": [
+            "ラグビー",
             "① 名  橄榄球"
-        ],
-        "notation": "ラグビー"
+        ]
     },
     {
         "name": "okkanai",
         "trans": [
+            "おっかない",
             "④ イ形  可怕的，令人害怕的"
-        ],
-        "notation": "おっかない"
+        ]
     },
     {
         "name": "kyoumei",
         "trans": [
+            "共鳴(きょうめい)",
             "⓪ 名·自动3  共鸣，同感"
-        ],
-        "notation": "共鳴(きょうめい)"
+        ]
     },
     {
         "name": "kaikyuu",
         "trans": [
+            "階級(かいきゅう)",
             "⓪ 名  阶级，阶层"
-        ],
-        "notation": "階級(かいきゅう)"
+        ]
     },
     {
         "name": "iiwatasu",
         "trans": [
+            "言(い)い渡(わた)す",
             "④ 他动1  宣告，宣判；命令，吩咐"
-        ],
-        "notation": "言(い)い渡(わた)す"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "施行(しこう)",
             "⓪ 名·他动3  实施，实行"
-        ],
-        "notation": "施行(しこう)"
+        ]
     },
     {
         "name": "tokugi",
         "trans": [
+            "特技(とくぎ)",
             "① 名  特殊技能，拿手的技术"
-        ],
-        "notation": "特技(とくぎ)"
+        ]
     },
     {
         "name": "tadoru",
         "trans": [
+            "辿(たど)る",
             "② 自动1  沿路前进；追寻，追溯"
-        ],
-        "notation": "辿(たど)る"
+        ]
     },
     {
         "name": "naisen",
         "trans": [
+            "内線(ないせん)",
             "⓪ 名  内线电话"
-        ],
-        "notation": "内線(ないせん)"
+        ]
     },
     {
         "name": "pinchi",
         "trans": [
+            "ピンチ",
             "① 名  紧急关头，危机"
-        ],
-        "notation": "ピンチ"
+        ]
     },
     {
         "name": "minasu",
         "trans": [
+            "見(み)なす",
             "⓪ 他动1  看作，认为；当作"
-        ],
-        "notation": "見(み)なす"
+        ]
     },
     {
         "name": "kokuhaku",
         "trans": [
+            "告白(こくはく)",
             "⓪ 名·他动3  坦白，告白"
-        ],
-        "notation": "告白(こくはく)"
+        ]
     },
     {
         "name": "tsuikyuu",
         "trans": [
+            "追究(ついきゅう)",
             "⓪ 名·他动3  追求，追究，搞清，弄清"
-        ],
-        "notation": "追究(ついきゅう)"
+        ]
     },
     {
         "name": "osoreiru",
         "trans": [
+            "恐(おそ)れ入(い)る",
             "② 自动1  不好意思；非常感激；佩服"
-        ],
-        "notation": "恐(おそ)れ入(い)る"
+        ]
     },
     {
         "name": "itten",
         "trans": [
+            "一転(いってん)",
             "⓪ 名·自动3  突然一变，一转"
-        ],
-        "notation": "一転(いってん)"
+        ]
     },
     {
         "name": "soshitsu",
         "trans": [
+            "素質(そしつ)",
             "⓪ 名  素质；天分，资质"
-        ],
-        "notation": "素質(そしつ)"
+        ]
     },
     {
         "name": "kicchiri",
         "trans": [
+            "きっちり",
             "③ 副  正好，恰好；（大小）正合适；严实，没有空隙"
-        ],
-        "notation": "きっちり"
+        ]
     },
     {
         "name": "engi",
         "trans": [
+            "縁起(えんぎ)",
             "⓪ 名  起源，由来；兆头"
-        ],
-        "notation": "縁起(えんぎ)"
+        ]
     },
     {
         "name": "ashigakari",
         "trans": [
+            "足掛(あしが)かり",
             "③ 名  立足点；线索"
-        ],
-        "notation": "足掛(あしが)かり"
+        ]
     },
     {
         "name": "kando",
         "trans": [
+            "感度(かんど)",
             "① 名  灵敏度，灵敏性"
-        ],
-        "notation": "感度(かんど)"
+        ]
     },
     {
         "name": "sasuru",
         "trans": [
+            "摩(さす)る",
             "⓪ 他动1  摸，抚摸；搓"
-        ],
-        "notation": "摩(さす)る"
+        ]
     },
     {
         "name": "tassha",
         "trans": [
+            "達者(たっしゃ)",
             "⓪ 名·ナ形  精通，熟练；健康，健壮"
-        ],
-        "notation": "達者(たっしゃ)"
+        ]
     },
     {
         "name": "nagamochi",
         "trans": [
+            "長持(ながも)ち",
             "③ 名·自动3  耐用，持久"
-        ],
-        "notation": "長持(ながも)ち"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "諮(はか)る",
             "② 他动1  磋商，咨询"
-        ],
-        "notation": "諮(はか)る"
+        ]
     },
     {
         "name": "masui",
         "trans": [
+            "麻酔(ますい)",
             "⓪ 名  麻醉"
-        ],
-        "notation": "麻酔(ますい)"
+        ]
     },
     {
         "name": "yuusei",
         "trans": [
+            "優勢(ゆうせい)",
             "⓪ 名·ナ形  优势"
-        ],
-        "notation": "優勢(ゆうせい)"
+        ]
     },
     {
         "name": "ikasu",
         "trans": [
+            "生(い)かす",
             "② 他动1  救活；有效利用"
-        ],
-        "notation": "生(い)かす"
+        ]
     },
     {
         "name": "charakuta-",
         "trans": [
+            "キャラクター",
             "① 名  性格，个性；角色"
-        ],
-        "notation": "キャラクター"
+        ]
     },
     {
         "name": "shikaeshi",
         "trans": [
+            "仕返(しかえ)し",
             "⓪ 名·自动3  重做；报复，报仇"
-        ],
-        "notation": "仕返(しかえ)し"
+        ]
     },
     {
         "name": "choichoi",
         "trans": [
+            "ちょいちょい",
             "① 副  时常，经常"
-        ],
-        "notation": "ちょいちょい"
+        ]
     },
     {
         "name": "nichiya",
         "trans": [
+            "日夜(にちや)",
             "⓪ 名·副  日夜；经常不断地，总是"
-        ],
-        "notation": "日夜(にちや)"
+        ]
     },
     {
         "name": "hikage",
         "trans": [
+            "日陰(ひかげ)",
             "⓪ 名  背阴处，阴凉处"
-        ],
-        "notation": "日陰(ひかげ)"
+        ]
     },
     {
         "name": "miotosu",
         "trans": [
+            "見落(みお)とす",
             "⓪ 他动1  看漏，没看出来，忽略"
-        ],
-        "notation": "見落(みお)とす"
+        ]
     },
     {
         "name": "youjin",
         "trans": [
+            "用心(ようじん)",
             "① 名·自动3  提防，小心"
-        ],
-        "notation": "用心(ようじん)"
+        ]
     },
     {
         "name": "ri-da-",
         "trans": [
+            "リーダー",
             "① 名  领导者，领导人"
-        ],
-        "notation": "リーダー"
+        ]
     },
     {
         "name": "ushirometai",
         "trans": [
+            "後(うし)ろめたい",
             "⑤ イ形  内疚的，亏心的"
-        ],
-        "notation": "後(うし)ろめたい"
+        ]
     },
     {
         "name": "kuchikomi",
         "trans": [
+            "口(くち)コミ",
             "⓪ 名  小道消息，口口相传"
-        ],
-        "notation": "口(くち)コミ"
+        ]
     },
     {
         "name": "suishin",
         "trans": [
+            "推進(すいしん)",
             "⓪ 名·他动3  推进，推动"
-        ],
-        "notation": "推進(すいしん)"
+        ]
     },
     {
         "name": "tsukidasu",
         "trans": [
+            "突(つ)き出(だ)す",
             "③ 他动1  推出去；伸出，探出；扭送"
-        ],
-        "notation": "突(つ)き出(だ)す"
+        ]
     },
     {
         "name": "ne-mubaryu-",
         "trans": [
+            "ネームバリュー",
             "④ 名  名声，声誉"
-        ],
-        "notation": "ネームバリュー"
+        ]
     },
     {
         "name": "fui",
         "trans": [
+            "不意(ふい)",
             "⓪ 名·ナ形  冷不防，突然"
-        ],
-        "notation": "不意(ふい)"
+        ]
     },
     {
         "name": "mukamuka",
         "trans": [
+            "むかむか",
             "① 副·自动3  恶心，想吐；生气，火冒三丈"
-        ],
-        "notation": "むかむか"
+        ]
     },
     {
         "name": "yuudou",
         "trans": [
+            "誘導(ゆうどう)",
             "⓪ 名·他动3  引导，诱导"
-        ],
-        "notation": "誘導(ゆうどう)"
+        ]
     },
     {
         "name": "ruikei",
         "trans": [
+            "累計(るいけい)",
             "⓪ 名·他动3  累计，总计"
-        ],
-        "notation": "累計(るいけい)"
+        ]
     },
     {
         "name": "aseru",
         "trans": [
+            "焦(あせ)る",
             "② 自他动1  焦急，急躁；急于"
-        ],
-        "notation": "焦(あせ)る"
+        ]
     },
     {
         "name": "keisai",
         "trans": [
+            "掲載(けいさい)",
             "⓪ 名·他动3  刊登，登载"
-        ],
-        "notation": "掲載(けいさい)"
+        ]
     },
     {
         "name": "seiippai",
         "trans": [
+            "精(せい)いっぱい",
             "③ 名·副  竭尽全力"
-        ],
-        "notation": "精(せい)いっぱい"
+        ]
     },
     {
         "name": "tekipaki",
         "trans": [
+            "てきぱき",
             "① 副·自动3  爽快；麻利，利落"
-        ],
-        "notation": "てきぱき"
+        ]
     },
     {
         "name": "naresome",
         "trans": [
+            "馴(な)れ初(そ)め",
             "⓪ 名  恋爱关系的开端"
-        ],
-        "notation": "馴(な)れ初(そ)め"
+        ]
     },
     {
         "name": "betto",
         "trans": [
+            "別途(べっと)",
             "① 名·副  另外，另行"
-        ],
-        "notation": "別途(べっと)"
+        ]
     },
     {
         "name": "moushiireru",
         "trans": [
+            "申(もう)し入(い)れる",
             "⑤ 他动2  提议，要求"
-        ],
-        "notation": "申(もう)し入(い)れる"
+        ]
     },
     {
         "name": "renjuu/renchuu",
         "trans": [
+            "連中(れんじゅう/れんちゅう)",
             "⓪ 名  伙伴，同伙"
-        ],
-        "notation": "連中(れんじゅう/れんちゅう)"
+        ]
     },
     {
         "name": "oukyuu",
         "trans": [
+            "応急(おうきゅう)",
             "⓪ 名  应急　"
-        ],
-        "notation": "応急(おうきゅう)"
+        ]
     },
     {
         "name": "kotoniyoruto",
         "trans": [
+            "ことによると",
             "⓪ 连语·副  可能，也许，说不定"
-        ],
-        "notation": "ことによると"
+        ]
     },
     {
         "name": "souou",
         "trans": [
+            "相応(そうおう)",
             "⓪ 名·ナ形·自动3  相称，适宜，适合"
-        ],
-        "notation": "相応(そうおう)"
+        ]
     },
     {
         "name": "nori",
         "trans": [
+            "糊(のり)",
             "② 名  糨糊"
-        ],
-        "notation": "糊(のり)"
+        ]
     },
     {
         "name": "uchidasu",
         "trans": [
+            "打(う)ち出(だ)す",
             "③ 他动1  提出（想法、主张等）"
-        ],
-        "notation": "打(う)ち出(だ)す"
+        ]
     },
     {
         "name": "katagaki",
         "trans": [
+            "肩書(かたが)き",
             "⓪ 名  头衔，职位"
-        ],
-        "notation": "肩書(かたが)き"
+        ]
     },
     {
         "name": "kouhai",
         "trans": [
+            "高配(こうはい)",
             "⓪ 名  关怀，照顾"
-        ],
-        "notation": "高配(こうはい)"
+        ]
     },
     {
         "name": "sonaetsukeru",
         "trans": [
+            "備(そな)え付(つ)ける",
             "⑤ 他动2  设置，安置"
-        ],
-        "notation": "備(そな)え付(つ)ける"
+        ]
     },
     {
         "name": "tesuu",
         "trans": [
+            "手数(てすう)",
             "② 名  麻烦，费事"
-        ],
-        "notation": "手数(てすう)"
+        ]
     },
     {
         "name": "nyuushou",
         "trans": [
+            "入賞(にゅうしょう)",
             "⓪ 名·自动3  获奖"
-        ],
-        "notation": "入賞(にゅうしょう)"
+        ]
     },
     {
         "name": "bakeru",
         "trans": [
+            "化(ば)ける",
             "② 自动2  化为；乔装；完全变样"
-        ],
-        "notation": "化(ば)ける"
+        ]
     },
     {
         "name": "mapputatsu",
         "trans": [
+            "真(ま)っ二(ぷた)つ",
             "③ 名  刚好两半儿；两派"
-        ],
-        "notation": "真(ま)っ二(ぷた)つ"
+        ]
     },
     {
         "name": "yousei",
         "trans": [
+            "養成(ようせい)",
             "⓪ 名·他动3  培养，培训"
-        ],
-        "notation": "養成(ようせい)"
+        ]
     },
     {
         "name": "asamashii",
         "trans": [
+            "浅(あさ)ましい",
             "④ イ形  卑鄙的；可耻的；可叹的；凄惨的"
-        ],
-        "notation": "浅(あさ)ましい"
+        ]
     },
     {
         "name": "kyouson",
         "trans": [
+            "共存(きょうそん)",
             "⓪ 名·自动3  共存，共处"
-        ],
-        "notation": "共存(きょうそん)"
+        ]
     },
     {
         "name": "shutten",
         "trans": [
+            "出店(しゅってん)",
             "⓪ 名·自动3  开（分）店"
-        ],
-        "notation": "出店(しゅってん)"
+        ]
     },
     {
         "name": "dassuru",
         "trans": [
+            "脱(だっ)する",
             "⓪ 自他动3  逃脱；脱离；去除，去掉"
-        ],
-        "notation": "脱(だっ)する"
+        ]
     },
     {
         "name": "debyu-",
         "trans": [
+            "デビュー",
             "① 名·自动3  初次登台；新上市"
-        ],
-        "notation": "デビュー"
+        ]
     },
     {
         "name": "nankou",
         "trans": [
+            "難航(なんこう)",
             "⓪ 名·自动3  难以航行；难以进展"
-        ],
-        "notation": "難航(なんこう)"
+        ]
     },
     {
         "name": "hikitsugu",
         "trans": [
+            "引(ひ)き継(つ)ぐ",
             "③ 他动1  交接，移交；继承"
-        ],
-        "notation": "引(ひ)き継(つ)ぐ"
+        ]
     },
     {
         "name": "miki",
         "trans": [
+            "幹(みき)",
             "① 名  树干；事物的主要部分"
-        ],
-        "notation": "幹(みき)"
+        ]
     },
     {
         "name": "risutora",
         "trans": [
+            "リストラ",
             "⓪ 名·他动3  裁员"
-        ],
-        "notation": "リストラ"
+        ]
     },
     {
         "name": "ikanaru",
         "trans": [
+            "いかなる",
             "② 连体  如何的，怎样的"
-        ],
-        "notation": "いかなる"
+        ]
     },
     {
         "name": "gouin",
         "trans": [
+            "強引(ごういん)",
             "⓪ ナ形  强行的；强制的；蛮干的"
-        ],
-        "notation": "強引(ごういん)"
+        ]
     },
     {
         "name": "kaomake",
         "trans": [
+            "顔負(かおま)け",
             "⓪ 名·自动3  甘拜下风，相形见绌"
-        ],
-        "notation": "顔負(かおま)け"
+        ]
     },
     {
         "name": "shigamitsuku",
         "trans": [
+            "しがみつく",
             "④ 自动1  紧紧抱住；抓住不放手"
-        ],
-        "notation": "しがみつく"
+        ]
     },
     {
         "name": "zenkai",
         "trans": [
+            "全快(ぜんかい)",
             "⓪ 名·自动3  痊愈"
-        ],
-        "notation": "全快(ぜんかい)"
+        ]
     },
     {
         "name": "chokumen",
         "trans": [
+            "直面(ちょくめん)",
             "⓪ 名·自动3  直面，面对"
-        ],
-        "notation": "直面(ちょくめん)"
+        ]
     },
     {
         "name": "togameru",
         "trans": [
+            "咎(とが)める",
             "③ 自他动2  责备，责难；红肿，发炎"
-        ],
-        "notation": "咎(とが)める"
+        ]
     },
     {
         "name": "natsuin",
         "trans": [
+            "捺印(なついん)",
             "⓪ 名·自动3  盖章"
-        ],
-        "notation": "捺印(なついん)"
+        ]
     },
     {
         "name": "fuusa",
         "trans": [
+            "封鎖(ふうさ)",
             "⓪ 名·他动3  封锁；冻结"
-        ],
-        "notation": "封鎖(ふうさ)"
+        ]
     },
     {
         "name": "mukuiru",
         "trans": [
+            "報(むく)いる",
             "③ 自他动2  报答，报偿；报复，报仇"
-        ],
-        "notation": "報(むく)いる"
+        ]
     },
     {
         "name": "yuubi",
         "trans": [
+            "優美(ゆうび)",
             "① 名·ナ形  优美"
-        ],
-        "notation": "優美(ゆうび)"
+        ]
     },
     {
         "name": "ryuutsuu",
         "trans": [
+            "流通(りゅうつう)",
             "⓪ 名·自动3  （气体、货币等）流通"
-        ],
-        "notation": "流通(りゅうつう)"
+        ]
     },
     {
         "name": "uruwashii",
         "trans": [
+            "麗(うるわ)しい",
             "④ イ形  优美的；心情好的；暖心的，感人的"
-        ],
-        "notation": "麗(うるわ)しい"
+        ]
     },
     {
         "name": "ikiataribattari",
         "trans": [
+            "行(い)き当(あ)たりばったり",
             "⑥ 名·ナ形  漫无目的，没有计划，听天由命"
-        ],
-        "notation": "行(い)き当(あ)たりばったり"
+        ]
     },
     {
         "name": "keiji",
         "trans": [
+            "掲示(けいじ)",
             "⓪ 名·他动3  布告，公布"
-        ],
-        "notation": "掲示(けいじ)"
+        ]
     },
     {
         "name": "kojiraseru",
         "trans": [
+            "拗(こじ)らせる",
             "④ 他动2  使复杂化，使恶化"
-        ],
-        "notation": "拗(こじ)らせる"
+        ]
     },
     {
         "name": "shitagokoro",
         "trans": [
+            "下心(したごころ)",
             "③ 名  内心；企图，预谋"
-        ],
-        "notation": "下心(したごころ)"
+        ]
     },
     {
         "name": "suro-gan",
         "trans": [
+            "スローガン",
             "② 名  标语，口号"
-        ],
-        "notation": "スローガン"
+        ]
     },
     {
         "name": "soretohanashini",
         "trans": [
+            "それとはなしに",
             "③ 连语·副  拐弯抹角地，婉转地"
-        ],
-        "notation": "それとはなしに"
+        ]
     },
     {
         "name": "chakushoku",
         "trans": [
+            "着色(ちゃくしょく)",
             "⓪ 名·自动3  着色，上颜色"
-        ],
-        "notation": "着色(ちゃくしょく)"
+        ]
     },
     {
         "name": "donkan",
         "trans": [
+            "鈍感(どんかん)",
             "⓪ 名·ナ形  感觉迟钝"
-        ],
-        "notation": "鈍感(どんかん)"
+        ]
     },
     {
         "name": "fumaeru",
         "trans": [
+            "踏(ふ)まえる",
             "③ 他动2  踩，踏；根据，立足于"
-        ],
-        "notation": "踏(ふ)まえる"
+        ]
     },
     {
         "name": "maki",
         "trans": [
+            "薪(まき)",
             "⓪ 名  木柴，柴火"
-        ],
-        "notation": "薪(まき)"
+        ]
     },
     {
         "name": "yokuatsu",
         "trans": [
+            "抑圧(よくあつ)",
             "⓪ 名·他动3  压制，压迫"
-        ],
-        "notation": "抑圧(よくあつ)"
+        ]
     },
     {
         "name": "ayamaru",
         "trans": [
+            "誤(あやま)る",
             "③ 自他动1  错，弄错；贻害，贻误"
-        ],
-        "notation": "誤(あやま)る"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "加味(かみ)",
             "① 名·他动3  调味，加佐料；加入，掺入"
-        ],
-        "notation": "加味(かみ)"
+        ]
     },
     {
         "name": "sa-bisueria",
         "trans": [
+            "サービスエリア",
             "⑤ 名  （电波）可接收范围；服务区"
-        ],
-        "notation": "サービスエリア"
+        ]
     },
     {
         "name": "zuratto/zurarito",
         "trans": [
+            "ずらっと/ずらりと",
             "② 副  排成一长排"
-        ],
-        "notation": "ずらっと/ずらりと"
+        ]
     },
     {
         "name": "chiiku",
         "trans": [
+            "知育(ちいく)",
             "① 名  智育，提升智力的教育"
-        ],
-        "notation": "知育(ちいく)"
+        ]
     },
     {
         "name": "baikyaku",
         "trans": [
+            "売却(ばいきゃく)",
             "⓪ 名·他动3  出售，变卖"
-        ],
-        "notation": "売却(ばいきゃく)"
+        ]
     },
     {
         "name": "majiwaru",
         "trans": [
+            "交(まじ)わる",
             "③ 自动1  （数学）相交；交往，交际"
-        ],
-        "notation": "交(まじ)わる"
+        ]
     },
     {
         "name": "rachi/racchi",
         "trans": [
+            "拉致(らち/らっち)",
             "① 名·他动3  强行拉走；绑架"
-        ],
-        "notation": "拉致(らち/らっち)"
+        ]
     },
     {
         "name": "uten",
         "trans": [
+            "雨天(うてん)",
             "① 名  雨天"
-        ],
-        "notation": "雨天(うてん)"
+        ]
     },
     {
         "name": "kimazui",
         "trans": [
+            "気(き)まずい",
             "⓪ イ形  不融洽的，不愉快的"
-        ],
-        "notation": "気(き)まずい"
+        ]
     },
     {
         "name": "afuta-sa-bisu",
         "trans": [
+            "アフターサービス",
             "⑤ 名  售后服务；保修"
-        ],
-        "notation": "アフターサービス"
+        ]
     },
     {
         "name": "shikkou",
         "trans": [
+            "執行(しっこう)",
             "⓪ 名·他动3  执行"
-        ],
-        "notation": "執行(しっこう)"
+        ]
     },
     {
         "name": "nogareru",
         "trans": [
+            "逃(のが)れる",
             "③ 自动2  逃跑，逃脱；逃避"
-        ],
-        "notation": "逃(のが)れる"
+        ]
     },
     {
         "name": "hikeme",
         "trans": [
+            "引(ひ)け目(め)",
             "⓪ 名  自卑感"
-        ],
-        "notation": "引(ひ)け目(め)"
+        ]
     },
     {
         "name": "hosou",
         "trans": [
+            "舗装(ほそう)",
             "⓪ 名·他动3  铺路"
-        ],
-        "notation": "舗装(ほそう)"
+        ]
     },
     {
         "name": "musaboru",
         "trans": [
+            "貪(むさぼ)る",
             "③ 他动1  贪图，贪婪"
-        ],
-        "notation": "貪(むさぼ)る"
+        ]
     },
     {
         "name": "ikken",
         "trans": [
+            "一見(いっけん)",
             "⓪ 名·他动3·副  （值得）一看；看一眼；乍一看"
-        ],
-        "notation": "一見(いっけん)"
+        ]
     },
     {
         "name": "kanben",
         "trans": [
+            "勘弁(かんべん)",
             "① 名·他动3  原谅，饶恕"
-        ],
-        "notation": "勘弁(かんべん)"
+        ]
     },
     {
         "name": "hagu",
         "trans": [
+            "剥(は)ぐ",
             "① 他动1  剥下，揭下；（强行）扒下；剥夺（官职等）"
-        ],
-        "notation": "剥(は)ぐ"
+        ]
     },
     {
         "name": "shoji",
         "trans": [
+            "所持(しょじ)",
             "① 名·他动3  所持，所有；携带"
-        ],
-        "notation": "所持(しょじ)"
+        ]
     },
     {
         "name": "ashiba",
         "trans": [
+            "足場(あしば)",
             "③ 名  立脚点；基础；交通的方便性"
-        ],
-        "notation": "足場(あしば)"
+        ]
     },
     {
         "name": "kaikyou",
         "trans": [
+            "海峡(かいきょう)",
             "⓪ 名  海峡"
-        ],
-        "notation": "海峡(かいきょう)"
+        ]
     },
     {
         "name": "sadamaru",
         "trans": [
+            "定(さだ)まる",
             "③ 自动1  决定，确定；安定，稳定"
-        ],
-        "notation": "定(さだ)まる"
+        ]
     },
     {
         "name": "oukou",
         "trans": [
+            "横行(おうこう)",
             "⓪ 名·自动3  横冲直撞；横行，跋扈"
-        ],
-        "notation": "横行(おうこう)"
+        ]
     },
     {
         "name": "kyuukaku",
         "trans": [
+            "嗅覚(きゅうかく)",
             "⓪ 名  嗅觉"
-        ],
-        "notation": "嗅覚(きゅうかく)"
+        ]
     },
     {
         "name": "setsunai",
         "trans": [
+            "切(せつ)ない",
             "③ イ形  心里难受的，苦闷的"
-        ],
-        "notation": "切(せつ)ない"
+        ]
     },
     {
         "name": "tabu-",
         "trans": [
+            "タブー",
             "② 名  禁忌"
-        ],
-        "notation": "タブー"
+        ]
     },
     {
         "name": "douchou",
         "trans": [
+            "同調(どうちょう)",
             "⓪ 名·自动3  赞同，步调一致"
-        ],
-        "notation": "同調(どうちょう)"
+        ]
     },
     {
         "name": "ikani",
         "trans": [
+            "いかに",
             "② 副  如何，怎样；无论怎样；多么"
-        ],
-        "notation": "いかに"
+        ]
     },
     {
         "name": "shikisai",
         "trans": [
+            "色彩(しきさい)",
             "⓪ 名  色彩；倾向，特色"
-        ],
-        "notation": "色彩(しきさい)"
+        ]
     },
     {
         "name": "tsuba",
         "trans": [
+            "唾(つば)",
             "① 名  唾液，唾沫"
-        ],
-        "notation": "唾(つば)"
+        ]
     },
     {
         "name": "habahiroi",
         "trans": [
+            "幅広(はばひろ)い",
             "④ イ形  宽阔的；广泛的，丰富的"
-        ],
-        "notation": "幅広(はばひろ)い"
+        ]
     },
     {
         "name": "benkai",
         "trans": [
+            "弁解(べんかい)",
             "⓪ 名·自他动3  辩解，分辩"
-        ],
-        "notation": "弁解(べんかい)"
+        ]
     },
     {
         "name": "minamoto",
         "trans": [
+            "源(みなもと)",
             "⓪ 名  发源地；起源"
-        ],
-        "notation": "源(みなもと)"
+        ]
     },
     {
         "name": "motsureru",
         "trans": [
+            "もつれる",
             "③ 自动2  纠缠在一起；发生纠纷；不听使唤"
-        ],
-        "notation": "もつれる"
+        ]
     },
     {
         "name": "ekisu",
         "trans": [
+            "エキス",
             "① 名  （药和食物的）提取物；精华"
-        ],
-        "notation": "エキス"
+        ]
     },
     {
         "name": "giketsu",
         "trans": [
+            "議決(ぎけつ)",
             "⓪ 名·他动3  决议，表决"
-        ],
-        "notation": "議決(ぎけつ)"
+        ]
     },
     {
         "name": "sukoburu",
         "trans": [
+            "頗(すこぶ)る",
             "③ 副  颇，非常"
-        ],
-        "notation": "頗(すこぶ)る"
+        ]
     },
     {
         "name": "keisha",
         "trans": [
+            "傾斜(けいしゃ)",
             "⓪ 名·自动3  倾斜，坡度；倾向"
-        ],
-        "notation": "傾斜(けいしゃ)"
+        ]
     },
     {
         "name": "taikyuuryoku",
         "trans": [
+            "耐久力(たいきゅうりょく)",
             "③ 名  耐用性，耐久力"
-        ],
-        "notation": "耐久力(たいきゅうりょく)"
+        ]
     },
     {
         "name": "tojikomoru",
         "trans": [
+            "閉(と)じこもる",
             "④ 自动1  闭门不出"
-        ],
-        "notation": "閉(と)じこもる"
+        ]
     },
     {
         "name": "negoro",
         "trans": [
+            "値頃(ねごろ)",
             "⓪ 名·ナ形  价格合适"
-        ],
-        "notation": "値頃(ねごろ)"
+        ]
     },
     {
         "name": "bikou",
         "trans": [
+            "尾行(びこう)",
             "⓪ 名·自他动3  尾随，跟踪"
-        ],
-        "notation": "尾行(びこう)"
+        ]
     },
     {
         "name": "hodokeru",
         "trans": [
+            "解(ほど)ける",
             "③ 自动2  松开，解开"
-        ],
-        "notation": "解(ほど)ける"
+        ]
     },
     {
         "name": "manneri",
         "trans": [
+            "マンネリ",
             "⓪ 名  因循守旧，墨守成规，千篇一律，老一套"
-        ],
-        "notation": "マンネリ"
+        ]
     },
     {
         "name": "yuuryoku",
         "trans": [
+            "有力(ゆうりょく)",
             "⓪ ナ形  有势力的；有权威的；最有希望的"
-        ],
-        "notation": "有力(ゆうりょく)"
+        ]
     },
     {
         "name": "uzumeru",
         "trans": [
+            "埋(うず)める",
             "⓪ 他动2  埋，掩埋，填上；捂（脸）；挤满，充满"
-        ],
-        "notation": "埋(うず)める"
+        ]
     },
     {
         "name": "kakine",
         "trans": [
+            "垣根(かきね)",
             "② 名  篱笆，栅栏；墙根"
-        ],
-        "notation": "垣根(かきね)"
+        ]
     },
     {
         "name": "shimyure-shon",
         "trans": [
+            "シミュレーション",
             "③ 名·他动3  模拟，仿真"
-        ],
-        "notation": "シミュレーション"
+        ]
     },
     {
         "name": "kuiru",
         "trans": [
+            "悔(く)いる",
             "② 他动2  懊悔，后悔"
-        ],
-        "notation": "悔(く)いる"
+        ]
     },
     {
         "name": "daketsu",
         "trans": [
+            "妥結(だけつ)",
             "⓪ 名·自动3  谈妥，达成协议"
-        ],
-        "notation": "妥結(だけつ)"
+        ]
     },
     {
         "name": "hankyou",
         "trans": [
+            "反響(はんきょう)",
             "⓪ 名·自动3  反应，反响；回响"
-        ],
-        "notation": "反響(はんきょう)"
+        ]
     },
     {
         "name": "mikiwameru",
         "trans": [
+            "見極(みきわ)める",
             "④ 他动2  看清，看透（本质）；弄清楚，辨别"
-        ],
-        "notation": "見極(みきわ)める"
+        ]
     },
     {
         "name": "atomawashi",
         "trans": [
+            "後回(あとまわ)し",
             "③ 名  推后，推迟"
-        ],
-        "notation": "後回(あとまわ)し"
+        ]
     },
     {
         "name": "kujuu",
         "trans": [
+            "苦渋(くじゅう)",
             "⓪ 名·自动3  苦恼，痛苦"
-        ],
-        "notation": "苦渋(くじゅう)"
+        ]
     },
     {
         "name": "kaerimiru",
         "trans": [
+            "顧(かえり)みる",
             "④ 他动2  往后看；回顾；顾及"
-        ],
-        "notation": "顧(かえり)みる"
+        ]
     },
     {
         "name": "shiki",
         "trans": [
+            "指揮(しき)",
             "② 名·他动3  指挥"
-        ],
-        "notation": "指揮(しき)"
+        ]
     },
     {
         "name": "chakumoku",
         "trans": [
+            "着目(ちゃくもく)",
             "⓪ 名·自动3  着眼，注目"
-        ],
-        "notation": "着目(ちゃくもく)"
+        ]
     },
     {
         "name": "toritsugu",
         "trans": [
+            "取(と)り次(つ)ぐ",
             "⓪ 他动1  传达，转达；经销，代销"
-        ],
-        "notation": "取(と)り次(つ)ぐ"
+        ]
     },
     {
         "name": "haikyuu",
         "trans": [
+            "配給(はいきゅう)",
             "⓪ 名·他动3  配给，定量供应（物资）"
-        ],
-        "notation": "配給(はいきゅう)"
+        ]
     },
     {
         "name": "foro-",
         "trans": [
+            "フォロー",
             "① 名·他动3  跟随；跟踪"
-        ],
-        "notation": "フォロー"
+        ]
     },
     {
         "name": "matagaru",
         "trans": [
+            "跨(またが)る",
             "③ 自动1  骑；横跨，跨越；拖延"
-        ],
-        "notation": "跨(またが)る"
+        ]
     },
     {
         "name": "meihaku",
         "trans": [
+            "明白(めいはく)",
             "⓪ 名·ナ形  明白，明显"
-        ],
-        "notation": "明白(めいはく)"
+        ]
     },
     {
         "name": "ryouiki",
         "trans": [
+            "領域(りょういき)",
             "⓪ 名  领域；范围"
-        ],
-        "notation": "領域(りょういき)"
+        ]
     },
     {
         "name": "uttoushii",
         "trans": [
+            "うっとうしい",
             "⑤ イ形  郁闷的，阴郁的；不痛快的"
-        ],
-        "notation": "うっとうしい"
+        ]
     },
     {
         "name": "ku-ru",
         "trans": [
+            "クール",
             "① ナ形  凉爽的，凉快的；冷静的，沉着的"
-        ],
-        "notation": "クール"
+        ]
     },
     {
         "name": "shishou",
         "trans": [
+            "支障(ししょう)",
             "⓪ 名  故障，障碍"
-        ],
-        "notation": "支障(ししょう)"
+        ]
     },
     {
         "name": "kozotte",
         "trans": [
+            "挙(こぞ)って",
             "② 副  全部，全都"
-        ],
-        "notation": "挙(こぞ)って"
+        ]
     },
     {
         "name": "tenka",
         "trans": [
+            "転嫁(てんか)",
             "⓪ 名·他动3  转嫁，推卸（责任）"
-        ],
-        "notation": "転嫁(てんか)"
+        ]
     },
     {
         "name": "haken",
         "trans": [
+            "覇権(はけん)",
             "⓪ 名  霸权；冠军"
-        ],
-        "notation": "覇権(はけん)"
+        ]
     },
     {
         "name": "fumikomu",
         "trans": [
+            "踏(ふ)み込(こ)む",
             "③ 自他动1  陷入，踩进；闯入，擅自进入；用力踩"
-        ],
-        "notation": "踏(ふ)み込(こ)む"
+        ]
     },
     {
         "name": "manazashi",
         "trans": [
+            "眼差(まなざ)し",
             "⓪ 名  目光，眼神"
-        ],
-        "notation": "眼差(まなざ)し"
+        ]
     },
     {
         "name": "yochi",
         "trans": [
+            "余地(よち)",
             "① 名  余地"
-        ],
-        "notation": "余地(よち)"
+        ]
     },
     {
         "name": "akkenai",
         "trans": [
+            "あっけない",
             "④ イ形  太简单的，不尽兴的，不过瘾的"
-        ],
-        "notation": "あっけない"
+        ]
     },
     {
         "name": "kaigyou",
         "trans": [
+            "開業(かいぎょう)",
             "⓪ 名·自他动3  开业"
-        ],
-        "notation": "開業(かいぎょう)"
+        ]
     },
     {
         "name": "kontakuto",
         "trans": [
+            "コンタクト",
             "① 名  接触，联络；“コンタクトレンズ”（隐形眼镜）的缩略语"
-        ],
-        "notation": "コンタクト"
+        ]
     },
     {
         "name": "sutareru",
         "trans": [
+            "廃(すた)れる",
             "⓪ 自动2  废除；不流行；衰落"
-        ],
-        "notation": "廃(すた)れる"
+        ]
     },
     {
         "name": "chuuritsu",
         "trans": [
+            "中立(ちゅうりつ)",
             "⓪ 名·自动3  中立（立场）"
-        ],
-        "notation": "中立(ちゅうりつ)"
+        ]
     },
     {
         "name": "toshigoro",
         "trans": [
+            "年頃(としごろ)",
             "⓪ 名  适龄；大约的年龄"
-        ],
-        "notation": "年頃(としごろ)"
+        ]
     },
     {
         "name": "najimu",
         "trans": [
+            "馴染(なじ)む",
             "② 自动1  熟悉，适应；融合；协调"
-        ],
-        "notation": "馴染(なじ)む"
+        ]
     },
     {
         "name": "pi-ku",
         "trans": [
+            "ピーク",
             "① 名  最高峰，顶点"
-        ],
-        "notation": "ピーク"
+        ]
     },
     {
         "name": "hossoku/hassoku",
         "trans": [
+            "発足(ほっそく/はっそく)",
             "⓪ 名·自动3  出发，动身；（组织等）开始活动"
-        ],
-        "notation": "発足(ほっそく/はっそく)"
+        ]
     },
     {
         "name": "marukiri/marukkiri",
         "trans": [
+            "まるきり/まるっきり",
             "⓪ 副  （后接否定）完全，根本"
-        ],
-        "notation": "まるきり/まるっきり"
+        ]
     },
     {
         "name": "yokomichi",
         "trans": [
+            "横道(よこみち)",
             "⓪ 名  岔路；岔开（话题），偏离正题"
-        ],
-        "notation": "横道(よこみち)"
+        ]
     },
     {
         "name": "shussha",
         "trans": [
+            "出社(しゅっしゃ)",
             "⓪ 名·自动3  上班"
-        ],
-        "notation": "出社(しゅっしゃ)"
+        ]
     },
     {
         "name": "guttari",
         "trans": [
+            "ぐったり",
             "③ 副  精疲力竭，软弱无力"
-        ],
-        "notation": "ぐったり"
+        ]
     },
     {
         "name": "ichidou",
         "trans": [
+            "一同(いちどう)",
             "③ 名  全体，大家"
-        ],
-        "notation": "一同(いちどう)"
+        ]
     },
     {
         "name": "sutoraiki",
         "trans": [
+            "ストライキ",
             "③ 名·自动3  罢工；罢市；罢课"
-        ],
-        "notation": "ストライキ"
+        ]
     },
     {
         "name": "shinobu",
         "trans": [
+            "忍(しの)ぶ",
             "② 自他动1  忍耐，忍受；偷偷地"
-        ],
-        "notation": "忍(しの)ぶ"
+        ]
     },
     {
         "name": "soujuu",
         "trans": [
+            "操縦(そうじゅう)",
             "⓪ 名·他动3  驾驶（飞机）；操纵，控制（他人）"
-        ],
-        "notation": "操縦(そうじゅう)"
+        ]
     },
     {
         "name": "kaidaku",
         "trans": [
+            "快諾(かいだく)",
             "⓪ 名·他动3  欣然允诺"
-        ],
-        "notation": "快諾(かいだく)"
+        ]
     },
     {
         "name": "itonamu",
         "trans": [
+            "営(いとな)む",
             "③ 他动1  从事；经营"
-        ],
-        "notation": "営(いとな)む"
+        ]
     },
     {
         "name": "kaitei",
         "trans": [
+            "改定(かいてい)",
             "⓪ 名·他动3  修改，重新规定"
-        ],
-        "notation": "改定(かいてい)"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "興行(こうぎょう)",
             "⓪ 名·他动3  演出，公演；（电影）上映；（戏剧）上演"
-        ],
-        "notation": "興行(こうぎょう)"
+        ]
     },
     {
         "name": "shibui",
         "trans": [
+            "渋(しぶ)い",
             "② イ形  味道涩的；怏怏不乐的；雅致的；吝啬的"
-        ],
-        "notation": "渋(しぶ)い"
+        ]
     },
     {
         "name": "daiya",
         "trans": [
+            "ダイヤ",
             "① 名  运行时刻表；钻石"
-        ],
-        "notation": "ダイヤ"
+        ]
     },
     {
         "name": "nyuuka",
         "trans": [
+            "入荷(にゅうか)",
             "⓪ 名·自他动3  进货，到货"
-        ],
-        "notation": "入荷(にゅうか)"
+        ]
     },
     {
         "name": "harasu",
         "trans": [
+            "晴(は)らす",
             "② 他动1  解除，消除（心中的不快）"
-        ],
-        "notation": "晴(は)らす"
+        ]
     },
     {
         "name": "houki",
         "trans": [
+            "放棄(ほうき)",
             "① 名·他动3  放弃"
-        ],
-        "notation": "放棄(ほうき)"
+        ]
     },
     {
         "name": "michinori",
         "trans": [
+            "道程(みちのり)",
             "⓪ 名  路程，距离"
-        ],
-        "notation": "道程(みちのり)"
+        ]
     },
     {
         "name": "momeru",
         "trans": [
+            "揉(も)める",
             "⓪ 自动2  发生争执；心神不定"
-        ],
-        "notation": "揉(も)める"
+        ]
     },
     {
         "name": "yuuwaku",
         "trans": [
+            "誘惑(ゆうわく)",
             "⓪ 名·他动3  诱惑"
-        ],
-        "notation": "誘惑(ゆうわく)"
+        ]
     },
     {
         "name": "re-ru",
         "trans": [
+            "レール",
             "⓪ 名  铁轨，轨道"
-        ],
-        "notation": "レール"
+        ]
     },
     {
         "name": "uchiakeru",
         "trans": [
+            "打(う)ち明(あ)ける",
             "④ 他动2  坦率说出，开诚布公"
-        ],
-        "notation": "打(う)ち明(あ)ける"
+        ]
     },
     {
         "name": "gendou",
         "trans": [
+            "言動(げんどう)",
             "⓪ 名  言行，语言和行动"
-        ],
-        "notation": "言動(げんどう)"
+        ]
     },
     {
         "name": "sagaku",
         "trans": [
+            "差額(さがく)",
             "⓪ 名  差额"
-        ],
-        "notation": "差額(さがく)"
+        ]
     },
     {
         "name": "sewashii",
         "trans": [
+            "せわしい",
             "③ イ形  忙碌的；匆忙的"
-        ],
-        "notation": "せわしい"
+        ]
     },
     {
         "name": "chakuriku",
         "trans": [
+            "着陸(ちゃくりく)",
             "⓪ 名·自动3  着陆"
-        ],
-        "notation": "着陸(ちゃくりく)"
+        ]
     },
     {
         "name": "dengon",
         "trans": [
+            "伝言(でんごん)",
             "⓪ 名·他动3  传话，口信；带口信"
-        ],
-        "notation": "伝言(でんごん)"
+        ]
     },
     {
         "name": "gusshori",
         "trans": [
+            "ぐっしょり",
             "③ 副  湿透，淋透"
-        ],
-        "notation": "ぐっしょり"
+        ]
     },
     {
         "name": "ereganto",
         "trans": [
+            "エレガント",
             "① ナ形  优雅的，高雅的"
-        ],
-        "notation": "エレガント"
+        ]
     },
     {
         "name": "shuujitsu",
         "trans": [
+            "終日(しゅうじつ)",
             "⓪ 名·副  终日，整天"
-        ],
-        "notation": "終日(しゅうじつ)"
+        ]
     },
     {
         "name": "kasabaru",
         "trans": [
+            "嵩張(かさば)る",
             "③ 自动1  分量多，体积大"
-        ],
-        "notation": "嵩張(かさば)る"
+        ]
     },
     {
         "name": "totteoki",
         "trans": [
+            "とっておき",
             "⓪ 名  珍藏，秘藏"
-        ],
-        "notation": "とっておき"
+        ]
     },
     {
         "name": "moyori",
         "trans": [
+            "最寄(もよ)り",
             "⓪ 名  附近，最近处"
-        ],
-        "notation": "最寄(もよ)り"
+        ]
     },
     {
         "name": "nanra",
         "trans": [
+            "なんら",
             "① 副  （后接否定）任何；丝毫"
-        ],
-        "notation": "なんら"
+        ]
     },
     {
         "name": "henken",
         "trans": [
+            "偏見(へんけん)",
             "⓪ 名  偏见"
-        ],
-        "notation": "偏見(へんけん)"
+        ]
     },
     {
         "name": "mitei",
         "trans": [
+            "未定(みてい)",
             "⓪ 名·ナ形  尚未决定"
-        ],
-        "notation": "未定(みてい)"
+        ]
     },
     {
         "name": "yuragu",
         "trans": [
+            "揺(ゆ)らぐ",
             "② 自动1  摇晃；摇摇欲坠"
-        ],
-        "notation": "揺(ゆ)らぐ"
+        ]
     },
     {
         "name": "arasuji",
         "trans": [
+            "粗筋(あらすじ)",
             "⓪ 名  梗概，概要"
-        ],
-        "notation": "粗筋(あらすじ)"
+        ]
     },
     {
         "name": "ichiban'nori",
         "trans": [
+            "一番乗(いちばんの)り",
             "③ 名·自动3  最先到场"
-        ],
-        "notation": "一番乗(いちばんの)り"
+        ]
     },
     {
         "name": "kidou",
         "trans": [
+            "軌道(きどう)",
             "⓪ 名  轨道"
-        ],
-        "notation": "軌道(きどう)"
+        ]
     },
     {
         "name": "tatematsuru",
         "trans": [
+            "奉(たてまつ)る",
             "④ 他动1  献上，奉上；奉承，恭维"
-        ],
-        "notation": "奉(たてまつ)る"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "承認(しょうにん)",
             "⓪ 名·他动3  承认；批准"
-        ],
-        "notation": "承認(しょうにん)"
+        ]
     },
     {
         "name": "kanketsu",
         "trans": [
+            "完結(かんけつ)",
             "⓪ 名·自动3  完结，结束"
-        ],
-        "notation": "完結(かんけつ)"
+        ]
     },
     {
         "name": "tessuru",
         "trans": [
+            "徹(てっ)する",
             "⓪ 自他动3  透彻，贯彻；彻夜；彻底"
-        ],
-        "notation": "徹(てっ)する"
+        ]
     },
     {
         "name": "sensui",
         "trans": [
+            "潜水(せんすい)",
             "⓪ 名·自动3  潜水"
-        ],
-        "notation": "潜水(せんすい)"
+        ]
     },
     {
         "name": "guro-baru",
         "trans": [
+            "グローバル",
             "② ナ形  全球的，全世界的"
-        ],
-        "notation": "グローバル"
+        ]
     },
     {
         "name": "kamoshidasu",
         "trans": [
+            "醸(かも)し出(だ)す",
             "④ 他动1  营造（感觉和气氛）"
-        ],
-        "notation": "醸(かも)し出(だ)す"
+        ]
     },
     {
         "name": "kouteki",
         "trans": [
+            "公的(こうてき)",
             "⓪ ナ形  公共的；官方的"
-        ],
-        "notation": "公的(こうてき)"
+        ]
     },
     {
         "name": "taimen",
         "trans": [
+            "対面(たいめん)",
             "⓪ 名·自动3  会面，见面"
-        ],
-        "notation": "対面(たいめん)"
+        ]
     },
     {
         "name": "shindoi",
         "trans": [
+            "しんどい",
             "③ イ形  费劲的，吃力的；累的"
-        ],
-        "notation": "しんどい"
+        ]
     },
     {
         "name": "nyuushu",
         "trans": [
+            "入手(にゅうしゅ)",
             "⓪ 名·他动3  得到，到手"
-        ],
-        "notation": "入手(にゅうしゅ)"
+        ]
     },
     {
         "name": "sutenresu",
         "trans": [
+            "ステンレス",
             "② 名  不锈钢"
-        ],
-        "notation": "ステンレス"
+        ]
     },
     {
         "name": "nurasu",
         "trans": [
+            "濡(ぬ)らす",
             "⓪ 他动1  弄湿，浸湿"
-        ],
-        "notation": "濡(ぬ)らす"
+        ]
     },
     {
         "name": "hiriki",
         "trans": [
+            "非力(ひりき)",
             "⓪ 名·ナ形  无力，力量薄弱"
-        ],
-        "notation": "非力(ひりき)"
+        ]
     },
     {
         "name": "mahi",
         "trans": [
+            "麻痺(まひ)",
             "① 名·自动3  （身体）麻痹，麻木；（交通）瘫痪"
-        ],
-        "notation": "麻痺(まひ)"
+        ]
     },
     {
         "name": "moteamasu",
         "trans": [
+            "持(も)て余(あま)す",
             "④ 他动1  难以处理，无法对付"
-        ],
-        "notation": "持(も)て余(あま)す"
+        ]
     },
     {
         "name": "yuufuku",
         "trans": [
+            "裕福(ゆうふく)",
             "① 名·ナ形  富裕"
-        ],
-        "notation": "裕福(ゆうふく)"
+        ]
     },
     {
         "name": "ichimoku",
         "trans": [
+            "一目(いちもく)",
             "⓪ 名·自他动3  （看）一眼，一看；围棋的一个棋子"
-        ],
-        "notation": "一目(いちもく)"
+        ]
     },
     {
         "name": "gasshiri",
         "trans": [
+            "がっしり",
             "③ 副·自动3  结实；健壮；严密，紧密"
-        ],
-        "notation": "がっしり"
+        ]
     },
     {
         "name": "koujutsu",
         "trans": [
+            "口述(こうじゅつ)",
             "⓪ 名·他动3  口述"
-        ],
-        "notation": "口述(こうじゅつ)"
+        ]
     },
     {
         "name": "sho-uindo-",
         "trans": [
+            "ショーウインドー",
             "④ 名  橱窗，陈列窗"
-        ],
-        "notation": "ショーウインドー"
+        ]
     },
     {
         "name": "sokonau",
         "trans": [
+            "損(そこ)なう",
             "③ 他动1  损坏（物品）；伤害，损害（健康、感情等）"
-        ],
-        "notation": "損(そこ)なう"
+        ]
     },
     {
         "name": "denaoshi",
         "trans": [
+            "出直(でなお)し",
             "⓪ 名·他动3  重新开始"
-        ],
-        "notation": "出直(でなお)し"
+        ]
     },
     {
         "name": "hakujou",
         "trans": [
+            "白状(はくじょう)",
             "① 名·他动3  坦白，招供"
-        ],
-        "notation": "白状(はくじょう)"
+        ]
     },
     {
         "name": "hodokosu",
         "trans": [
+            "施(ほどこ)す",
             "③ 他动1  施舍，救济；施加，施行"
-        ],
-        "notation": "施(ほどこ)す"
+        ]
     },
     {
         "name": "mosaku",
         "trans": [
+            "模索(もさく)",
             "⓪ 名·他动3  摸索"
-        ],
-        "notation": "模索(もさく)"
+        ]
     },
     {
         "name": "risei",
         "trans": [
+            "理性(りせい)",
             "① 名  理性"
-        ],
-        "notation": "理性(りせい)"
+        ]
     },
     {
         "name": "ketobasu",
         "trans": [
+            "蹴飛(けと)ばす",
             "⓪ 他动1  踢开，踢倒；拒绝"
-        ],
-        "notation": "蹴飛(けと)ばす"
+        ]
     },
     {
         "name": "asaichi",
         "trans": [
+            "朝一(あさいち)",
             "② 名  一大早，早上头一件事"
-        ],
-        "notation": "朝一(あさいち)"
+        ]
     },
     {
         "name": "jinkaku",
         "trans": [
+            "人格(じんかく)",
             "⓪ 名  人格"
-        ],
-        "notation": "人格(じんかく)"
+        ]
     },
     {
         "name": "kimariwarui",
         "trans": [
+            "決(き)まり悪(わる)い",
             "⑤ イ形  不好意思的，难为情的，害羞的"
-        ],
-        "notation": "決(き)まり悪(わる)い"
+        ]
     },
     {
         "name": "tekunoroji-",
         "trans": [
+            "テクノロジー",
             "③ 名  技术"
-        ],
-        "notation": "テクノロジー"
+        ]
     },
     {
         "name": "fukakai",
         "trans": [
+            "不可解(ふかかい)",
             "② 名·ナ形  难以理解，不可思议"
-        ],
-        "notation": "不可解(ふかかい)"
+        ]
     },
     {
         "name": "magomago",
         "trans": [
+            "まごまご",
             "① 副·自动3  惊慌失措；闲逛；磨磨蹭蹭"
-        ],
-        "notation": "まごまご"
+        ]
     },
     {
         "name": "yokoduna",
         "trans": [
+            "横綱(よこづな)",
             "⓪ 名  （相扑冠军称号）横纲"
-        ],
-        "notation": "横綱(よこづな)"
+        ]
     },
     {
         "name": "etoku",
         "trans": [
+            "会得(えとく)",
             "⓪ 名·他动3  掌握；领会；理解"
-        ],
-        "notation": "会得(えとく)"
+        ]
     },
     {
         "name": "uchitokeru",
         "trans": [
+            "打(う)ち解(と)ける",
             "⓪ 自动2  亲密，融洽，无隔阂"
-        ],
-        "notation": "打(う)ち解(と)ける"
+        ]
     },
     {
         "name": "komon",
         "trans": [
+            "顧問(こもん)",
             "① 名  顾问"
-        ],
-        "notation": "顧問(こもん)"
+        ]
     },
     {
         "name": "shuujaku/shuuchaku",
         "trans": [
+            "執着(しゅうじゃく/しゅうちゃく)",
             "⓪ 名·自动3  执着，不肯舍弃，贪恋"
-        ],
-        "notation": "執着(しゅうじゃく/しゅうちゃく)"
+        ]
     },
     {
         "name": "sazokashi",
         "trans": [
+            "さぞかし",
             "① 副  想必，一定"
-        ],
-        "notation": "さぞかし"
+        ]
     },
     {
         "name": "kenbi",
         "trans": [
+            "兼備(けんび)",
             "① 名·他动3  兼备，兼具"
-        ],
-        "notation": "兼備(けんび)"
+        ]
     },
     {
         "name": "apuro-chi",
         "trans": [
+            "アプローチ",
             "③ 名·自动3  接近；研究"
-        ],
-        "notation": "アプローチ"
+        ]
     },
     {
         "name": "kuchiru",
         "trans": [
+            "朽(く)ちる",
             "② 自动2  腐朽，腐烂；衰败，衰亡"
-        ],
-        "notation": "朽(く)ちる"
+        ]
     },
     {
         "name": "sanbi",
         "trans": [
+            "賛美(さんび)",
             "① 名·他动3  赞美"
-        ],
-        "notation": "賛美(さんび)"
+        ]
     },
     {
         "name": "dokugaku",
         "trans": [
+            "独学(どくがく)",
             "⓪ 名·自他动3  自学，独自学习"
-        ],
-        "notation": "独学(どくがく)"
+        ]
     },
     {
         "name": "furumekashii",
         "trans": [
+            "古(ふる)めかしい",
             "⑤ イ形  古色古香的；陈旧的"
-        ],
-        "notation": "古(ふる)めかしい"
+        ]
     },
     {
         "name": "appaku",
         "trans": [
+            "圧迫(あっぱく)",
             "⓪ 名·他动3  压迫，压制"
-        ],
-        "notation": "圧迫(あっぱく)"
+        ]
     },
     {
         "name": "kakato",
         "trans": [
+            "踵(かかと)",
             "⓪ 名  脚后跟；鞋后跟"
-        ],
-        "notation": "踵(かかと)"
+        ]
     },
     {
         "name": "unzari",
         "trans": [
+            "うんざり",
             "③ 副·自动3  厌倦，厌烦，腻烦"
-        ],
-        "notation": "うんざり"
+        ]
     },
     {
         "name": "shishunki",
         "trans": [
+            "思春期(ししゅんき)",
             "② 名  青春期"
-        ],
-        "notation": "思春期(ししゅんき)"
+        ]
     },
     {
         "name": "sensu",
         "trans": [
+            "センス",
             "① 名  感觉；审美能力"
-        ],
-        "notation": "センス"
+        ]
     },
     {
         "name": "koraeru",
         "trans": [
+            "堪(こら)える",
             "③ 他动2  忍耐，忍受；原谅，宽恕"
-        ],
-        "notation": "堪(こら)える"
+        ]
     },
     {
         "name": "kyakushoku",
         "trans": [
+            "脚色(きゃくしょく)",
             "⓪ 名·他动3  改编（小说或电影）；夸大其词"
-        ],
-        "notation": "脚色(きゃくしょく)"
+        ]
     },
     {
         "name": "tsura",
         "trans": [
+            "面(つら)",
             "② 名  脸，颜面"
-        ],
-        "notation": "面(つら)"
+        ]
     },
     {
         "name": "tomoare",
         "trans": [
+            "ともあれ",
             "① 副  无论如何，不管怎样；姑且不论，姑且不说"
-        ],
-        "notation": "ともあれ"
+        ]
     },
     {
         "name": "nengan",
         "trans": [
+            "念願(ねんがん)",
             "⓪ 名·他动3  愿望，心愿"
-        ],
-        "notation": "念願(ねんがん)"
+        ]
     },
     {
         "name": "fuketsu",
         "trans": [
+            "不潔(ふけつ)",
             "⓪ 名·ナ形  不干净；不纯洁"
-        ],
-        "notation": "不潔(ふけつ)"
+        ]
     },
     {
         "name": "minarau",
         "trans": [
+            "見習(みなら)う",
             "⓪ 他动1  学习；以⋯⋯为榜样"
-        ],
-        "notation": "見習(みなら)う"
+        ]
     },
     {
         "name": "yuurei",
         "trans": [
+            "幽霊(ゆうれい)",
             "① 名  幽灵；有名无实"
-        ],
-        "notation": "幽霊(ゆうれい)"
+        ]
     },
     {
         "name": "o-da-meido",
         "trans": [
+            "オーダーメイド",
             "⑤ 名  定做，定制"
-        ],
-        "notation": "オーダーメイド"
+        ]
     },
     {
         "name": "ataisuru",
         "trans": [
+            "値(あたい)する",
             "⓪ 自动3  值得，有⋯⋯价值"
-        ],
-        "notation": "値(あたい)する"
+        ]
     },
     {
         "name": "shinausu",
         "trans": [
+            "品薄(しなうす)",
             "⓪ 名·ナ形  缺货"
-        ],
-        "notation": "品薄(しなうす)"
+        ]
     },
     {
         "name": "soshou",
         "trans": [
+            "訴訟(そしょう)",
             "⓪ 名·自动3  诉讼"
-        ],
-        "notation": "訴訟(そしょう)"
+        ]
     },
     {
         "name": "nanigenai",
         "trans": [
+            "何気(なにげ)ない",
             "④ イ形  若无其事的；无意识的"
-        ],
-        "notation": "何気(なにげ)ない"
+        ]
     },
     {
         "name": "hangeki",
         "trans": [
+            "反撃(はんげき)",
             "⓪ 名·自动3  反击，还击"
-        ],
-        "notation": "反撃(はんげき)"
+        ]
     },
     {
         "name": "benshou",
         "trans": [
+            "弁償(べんしょう)",
             "⓪ 名·他动3  赔偿"
-        ],
-        "notation": "弁償(べんしょう)"
+        ]
     },
     {
         "name": "matataku",
         "trans": [
+            "瞬(またた)く",
             "③ 自动1  闪烁；眨眼"
-        ],
-        "notation": "瞬(またた)く"
+        ]
     },
     {
         "name": "meritto",
         "trans": [
+            "メリット",
             "① 名  可取之处，优点"
-        ],
-        "notation": "メリット"
+        ]
     },
     {
         "name": "ryoukai",
         "trans": [
+            "了解(りょうかい)",
             "⓪ 名·他动3  理解，领会；谅解，体谅"
-        ],
-        "notation": "了解(りょうかい)"
+        ]
     },
     {
         "name": "imashimo",
         "trans": [
+            "今(いま)しも",
             "① 副  现在正要"
-        ],
-        "notation": "今(いま)しも"
+        ]
     },
     {
         "name": "kaikei",
         "trans": [
+            "会計(かいけい)",
             "⓪ 名  结账；会计"
-        ],
-        "notation": "会計(かいけい)"
+        ]
     },
     {
         "name": "shutsujou",
         "trans": [
+            "出場(しゅつじょう)",
             "⓪ 名·自动3  出场，参加（比赛）；走出会场"
-        ],
-        "notation": "出場(しゅつじょう)"
+        ]
     },
     {
         "name": "toutobu/tattobu",
         "trans": [
+            "尊(とうとぶ/たっと)ぶ",
             "③ 他动1  尊重，尊敬；重视，珍视"
-        ],
-        "notation": "尊(とうとぶ/たっと)ぶ"
+        ]
     },
     {
         "name": "nanahikari",
         "trans": [
+            "七光(ななひか)り",
             "③ 名  亲人的权势，余荫"
-        ],
-        "notation": "七光(ななひか)り"
+        ]
     },
     {
         "name": "batteri-",
         "trans": [
+            "バッテリー",
             "① 名  电池"
-        ],
-        "notation": "バッテリー"
+        ]
     },
     {
         "name": "boutto",
         "trans": [
+            "ぼうっと",
             "⓪ 副·自动3  朦胧，模糊；发呆，出神"
-        ],
-        "notation": "ぼうっと"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "無効(むこう)",
             "⓪ 名·ナ形  无效，失效"
-        ],
-        "notation": "無効(むこう)"
+        ]
     },
     {
         "name": "rouhou",
         "trans": [
+            "朗報(ろうほう)",
             "⓪ 名  好消息，喜讯"
-        ],
-        "notation": "朗報(ろうほう)"
+        ]
     },
     {
         "name": "obotsukanai",
         "trans": [
+            "覚束(おぼつか)ない",
             "⓪ イ形  可疑的，靠不住的；令人不放心的"
-        ],
-        "notation": "覚束(おぼつか)ない"
+        ]
     },
     {
         "name": "inta-chenji",
         "trans": [
+            "インターチェンジ",
             "⑤ 名  高速公路出入口"
-        ],
-        "notation": "インターチェンジ"
+        ]
     },
     {
         "name": "kondate",
         "trans": [
+            "献立(こんだて)",
             "⓪ 名  菜单，食谱"
-        ],
-        "notation": "献立(こんだて)"
+        ]
     },
     {
         "name": "kanau",
         "trans": [
+            "敵(かな)う",
             "② 自动1  敌得过，比得上"
-        ],
-        "notation": "敵(かな)う"
+        ]
     },
     {
         "name": "seiki",
         "trans": [
+            "正規(せいき)",
             "① 名·ナ形  正规，标准"
-        ],
-        "notation": "正規(せいき)"
+        ]
     },
     {
         "name": "teikei",
         "trans": [
+            "提携(ていけい)",
             "⓪ 名·自他动3  合作，协作"
-        ],
-        "notation": "提携(ていけい)"
+        ]
     },
     {
         "name": "donyori",
         "trans": [
+            "どんより",
             "③ 副·自动3  阴沉沉；（眼睛）浑浊"
-        ],
-        "notation": "どんより"
+        ]
     },
     {
         "name": "nouhau/no-hau",
         "trans": [
+            "ノウハウ/ノーハウ",
             "① 名  技术知识；诀窍"
-        ],
-        "notation": "ノウハウ/ノーハウ"
+        ]
     },
     {
         "name": "hyoushou",
         "trans": [
+            "表彰(ひょうしょう)",
             "⓪ 名·他动3  表彰"
-        ],
-        "notation": "表彰(ひょうしょう)"
+        ]
     },
     {
         "name": "bosoboso",
         "trans": [
+            "ぼそぼそ",
             "① 副·自动3  叽叽咕咕；干巴巴"
-        ],
-        "notation": "ぼそぼそ"
+        ]
     },
     {
         "name": "meibo",
         "trans": [
+            "名簿(めいぼ)",
             "⓪ 名  名册，名簿"
-        ],
-        "notation": "名簿(めいぼ)"
+        ]
     },
     {
         "name": "engi",
         "trans": [
+            "演技(えんぎ)",
             "① 名·自动3  演技；花招儿，把戏"
-        ],
-        "notation": "演技(えんぎ)"
+        ]
     },
     {
         "name": "kutsurogu",
         "trans": [
+            "寛(くつろ)ぐ",
             "③ 自动1  惬意；愉快地休息；不拘礼节"
-        ],
-        "notation": "寛(くつろ)ぐ"
+        ]
     },
     {
         "name": "sahou",
         "trans": [
+            "作法(さほう)",
             "① 名  礼节，礼貌"
-        ],
-        "notation": "作法(さほう)"
+        ]
     },
     {
         "name": "shoumi",
         "trans": [
+            "正味(しょうみ)",
             "① 名  实质，内容；净重；实价"
-        ],
-        "notation": "正味(しょうみ)"
+        ]
     },
     {
         "name": "kotogotoku",
         "trans": [
+            "悉(ことごと)く",
             "③ 名·副  全部，所有"
-        ],
-        "notation": "悉(ことごと)く"
+        ]
     },
     {
         "name": "dekimono",
         "trans": [
+            "出来物(できもの)",
             "③ 名  疙瘩，囊肿"
-        ],
-        "notation": "出来物(できもの)"
+        ]
     },
     {
         "name": "hankou",
         "trans": [
+            "犯行(はんこう)",
             "⓪ 名  罪行"
-        ],
-        "notation": "犯行(はんこう)"
+        ]
     },
     {
         "name": "isagiyoi",
         "trans": [
+            "潔(いさぎよ)い",
             "④ イ形  清高的，纯洁的；勇敢的，果断的，痛快的"
-        ],
-        "notation": "潔(いさぎよ)い"
+        ]
     },
     {
         "name": "kabin",
         "trans": [
+            "過敏(かびん)",
             "⓪ 名·ナ形  过敏；过于敏感"
-        ],
-        "notation": "過敏(かびん)"
+        ]
     },
     {
         "name": "anaume",
         "trans": [
+            "穴埋(あなう)め",
             "⓪ 名·他动3  填坑；填补（空白），弥补"
-        ],
-        "notation": "穴埋(あなう)め"
+        ]
     },
     {
         "name": "kasetsu",
         "trans": [
+            "仮設(かせつ)",
             "⓪ 名·他动3  临时设立；假设"
-        ],
-        "notation": "仮設(かせつ)"
+        ]
     },
     {
         "name": "sadameru",
         "trans": [
+            "定(さだ)める",
             "③ 他动2  决定；制定；平定（内乱）；奠定"
-        ],
-        "notation": "定(さだ)める"
+        ]
     },
     {
         "name": "youjinbukai",
         "trans": [
+            "用心深(ようじんぶか)い",
             "⑥ イ形  小心谨慎的"
-        ],
-        "notation": "用心深(ようじんぶか)い"
+        ]
     },
     {
         "name": "gyakutai",
         "trans": [
+            "虐待(ぎゃくたい)",
             "⓪ 名·他动3  虐待"
-        ],
-        "notation": "虐待(ぎゃくたい)"
+        ]
     },
     {
         "name": "shikumu",
         "trans": [
+            "仕組(しく)む",
             "② 他动1  策划，谋划；构思（小说等）"
-        ],
-        "notation": "仕組(しく)む"
+        ]
     },
     {
         "name": "taisei",
         "trans": [
+            "態勢(たいせい)",
             "⓪ 名  态势，姿态"
-        ],
-        "notation": "態勢(たいせい)"
+        ]
     },
     {
         "name": "sutokku",
         "trans": [
+            "ストック",
             "② 名·他动3  存货，库存"
-        ],
-        "notation": "ストック"
+        ]
     },
     {
         "name": "kokoroyoi",
         "trans": [
+            "快(こころよ)い",
             "④ イ形  高兴的，愉快的"
-        ],
-        "notation": "快(こころよ)い"
+        ]
     },
     {
         "name": "denpyou",
         "trans": [
+            "伝票(でんぴょう)",
             "⓪ 名  发票，单据"
-        ],
-        "notation": "伝票(でんぴょう)"
+        ]
     },
     {
         "name": "soukou",
         "trans": [
+            "走行(そうこう)",
             "⓪ 名·自动3  （汽车）行驶"
-        ],
-        "notation": "走行(そうこう)"
+        ]
     },
     {
         "name": "zuruzuru",
         "trans": [
+            "ずるずる",
             "① 副·自动3  拖拉着；滑溜溜；（时间上）拖拖拉拉"
-        ],
-        "notation": "ずるずる"
+        ]
     },
     {
         "name": "kenmei",
         "trans": [
+            "賢明(けんめい)",
             "⓪ ナ形  贤明的，高明的"
-        ],
-        "notation": "賢明(けんめい)"
+        ]
     },
     {
         "name": "tomobataraki",
         "trans": [
+            "共働(ともばたら)き",
             "③ 名  夫妻都工作"
-        ],
-        "notation": "共働(ともばたら)き"
+        ]
     },
     {
         "name": "otoroeru",
         "trans": [
+            "衰(おとろ)える",
             "④ 自动2  衰弱；衰退；衰亡"
-        ],
-        "notation": "衰(おとろ)える"
+        ]
     },
     {
         "name": "hakaku",
         "trans": [
+            "破格(はかく)",
             "⓪ 名·ナ形  破格，破例；打破常规"
-        ],
-        "notation": "破格(はかく)"
+        ]
     },
     {
         "name": "mizumashi",
         "trans": [
+            "水増(みずま)し",
             "⓪ 名·自他动3  掺水；弄虚作假"
-        ],
-        "notation": "水増(みずま)し"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "老(ふ)ける",
             "② 自动2  上年纪，衰老"
-        ],
-        "notation": "老(ふ)ける"
+        ]
     },
     {
         "name": "mesu",
         "trans": [
+            "メス",
             " ① 名  手术刀"
-        ],
-        "notation": "メス"
+        ]
     },
     {
         "name": "ryoukin",
         "trans": [
+            "料金(りょうきん)",
             "① 名  费用；手续费"
-        ],
-        "notation": "料金(りょうきん)"
+        ]
     },
     {
         "name": "imasara",
         "trans": [
+            "今更(いまさら)",
             "⓪ 副  事到如今，现在才"
-        ],
-        "notation": "今更(いまさら)"
+        ]
     },
     {
         "name": "kiken",
         "trans": [
+            "棄権(きけん)",
             "⓪ 名·他动3  弃权"
-        ],
-        "notation": "棄権(きけん)"
+        ]
     },
     {
         "name": "gokuraku",
         "trans": [
+            "極楽(ごくらく)",
             "⓪ 名  天堂"
-        ],
-        "notation": "極楽(ごくらく)"
+        ]
     },
     {
         "name": "suetsukeru",
         "trans": [
+            "据(す)え付(つ)ける",
             "④ 他动2  安装；配备；固定"
-        ],
-        "notation": "据(す)え付(つ)ける"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "視覚(しかく)",
             "⓪ 名  视觉"
-        ],
-        "notation": "視覚(しかく)"
+        ]
     },
     {
         "name": "koueki",
         "trans": [
+            "交易(こうえき)",
             "⓪ 名·自动3  交易，贸易"
-        ],
-        "notation": "交易(こうえき)"
+        ]
     },
     {
         "name": "semeru",
         "trans": [
+            "責(せ)める",
             "② 他动2  责备；拷打；折磨；催逼"
-        ],
-        "notation": "責(せ)める"
+        ]
     },
     {
         "name": "akuseru",
         "trans": [
+            "アクセル",
             "① 名  加速装置，油门"
-        ],
-        "notation": "アクセル"
+        ]
     },
     {
         "name": "kubikazari",
         "trans": [
+            "首飾(くびかざ)り",
             "③ 名  项链"
-        ],
-        "notation": "首飾(くびかざ)り"
+        ]
     },
     {
         "name": "daburu",
         "trans": [
+            "ダブる",
             "② 自动1  重了，重复；留级"
-        ],
-        "notation": "ダブる"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "新興(しんこう)",
             "⓪ 名  新兴"
-        ],
-        "notation": "新興(しんこう)"
+        ]
     },
     {
         "name": "totsunyuu",
         "trans": [
+            "突入(とつにゅう)",
             "⓪ 名·自动3  突然闯进；进入（重大事态、局面）"
-        ],
-        "notation": "突入(とつにゅう)"
+        ]
     },
     {
         "name": "netamashii",
         "trans": [
+            "妬(ねた)ましい",
             "④ イ形  令人嫉妒的"
-        ],
-        "notation": "妬(ねた)ましい"
+        ]
     },
     {
         "name": "bakkuappu",
         "trans": [
+            "バックアップ",
             "④ 名·他动3  做后盾，后援；备份"
-        ],
-        "notation": "バックアップ"
+        ]
     },
     {
         "name": "fukkatsu",
         "trans": [
+            "復活(ふっかつ)",
             "⓪ 名·自动3  复活，复苏"
-        ],
-        "notation": "復活(ふっかつ)"
+        ]
     },
     {
         "name": "mattousuru",
         "trans": [
+            "全(まっと)うする",
             "⓪ 他动3  保全（性命）；完成"
-        ],
-        "notation": "全(まっと)うする"
+        ]
     },
     {
         "name": "monozuki",
         "trans": [
+            "物好(ものず)き",
             "③ 名·ナ形  好奇，好事（者）"
-        ],
-        "notation": "物好(ものず)き"
+        ]
     },
     {
         "name": "yosei",
         "trans": [
+            "余生(よせい)",
             "① 名  余生"
-        ],
-        "notation": "余生(よせい)"
+        ]
     },
     {
         "name": "obieru",
         "trans": [
+            "怯(おび)える",
             "⓪ 自动2  害怕，胆怯"
-        ],
-        "notation": "怯(おび)える"
+        ]
     },
     {
         "name": "ikusei",
         "trans": [
+            "育成(いくせい)",
             "⓪ 名·他动3  培育，培养"
-        ],
-        "notation": "育成(いくせい)"
+        ]
     },
     {
         "name": "keishou",
         "trans": [
+            "継承(けいしょう)",
             "⓪ 名·他动3  继承"
-        ],
-        "notation": "継承(けいしょう)"
+        ]
     },
     {
         "name": "samasu",
         "trans": [
+            "冷(さ)ます",
             "② 他动1  冷却，弄凉；泼冷水，扫兴"
-        ],
-        "notation": "冷(さ)ます"
+        ]
     },
     {
         "name": "ke-buru",
         "trans": [
+            "ケーブル",
             "① 名  缆绳；电缆"
-        ],
-        "notation": "ケーブル"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "先行(せんこう)",
             "⓪ 名·自动3  先行，领先；优先实行"
-        ],
-        "notation": "先行(せんこう)"
+        ]
     },
     {
         "name": "daradara",
         "trans": [
+            "だらだら",
             "① 副·自动3  （液体）滴滴答答；冗长，不简练"
-        ],
-        "notation": "だらだら"
+        ]
     },
     {
         "name": "tenkyo",
         "trans": [
+            "転居(てんきょ)",
             "⓪ 名·自动3  迁居，搬家"
-        ],
-        "notation": "転居(てんきょ)"
+        ]
     },
     {
         "name": "joui",
         "trans": [
+            "上位(じょうい)",
             "① 名  上位，上座"
-        ],
-        "notation": "上位(じょうい)"
+        ]
     },
     {
         "name": "sokuji",
         "trans": [
+            "即時(そくじ)",
             "① 名·副  立刻，马上；即时"
-        ],
-        "notation": "即時(そくじ)"
+        ]
     },
     {
         "name": "kyoudou",
         "trans": [
+            "共同(きょうどう)",
             "⓪ 名·自动3  共同"
-        ],
-        "notation": "共同(きょうどう)"
+        ]
     },
     {
         "name": "nyojitsu",
         "trans": [
+            "如実(にょじつ)",
             "⓪ 名  如实，真实"
-        ],
-        "notation": "如実(にょじつ)"
+        ]
     },
     {
         "name": "barasu",
         "trans": [
+            "ばらす",
             "② 他动1  拆卸；卖掉（赃物）；揭穿，泄露（秘密）"
-        ],
-        "notation": "ばらす"
+        ]
     },
     {
         "name": "bureikou",
         "trans": [
+            "無礼講(ぶれいこう)",
             "⓪ 名  （不讲虚礼）开怀畅饮的宴会"
-        ],
-        "notation": "無礼講(ぶれいこう)"
+        ]
     },
     {
         "name": "munou",
         "trans": [
+            "無能(むのう)",
             "⓪ 名·ナ形  无能，无才能"
-        ],
-        "notation": "無能(むのう)"
+        ]
     },
     {
         "name": "yawarageru",
         "trans": [
+            "和(やわ)らげる",
             "④ 他动2  使⋯⋯缓和，使⋯⋯柔和"
-        ],
-        "notation": "和(やわ)らげる"
+        ]
     },
     {
         "name": "risuku",
         "trans": [
+            "リスク",
             "① 名  风险，危险"
-        ],
-        "notation": "リスク"
+        ]
     },
     {
         "name": "un'ei",
         "trans": [
+            "運営(うんえい)",
             "⓪ 名·他动3  运营，经营，管理"
-        ],
-        "notation": "運営(うんえい)"
+        ]
     },
     {
         "name": "utagawashii",
         "trans": [
+            "疑(うたが)わしい",
             "⑤ イ形  不确定的，有疑问的；可疑的"
-        ],
-        "notation": "疑(うたが)わしい"
+        ]
     },
     {
         "name": "kiretsu",
         "trans": [
+            "亀裂(きれつ)",
             "⓪ 名  裂缝，龟裂"
-        ],
-        "notation": "亀裂(きれつ)"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "証人(しょうにん)",
             "⓪ 名  证人"
-        ],
-        "notation": "証人(しょうにん)"
+        ]
     },
     {
         "name": "chokochoko",
         "trans": [
+            "ちょこちょこ",
             "① 副  小步走；匆忙，慌张"
-        ],
-        "notation": "ちょこちょこ"
+        ]
     },
     {
         "name": "naita-",
         "trans": [
+            "ナイター",
             "(棒球)  ① 名  （棒球）夜场比赛"
-        ],
-        "notation": "ナイター"
+        ]
     },
     {
         "name": "hittakuri",
         "trans": [
+            "ひったくり",
             "⓪ 名  强盗；抢劫"
-        ],
-        "notation": "ひったくり"
+        ]
     },
     {
         "name": "masashiku",
         "trans": [
+            "正(まさ)しく",
             "② 副  的确，确实"
-        ],
-        "notation": "正(まさ)しく"
+        ]
     },
     {
         "name": "yukute",
         "trans": [
+            "行(ゆ)く手(て)",
             "⓪ 名  去路，前方；前途"
-        ],
-        "notation": "行(ゆ)く手(て)"
+        ]
     },
     {
         "name": "ryoukou",
         "trans": [
+            "良好(りょうこう)",
             "⓪ 名·ナ形  良好，优良"
-        ],
-        "notation": "良好(りょうこう)"
+        ]
     },
     {
         "name": "inokoru",
         "trans": [
+            "居残(いのこ)る",
             "③ 自动1  （别人走后）留下；加班"
-        ],
-        "notation": "居残(いのこ)る"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "機嫌(きげん)",
             "⓪ 名  心情，情绪"
-        ],
-        "notation": "機嫌(きげん)"
+        ]
     },
     {
         "name": "saimu",
         "trans": [
+            "債務(さいむ)",
             "① 名  债务"
-        ],
-        "notation": "債務(さいむ)"
+        ]
     },
     {
         "name": "takumashii",
         "trans": [
+            "逞(たくま)しい",
             "④ イ形  健壮的，强壮的；旺盛的"
-        ],
-        "notation": "逞(たくま)しい"
+        ]
     },
     {
         "name": "nyuuyoku",
         "trans": [
+            "入浴(にゅうよく)",
             "⓪ 名·自动3  沐浴，洗澡"
-        ],
-        "notation": "入浴(にゅうよく)"
+        ]
     },
     {
         "name": "fo-mu",
         "trans": [
+            "フォーム",
             "① 名  姿势；形式，样式"
-        ],
-        "notation": "フォーム"
+        ]
     },
     {
         "name": "marumeru",
         "trans": [
+            "丸(まる)める",
             "⓪ 他动2  弄圆，揉成团；笼络，拉拢（他人）"
-        ],
-        "notation": "丸(まる)める"
+        ]
     },
     {
         "name": "yogen",
         "trans": [
+            "予言(よげん)",
             "⓪ 名·他动3  预言"
-        ],
-        "notation": "予言(よげん)"
+        ]
     },
     {
         "name": "ashibumi",
         "trans": [
+            "足踏(あしぶ)み",
             "③ 名·自动3  踏步；停顿，停滞不前"
-        ],
-        "notation": "足踏(あしぶ)み"
+        ]
     },
     {
         "name": "kikkari",
         "trans": [
+            "きっかり",
             "③ 副  正，整；正好，恰好"
-        ],
-        "notation": "きっかり"
+        ]
     },
     {
         "name": "jikiso",
         "trans": [
+            "直訴(じきそ)",
             "① 名·他动3  直接上诉"
-        ],
-        "notation": "直訴(じきそ)"
+        ]
     },
     {
         "name": "chouri",
         "trans": [
+            "調理(ちょうり)",
             "① 名·他动3  烹饪，做菜"
-        ],
-        "notation": "調理(ちょうり)"
+        ]
     },
     {
         "name": "hikkaku",
         "trans": [
+            "引(ひ)っ掻(か)く",
             "③ 他动1  搔，挠"
-        ],
-        "notation": "引(ひ)っ掻(か)く"
+        ]
     },
     {
         "name": "nenkan",
         "trans": [
+            "年鑑(ねんかん)",
             "⓪ 名  年鉴"
-        ],
-        "notation": "年鑑(ねんかん)"
+        ]
     },
     {
         "name": "mugon",
         "trans": [
+            "無言(むごん)",
             "⓪ 名  无言，沉默"
-        ],
-        "notation": "無言(むごん)"
+        ]
     },
     {
         "name": "yayamosureba",
         "trans": [
+            "ややもすれば",
             "① 副  动辄，动不动就"
-        ],
-        "notation": "ややもすれば"
+        ]
     },
     {
         "name": "ukai",
         "trans": [
+            "迂回(うかい)",
             "⓪ 名·自动3  迂回，走弯路"
-        ],
-        "notation": "迂回(うかい)"
+        ]
     },
     {
         "name": "kuesuchonma-ku",
         "trans": [
+            "クエスチョンマーク",
             "⑥ 名  问号"
-        ],
-        "notation": "クエスチョンマーク"
+        ]
     },
     {
         "name": "suku",
         "trans": [
+            "好(す)く",
             "① 他动1  喜欢，爱慕；爱好"
-        ],
-        "notation": "好(す)く"
+        ]
     },
     {
         "name": "tsuukan",
         "trans": [
+            "痛感(つうかん)",
             "⓪ 名·他动3  痛感，深切地感觉到"
-        ],
-        "notation": "痛感(つうかん)"
+        ]
     },
     {
         "name": "netsuryou",
         "trans": [
+            "熱量(ねつりょう)",
             "② 名  热量"
-        ],
-        "notation": "熱量(ねつりょう)"
+        ]
     },
     {
         "name": "furafura",
         "trans": [
+            "ふらふら",
             "① 副·自动3·ナ形  摇晃，蹒跚；（意志）不坚定；稀里糊涂"
-        ],
-        "notation": "ふらふら"
+        ]
     },
     {
         "name": "mitooshi",
         "trans": [
+            "見通(みとお)し",
             "⓪ 名  眺望；（对前景的）预料，推测"
-        ],
-        "notation": "見通(みとお)し"
+        ]
     },
     {
         "name": "risoku",
         "trans": [
+            "利息(りそく)",
             "⓪ 名  利息"
-        ],
-        "notation": "利息(りそく)"
+        ]
     },
     {
         "name": "ogamu",
         "trans": [
+            "拝(おが)む",
             "② 他动1  叩拜；请求，央求"
-        ],
-        "notation": "拝(おが)む"
+        ]
     },
     {
         "name": "keisotsu",
         "trans": [
+            "軽率(けいそつ)",
             "⓪ 名·ナ形  轻率，草率"
-        ],
-        "notation": "軽率(けいそつ)"
+        ]
     },
     {
         "name": "seikou",
         "trans": [
+            "精巧(せいこう)",
             "⓪ 名·ナ形  精巧"
-        ],
-        "notation": "精巧(せいこう)"
+        ]
     },
     {
         "name": "teatarishidai",
         "trans": [
+            "手(て)あたり次第(しだい)",
             "⑤ 副  随手抓到什么算什么"
-        ],
-        "notation": "手(て)あたり次第(しだい)"
+        ]
     },
     {
         "name": "nouhin",
         "trans": [
+            "納品(のうひん)",
             "⓪ 名·他动3  交的货，交付的物品；交货，交付"
-        ],
-        "notation": "納品(のうひん)"
+        ]
     },
     {
         "name": "be-su",
         "trans": [
+            "ベース",
             "① 名  基础"
-        ],
-        "notation": "ベース"
+        ]
     },
     {
         "name": "mechakucha",
         "trans": [
+            "めちゃくちゃ",
             "⓪ 名·ナ形  不合理；胡闹，荒谬；杂乱无章，乱七八糟"
-        ],
-        "notation": "めちゃくちゃ"
+        ]
     },
     {
         "name": "ichimatsu",
         "trans": [
+            "一抹(いちまつ)",
             "⓪ 名  一缕，一丝；一片"
-        ],
-        "notation": "一抹(いちまつ)"
+        ]
     },
     {
         "name": "kokoromi",
         "trans": [
+            "試(こころ)み",
             "④ 名  尝试"
-        ],
-        "notation": "試(こころ)み"
+        ]
     },
     {
         "name": "soeru",
         "trans": [
+            "添(そ)える",
             "⓪ 他动2  附上，附加；伴随，陪同"
-        ],
-        "notation": "添(そ)える"
+        ]
     },
     {
         "name": "houchi",
         "trans": [
+            "報知(ほうち)",
             "⓪ 名·他动3  报告，通知"
-        ],
-        "notation": "報知(ほうち)"
+        ]
     },
     {
         "name": "asameshimae",
         "trans": [
+            "朝飯前(あさめしまえ)",
             "⑤ 名  轻而易举，极其容易"
-        ],
-        "notation": "朝飯前(あさめしまえ)"
+        ]
     },
     {
         "name": "kakuage",
         "trans": [
+            "格上(かくあ)げ",
             "⓪ 名·他动3  升级，升格"
-        ],
-        "notation": "格上(かくあ)げ"
+        ]
     },
     {
         "name": "sassuru",
         "trans": [
+            "察(さっ)する",
             "⓪ 名·他动3  推测，揣测；体谅"
-        ],
-        "notation": "察(さっ)する"
+        ]
     },
     {
         "name": "daitan",
         "trans": [
+            "大胆(だいたん)",
             "③ 名·ナ形  大胆，勇敢"
-        ],
-        "notation": "大胆(だいたん)"
+        ]
     },
     {
         "name": "nairan",
         "trans": [
+            "内乱(ないらん)",
             "⓪ 名  内乱"
-        ],
-        "notation": "内乱(ないらん)"
+        ]
     },
     {
         "name": "bakabakashii",
         "trans": [
+            "ばかばかしい",
             "⑤ イ形  无聊的；荒谬的，愚蠢的"
-        ],
-        "notation": "ばかばかしい"
+        ]
     },
     {
         "name": "mato",
         "trans": [
+            "的(まと)",
             "⓪ 名  靶子；目标，目的；要点"
-        ],
-        "notation": "的(まと)"
+        ]
     },
     {
         "name": "yunifo-mu",
         "trans": [
+            "ユニフォーム",
             "③ 名  制服"
-        ],
-        "notation": "ユニフォーム"
+        ]
     },
     {
         "name": "jirojiro",
         "trans": [
+            "じろじろ",
             "① 副  盯着看，目不转睛地看"
-        ],
-        "notation": "じろじろ"
+        ]
     },
     {
         "name": "moushibun",
         "trans": [
+            "申(もう)し分(ぶん)",
             "⓪ 名  缺陷，缺点；理由，意见"
-        ],
-        "notation": "申(もう)し分(ぶん)"
+        ]
     },
     {
         "name": "bouchou",
         "trans": [
+            "膨張(ぼうちょう)",
             "⓪ 名·自动3  膨胀；增加，扩大"
-        ],
-        "notation": "膨張(ぼうちょう)"
+        ]
     },
     {
         "name": "nottoru",
         "trans": [
+            "乗(の)っ取(と)る",
             "③ 他动1  攻占，夺取"
-        ],
-        "notation": "乗(の)っ取(と)る"
+        ]
     },
     {
         "name": "to-taru",
         "trans": [
+            "トータル",
             "① 名·他动3·ナ形  总计，合计，共计；整体，总体"
-        ],
-        "notation": "トータル"
+        ]
     },
     {
         "name": "soubi",
         "trans": [
+            "装備(そうび)",
             "① 名·他动3  装备，配备"
-        ],
-        "notation": "装備(そうび)"
+        ]
     },
     {
         "name": "koriru",
         "trans": [
+            "懲(こ)りる",
             "② 自动2  因尝过苦头而不敢再尝试"
-        ],
-        "notation": "懲(こ)りる"
+        ]
     },
     {
         "name": "oushin",
         "trans": [
+            "往診(おうしん)",
             "⓪ 名·他动3  出诊"
-        ],
-        "notation": "往診(おうしん)"
+        ]
     },
     {
         "name": "ikigomi",
         "trans": [
+            "意気込(いきご)み",
             "⓪ 名  干劲儿，热情"
-        ],
-        "notation": "意気込(いきご)み"
+        ]
     },
     {
         "name": "kukuru",
         "trans": [
+            "括(くく)る",
             "⓪ 他动1  捆扎；总结，总括；（用括号）括起来"
-        ],
-        "notation": "括(くく)る"
+        ]
     },
     {
         "name": "dasoku",
         "trans": [
+            "蛇足(だそく)",
             "⓪ 名  蛇足；多余"
-        ],
-        "notation": "蛇足(だそく)"
+        ]
     },
     {
         "name": "tsu-ru",
         "trans": [
+            "ツール",
             "① 名  工具，道具"
-        ],
-        "notation": "ツール"
+        ]
     },
     {
         "name": "furuu",
         "trans": [
+            "振(ふ)るう",
             "⓪ 他动1  挥动；发挥"
-        ],
-        "notation": "振(ふ)るう"
+        ]
     },
     {
         "name": "teiketsu",
         "trans": [
+            "締結(ていけつ)",
             "⓪ 名·他动3  缔结，签订"
-        ],
-        "notation": "締結(ていけつ)"
+        ]
     },
     {
         "name": "muzai",
         "trans": [
+            "無罪(むざい)",
             "① 名  无罪"
-        ],
-        "notation": "無罪(むざい)"
+        ]
     },
     {
         "name": "yanwari",
         "trans": [
+            "やんわり",
             "③ 副·自动3  柔软地；委婉地，温和地"
-        ],
-        "notation": "やんわり"
+        ]
     },
     {
         "name": "ryouritsu",
         "trans": [
+            "両立(りょうりつ)",
             "⓪ 名·自动3  两立，并存"
-        ],
-        "notation": "両立(りょうりつ)"
+        ]
     },
     {
         "name": "meiyo",
         "trans": [
+            "名誉(めいよ)",
             "① 名·ナ形  名誉"
-        ],
-        "notation": "名誉(めいよ)"
+        ]
     },
     {
         "name": "hedataru",
         "trans": [
+            "隔(へだ)たる",
             "③ 自动1  (时间、空间)相隔；有差别；疏远，产生隔阂"
-        ],
-        "notation": "隔(へだ)たる"
+        ]
     },
     {
         "name": "toomawari",
         "trans": [
+            "遠回(とおまわ)り",
             "③ 名·自动3·ナ形  绕远，绕路"
-        ],
-        "notation": "遠回(とおまわ)り"
+        ]
     },
     {
         "name": "sousa",
         "trans": [
+            "捜査(そうさ)",
             "① 名·他动3  搜查，查找"
-        ],
-        "notation": "捜査(そうさ)"
+        ]
     },
     {
         "name": "kobiru",
         "trans": [
+            "媚(こ)びる",
             "② 自动2  巴结，谄媚"
-        ],
-        "notation": "媚(こ)びる"
+        ]
     },
     {
         "name": "ekisutora",
         "trans": [
+            "エキストラ",
             "③ 名  临时演员；临时，额外；增刊，号外"
-        ],
-        "notation": "エキストラ"
+        ]
     },
     {
         "name": "akunin",
         "trans": [
+            "悪人(あくにん)",
             "⓪ 名  坏人"
-        ],
-        "notation": "悪人(あくにん)"
+        ]
     },
     {
         "name": "gakkuri",
         "trans": [
+            "がっくり",
             "③ 副·自动3  突然无力地，颓丧"
-        ],
-        "notation": "がっくり"
+        ]
     },
     {
         "name": "san'nyuu",
         "trans": [
+            "参入(さんにゅう)",
             "⓪ 名  进入，进来"
-        ],
-        "notation": "参入(さんにゅう)"
+        ]
     },
     {
         "name": "chuusen",
         "trans": [
+            "抽選(ちゅうせん)",
             "⓪ 名·自动3  抽签"
-        ],
-        "notation": "抽選(ちゅうせん)"
+        ]
     },
     {
         "name": "tsukimatou",
         "trans": [
+            "付(つ)き纏(まと)う",
             "④ 自动1  纠缠，缠住"
-        ],
-        "notation": "付(つ)き纏(まと)う"
+        ]
     },
     {
         "name": "namitaitei",
         "trans": [
+            "並大抵(なみたいてい)",
             "⓪ 名·ナ形  （后多接否定）普通，寻常"
-        ],
-        "notation": "並大抵(なみたいてい)"
+        ]
     },
     {
         "name": "biriya-do",
         "trans": [
+            "ビリヤード",
             "③ 名  台球"
-        ],
-        "notation": "ビリヤード"
+        ]
     },
     {
         "name": "motenasu",
         "trans": [
+            "もてなす",
             "③ 他动1  接待；招待，款待"
-        ],
-        "notation": "もてなす"
+        ]
     },
     {
         "name": "youhou",
         "trans": [
+            "用法(ようほう)",
             "⓪ 名  用法，使用方法"
-        ],
-        "notation": "用法(ようほう)"
+        ]
     },
     {
         "name": "ruisui",
         "trans": [
+            "類推(るいすい)",
             "⓪ 名·他动3  类推，类比"
-        ],
-        "notation": "類推(るいすい)"
+        ]
     },
     {
         "name": "arasu",
         "trans": [
+            "荒(あ)らす",
             "⓪ 他动1  使荒芜，糟蹋；扰乱；偷窃"
-        ],
-        "notation": "荒(あ)らす"
+        ]
     },
     {
         "name": "kakudan",
         "trans": [
+            "格段(かくだん)",
             "⓪ 名·ナ形  格外，特别"
-        ],
-        "notation": "格段(かくだん)"
+        ]
     },
     {
         "name": "saiku",
         "trans": [
+            "細工(さいく)",
             "③ 名·他动3  工艺品；耍花招"
-        ],
-        "notation": "細工(さいく)"
+        ]
     },
     {
         "name": "takadaka",
         "trans": [
+            "高(こう)々",
             "② 副  高高地；大声地；顶多，充其量"
-        ],
-        "notation": "高(こう)々"
+        ]
     },
     {
         "name": "nairiku",
         "trans": [
+            "内陸(ないりく)",
             "⓪ 名  内陆"
-        ],
-        "notation": "内陸(ないりく)"
+        ]
     },
     {
         "name": "baburu",
         "trans": [
+            "バブル",
             "① 名  泡沫"
-        ],
-        "notation": "バブル"
+        ]
     },
     {
         "name": "yomiageru",
         "trans": [
+            "読(よ)み上(あ)げる",
             "④ 他动2  高声朗读；读完，念完"
-        ],
-        "notation": "読(よ)み上(あ)げる"
+        ]
     },
     {
         "name": "mabataki",
         "trans": [
+            "瞬(まばた)き",
             "② 名·自动3  眨眼"
-        ],
-        "notation": "瞬(まばた)き"
+        ]
     },
     {
         "name": "mochikiri",
         "trans": [
+            "持(も)ち切(き)り",
             "⓪ 名  始终谈论一件事；热门话题"
-        ],
-        "notation": "持(も)ち切(き)り"
+        ]
     },
     {
         "name": "niganigashii",
         "trans": [
+            "苦々しい(にがにがしい)",
             "⑤ イ形  非常讨厌的；别扭的"
-        ],
-        "notation": "苦々しい(にがにがしい)"
+        ]
     },
     {
         "name": "chien",
         "trans": [
+            "遅延(ちえん)",
             "⓪ 名·自动3  延迟，误点"
-        ],
-        "notation": "遅延(ちえん)"
+        ]
     },
     {
         "name": "shihyou",
         "trans": [
+            "指標(しひょう)",
             "⓪ 名  指标"
-        ],
-        "notation": "指標(しひょう)"
+        ]
     },
     {
         "name": "kippari",
         "trans": [
+            "きっぱり",
             "③ 副·自动3  断然，干脆"
-        ],
-        "notation": "きっぱり"
+        ]
     },
     {
         "name": "ishuku",
         "trans": [
+            "萎縮(いしゅく)",
             "⓪ 名·自动3  萎缩，变小"
-        ],
-        "notation": "萎縮(いしゅく)"
+        ]
     },
     {
         "name": "kuuhaku",
         "trans": [
+            "空白(くうはく)",
             "⓪ 名·ナ形  空白；空虚"
-        ],
-        "notation": "空白(くうはく)"
+        ]
     },
     {
         "name": "uttaeru",
         "trans": [
+            "訴(うった)える",
             "④ 他动2  起诉；诉说；求助于；打动"
-        ],
-        "notation": "訴(うった)える"
+        ]
     },
     {
         "name": "sutoro-",
         "trans": [
+            "ストロー",
             "② 名  吸管；麦秆"
-        ],
-        "notation": "ストロー"
+        ]
     },
     {
         "name": "tsuuro",
         "trans": [
+            "通路(つうろ)",
             "① 名  通道，过道"
-        ],
-        "notation": "通路(つうろ)"
+        ]
     },
     {
         "name": "nejireru",
         "trans": [
+            "捩(ねじ)れる",
             "③ 自动2  歪，弯曲；（性情）乖僻"
-        ],
-        "notation": "捩(ねじ)れる"
+        ]
     },
     {
         "name": "furikae",
         "trans": [
+            "振(ふ)り替(か)え",
             "⓪ 名  调换，更换；转账"
-        ],
-        "notation": "振(ふ)り替(か)え"
+        ]
     },
     {
         "name": "musen",
         "trans": [
+            "無線(むせん)",
             "⓪ 名  无线；无线电"
-        ],
-        "notation": "無線(むせん)"
+        ]
     },
     {
         "name": "yatara",
         "trans": [
+            "やたら",
             "⓪ 副·ナ形  胡乱，随便；非常，特别"
-        ],
-        "notation": "やたら"
+        ]
     },
     {
         "name": "meiryou",
         "trans": [
+            "明瞭(めいりょう)",
             "⓪ 名·ナ形  明了，清楚"
-        ],
-        "notation": "明瞭(めいりょう)"
+        ]
     },
     {
         "name": "henkan",
         "trans": [
+            "返還(へんかん)",
             "⓪ 名·他动3  返还，归还"
-        ],
-        "notation": "返還(へんかん)"
+        ]
     },
     {
         "name": "demawaru",
         "trans": [
+            "出回(でまわ)る",
             "⓪ 自动1  （产品大量）上市"
-        ],
-        "notation": "出回(でまわ)る"
+        ]
     },
     {
         "name": "zensei",
         "trans": [
+            "全盛(ぜんせい)",
             "⓪ 名  全盛，鼎盛"
-        ],
-        "notation": "全盛(ぜんせい)"
+        ]
     },
     {
         "name": "genkei",
         "trans": [
+            "原形(げんけい)",
             "⓪ 名  原样，原状"
-        ],
-        "notation": "原形(げんけい)"
+        ]
     },
     {
         "name": "oshimu",
         "trans": [
+            "惜(お)しむ",
             "② 他动1  吝惜，舍不得；惋惜；爱惜，珍惜"
-        ],
-        "notation": "惜(お)しむ"
+        ]
     },
     {
         "name": "inta-fon",
         "trans": [
+            "インターフォン",
             "③ 名  内线电话，对讲机"
-        ],
-        "notation": "インターフォン"
+        ]
     },
     {
         "name": "shuen",
         "trans": [
+            "主演(しゅえん)",
             "⓪ 名·自动3  主演"
-        ],
-        "notation": "主演(しゅえん)"
+        ]
     },
     {
         "name": "ashikarazu",
         "trans": [
+            "悪(あ)しからず",
             "③ 副  不要见怪，原谅"
-        ],
-        "notation": "悪(あ)しからず"
+        ]
     },
     {
         "name": "kaiken",
         "trans": [
+            "会見(かいけん)",
             "⓪ 名·自动3  会见，接见"
-        ],
-        "notation": "会見(かいけん)"
+        ]
     },
     {
         "name": "zaimu",
         "trans": [
+            "財務(ざいむ)",
             "① 名  财务"
-        ],
-        "notation": "財務(ざいむ)"
+        ]
     },
     {
         "name": "shinogu",
         "trans": [
+            "凌(しの)ぐ",
             "② 他动1  忍耐，忍受；应付；凌驾，超过"
-        ],
-        "notation": "凌(しの)ぐ"
+        ]
     },
     {
         "name": "nakaba",
         "trans": [
+            "半(なか)ば",
             "③ 名  一半；中间；中途"
-        ],
-        "notation": "半(なか)ば"
+        ]
     },
     {
         "name": "haki",
         "trans": [
+            "破棄(はき)",
             "① 名·他动3  废弃，撕毁（条约）；取消，撤销（判决）"
-        ],
-        "notation": "破棄(はき)"
+        ]
     },
     {
         "name": "matagu",
         "trans": [
+            "跨(また)ぐ",
             "② 他动1  跨过，跨越"
-        ],
-        "notation": "跨(また)ぐ"
+        ]
     },
     {
         "name": "teisetsu",
         "trans": [
+            "定説(ていせつ)",
             "⓪ 名  定说，定论"
-        ],
-        "notation": "定説(ていせつ)"
+        ]
     },
     {
         "name": "koutou",
         "trans": [
+            "高騰(こうとう)",
             "⓪ 名·自动3  高涨，上涨"
-        ],
-        "notation": "高騰(こうとう)"
+        ]
     },
     {
         "name": "imada",
         "trans": [
+            "未(いま)だ",
             "⓪ 副  （后多接否定）未曾，尚未"
-        ],
-        "notation": "未(いま)だ"
+        ]
     },
     {
         "name": "gyouten",
         "trans": [
+            "仰天(ぎょうてん)",
             "⓪ 名·自动3  非常吃惊，大吃一惊"
-        ],
-        "notation": "仰天(ぎょうてん)"
+        ]
     },
     {
         "name": "shikitari",
         "trans": [
+            "しきたり",
             "⓪ 名  惯例，常规"
-        ],
-        "notation": "しきたり"
+        ]
     },
     {
         "name": "chinamini",
         "trans": [
+            "ちなみに",
             "⓪ 接续  顺便，附带"
-        ],
-        "notation": "ちなみに"
+        ]
     },
     {
         "name": "nikutai",
         "trans": [
+            "肉体(にくたい)",
             "⓪ 名  肉体"
-        ],
-        "notation": "肉体(にくたい)"
+        ]
     },
     {
         "name": "hitto",
         "trans": [
+            "ヒット",
             "① 名·自动3  大受欢迎，巨大成功"
-        ],
-        "notation": "ヒット"
+        ]
     },
     {
         "name": "minogasu",
         "trans": [
+            "見逃(みのが)す",
             "⓪ 他动1  看漏；宽恕，饶恕；放过，错过"
-        ],
-        "notation": "見逃(みのが)す"
+        ]
     },
     {
         "name": "ekizochikku",
         "trans": [
+            "エキゾチック",
             "④ ナ形  异国情调的"
-        ],
-        "notation": "エキゾチック"
+        ]
     },
     {
         "name": "kukan",
         "trans": [
+            "区間(くかん)",
             "② 名  区间，段"
-        ],
-        "notation": "区間(くかん)"
+        ]
     },
     {
         "name": "zubari",
         "trans": [
+            "ずばり",
             "② 副  （一刀）锋利切下；击中要害，一语道破"
-        ],
-        "notation": "ずばり"
+        ]
     },
     {
         "name": "tsutsu",
         "trans": [
+            "筒(つつ)",
             "⓪ 名  筒，管"
-        ],
-        "notation": "筒(つつ)"
+        ]
     },
     {
         "name": "nenshutsu",
         "trans": [
+            "捻出(ねんしゅつ)",
             "⓪ 名·他动3  想出（方案）；挤出，筹措出来"
-        ],
-        "notation": "捻出(ねんしゅつ)"
+        ]
     },
     {
         "name": "bukabuka",
         "trans": [
+            "ぶかぶか",
             "⓪ 副·ナ形  （衣服等）肥大"
-        ],
-        "notation": "ぶかぶか"
+        ]
     },
     {
         "name": "muchi",
         "trans": [
+            "無知(むち)",
             "① 名·ナ形  无知"
-        ],
-        "notation": "無知(むち)"
+        ]
     },
     {
         "name": "adana",
         "trans": [
+            "あだ名(な)",
             "⓪ 名  绰号，外号"
-        ],
-        "notation": "あだ名(な)"
+        ]
     },
     {
         "name": "osowaru",
         "trans": [
+            "教(おそ)わる",
             "⓪ 他动1  受教，向⋯⋯学习"
-        ],
-        "notation": "教(おそ)わる"
+        ]
     },
     {
         "name": "keitai",
         "trans": [
+            "形態(けいたい)",
             "⓪ 名  形态，样子"
-        ],
-        "notation": "形態(けいたい)"
+        ]
     },
     {
         "name": "shizuku",
         "trans": [
+            "滴(しずく)",
             "③ 名  水滴，水珠"
-        ],
-        "notation": "滴(しずく)"
+        ]
     },
     {
         "name": "kokoroduyoi",
         "trans": [
+            "心強(こころづよ)い",
             "⑤ イ形  心里有底的；受鼓舞的；有把握的"
-        ],
-        "notation": "心強(こころづよ)い"
+        ]
     },
     {
         "name": "sekuhara",
         "trans": [
+            "セクハラ",
             "⓪ 名  性骚扰"
-        ],
-        "notation": "セクハラ"
+        ]
     },
     {
         "name": "ichimen",
         "trans": [
+            "一面(いちめん)",
             "⓪ 名·副  一面；另一面；全体，整个"
-        ],
-        "notation": "一面(いちめん)"
+        ]
     },
     {
         "name": "kaigo",
         "trans": [
+            "介護(かいご)",
             "① 名·他动3  护理，照顾"
-        ],
-        "notation": "介護(かいご)"
+        ]
     },
     {
         "name": "sahodo",
         "trans": [
+            "さほど",
             "⓪ 副  （后接否定）那么，那样"
-        ],
-        "notation": "さほど"
+        ]
     },
     {
         "name": "taishuu",
         "trans": [
+            "大衆(たいしゅう)",
             "⓪ 名  大众，群众"
-        ],
-        "notation": "大衆(たいしゅう)"
+        ]
     },
     {
         "name": "nae",
         "trans": [
+            "苗(なえ)",
             "① 名  幼苗；秧苗"
-        ],
-        "notation": "苗(なえ)"
+        ]
     },
     {
         "name": "togireru",
         "trans": [
+            "途切(とぎ)れる",
             "③ 自动2  中断，间断，断绝"
-        ],
-        "notation": "途切(とぎ)れる"
+        ]
     },
     {
         "name": "jitai",
         "trans": [
+            "辞退(じたい)",
             "① 名·他动3  辞谢，谢绝"
-        ],
-        "notation": "辞退(じたい)"
+        ]
     },
     {
         "name": "kosuchu-mu",
         "trans": [
+            "コスチューム",
             "① 名  服装，装束；戏装"
-        ],
-        "notation": "コスチューム"
+        ]
     },
     {
         "name": "hakarishirenai",
         "trans": [
+            "計(はか)り知(し)れない",
             "⓪ イ形  不可估量的"
-        ],
-        "notation": "計(はか)り知(し)れない"
+        ]
     },
     {
         "name": "hokyou",
         "trans": [
+            "補強(ほきょう)",
             "⓪ 名·他动3  加强，强化"
-        ],
-        "notation": "補強(ほきょう)"
+        ]
     },
     {
         "name": "mayuge",
         "trans": [
+            "眉毛(まゆげ)",
             "① 名  眉毛"
-        ],
-        "notation": "眉毛(まゆげ)"
+        ]
     },
     {
         "name": "yasumeru",
         "trans": [
+            "休(やす)める",
             "③ 他动2  使休息；使平静；使安心"
-        ],
-        "notation": "休(やす)める"
+        ]
     },
     {
         "name": "soushitsu",
         "trans": [
+            "喪失(そうしつ)",
             "⓪ 名·他动3  丧失"
-        ],
-        "notation": "喪失(そうしつ)"
+        ]
     },
     {
         "name": "touka",
         "trans": [
+            "投下(とうか)",
             "⓪ 名·他动3  投下，投掷；投资"
-        ],
-        "notation": "投下(とうか)"
+        ]
     },
     {
         "name": "ajiwau",
         "trans": [
+            "味(あじ)わう",
             "③ 他动1  品尝；玩味，鉴赏；体验"
-        ],
-        "notation": "味(あじ)わう"
+        ]
     },
     {
         "name": "kigeki",
         "trans": [
+            "喜劇(きげき)",
             "① 名  喜剧"
-        ],
-        "notation": "喜劇(きげき)"
+        ]
     },
     {
         "name": "koma-sharu",
         "trans": [
+            "コマーシャル",
             "② 名  商业，商务；商业广告"
-        ],
-        "notation": "コマーシャル"
+        ]
     },
     {
         "name": "odateru",
         "trans": [
+            "煽(おだ)てる",
             "⓪ 他动2  煽动，怂恿；奉承，给人戴高帽"
-        ],
-        "notation": "煽(おだ)てる"
+        ]
     },
     {
         "name": "shikijou",
         "trans": [
+            "式場(しきじょう)",
             "⓪ 名  举行仪式的场所"
-        ],
-        "notation": "式場(しきじょう)"
+        ]
     },
     {
         "name": "chouwa",
         "trans": [
+            "調和(ちょうわ)",
             "⓪ 名·他动3  协调，调合；和谐"
-        ],
-        "notation": "調和(ちょうわ)"
+        ]
     },
     {
         "name": "kidukau",
         "trans": [
+            "気遣(きづか)う",
             "③ 他动1  担心，挂念"
-        ],
-        "notation": "気遣(きづか)う"
+        ]
     },
     {
         "name": "nishibi",
         "trans": [
+            "西日(にしび)",
             "⓪ 名  夕阳"
-        ],
-        "notation": "西日(にしび)"
+        ]
     },
     {
         "name": "hijuu",
         "trans": [
+            "比重(ひじゅう)",
             "⓪ 名  比重；（所占的）比例"
-        ],
-        "notation": "比重(ひじゅう)"
+        ]
     },
     {
         "name": "midasu",
         "trans": [
+            "乱(みだ)す",
             "② 他动1  弄乱，扰乱"
-        ],
-        "notation": "乱(みだ)す"
+        ]
     },
     {
         "name": "rakka",
         "trans": [
+            "落下(らっか)",
             "⓪ 名·自动3  下降，落下"
-        ],
-        "notation": "落下(らっか)"
+        ]
     },
     {
         "name": "eko",
         "trans": [
+            "エコ",
             "① 名  生态学；环保运动"
-        ],
-        "notation": "エコ"
+        ]
     },
     {
         "name": "ukiuki",
         "trans": [
+            "うきうき",
             "① 副·自动3  高兴，兴奋，喜不自禁"
-        ],
-        "notation": "うきうき"
+        ]
     },
     {
         "name": "kubiwa",
         "trans": [
+            "首輪(くびわ)",
             "⓪ 名  项圈；项链"
-        ],
-        "notation": "首輪(くびわ)"
+        ]
     },
     {
         "name": "suisou",
         "trans": [
+            "吹奏(すいそう)",
             "⓪ 名·他动3  吹奏"
-        ],
-        "notation": "吹奏(すいそう)"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "突(つ)く",
             "⓪ 他动1  扎，刺；撞击；扶着"
-        ],
-        "notation": "突(つ)く"
+        ]
     },
     {
         "name": "jouen",
         "trans": [
+            "上演(じょうえん)",
             "⓪ 名·自动3  上演，演出"
-        ],
-        "notation": "上演(じょうえん)"
+        ]
     },
     {
         "name": "doumei",
         "trans": [
+            "同盟(どうめい)",
             "⓪ 名·自动3  同盟，结盟"
-        ],
-        "notation": "同盟(どうめい)"
+        ]
     },
     {
         "name": "hiratai",
         "trans": [
+            "平(ひら)たい",
             "⓪ イ形  扁平的，平坦的；浅显易懂的"
-        ],
-        "notation": "平(ひら)たい"
+        ]
     },
     {
         "name": "mucha",
         "trans": [
+            "無茶(むちゃ)",
             "① 名·ナ形  毫无道理；胡乱，胡来"
-        ],
-        "notation": "無茶(むちゃ)"
+        ]
     },
     {
         "name": "rihabiri",
         "trans": [
+            "リハビリ",
             "⓪ 名  医疗指导，康复训练"
-        ],
-        "notation": "リハビリ"
+        ]
     },
     {
         "name": "oshiageru",
         "trans": [
+            "押(お)し上(あ)げる",
             "④ 他动2  推上去，顶上去；推举，提拔"
-        ],
-        "notation": "押(お)し上(あ)げる"
+        ]
     },
     {
         "name": "itabasami",
         "trans": [
+            "板挟(いたばさ)み",
             "③ 名  受夹板气，左右为难"
-        ],
-        "notation": "板挟(いたばさ)み"
+        ]
     },
     {
         "name": "keibatsu",
         "trans": [
+            "刑罰(けいばつ)",
             "① 名  刑罚"
-        ],
-        "notation": "刑罰(けいばつ)"
+        ]
     },
     {
         "name": "seisuru",
         "trans": [
+            "制(せい)する",
             "③ 他动3  压制，控制；制定（法律）；限制（饮食）"
-        ],
-        "notation": "制(せい)する"
+        ]
     },
     {
         "name": "derike-to",
         "trans": [
+            "デリケート",
             "③ ナ形  精致的；微妙的；敏感的，脆弱的"
-        ],
-        "notation": "デリケート"
+        ]
     },
     {
         "name": "nen'iri",
         "trans": [
+            "念入(ねんい)り",
             "⓪ 名·ナ形  周到，细致"
-        ],
-        "notation": "念入(ねんい)り"
+        ]
     },
     {
         "name": "herikudaru",
         "trans": [
+            "遜(へりくだ)る",
             "④ 自动1  谦恭，谦逊"
-        ],
-        "notation": "遜(へりくだ)る"
+        ]
     },
     {
         "name": "meirou",
         "trans": [
+            "明朗(めいろう)",
             "⓪ 名·ナ形  开朗；公正无私"
-        ],
-        "notation": "明朗(めいろう)"
+        ]
     },
     {
         "name": "shuppi",
         "trans": [
+            "出費(しゅっぴ)",
             "⓪ 名·自动3  花费，开销"
-        ],
-        "notation": "出費(しゅっぴ)"
+        ]
     },
     {
         "name": "isso",
         "trans": [
+            "いっそ",
             "⓪ 副  索性，干脆"
-        ],
-        "notation": "いっそ"
+        ]
     },
     {
         "name": "kouen",
         "trans": [
+            "講演(こうえん)",
             "⓪ 名·自他动3  演讲，讲话"
-        ],
-        "notation": "講演(こうえん)"
+        ]
     },
     {
         "name": "soukan",
         "trans": [
+            "創刊(そうかん)",
             "⓪ 名·他动3  创刊"
-        ],
-        "notation": "創刊(そうかん)"
+        ]
     },
     {
         "name": "dounokouno",
         "trans": [
+            "どうのこうの",
             "① 副  这呀那呀，说这说那"
-        ],
-        "notation": "どうのこうの"
+        ]
     },
     {
         "name": "nodoka",
         "trans": [
+            "長閑(のどか)",
             "① ナ形  晴朗的；恬静的，休闲的"
-        ],
-        "notation": "長閑(のどか)"
+        ]
     },
     {
         "name": "housaku",
         "trans": [
+            "豊作(ほうさく)",
             "⓪ 名  丰收"
-        ],
-        "notation": "豊作(ほうさく)"
+        ]
     },
     {
         "name": "morasu",
         "trans": [
+            "漏(も)らす",
             "② 他动1  漏；泄露；遗漏；流露"
-        ],
-        "notation": "漏(も)らす"
+        ]
     },
     {
         "name": "shijou",
         "trans": [
+            "私情(しじょう)",
             "⓪ 名  个人感情；私心"
-        ],
-        "notation": "私情(しじょう)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "精算(せいさん)",
             "⓪ 名·他动3  细算；补票"
-        ],
-        "notation": "精算(せいさん)"
+        ]
     },
     {
         "name": "assari",
         "trans": [
+            "あっさり",
             "③ 副·自动3  (味道)清淡；素雅，朴素；轻松，干脆"
-        ],
-        "notation": "あっさり"
+        ]
     },
     {
         "name": "kaigou",
         "trans": [
+            "会合(かいごう)",
             "⓪ 名·自动3  集会，聚会"
-        ],
-        "notation": "会合(かいごう)"
+        ]
     },
     {
         "name": "sapurimento",
         "trans": [
+            "サプリメント",
             "① 名  营养补品；增刊；附录"
-        ],
-        "notation": "サプリメント"
+        ]
     },
     {
         "name": "ijiru",
         "trans": [
+            "弄(いじ)る",
             "② 他动1  摆弄，玩弄；玩赏（物品）"
-        ],
-        "notation": "弄(いじ)る"
+        ]
     },
     {
         "name": "sossen",
         "trans": [
+            "率先(そっせん)",
             "⓪ 名·自动3  率先，带头"
-        ],
-        "notation": "率先(そっせん)"
+        ]
     },
     {
         "name": "kougen",
         "trans": [
+            "公言(こうげん)",
             "⓪ 名·他动3  公开说，声明"
-        ],
-        "notation": "公言(こうげん)"
+        ]
     },
     {
         "name": "tettoribayai",
         "trans": [
+            "手(て)っ取(と)り早(ばや)い",
             "⑥ イ形  迅速的；简单的，直截了当的"
-        ],
-        "notation": "手(て)っ取(と)り早(ばや)い"
+        ]
     },
     {
         "name": "narimonoiri",
         "trans": [
+            "鳴(な)り物入(ものい)り",
             "⓪ 名  敲锣打鼓；大张旗鼓"
-        ],
-        "notation": "鳴(な)り物入(ものい)り"
+        ]
     },
     {
         "name": "barie-shon",
         "trans": [
+            "バリエーション",
             "③ 名  变化"
-        ],
-        "notation": "バリエーション"
+        ]
     },
     {
         "name": "matomaru",
         "trans": [
+            "まとまる",
             "⓪ 自动1  谈妥，解决；凑齐；归纳起来；统一（意见）"
-        ],
-        "notation": "まとまる"
+        ]
     },
     {
         "name": "rentai",
         "trans": [
+            "連帯(れんたい)",
             "⓪ 名·自动3  联合，合作；（法律上）连带，共同负责"
-        ],
-        "notation": "連帯(れんたい)"
+        ]
     },
     {
         "name": "interi",
         "trans": [
+            "インテリ",
             "⓪ 名  知识分子"
-        ],
-        "notation": "インテリ"
+        ]
     },
     {
         "name": "omowashii",
         "trans": [
+            "思(おも)わしい",
             "③ イ形  令人满意的，中意的"
-        ],
-        "notation": "思(おも)わしい"
+        ]
     },
     {
         "name": "kikaku",
         "trans": [
+            "規格(きかく)",
             "⓪ 名  规格"
-        ],
-        "notation": "規格(きかく)"
+        ]
     },
     {
         "name": "shisso",
         "trans": [
+            "質素(しっそ)",
             "① 名·ナ形  简朴，朴素"
-        ],
-        "notation": "質素(しっそ)"
+        ]
     },
     {
         "name": "awasu",
         "trans": [
+            "合(あ)わす",
             "② 他动1  合在一起；配合；核对"
-        ],
-        "notation": "合(あ)わす"
+        ]
     },
     {
         "name": "chakuseki",
         "trans": [
+            "着席(ちゃくせき)",
             "⓪ 名·自动3  就座"
-        ],
-        "notation": "着席(ちゃくせき)"
+        ]
     },
     {
         "name": "nyuuryoku",
         "trans": [
+            "入力(にゅうりょく)",
             "⓪ 名·他动3  输入"
-        ],
-        "notation": "入力(にゅうりょく)"
+        ]
     },
     {
         "name": "hitasu",
         "trans": [
+            "浸(ひた)す",
             "⓪ 他动1  浸，泡"
-        ],
-        "notation": "浸(ひた)す"
+        ]
     },
     {
         "name": "misu",
         "trans": [
+            "ミス",
             "① 名·自动3  错误；失败；失误"
-        ],
-        "notation": "ミス"
+        ]
     },
     {
         "name": "asahaka",
         "trans": [
+            "浅(あさ)はか",
             "② ナ形  浅薄的，肤浅的，浅见的"
-        ],
-        "notation": "浅(あさ)はか"
+        ]
     },
     {
         "name": "oshikiru",
         "trans": [
+            "押(お)し切(き)る",
             "③ 他动1  切断；（排除困难）坚持到底"
-        ],
-        "notation": "押(お)し切(き)る"
+        ]
     },
     {
         "name": "kujira",
         "trans": [
+            "鯨(くじら)",
             "⓪ 名  鲸"
-        ],
-        "notation": "鯨(くじら)"
+        ]
     },
     {
         "name": "sukyandaru",
         "trans": [
+            "スキャンダル",
             "② 名  丑闻；丑事"
-        ],
-        "notation": "スキャンダル"
+        ]
     },
     {
         "name": "tsupparu",
         "trans": [
+            "突(つ)っ張(ぱ)る",
             "③ 自他动1  抽筋；支撑；坚持己见"
-        ],
-        "notation": "突(つ)っ張(ぱ)る"
+        ]
     },
     {
         "name": "haisen",
         "trans": [
+            "配線(はいせん)",
             "⓪ 名·自动3  接线，架线"
-        ],
-        "notation": "配線(はいせん)"
+        ]
     },
     {
         "name": "funin",
         "trans": [
+            "赴任(ふにん)",
             "⓪ 名·自动3  赴任，上任"
-        ],
-        "notation": "赴任(ふにん)"
+        ]
     },
     {
         "name": "mushiru",
         "trans": [
+            "毟(むし)る",
             "⓪ 他动1  拔，揪，薅（草）；撕（面包）"
-        ],
-        "notation": "毟(むし)る"
+        ]
     },
     {
         "name": "engawa",
         "trans": [
+            "縁側(えんがわ)",
             "⓪ 名  外廊，檐廊"
-        ],
-        "notation": "縁側(えんがわ)"
+        ]
     },
     {
         "name": "keihi",
         "trans": [
+            "経費(けいひ)",
             "① 名  经费"
-        ],
-        "notation": "経費(けいひ)"
+        ]
     },
     {
         "name": "suresure",
         "trans": [
+            "すれすれ",
             "⓪ 名·ナ形  擦过，掠过；逼近；勉勉强强，好不容易才"
-        ],
-        "notation": "すれすれ"
+        ]
     },
     {
         "name": "tejun",
         "trans": [
+            "手順(てじゅん)",
             "⓪ 名  次序，程序"
-        ],
-        "notation": "手順(てじゅん)"
+        ]
     },
     {
         "name": "bengi",
         "trans": [
+            "便宜(べんぎ)",
             "① 名·ナ形  方便；权宜"
-        ],
-        "notation": "便宜(べんぎ)"
+        ]
     },
     {
         "name": "moushideru",
         "trans": [
+            "申(もう)し出(で)る",
             "④ 他动2  提议，提出；报名"
-        ],
-        "notation": "申(もう)し出(で)る"
+        ]
     },
     {
         "name": "uchiki",
         "trans": [
+            "内気(うちき)",
             "⓪ 名·ナ形  内向，腼腆"
-        ],
-        "notation": "内気(うちき)"
+        ]
     },
     {
         "name": "koujitsu",
         "trans": [
+            "口実(こうじつ)",
             "⓪ 名  借口，辩解"
-        ],
-        "notation": "口実(こうじつ)"
+        ]
     },
     {
         "name": "sokkenai",
         "trans": [
+            "そっけない",
             "④ イ形  冷淡的，无情的；不客气的"
-        ],
-        "notation": "そっけない"
+        ]
     },
     {
         "name": "touge",
         "trans": [
+            "峠(とうげ)",
             "③ 名  山顶，岭；危险期，关口"
-        ],
-        "notation": "峠(とうげ)"
+        ]
     },
     {
         "name": "shitauke",
         "trans": [
+            "下請(したう)け",
             "⓪ 名·他动3  转包，分包"
-        ],
-        "notation": "下請(したう)け"
+        ]
     },
     {
         "name": "boyaku",
         "trans": [
+            "ぼやく",
             "② 自他动1  嘟囔，发牢骚"
-        ],
-        "notation": "ぼやく"
+        ]
     },
     {
         "name": "monita-",
         "trans": [
+            "モニター",
             "① 名·他动3  评论员；监视器"
-        ],
-        "notation": "モニター"
+        ]
     },
     {
         "name": "setsujitsu",
         "trans": [
+            "切実(せつじつ)",
             "⓪ ナ形  切实的，迫切的"
-        ],
-        "notation": "切実(せつじつ)"
+        ]
     },
     {
         "name": "atakamo",
         "trans": [
+            "あたかも",
             "① 副  宛如，好像；正好，恰好"
-        ],
-        "notation": "あたかも"
+        ]
     },
     {
         "name": "tekiou",
         "trans": [
+            "適応(てきおう)",
             "⓪ 名·自动3  适应，适合"
-        ],
-        "notation": "適応(てきおう)"
+        ]
     },
     {
         "name": "butsugi",
         "trans": [
+            "物議(ぶつぎ)",
             "① 名  群众的批评，社会舆论"
-        ],
-        "notation": "物議(ぶつぎ)"
+        ]
     },
     {
         "name": "tonaeru",
         "trans": [
+            "唱(とな)える",
             "③ 他动2  诵（诗），念；提倡；提出"
-        ],
-        "notation": "唱(とな)える"
+        ]
     },
     {
         "name": "kakurega",
         "trans": [
+            "隠(かく)れ家(が)",
             "③ 名  隐居之处；藏匿之处"
-        ],
-        "notation": "隠(かく)れ家(が)"
+        ]
     },
     {
         "name": "ashiato",
         "trans": [
+            "足跡(あしあと)",
             "③ 名  足迹，脚印；业绩，成就"
-        ],
-        "notation": "足跡(あしあと)"
+        ]
     },
     {
         "name": "kaisatsu",
         "trans": [
+            "改札(かいさつ)",
             "⓪ 名·自动3  检票"
-        ],
-        "notation": "改札(かいさつ)"
+        ]
     },
     {
         "name": "unagasu",
         "trans": [
+            "促(うなが)す",
             "③ 他动1  催促；促进，促使"
-        ],
-        "notation": "促(うなが)す"
+        ]
     },
     {
         "name": "kesshou",
         "trans": [
+            "結晶(けっしょう)",
             "⓪ 名·自动3  （雪）结晶；成果，结晶"
-        ],
-        "notation": "結晶(けっしょう)"
+        ]
     },
     {
         "name": "sa-fin",
         "trans": [
+            "サーフィン",
             "① 名  冲浪运动；冲浪板"
-        ],
-        "notation": "サーフィン"
+        ]
     },
     {
         "name": "kirikaeru",
         "trans": [
+            "切(き)り替(か)える",
             "④ 他动2  转换（开关），更换；兑换（钱）"
-        ],
-        "notation": "切(き)り替(か)える"
+        ]
     },
     {
         "name": "taiketsu",
         "trans": [
+            "対決(たいけつ)",
             "⓪ 名·自动3  对证，对质；对决，交锋"
-        ],
-        "notation": "対決(たいけつ)"
+        ]
     },
     {
         "name": "dosha",
         "trans": [
+            "土砂(どしゃ)",
             "① 名  沙土"
-        ],
-        "notation": "土砂(どしゃ)"
+        ]
     },
     {
         "name": "chiyahoya",
         "trans": [
+            "ちやほや",
             "① 副·他动3  溺爱，娇生惯养；奉承"
-        ],
-        "notation": "ちやほや"
+        ]
     },
     {
         "name": "nenkoujoretsu",
         "trans": [
+            "年功序列(ねんこうじょれつ)",
             "⑤ 名  论资排辈"
-        ],
-        "notation": "年功序列(ねんこうじょれつ)"
+        ]
     },
     {
         "name": "baikin",
         "trans": [
+            "黴菌(ばいきん)",
             "⓪ 名  细菌"
-        ],
-        "notation": "黴菌(ばいきん)"
+        ]
     },
     {
         "name": "nagorioshii",
         "trans": [
+            "名残惜(なごりお)しい",
             "⑤ イ形  依依不舍的，恋恋不舍的"
-        ],
-        "notation": "名残惜(なごりお)しい"
+        ]
     },
     {
         "name": "bijon",
         "trans": [
+            "ビジョン",
             "① 名  想象，幻想；理想，前景"
-        ],
-        "notation": "ビジョン"
+        ]
     },
     {
         "name": "mankitsu",
         "trans": [
+            "満喫(まんきつ)",
             "⓪ 名·他动3  吃饱，喝足；充分享受"
-        ],
-        "notation": "満喫(まんきつ)"
+        ]
     },
     {
         "name": "mohaya",
         "trans": [
+            "もはや",
             "① 副  （事到如今）已经"
-        ],
-        "notation": "もはや"
+        ]
     },
     {
         "name": "ikisatsu",
         "trans": [
+            "経緯(いきさつ)",
             "⓪ 名  事情的经过，原委"
-        ],
-        "notation": "経緯(いきさつ)"
+        ]
     },
     {
         "name": "kyousei",
         "trans": [
+            "強制(きょうせい)",
             "⓪ 名·他动3  强制，强迫"
-        ],
-        "notation": "強制(きょうせい)"
+        ]
     },
     {
         "name": "oshisusumeru",
         "trans": [
+            "推(お)し進(すす)める",
             "⑤ 他动2  推进，推动，推行"
-        ],
-        "notation": "推(お)し進(すす)める"
+        ]
     },
     {
         "name": "shisaku",
         "trans": [
+            "施策(しさく)",
             "⓪ 名  对策，措施"
-        ],
-        "notation": "施策(しさく)"
+        ]
     },
     {
         "name": "tsuusetsu",
         "trans": [
+            "痛切(つうせつ)",
             "⓪ 名·ナ形  痛切，深切，迫切"
-        ],
-        "notation": "痛切(つうせつ)"
+        ]
     },
     {
         "name": "nigiwau",
         "trans": [
+            "賑(にぎ)わう",
             "③ 自动1  热闹，拥挤；繁荣，兴盛"
-        ],
-        "notation": "賑(にぎ)わう"
+        ]
     },
     {
         "name": "seiza",
         "trans": [
+            "星座(せいざ)",
             "⓪ 名  星座"
-        ],
-        "notation": "星座(せいざ)"
+        ]
     },
     {
         "name": "hitode",
         "trans": [
+            "人出(ひとで)",
             "⓪ 名  外出的人群"
-        ],
-        "notation": "人出(ひとで)"
+        ]
     },
     {
         "name": "miyaburu",
         "trans": [
+            "見破(みやぶ)る",
             "⓪ 他动1  识破，看穿，看透"
-        ],
-        "notation": "見破(みやぶ)る"
+        ]
     },
     {
         "name": "ryousan",
         "trans": [
+            "量産(りょうさん)",
             "⓪ 名·他动3  批量生产"
-        ],
-        "notation": "量産(りょうさん)"
+        ]
     },
     {
         "name": "ukatsu",
         "trans": [
+            "迂闊(うかつ)",
             "⓪ 名·ナ形  粗心大意，疏忽；愚蠢"
-        ],
-        "notation": "迂闊(うかつ)"
+        ]
     },
     {
         "name": "kusuguttai",
         "trans": [
+            "くすぐったい",
             "⑤ イ形  发痒的；难为情的，害羞的"
-        ],
-        "notation": "くすぐったい"
+        ]
     },
     {
         "name": "zuihitsu",
         "trans": [
+            "随筆(ずいひつ)",
             "⓪ 名  随笔，散文"
-        ],
-        "notation": "随筆(ずいひつ)"
+        ]
     },
     {
         "name": "teisei",
         "trans": [
+            "訂正(ていせい)",
             "⓪ 名·他动3  订正，修订"
-        ],
-        "notation": "訂正(ていせい)"
+        ]
     },
     {
         "name": "houjiru",
         "trans": [
+            "報(ほう)じる",
             "⓪ 自他动2  报答；报告，通知"
-        ],
-        "notation": "報(ほう)じる"
+        ]
     },
     {
         "name": "nikutarashii",
         "trans": [
+            "憎(にく)たらしい",
             "⑤ イ形  可憎的，可恶的"
-        ],
-        "notation": "憎(にく)たらしい"
+        ]
     },
     {
         "name": "enkatsu",
         "trans": [
+            "円滑(えんかつ)",
             "⓪ 名·ナ形  圆满，顺利"
-        ],
-        "notation": "円滑(えんかつ)"
+        ]
     },
     {
         "name": "geragera",
         "trans": [
+            "げらげら",
             "① 副  哈哈大笑"
-        ],
-        "notation": "げらげら"
+        ]
     },
     {
         "name": "senzo",
         "trans": [
+            "先祖(せんぞ)",
             "① 名  祖先"
-        ],
-        "notation": "先祖(せんぞ)"
+        ]
     },
     {
         "name": "tebura",
         "trans": [
+            "手(て)ぶら",
             "⓪ 名·ナ形  空着手，赤手空拳"
-        ],
-        "notation": "手(て)ぶら"
+        ]
     },
     {
         "name": "nebaru",
         "trans": [
+            "粘(ねば)る",
             "② 自动1  发黏；坚持不懈；赖着不走"
-        ],
-        "notation": "粘(ねば)る"
+        ]
     },
     {
         "name": "bengo",
         "trans": [
+            "弁護(べんご)",
             "① 名·他动3  辩护，辩解"
-        ],
-        "notation": "弁護(べんご)"
+        ]
     },
     {
         "name": "muchi",
         "trans": [
+            "鞭(むち)",
             "① 名  鞭子，教鞭；鞭策"
-        ],
-        "notation": "鞭(むち)"
+        ]
     },
     {
         "name": "roku",
         "trans": [
+            "ろく",
             "⓪ ナ形  （后多接否定）令人满意的；正经的，正常的"
-        ],
-        "notation": "ろく"
+        ]
     },
     {
         "name": "arufabetto",
         "trans": [
+            "アルファベット",
             "④ 名  字母表，字母序列；基本知识，入门"
-        ],
-        "notation": "アルファベット"
+        ]
     },
     {
         "name": "oroshiuri",
         "trans": [
+            "卸売(おろしう)り",
             "⓪ 名  批发，批售"
-        ],
-        "notation": "卸売(おろしう)り"
+        ]
     },
     {
         "name": "kosu",
         "trans": [
+            "濾(こ)す",
             "⓪ 他动1  过滤"
-        ],
-        "notation": "濾(こ)す"
+        ]
     },
     {
         "name": "souzoku",
         "trans": [
+            "相続(そうぞく)",
             "⓪ 名·他动3  继承，继任"
-        ],
-        "notation": "相続(そうぞく)"
+        ]
     },
     {
         "name": "dokusou",
         "trans": [
+            "独創(どくそう)",
             "⓪ 名·他动3  独创"
-        ],
-        "notation": "独創(どくそう)"
+        ]
     },
     {
         "name": "itamu",
         "trans": [
+            "傷(いた)む",
             "② 自动1  （食品）腐烂；（物品）损坏"
-        ],
-        "notation": "傷(いた)む"
+        ]
     },
     {
         "name": "noruma",
         "trans": [
+            "ノルマ",
             "① 名  标准；劳动定额"
-        ],
-        "notation": "ノルマ"
+        ]
     },
     {
         "name": "jitsujou",
         "trans": [
+            "実情(じつじょう)",
             "⓪ 名  实际情况"
-        ],
-        "notation": "実情(じつじょう)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "賭(か)ける",
             "② 他动2  赌钱，赌输赢；拼（命），不惜"
-        ],
-        "notation": "賭(か)ける"
+        ]
     },
     {
         "name": "secchuu",
         "trans": [
+            "折衷(せっちゅう)",
             "⓪ 名·他动3  折中"
-        ],
-        "notation": "折衷(せっちゅう)"
+        ]
     },
     {
         "name": "torihikidaka",
         "trans": [
+            "取引高(とりひきだか)",
             "④ 名  交易额，成交额 "
-        ],
-        "notation": "取引高(とりひきだか)"
+        ]
     },
     {
         "name": "aseru",
         "trans": [
+            "褪(あ)せる",
             "② 自动2  褪色，掉色"
-        ],
-        "notation": "褪(あ)せる"
+        ]
     },
     {
         "name": "kikou",
         "trans": [
+            "機構(きこう)",
             "⓪ 名  机构，组织；结构，构造"
-        ],
-        "notation": "機構(きこう)"
+        ]
     },
     {
         "name": "takabisha",
         "trans": [
+            "高飛車(たかびしゃ)",
             "⓪ 名·ナ形  高压，盛气凌人"
-        ],
-        "notation": "高飛車(たかびしゃ)"
+        ]
     },
     {
         "name": "kagayakashii",
         "trans": [
+            "輝(かがや)かしい",
             "⑤ イ形  耀眼的；辉煌的，光辉的"
-        ],
-        "notation": "輝(かがや)かしい"
+        ]
     },
     {
         "name": "kochou",
         "trans": [
+            "誇張(こちょう)",
             "⓪ 名·他动3  夸张，夸大"
-        ],
-        "notation": "誇張(こちょう)"
+        ]
     },
     {
         "name": "jushin",
         "trans": [
+            "受信(じゅしん)",
             "⓪ 名·他动3  接收（信件、广播等）"
-        ],
-        "notation": "受信(じゅしん)"
+        ]
     },
     {
         "name": "samonaito",
         "trans": [
+            "さもないと",
             "① 接续  不然的话，否则"
-        ],
-        "notation": "さもないと"
+        ]
     },
     {
         "name": "machiakasu",
         "trans": [
+            "待(ま)ち明(あ)かす",
             "④ 他动1  彻夜等候；久候"
-        ],
-        "notation": "待(ま)ち明(あ)かす"
+        ]
     },
     {
         "name": "nakahodo",
         "trans": [
+            "なかほど",
             "⓪ 名  （场所）中间，中央；中途；（程度）中等"
-        ],
-        "notation": "なかほど"
+        ]
     },
     {
         "name": "hajirau",
         "trans": [
+            "恥(はじ)らう",
             "③ 自他动1  害羞，羞涩"
-        ],
-        "notation": "恥(はじ)らう"
+        ]
     },
     {
         "name": "bokin",
         "trans": [
+            "募金(ぼきん)",
             "⓪ 名·自动3  募捐"
-        ],
-        "notation": "募金(ぼきん)"
+        ]
     },
     {
         "name": "manjou",
         "trans": [
+            "満場(まんじょう)",
             "⓪ 名  全场，满场，满堂"
-        ],
-        "notation": "満場(まんじょう)"
+        ]
     },
     {
         "name": "yurumu",
         "trans": [
+            "緩(ゆる)む",
             "② 自动1  松弛；松懈；缓和，放宽"
-        ],
-        "notation": "緩(ゆる)む"
+        ]
     },
     {
         "name": "iji",
         "trans": [
+            "意地(いじ)",
             "② 名  心术，用心；固执，倔强；志气，气魄"
-        ],
-        "notation": "意地(いじ)"
+        ]
     },
     {
         "name": "kigokoro",
         "trans": [
+            "気心(きごころ)",
             "② 名  性情，脾气"
-        ],
-        "notation": "気心(きごころ)"
+        ]
     },
     {
         "name": "janjan",
         "trans": [
+            "じゃんじゃん",
             "① 副  连续不断地，一个劲儿地；（钟）当当响"
-        ],
-        "notation": "じゃんじゃん"
+        ]
     },
     {
         "name": "girigatai",
         "trans": [
+            "義理堅(ぎりがた)い",
             "④ イ形  讲义气的，够交情的"
-        ],
-        "notation": "義理堅(ぎりがた)い"
+        ]
     },
     {
         "name": "chosho",
         "trans": [
+            "著書(ちょしょ)",
             "① 名  著书，著作"
-        ],
-        "notation": "著書(ちょしょ)"
+        ]
     },
     {
         "name": "netsuzou",
         "trans": [
+            "捏造(ねつぞう)",
             "⓪ 名·他动3  捏造，编造"
-        ],
-        "notation": "捏造(ねつぞう)"
+        ]
     },
     {
         "name": "haiteku",
         "trans": [
+            "ハイテク",
             "⓪ 名  高新技术"
-        ],
-        "notation": "ハイテク"
+        ]
     },
     {
         "name": "houjin",
         "trans": [
+            "法人(ほうじん)",
             "⓪ 名  法人"
-        ],
-        "notation": "法人(ほうじん)"
+        ]
     },
     {
         "name": "uranau",
         "trans": [
+            "占(うらな)う",
             "③ 他动1  占卜，算卦"
-        ],
-        "notation": "占(うらな)う"
+        ]
     },
     {
         "name": "kahogo",
         "trans": [
+            "過保護(かほご)",
             "② 名  过度保护，过于娇生惯养"
-        ],
-        "notation": "過保護(かほご)"
+        ]
     },
     {
         "name": "seidaku",
         "trans": [
+            "清濁(せいだく)",
             "① 名  （水）清浊；善恶，好坏"
-        ],
-        "notation": "清濁(せいだく)"
+        ]
     },
     {
         "name": "kokorobosoi",
         "trans": [
+            "心細(こころぼそ)い",
             "⑤ イ形  心里没底的，心中不安的"
-        ],
-        "notation": "心細(こころぼそ)い"
+        ]
     },
     {
         "name": "jouho",
         "trans": [
+            "譲歩(じょうほ)",
             "① 名·自动3  让步"
-        ],
-        "notation": "譲歩(じょうほ)"
+        ]
     },
     {
         "name": "fuzai",
         "trans": [
+            "不在(ふざい)",
             "⓪ 名  不在，不在家"
-        ],
-        "notation": "不在(ふざい)"
+        ]
     },
     {
         "name": "haramu",
         "trans": [
+            "孕(はら)む",
             "② 自他动1  怀孕；孕育，内含；（穗）鼓胀"
-        ],
-        "notation": "孕(はら)む"
+        ]
     },
     {
         "name": "esukare-to",
         "trans": [
+            "エスカレート",
             "④ 名·自动3  （纷争）逐步升级"
-        ],
-        "notation": "エスカレート"
+        ]
     },
     {
         "name": "amaashi",
         "trans": [
+            "雨足(あまあし)",
             "⓪ 名  雨势"
-        ],
-        "notation": "雨足(あまあし)"
+        ]
     },
     {
         "name": "satosu",
         "trans": [
+            "諭(さと)す",
             "② 他动1  教诲，教导"
-        ],
-        "notation": "諭(さと)す"
+        ]
     },
     {
         "name": "kaishuu",
         "trans": [
+            "回収(かいしゅう)",
             "⓪ 名·他动3  回收，收回"
-        ],
-        "notation": "回収(かいしゅう)"
+        ]
     },
     {
         "name": "keibetsu",
         "trans": [
+            "軽蔑(けいべつ)",
             "⓪ 名·他动3  轻蔑，蔑视，看不起"
-        ],
-        "notation": "軽蔑(けいべつ)"
+        ]
     },
     {
         "name": "imadani",
         "trans": [
+            "未(いま)だに",
             "⓪ 副  （后接否定）仍然，尚未"
-        ],
-        "notation": "未(いま)だに"
+        ]
     },
     {
         "name": "o-tomachikku",
         "trans": [
+            "オートマチック",
             "⑤ 名·ナ形  自动装置；自动的，自动式的"
-        ],
-        "notation": "オートマチック"
+        ]
     },
     {
         "name": "sakasama",
         "trans": [
+            "逆様(さかさま)",
             "⓪ 名·ナ形  颠倒，相反"
-        ],
-        "notation": "逆様(さかさま)"
+        ]
     },
     {
         "name": "sun'nari",
         "trans": [
+            "すんなり",
             "③ 副·自动3  苗条，纤细；容易，不费力"
-        ],
-        "notation": "すんなり"
+        ]
     },
     {
         "name": "teitai",
         "trans": [
+            "停滞(ていたい)",
             "⓪ 名·自动3  停滞，停顿"
-        ],
-        "notation": "停滞(ていたい)"
+        ]
     },
     {
         "name": "ninjou",
         "trans": [
+            "人情(にんじょう)",
             "① 名  人情，情义"
-        ],
-        "notation": "人情(にんじょう)"
+        ]
     },
     {
         "name": "hinsuru",
         "trans": [
+            "瀕(ひん)する",
             "③ 自动3  濒临，面临"
-        ],
-        "notation": "瀕(ひん)する"
+        ]
     },
     {
         "name": "houi",
         "trans": [
+            "方位(ほうい)",
             "① 名  方位，方向"
-        ],
-        "notation": "方位(ほうい)"
+        ]
     },
     {
         "name": "minoue",
         "trans": [
+            "身(み)の上(うえ)",
             "⓪ 名  境遇，身世；命运"
-        ],
-        "notation": "身(み)の上(うえ)"
+        ]
     },
     {
         "name": "yuyushii",
         "trans": [
+            "ゆゆしい",
             "③ イ形  严重的，重大的"
-        ],
-        "notation": "ゆゆしい"
+        ]
     },
     {
         "name": "ukemi",
         "trans": [
+            "受(う)け身(み)",
             "③ 名  被动，消极"
-        ],
-        "notation": "受(う)け身(み)"
+        ]
     },
     {
         "name": "muriyari",
         "trans": [
+            "無理(むり)やり",
             "⓪ 副  强行，强迫"
-        ],
-        "notation": "無理(むり)やり"
+        ]
     },
     {
         "name": "kokorozasu",
         "trans": [
+            "志(こころざ)す",
             "④ 他动1  立志，志向"
-        ],
-        "notation": "志(こころざ)す"
+        ]
     },
     {
         "name": "janru",
         "trans": [
+            "ジャンル",
             " ① 名  种类；类型；体裁；流派"
-        ],
-        "notation": "ジャンル"
+        ]
     },
     {
         "name": "haifu",
         "trans": [
+            "配布(はいふ)",
             "⓪ 名·他动3  （范围广的）散发，分发"
-        ],
-        "notation": "配布(はいふ)"
+        ]
     },
     {
         "name": "muragaru",
         "trans": [
+            "群(むら)がる",
             "③ 自动1  聚，聚集"
-        ],
-        "notation": "群(むら)がる"
+        ]
     },
     {
         "name": "enkyoku",
         "trans": [
+            "婉曲(えんきょく)",
             "⓪ ナ形  委婉的，婉转的"
-        ],
-        "notation": "婉曲(えんきょく)"
+        ]
     },
     {
         "name": "ago",
         "trans": [
+            "顎(あご)",
             "② 名  下巴，下颚"
-        ],
-        "notation": "顎(あご)"
+        ]
     },
     {
         "name": "kan'yuu",
         "trans": [
+            "勧誘(かんゆう)",
             "⓪ 名·他动3  劝诱，劝说"
-        ],
-        "notation": "勧誘(かんゆう)"
+        ]
     },
     {
         "name": "iradatsu",
         "trans": [
+            "苛立(いらだ)つ",
             "③ 自动1  着急，焦急，急不可待"
-        ],
-        "notation": "苛立(いらだ)つ"
+        ]
     },
     {
         "name": "kyoui",
         "trans": [
+            "驚異(きょうい)",
             "① 名  惊异，惊奇；奇事，不可思议的事"
-        ],
-        "notation": "驚異(きょうい)"
+        ]
     },
     {
         "name": "sapo-to",
         "trans": [
+            "サポート",
             "② 名·他动3  支持，支援"
-        ],
-        "notation": "サポート"
+        ]
     },
     {
         "name": "kujiku",
         "trans": [
+            "挫(くじ)く",
             "② 他动1  挫伤；挫败；挫（锐气）"
-        ],
-        "notation": "挫(くじ)く"
+        ]
     },
     {
         "name": "shiba",
         "trans": [
+            "芝(しば)",
             "⓪ 名  （草坪里的）草"
-        ],
-        "notation": "芝(しば)"
+        ]
     },
     {
         "name": "soufu",
         "trans": [
+            "送付(そうふ)",
             "① 名·他动3  发送，寄送"
-        ],
-        "notation": "送付(そうふ)"
+        ]
     },
     {
         "name": "chirasu",
         "trans": [
+            "散(ち)らす",
             "⓪ 他动1  驱散（人群）；散，撒；散布，传播"
-        ],
-        "notation": "散(ち)らす"
+        ]
     },
     {
         "name": "dashin",
         "trans": [
+            "打診(だしん)",
             "⓪ 名·他动3  打探，试探"
-        ],
-        "notation": "打診(だしん)"
+        ]
     },
     {
         "name": "fuchi",
         "trans": [
+            "淵(ふち)",
             "② 名  渊，潭；（比喻）深渊"
-        ],
-        "notation": "淵(ふち)"
+        ]
     },
     {
         "name": "tegowai",
         "trans": [
+            "手強(てごわ)い",
             "③ イ形  难对付的，不好对付的"
-        ],
-        "notation": "手強(てごわ)い"
+        ]
     },
     {
         "name": "nansensu",
         "trans": [
+            "ナンセンス",
             "① 名·ナ形  无意义，无聊，荒谬；废话"
-        ],
-        "notation": "ナンセンス"
+        ]
     },
     {
         "name": "mekata",
         "trans": [
+            "目方(めかた)",
             "⓪ 名  分量，重量"
-        ],
-        "notation": "目方(めかた)"
+        ]
     },
     {
         "name": "uketamawaru",
         "trans": [
+            "承(うけたまわ)る",
             "⑤ 他动1  （洗耳）恭听；接受；知道；听说，传闻"
-        ],
-        "notation": "承(うけたまわ)る"
+        ]
     },
     {
         "name": "geppu",
         "trans": [
+            "月賦(げっぷ)",
             "⓪ 名  按月分期付款，月供"
-        ],
-        "notation": "月賦(げっぷ)"
+        ]
     },
     {
         "name": "jimichi",
         "trans": [
+            "地道(じみち)",
             "⓪ 名·ナ形  勤恳，踏实"
-        ],
-        "notation": "地道(じみち)"
+        ]
     },
     {
         "name": "abunagenai",
         "trans": [
+            "危(あぶ)なげない",
             "⑤ イ形  有把握的，十拿九稳的"
-        ],
-        "notation": "危(あぶ)なげない"
+        ]
     },
     {
         "name": "kyoukou",
         "trans": [
+            "強行(きょうこう)",
             "⓪ 名·他动3  强行，硬干"
-        ],
-        "notation": "強行(きょうこう)"
+        ]
     },
     {
         "name": "seisai",
         "trans": [
+            "制裁(せいさい)",
             "⓪ 名·他动3  制裁"
-        ],
-        "notation": "制裁(せいさい)"
+        ]
     },
     {
         "name": "itatte",
         "trans": [
+            "至(いた)って",
             "⓪ 副  极其，很"
-        ],
-        "notation": "至(いた)って"
+        ]
     },
     {
         "name": "kounetsuhi",
         "trans": [
+            "光熱費(こうねつひ)",
             "④ 名  电费和煤气费"
-        ],
-        "notation": "光熱費(こうねつひ)"
+        ]
     },
     {
         "name": "sensai",
         "trans": [
+            "繊細(せんさい)",
             "⓪ 名·ナ形  纤细，柔嫩；感情细腻"
-        ],
-        "notation": "繊細(せんさい)"
+        ]
     },
     {
         "name": "hareru",
         "trans": [
+            "腫(は)れる",
             "⓪ 自动2  肿，肿胀"
-        ],
-        "notation": "腫(は)れる"
+        ]
     },
     {
         "name": "to-n",
         "trans": [
+            "トーン",
             "① 名  音调；色调；气氛"
-        ],
-        "notation": "トーン"
+        ]
     },
     {
         "name": "funaka",
         "trans": [
+            "不仲(ふなか)",
             "① 名·ナ形  不和，关系不好"
-        ],
-        "notation": "不仲(ふなか)"
+        ]
     },
     {
         "name": "manugareru",
         "trans": [
+            "免(まぬが)れる",
             "④ 他动2  避免，摆脱"
-        ],
-        "notation": "免(まぬが)れる"
+        ]
     },
     {
         "name": "moya",
         "trans": [
+            "靄(もや)",
             "① 名  云气，轻雾"
-        ],
-        "notation": "靄(もや)"
+        ]
     },
     {
         "name": "doujou",
         "trans": [
+            "同乗(どうじょう)",
             "⓪ 名·自动3  同乘，同坐"
-        ],
-        "notation": "同乗(どうじょう)"
+        ]
     },
     {
         "name": "anagachi",
         "trans": [
+            "あながち",
             "⓪ 副  （后多接否定）未必，不见得"
-        ],
-        "notation": "あながち"
+        ]
     },
     {
         "name": "esute",
         "trans": [
+            "エステ",
             "① 名  美容院"
-        ],
-        "notation": "エステ"
+        ]
     },
     {
         "name": "kokkou",
         "trans": [
+            "国交(こっこう)",
             "⓪ 名  邦交"
-        ],
-        "notation": "国交(こっこう)"
+        ]
     },
     {
         "name": "suru",
         "trans": [
+            "擂(す)る",
             "① 他动1  用力摩擦；研磨，研碎"
-        ],
-        "notation": "擂(す)る"
+        ]
     },
     {
         "name": "saigo",
         "trans": [
+            "最期(さいご)",
             "① 名  临终，临死"
-        ],
-        "notation": "最期(さいご)"
+        ]
     },
     {
         "name": "tenohira",
         "trans": [
+            "掌(てのひら)",
             "① 名  手掌心"
-        ],
-        "notation": "掌(てのひら)"
+        ]
     },
     {
         "name": "himashini",
         "trans": [
+            "日増(ひま)しに",
             "⓪ 副  日益，一天天地"
-        ],
-        "notation": "日増(ひま)しに"
+        ]
     },
     {
         "name": "doraibuin",
         "trans": [
+            "ドライブイン",
             "④ 名  免下车服务设施"
-        ],
-        "notation": "ドライブイン"
+        ]
     },
     {
         "name": "heinen",
         "trans": [
+            "平年(へいねん)",
             "⓪ 名  平年，常年(没有异常的年份)"
-        ],
-        "notation": "平年(へいねん)"
+        ]
     },
     {
         "name": "kushakusha",
         "trans": [
+            "くしゃくしゃ",
             "① 副·ナ形  皱巴巴；乱糟糟"
-        ],
-        "notation": "くしゃくしゃ"
+        ]
     },
     {
         "name": "jouryuu",
         "trans": [
+            "蒸留(じょうりゅう)",
             "⓪ 名·他动3  蒸馏"
-        ],
-        "notation": "蒸留(じょうりゅう)"
+        ]
     },
     {
         "name": "utatane",
         "trans": [
+            "転寝(うたたね)",
             "⓪ 名·自动3  假寐，打盹儿"
-        ],
-        "notation": "転寝(うたたね)"
+        ]
     },
     {
         "name": "korasu",
         "trans": [
+            "凝(こ)らす",
             "② 他动1  凝（视），集中（精神）"
-        ],
-        "notation": "凝(こ)らす"
+        ]
     },
     {
         "name": "kadou",
         "trans": [
+            "稼働(かどう)",
             "⓪ 名·自他动3  劳动，工作；机器运转"
-        ],
-        "notation": "稼働(かどう)"
+        ]
     },
     {
         "name": "issou",
         "trans": [
+            "一掃(いっそう)",
             "⓪ 名·他动3  扫除，清除"
-        ],
-        "notation": "一掃(いっそう)"
+        ]
     },
     {
         "name": "michibiku",
         "trans": [
+            "導(みちび)く",
             "③ 他动1  引导，指引；导致"
-        ],
-        "notation": "導(みちび)く"
+        ]
     },
     {
         "name": "mottekoi",
         "trans": [
+            "もってこい",
             "④ 连语  正合适，理想，再好不过"
-        ],
-        "notation": "もってこい"
+        ]
     },
     {
         "name": "teika",
         "trans": [
+            "低下(ていか)",
             "⓪ 名·自动3  降低，下降"
-        ],
-        "notation": "低下(ていか)"
+        ]
     },
     {
         "name": "kanete",
         "trans": [
+            "かねて",
             "① 副  事先，早已"
-        ],
-        "notation": "かねて"
+        ]
     },
     {
         "name": "ouryou",
         "trans": [
+            "横領(おうりょう)",
             "⓪ 名·他动3  侵占，霸占，贪污"
-        ],
-        "notation": "横領(おうりょう)"
+        ]
     },
     {
         "name": "bajji",
         "trans": [
+            "バッジ",
             "① 名  徽章"
-        ],
-        "notation": "バッジ"
+        ]
     },
     {
         "name": "arifureta",
         "trans": [
+            "ありふれた",
             "⓪ 连体  常见的，不稀奇的"
-        ],
-        "notation": "ありふれた"
+        ]
     },
     {
         "name": "kisaku",
         "trans": [
+            "気(き)さく",
             "⓪ ナ形  坦率的，直爽的，爽快的"
-        ],
-        "notation": "気(き)さく"
+        ]
     },
     {
         "name": "jukuchi",
         "trans": [
+            "熟知(じゅくち)",
             "① 名·他动3  熟悉"
-        ],
-        "notation": "熟知(じゅくち)"
+        ]
     },
     {
         "name": "kirinukeru",
         "trans": [
+            "切(き)り抜(ぬ)ける",
             "④ 他动2  突围；摆脱，闯过"
-        ],
-        "notation": "切(き)り抜(ぬ)ける"
+        ]
     },
     {
         "name": "uzu",
         "trans": [
+            "渦(うず)",
             "① 名  漩涡"
-        ],
-        "notation": "渦(うず)"
+        ]
     },
     {
         "name": "hitomebore",
         "trans": [
+            "一目(ひとめ)ぼれ",
             "⓪ 名·自动3  一见钟情"
-        ],
-        "notation": "一目(ひとめ)ぼれ"
+        ]
     },
     {
         "name": "botsubotsu",
         "trans": [
+            "ぼつぼつ",
             "① 副·名  渐渐；就要，快要；稀稀拉拉；小洞，斑点"
-        ],
-        "notation": "ぼつぼつ"
+        ]
     },
     {
         "name": "taki",
         "trans": [
+            "多岐(たき)",
             "① 名·ナ形  多方面，复杂"
-        ],
-        "notation": "多岐(たき)"
+        ]
     },
     {
         "name": "soukai",
         "trans": [
+            "総会(そうかい)",
             "⓪ 名  大会，全会"
-        ],
-        "notation": "総会(そうかい)"
+        ]
     },
     {
         "name": "gikochinai",
         "trans": [
+            "ぎこちない",
             "④ イ形  笨拙的，生硬的"
-        ],
-        "notation": "ぎこちない"
+        ]
     },
     {
         "name": "afuta-kea",
         "trans": [
+            "アフターケア",
             "⑤ 名  病后疗养；售后服务"
-        ],
-        "notation": "アフターケア"
+        ]
     },
     {
         "name": "kan'yo",
         "trans": [
+            "関与(かんよ)",
             "① 名·自动3  参与，干预"
-        ],
-        "notation": "関与(かんよ)"
+        ]
     },
     {
         "name": "otoru",
         "trans": [
+            "劣(おと)る",
             "⓪ 自动1  不如，比不上"
-        ],
-        "notation": "劣(おと)る"
+        ]
     },
     {
         "name": "bouei",
         "trans": [
+            "防衛(ぼうえい)",
             "⓪ 名·他动3  防卫，捍卫，保卫"
-        ],
-        "notation": "防衛(ぼうえい)"
+        ]
     },
     {
         "name": "mizo",
         "trans": [
+            "溝(みぞ)",
             "⓪ 名  水沟；沟，槽；隔阂"
-        ],
-        "notation": "溝(みぞ)"
+        ]
     },
     {
         "name": "tsugu",
         "trans": [
+            "継(つ)ぐ",
             "⓪ 他动1  连接，接上；继承"
-        ],
-        "notation": "継(つ)ぐ"
+        ]
     },
     {
         "name": "shikkou",
         "trans": [
+            "失効(しっこう)",
             "⓪ 名·自动3  失效"
-        ],
-        "notation": "失効(しっこう)"
+        ]
     },
     {
         "name": "kyougi",
         "trans": [
+            "協議(きょうぎ)",
             "① 名·他动3  协议，协商，磋商"
-        ],
-        "notation": "協議(きょうぎ)"
+        ]
     },
     {
         "name": "torimaku",
         "trans": [
+            "取(と)り巻(ま)く",
             "③ 他动1  围住，围绕"
-        ],
-        "notation": "取(と)り巻(ま)く"
+        ]
     },
     {
         "name": "oriente-jon",
         "trans": [
+            "オリエンテーション",
             "⑤ 名  入学教育，新员工培训"
-        ],
-        "notation": "オリエンテーション"
+        ]
     },
     {
         "name": "hazure",
         "trans": [
+            "外(はず)れ",
             "⓪ 名  落空，不中；尽头"
-        ],
-        "notation": "外(はず)れ"
+        ]
     },
     {
         "name": "kokoroeru",
         "trans": [
+            "心得(こころえ)る",
             "④ 他动2  懂得，明白；答应，应允"
-        ],
-        "notation": "心得(こころえ)る"
+        ]
     },
     {
         "name": "ishou",
         "trans": [
+            "衣装(いしょう)",
             "① 名  服装；戏服"
-        ],
-        "notation": "衣装(いしょう)"
+        ]
     },
     {
         "name": "shuuake",
         "trans": [
+            "週明(しゅうあ)け",
             "⓪ 名  一周的开始，周一"
-        ],
-        "notation": "週明(しゅうあ)け"
+        ]
     },
     {
         "name": "moushitsukeru",
         "trans": [
+            "申(もう)し付(つ)ける",
             "⑤ 他动2  吩咐，命令"
-        ],
-        "notation": "申(もう)し付(つ)ける"
+        ]
     },
     {
         "name": "hansha",
         "trans": [
+            "反射(はんしゃ)",
             "⓪ 名·自他动3  （光、生理上的）反射"
-        ],
-        "notation": "反射(はんしゃ)"
+        ]
     },
     {
         "name": "tayorinai",
         "trans": [
+            "頼(たよ)りない",
             "④ イ形  靠不住的，不可靠的"
-        ],
-        "notation": "頼(たよ)りない"
+        ]
     },
     {
         "name": "ayatsuru",
         "trans": [
+            "操(あやつ)る",
             "③ 他动1  驾驶，操作；暗中控制，操纵；掌握"
-        ],
-        "notation": "操(あやつ)る"
+        ]
     },
     {
         "name": "gaika",
         "trans": [
+            "外貨(がいか)",
             "① 名  外币；进口货"
-        ],
-        "notation": "外貨(がいか)"
+        ]
     },
     {
         "name": "saiketsu",
         "trans": [
+            "採決(さいけつ)",
             "① 名·他动3  表决"
-        ],
-        "notation": "採決(さいけつ)"
+        ]
     },
     {
         "name": "unuboreru",
         "trans": [
+            "うぬぼれる",
             "⓪ 自动2  自负，骄傲自大"
-        ],
-        "notation": "うぬぼれる"
+        ]
     },
     {
         "name": "keimusho",
         "trans": [
+            "刑務所(けいむしょ)",
             "③ 名  监狱"
-        ],
-        "notation": "刑務所(けいむしょ)"
+        ]
     },
     {
         "name": "shinario",
         "trans": [
+            "シナリオ",
             "⓪ 名  脚本，剧本"
-        ],
-        "notation": "シナリオ"
+        ]
     },
     {
         "name": "soredeite",
         "trans": [
+            "それでいて",
             "⓪ 接续  尽管那样，虽然那样"
-        ],
-        "notation": "それでいて"
+        ]
     },
     {
         "name": "iiwake",
         "trans": [
+            "言(い)い訳(わけ)",
             "⓪ 名  辩解，分辩"
-        ],
-        "notation": "言(い)い訳(わけ)"
+        ]
     },
     {
         "name": "dangen",
         "trans": [
+            "断言(だんげん)",
             "③ 名·他动3  断言，断定"
-        ],
-        "notation": "断言(だんげん)"
+        ]
     },
     {
         "name": "najiru",
         "trans": [
+            "詰(なじ)る",
             "② 他动1  责问，责备，责难"
-        ],
-        "notation": "詰(なじ)る"
+        ]
     },
     {
         "name": "tougi",
         "trans": [
+            "討議(とうぎ)",
             "① 名·他动3  讨论，共同研讨"
-        ],
-        "notation": "討議(とうぎ)"
+        ]
     },
     {
         "name": "hadashi",
         "trans": [
+            "裸足(はだし)",
             "⓪ 名  赤足，光脚"
-        ],
-        "notation": "裸足(はだし)"
+        ]
     },
     {
         "name": "ichijirushii",
         "trans": [
+            "著(いちじる)しい",
             "⑤ イ形  显著的，明显的"
-        ],
-        "notation": "著(いちじる)しい"
+        ]
     },
     {
         "name": "oote",
         "trans": [
+            "大手(おおて)",
             "① 名  大企业，大户头"
-        ],
-        "notation": "大手(おおて)"
+        ]
     },
     {
         "name": "shouka",
         "trans": [
+            "消火(しょうか)",
             "⓪ 名·自动3  消防，灭火"
-        ],
-        "notation": "消火(しょうか)"
+        ]
     },
     {
         "name": "hourikomu",
         "trans": [
+            "放(ほう)り込(こ)む",
             "④ 他动1  扔进去，投进去"
-        ],
-        "notation": "放(ほう)り込(こ)む"
+        ]
     },
     {
         "name": "kyaria",
         "trans": [
+            "キャリア",
             "① 名  经验，履历；职业；比赛经历"
-        ],
-        "notation": "キャリア"
+        ]
     },
     {
         "name": "shozai",
         "trans": [
+            "所在(しょざい)",
             "⓪ 名·自动3  住处，所在地；（职责）所在；工作"
-        ],
-        "notation": "所在(しょざい)"
+        ]
     },
     {
         "name": "guzuguzu",
         "trans": [
+            "ぐずぐず",
             "① 副·自动3  磨磨蹭蹭；嘟囔，唠唠叨叨"
-        ],
-        "notation": "ぐずぐず"
+        ]
     },
     {
         "name": "zensen",
         "trans": [
+            "前線(ぜんせん)",
             "⓪ 名  前线；（气象）锋面"
-        ],
-        "notation": "前線(ぜんせん)"
+        ]
     },
     {
         "name": "hikaeme",
         "trans": [
+            "控(ひか)えめ",
             "⓪ 名·ナ形  保守，谨慎；节制"
-        ],
-        "notation": "控(ひか)えめ"
+        ]
     },
     {
         "name": "ikanimo",
         "trans": [
+            "いかにも",
             "② 副  的确，确实；实在，真的；果然"
-        ],
-        "notation": "いかにも"
+        ]
     },
     {
         "name": "kouotsu",
         "trans": [
+            "甲乙(こうおつ)",
             "① 名  优劣，上下"
-        ],
-        "notation": "甲乙(こうおつ)"
+        ]
     },
     {
         "name": "ison",
         "trans": [
+            "依存(いそん)",
             "⓪ 名·自动3  依存，依靠"
-        ],
-        "notation": "依存(いそん)"
+        ]
     },
     {
         "name": "kakuho",
         "trans": [
+            "確保(かくほ)",
             "① 名·他动3  确保"
-        ],
-        "notation": "確保(かくほ)"
+        ]
     },
     {
         "name": "ateru",
         "trans": [
+            "宛(あ)てる",
             "⓪ 他动2  寄给，发给"
-        ],
-        "notation": "宛(あ)てる"
+        ]
     },
     {
         "name": "kyoudo",
         "trans": [
+            "郷土(きょうど)",
             "① 名  故乡；地方，乡间"
-        ],
-        "notation": "郷土(きょうど)"
+        ]
     },
     {
         "name": "sahanji",
         "trans": [
+            "茶飯事(さはんじ)",
             "② 名  常有的事"
-        ],
-        "notation": "茶飯事(さはんじ)"
+        ]
     },
     {
         "name": "terasu",
         "trans": [
+            "照(て)らす",
             "② 他动1  照耀，照射；按照，参照"
-        ],
-        "notation": "照(て)らす"
+        ]
     },
     {
         "name": "jisa",
         "trans": [
+            "時差(じさ)",
             "① 名  时差"
-        ],
-        "notation": "時差(じさ)"
+        ]
     },
     {
         "name": "kenzai",
         "trans": [
+            "顕在(けんざい)",
             "⓪ 名·自动3  显在，显然存在"
-        ],
-        "notation": "顕在(けんざい)"
+        ]
     },
     {
         "name": "habakaru",
         "trans": [
+            "憚(はばか)る",
             "③ 自他动1  忌惮，顾忌；有势力，当权"
-        ],
-        "notation": "憚(はばか)る"
+        ]
     },
     {
         "name": "sekyurithi-",
         "trans": [
+            "セキュリティー",
             "② 名  安全，安保"
-        ],
-        "notation": "セキュリティー"
+        ]
     },
     {
         "name": "hochou",
         "trans": [
+            "歩調(ほちょう)",
             "⓪ 名  步调"
-        ],
-        "notation": "歩調(ほちょう)"
+        ]
     },
     {
         "name": "utsumuku",
         "trans": [
+            "俯(うつむ)く",
             "③ 自动1  俯首，低头"
-        ],
-        "notation": "俯(うつむ)く"
+        ]
     },
     {
         "name": "kihin",
         "trans": [
+            "気品(きひん)",
             "⓪ 名  风度，气度"
-        ],
-        "notation": "気品(きひん)"
+        ]
     },
     {
         "name": "sashihiki",
         "trans": [
+            "差(さ)し引(ひ)き",
             "② 名·自他动3  扣除，减去；相抵"
-        ],
-        "notation": "差(さ)し引(ひ)き"
+        ]
     },
     {
         "name": "surikireru",
         "trans": [
+            "擦(す)り切(き)れる",
             "④ 自动2  磨损，磨破"
-        ],
-        "notation": "擦(す)り切(き)れる"
+        ]
     },
     {
         "name": "tsuutatsu",
         "trans": [
+            "通達(つうたつ)",
             "⓪ 名·自他动3  通知，通告；精通，熟悉"
-        ],
-        "notation": "通達(つうたつ)"
+        ]
     },
     {
         "name": "doufuu",
         "trans": [
+            "同封(どうふう)",
             "⓪ 名·他动3  附在信内，和信一起"
-        ],
-        "notation": "同封(どうふう)"
+        ]
     },
     {
         "name": "nanitozo",
         "trans": [
+            "なにとぞ",
             "⓪ 副  务必，请；设法，想办法"
-        ],
-        "notation": "なにとぞ"
+        ]
     },
     {
         "name": "paionia",
         "trans": [
+            "パイオニア",
             "⓪ 名  先驱，开拓者"
-        ],
-        "notation": "パイオニア"
+        ]
     },
     {
         "name": "bunsan",
         "trans": [
+            "分散(ぶんさん)",
             "⓪ 名·自动3  分散，散开"
-        ],
-        "notation": "分散(ぶんさん)"
+        ]
     },
     {
         "name": "marumaru",
         "trans": [
+            "丸々(まるまる)",
             "⓪ 副  完全，全部；（身材）溜圆"
-        ],
-        "notation": "丸々(まるまる)"
+        ]
     },
     {
         "name": "rittai",
         "trans": [
+            "立体(りったい)",
             "⓪ 名  立体"
-        ],
-        "notation": "立体(りったい)"
+        ]
     },
     {
         "name": "enshou",
         "trans": [
+            "炎症(えんしょう)",
             "⓪ 名  炎症，发炎"
-        ],
-        "notation": "炎症(えんしょう)"
+        ]
     },
     {
         "name": "itawaru",
         "trans": [
+            "労(いた)わる",
             "③ 他动1  照顾，关心；安慰，慰劳"
-        ],
-        "notation": "労(いた)わる"
+        ]
     },
     {
         "name": "kumiai",
         "trans": [
+            "組合(くみあい)",
             "⓪ 名  工会；行会"
-        ],
-        "notation": "組合(くみあい)"
+        ]
     },
     {
         "name": "jitsumu",
         "trans": [
+            "実務(じつむ)",
             "① 名  实际业务"
-        ],
-        "notation": "実務(じつむ)"
+        ]
     },
     {
         "name": "oshidasu",
         "trans": [
+            "押(お)し出(だ)す",
             "③ 自他动1  蜂拥而出；挤出；推出"
-        ],
-        "notation": "押(お)し出(だ)す"
+        ]
     },
     {
         "name": "gekiteki",
         "trans": [
+            "劇的(げきてき)",
             "⓪ ナ形  戏剧性的"
-        ],
-        "notation": "劇的(げきてき)"
+        ]
     },
     {
         "name": "seigi",
         "trans": [
+            "正義(せいぎ)",
             "① 名  正义"
-        ],
-        "notation": "正義(せいぎ)"
+        ]
     },
     {
         "name": "tsutomaru",
         "trans": [
+            "勤(つと)まる",
             "③ 自动1  胜任，能担任，干得来"
-        ],
-        "notation": "勤(つと)まる"
+        ]
     },
     {
         "name": "nintai",
         "trans": [
+            "忍耐(にんたい)",
             "① 名·自动3  忍耐，忍受"
-        ],
-        "notation": "忍耐(にんたい)"
+        ]
     },
     {
         "name": "pakke-ji",
         "trans": [
+            "パッケージ",
             "① 名·他动3  包装；成套商品"
-        ],
-        "notation": "パッケージ"
+        ]
     },
     {
         "name": "furikomu",
         "trans": [
+            "振(ふ)り込(こ)む",
             "③ 他动1  （往账户）存入，转账"
-        ],
-        "notation": "振(ふ)り込(こ)む"
+        ]
     },
     {
         "name": "mibae",
         "trans": [
+            "見栄(みば)え",
             "⓪ 名  （显得）好看，美观"
-        ],
-        "notation": "見栄(みば)え"
+        ]
     },
     {
         "name": "yuwakashi",
         "trans": [
+            "湯沸(ゆわ)かし",
             "② 名  烧水壶"
-        ],
-        "notation": "湯沸(ゆわ)かし"
+        ]
     },
     {
         "name": "imani",
         "trans": [
+            "今(いま)に",
             "① 副  至今，直到现在；不久，早晚"
-        ],
-        "notation": "今(いま)に"
+        ]
     },
     {
         "name": "kisai",
         "trans": [
+            "記載(きさい)",
             "⓪ 名·他动3  记载；刊登"
-        ],
-        "notation": "記載(きさい)"
+        ]
     },
     {
         "name": "jisui",
         "trans": [
+            "自炊(じすい)",
             "⓪ 名·自动3  自己做饭"
-        ],
-        "notation": "自炊(じすい)"
+        ]
     },
     {
         "name": "somuku",
         "trans": [
+            "背(そむ)く",
             "② 自动1  背向；违背，违抗；背叛"
-        ],
-        "notation": "背(そむ)く"
+        ]
     },
     {
         "name": "dasshutsu",
         "trans": [
+            "脱出(だっしゅつ)",
             "⓪ 名·自动3  逃脱，逃亡"
-        ],
-        "notation": "脱出(だっしゅつ)"
+        ]
     },
     {
         "name": "toppa",
         "trans": [
+            "突破(とっぱ)",
             "⓪ 名·他动3  突破，冲破；超过"
-        ],
-        "notation": "突破(とっぱ)"
+        ]
     },
     {
         "name": "nonoshiru",
         "trans": [
+            "罵(ののし)る",
             "③ 自他动1  骂，斥责"
-        ],
-        "notation": "罵(ののし)る"
+        ]
     },
     {
         "name": "biryou",
         "trans": [
+            "微量(びりょう)",
             "⓪ 名  微量，少量"
-        ],
-        "notation": "微量(びりょう)"
+        ]
     },
     {
         "name": "menjo",
         "trans": [
+            "免除(めんじょ)",
             "① 名·他动3  免除"
-        ],
-        "notation": "免除(めんじょ)"
+        ]
     },
     {
         "name": "yomoya",
         "trans": [
+            "よもや",
             "① 副  （后多接否定）未必，不至于"
-        ],
-        "notation": "よもや"
+        ]
     },
     {
         "name": "houtei",
         "trans": [
+            "法廷(ほうてい)",
             "⓪ 名  法庭"
-        ],
-        "notation": "法廷(ほうてい)"
+        ]
     },
     {
         "name": "dokusai",
         "trans": [
+            "独裁(どくさい)",
             "⓪ 名·自动3  独裁，专断"
-        ],
-        "notation": "独裁(どくさい)"
+        ]
     },
     {
         "name": "zokuzoku",
         "trans": [
+            "ぞくぞく",
             "① 副·自动3  打寒战；心情激动"
-        ],
-        "notation": "ぞくぞく"
+        ]
     },
     {
         "name": "dekore-shon",
         "trans": [
+            "デコレーション",
             "③ 名  装饰，装潢"
-        ],
-        "notation": "デコレーション"
+        ]
     },
     {
         "name": "shinri",
         "trans": [
+            "真理(しんり)",
             "① 名  真理"
-        ],
-        "notation": "真理(しんり)"
+        ]
     },
     {
         "name": "kuwadateru",
         "trans": [
+            "企(くわだ)てる",
             "④ 他动2  计划，企图，策划；打算，试图"
-        ],
-        "notation": "企(くわだ)てる"
+        ]
     },
     {
         "name": "umaretsuki",
         "trans": [
+            "生(う)まれつき",
             "⓪ 名·副  天生，生来"
-        ],
-        "notation": "生(う)まれつき"
+        ]
     },
     {
         "name": "ijuu",
         "trans": [
+            "移住(いじゅう)",
             "⓪ 名·自动3  移居（国外）"
-        ],
-        "notation": "移住(いじゅう)"
+        ]
     },
     {
         "name": "gacchiri",
         "trans": [
+            "がっちり",
             "③ 副·自动3  结实，牢靠；精打细算"
-        ],
-        "notation": "がっちり"
+        ]
     },
     {
         "name": "oyakata",
         "trans": [
+            "親方(おやかた)",
             "③ 名  老板；头目"
-        ],
-        "notation": "親方(おやかた)"
+        ]
     },
     {
         "name": "kyoukan",
         "trans": [
+            "共感(きょうかん)",
             "⓪ 名·自动3  同感，共鸣"
-        ],
-        "notation": "共感(きょうかん)"
+        ]
     },
     {
         "name": "hyotto",
         "trans": [
+            "ひょっと",
             "⓪ 副  突然，忽然；偶然"
-        ],
-        "notation": "ひょっと"
+        ]
     },
     {
         "name": "shitaji",
         "trans": [
+            "下地(したじ)",
             "⓪ 名  基础，准备；资质"
-        ],
-        "notation": "下地(したじ)"
+        ]
     },
     {
         "name": "haisou",
         "trans": [
+            "配送(はいそう)",
             "⓪ 名·他动3  配送，发送，寄出"
-        ],
-        "notation": "配送(はいそう)"
+        ]
     },
     {
         "name": "sesseto",
         "trans": [
+            "せっせと",
             "① 副  拼命地，一个劲儿地"
-        ],
-        "notation": "せっせと"
+        ]
     },
     {
         "name": "aza",
         "trans": [
+            "痣(あざ)",
             "② 名  痣；（被打出来的）青斑，红斑"
-        ],
-        "notation": "痣(あざ)"
+        ]
     },
     {
         "name": "kairyou",
         "trans": [
+            "改良(かいりょう)",
             "⓪ 名·他动3  改良"
-        ],
-        "notation": "改良(かいりょう)"
+        ]
     },
     {
         "name": "kumikomu",
         "trans": [
+            "組(く)み込(こ)む",
             "③ 他动1  编入；入伙"
-        ],
-        "notation": "組(く)み込(こ)む"
+        ]
     },
     {
         "name": "sakkaku",
         "trans": [
+            "錯覚(さっかく)",
             "⓪ 名·自动3  错觉，误会"
-        ],
-        "notation": "錯覚(さっかく)"
+        ]
     },
     {
         "name": "seihi",
         "trans": [
+            "成否(せいひ)",
             "① 名  成败，成功与否"
-        ],
-        "notation": "成否(せいひ)"
+        ]
     },
     {
         "name": "kokochiyoi",
         "trans": [
+            "心地(ここち)よい",
             "④ イ形  愉快的，爽快的，惬意的"
-        ],
-        "notation": "心地(ここち)よい"
+        ]
     },
     {
         "name": "infome-shon",
         "trans": [
+            "インフォメーション",
             "④ 名  信息，通知，报告；问讯处"
-        ],
-        "notation": "インフォメーション"
+        ]
     },
     {
         "name": "konokata",
         "trans": [
+            "この方(かた)",
             "② 名  以来，以后"
-        ],
-        "notation": "この方(かた)"
+        ]
     },
     {
         "name": "tsuburu",
         "trans": [
+            "瞑(つぶ)る",
             "⓪ 他动1  闭上眼睛；假装没看见"
-        ],
-        "notation": "瞑(つぶ)る"
+        ]
     },
     {
         "name": "haigo",
         "trans": [
+            "背後(はいご)",
             "① 名  背后；背地，幕后"
-        ],
-        "notation": "背後(はいご)"
+        ]
     },
     {
         "name": "henshin",
         "trans": [
+            "変身(へんしん)",
             "⓪ 名·自动3  变身，改变装束"
-        ],
-        "notation": "変身(へんしん)"
+        ]
     },
     {
         "name": "mihakarau",
         "trans": [
+            "見計(みはか)らう",
             "⓪ 他动1  斟酌；估计"
-        ],
-        "notation": "見計(みはか)らう"
+        ]
     },
     {
         "name": "rippou",
         "trans": [
+            "立法(りっぽう)",
             "⓪ 名  立法"
-        ],
-        "notation": "立法(りっぽう)"
+        ]
     },
     {
         "name": "ushiromuki",
         "trans": [
+            "後(うし)ろ向(む)き",
             "⓪ 名·ナ形  背对着；（态度）消极"
-        ],
-        "notation": "後(うし)ろ向(む)き"
+        ]
     },
     {
         "name": "ochiiru",
         "trans": [
+            "陥(おちい)る",
             "⓪ 自动1  陷入，坠入（不好的状态）"
-        ],
-        "notation": "陥(おちい)る"
+        ]
     },
     {
         "name": "keiyu",
         "trans": [
+            "経由(けいゆ)",
             "① 名·自动3  经由，途经；通过"
-        ],
-        "notation": "経由(けいゆ)"
+        ]
     },
     {
         "name": "soboku",
         "trans": [
+            "素朴(そぼく)",
             "⓪ 名·ナ形  朴素，淳朴；单纯"
-        ],
-        "notation": "素朴(そぼく)"
+        ]
     },
     {
         "name": "koru",
         "trans": [
+            "凝(こ)る",
             "① 自动1  肌肉酸痛；热衷；讲究"
-        ],
-        "notation": "凝(こ)る"
+        ]
     },
     {
         "name": "teitaku",
         "trans": [
+            "邸宅(ていたく)",
             "⓪ 名  宅邸，公馆"
-        ],
-        "notation": "邸宅(ていたく)"
+        ]
     },
     {
         "name": "nagori",
         "trans": [
+            "名残(なごり)",
             "③ 名  惜别，依恋；痕迹，残余"
-        ],
-        "notation": "名残(なごり)"
+        ]
     },
     {
         "name": "hikitoru",
         "trans": [
+            "引(ひ)き取(と)る",
             "③ 自他动1  退出；回去；取回，领回；收养"
-        ],
-        "notation": "引(ひ)き取(と)る"
+        ]
     },
     {
         "name": "bouzu",
         "trans": [
+            "坊主(ぼうず)",
             "① 名  和尚；光头；光秃秃"
-        ],
-        "notation": "坊主(ぼうず)"
+        ]
     },
     {
         "name": "mokka",
         "trans": [
+            "目下(もっか)",
             "① 名  当前，眼下"
-        ],
-        "notation": "目下(もっか)"
+        ]
     },
     {
         "name": "yorisou",
         "trans": [
+            "寄(よ)り添(そ)う",
             "③ 自动1  贴近，挨近"
-        ],
-        "notation": "寄(よ)り添(そ)う"
+        ]
     },
     {
         "name": "azayaka",
         "trans": [
+            "鮮(あざ)やか",
             "② ナ形  鲜明的，鲜艳的；巧妙的，熟练的"
-        ],
-        "notation": "鮮(あざ)やか"
+        ]
     },
     {
         "name": "kiryoku",
         "trans": [
+            "気力(きりょく)",
             "⓪ 名  精神，元气；魄力，勇气"
-        ],
-        "notation": "気力(きりょく)"
+        ]
     },
     {
         "name": "uruou",
         "trans": [
+            "潤(うるお)う",
             "③ 自动1  湿润；宽绰起来；受惠"
-        ],
-        "notation": "潤(うるお)う"
+        ]
     },
     {
         "name": "kokuyuu",
         "trans": [
+            "国有(こくゆう)",
             "⓪ 名  国有"
-        ],
-        "notation": "国有(こくゆう)"
+        ]
     },
     {
         "name": "ja-narisuto",
         "trans": [
+            "ジャーナリスト",
             "④ 名  记者；编辑"
-        ],
-        "notation": "ジャーナリスト"
+        ]
     },
     {
         "name": "moshikuha",
         "trans": [
+            "もしくは",
             "① 接续  或，或者"
-        ],
-        "notation": "もしくは"
+        ]
     },
     {
         "name": "tejou",
         "trans": [
+            "手錠(てじょう)",
             "⓪ 名  手铐"
-        ],
-        "notation": "手錠(てじょう)"
+        ]
     },
     {
         "name": "houka",
         "trans": [
+            "放火(ほうか)",
             "⓪ 名·自动3  放火，纵火"
-        ],
-        "notation": "放火(ほうか)"
+        ]
     },
     {
         "name": "tohoumonai",
         "trans": [
+            "途方(とほう)もない",
             "④ イ形  毫无道理的；出奇的，骇人听闻的"
-        ],
-        "notation": "途方(とほう)もない"
+        ]
     },
     {
         "name": "taibyou",
         "trans": [
+            "大病(たいびょう)",
             "① 名  重病，大病"
-        ],
-        "notation": "大病(たいびょう)"
+        ]
     },
     {
         "name": "tehon",
         "trans": [
+            "手本(てほん)",
             "② 名  字帖，范本；模范，榜样"
-        ],
-        "notation": "手本(てほん)"
+        ]
     },
     {
         "name": "kutabireru",
         "trans": [
+            "くたびれる",
             "④ 自动2  疲劳；用旧，穿旧"
-        ],
-        "notation": "くたびれる"
+        ]
     },
     {
         "name": "saiketsu",
         "trans": [
+            "裁決(さいけつ)",
             "① 名·他动3  裁决，裁断"
-        ],
-        "notation": "裁決(さいけつ)"
+        ]
     },
     {
         "name": "kyoukyuu",
         "trans": [
+            "供給(きょうきゅう)",
             "⓪ 名·他动3  供给，供应"
-        ],
-        "notation": "供給(きょうきゅう)"
+        ]
     },
     {
         "name": "kasuru",
         "trans": [
+            "掠(かす)る",
             "② 他动1  擦过，掠过"
-        ],
-        "notation": "掠(かす)る"
+        ]
     },
     {
         "name": "okurijou",
         "trans": [
+            "送(おく)り状(じょう)",
             "⓪ 名  发货单"
-        ],
-        "notation": "送(おく)り状(じょう)"
+        ]
     },
     {
         "name": "ashigatame",
         "trans": [
+            "足固(あしがた)め",
             "③ 名·自动3  打好基础，做好准备"
-        ],
-        "notation": "足固(あしがた)め"
+        ]
     },
     {
         "name": "kaishuu",
         "trans": [
+            "改修(かいしゅう)",
             "⓪ 名·他动3  修缮，整修，修复"
-        ],
-        "notation": "改修(かいしゅう)"
+        ]
     },
     {
         "name": "ikidooru",
         "trans": [
+            "憤(いきどお)る",
             "③ 自动1  愤怒，气愤，愤慨"
-        ],
-        "notation": "憤(いきどお)る"
+        ]
     },
     {
         "name": "kyoubai",
         "trans": [
+            "競売(きょうばい)",
             "⓪ 名·他动3  拍卖"
-        ],
-        "notation": "競売(きょうばい)"
+        ]
     },
     {
         "name": "kokorogamae",
         "trans": [
+            "心構(こころがま)え",
             "④ 名  思想准备，精神准备"
-        ],
-        "notation": "心構(こころがま)え"
+        ]
     },
     {
         "name": "sumasu",
         "trans": [
+            "澄(す)ます",
             "② 自他动1  集中注意力；装模作样；使清澈"
-        ],
-        "notation": "澄(す)ます"
+        ]
     },
     {
         "name": "shea",
         "trans": [
+            "シェア",
             "① 名  市场占有率，份额"
-        ],
-        "notation": "シェア"
+        ]
     },
     {
         "name": "sangaku",
         "trans": [
+            "山岳(さんがく)",
             "⓪ 名  山岳"
-        ],
-        "notation": "山岳(さんがく)"
+        ]
     },
     {
         "name": "demuku",
         "trans": [
+            "出向(でむ)く",
             "② 自动1  前往，前去"
-        ],
-        "notation": "出向(でむ)く"
+        ]
     },
     {
         "name": "daiyou",
         "trans": [
+            "代用(だいよう)",
             "⓪ 名·他动3  代替使用"
-        ],
-        "notation": "代用(だいよう)"
+        ]
     },
     {
         "name": "jisshitsu",
         "trans": [
+            "実質(じっしつ)",
             "⓪ 名  实质，本质"
-        ],
-        "notation": "実質(じっしつ)"
+        ]
     },
     {
         "name": "tsuranaru",
         "trans": [
+            "連(つら)なる",
             "③ 自动1  绵延，相连；列席，参加；关系到，关联"
-        ],
-        "notation": "連(つら)なる"
+        ]
     },
     {
         "name": "ninmu",
         "trans": [
+            "任務(にんむ)",
             "① 名  任务"
-        ],
-        "notation": "任務(にんむ)"
+        ]
     },
     {
         "name": "dorai",
         "trans": [
+            "ドライ",
             "② ナ形  干燥的；理智的，冷冰冰的"
-        ],
-        "notation": "ドライ"
+        ]
     },
     {
         "name": "harubaru",
         "trans": [
+            "はるばる",
             "③ 副  遥远；远道而来"
-        ],
-        "notation": "はるばる"
+        ]
     },
     {
         "name": "bunsouou",
         "trans": [
+            "分相応(ぶんそうおう)",
             "① 名·ナ形  合乎身份，与身份相称"
-        ],
-        "notation": "分相応(ぶんそうおう)"
+        ]
     },
     {
         "name": "madika",
         "trans": [
+            "間近(まぢか)",
             "① 名·ナ形  临近，眼前"
-        ],
-        "notation": "間近(まぢか)"
+        ]
     },
     {
         "name": "yamu",
         "trans": [
+            "病(や)む",
             "① 自他动1  生病；烦恼，忧心"
-        ],
-        "notation": "病(や)む"
+        ]
     },
     {
         "name": "ichiyou",
         "trans": [
+            "一様(いちよう)",
             "⓪ 名·ナ形  同样；寻常，平常"
-        ],
-        "notation": "一様(いちよう)"
+        ]
     },
     {
         "name": "fuchi",
         "trans": [
+            "縁(ふち)",
             "② 名  边缘；框架"
-        ],
-        "notation": "縁(ふち)"
+        ]
     },
     {
         "name": "kimuzukashii",
         "trans": [
+            "気難(きむずか)しい",
             "⓪ イ形  难以取悦的，不好伺候的"
-        ],
-        "notation": "気難(きむずか)しい"
+        ]
     },
     {
         "name": "genbaku",
         "trans": [
+            "原爆(げんばく)",
             "⓪ 名  原子弹"
-        ],
-        "notation": "原爆(げんばく)"
+        ]
     },
     {
         "name": "dessan",
         "trans": [
+            "デッサン",
             "① 名  素描，草图"
-        ],
-        "notation": "デッサン"
+        ]
     },
     {
         "name": "sorasu",
         "trans": [
+            "逸(そ)らす",
             "② 他动1  转移(视线)；岔开（话题）；错过（机会）"
-        ],
-        "notation": "逸(そ)らす"
+        ]
     },
     {
         "name": "hadome",
         "trans": [
+            "歯止(はど)め",
             "⓪ 名  车闸；制止，抑制"
-        ],
-        "notation": "歯止(はど)め"
+        ]
     },
     {
         "name": "chakkou",
         "trans": [
+            "着工(ちゃっこう)",
             "⓪ 名·自动3  动工，开工"
-        ],
-        "notation": "着工(ちゃっこう)"
+        ]
     },
     {
         "name": "nanraka",
         "trans": [
+            "なんらか",
             "④ 副  一些，某些，多少"
-        ],
-        "notation": "なんらか"
+        ]
     },
     {
         "name": "hikoku",
         "trans": [
+            "被告(ひこく)",
             "⓪ 名  被告"
-        ],
-        "notation": "被告(ひこく)"
+        ]
     },
     {
         "name": "honsuji",
         "trans": [
+            "本筋(ほんすじ)",
             "⓪ 名  主要情节；正题，本题"
-        ],
-        "notation": "本筋(ほんすじ)"
+        ]
     },
     {
         "name": "miharu",
         "trans": [
+            "見張(みは)る",
             "⓪ 他动1  瞠目而视；看守，监视"
-        ],
-        "notation": "見張(みは)る"
+        ]
     },
     {
         "name": "episo-do",
         "trans": [
+            "エピソード",
             "① 名  插曲，小故事；轶事，趣闻 "
-        ],
-        "notation": "エピソード"
+        ]
     },
     {
         "name": "keiri",
         "trans": [
+            "経理(けいり)",
             "① 名  财务，会计"
-        ],
-        "notation": "経理(けいり)"
+        ]
     },
     {
         "name": "shosuru",
         "trans": [
+            "処(しょ)する",
             "② 自他动3  处理，应付；处罚"
-        ],
-        "notation": "処(しょ)する"
+        ]
     },
     {
         "name": "zadankai",
         "trans": [
+            "座談会(ざだんかい)",
             "② 名  座谈会"
-        ],
-        "notation": "座談会(ざだんかい)"
+        ]
     },
     {
         "name": "chozou",
         "trans": [
+            "貯蔵(ちょぞう)",
             "⓪ 名·他动3  储藏，储存"
-        ],
-        "notation": "貯蔵(ちょぞう)"
+        ]
     },
     {
         "name": "douyara",
         "trans": [
+            "どうやら",
             "① 副  总算，好不容易才；仿佛，似乎"
-        ],
-        "notation": "どうやら"
+        ]
     },
     {
         "name": "hakyuu",
         "trans": [
+            "波及(はきゅう)",
             "⓪ 名·自动3  波及，影响"
-        ],
-        "notation": "波及(はきゅう)"
+        ]
     },
     {
         "name": "meishin",
         "trans": [
+            "迷信(めいしん)",
             "⓪ 名  迷信"
-        ],
-        "notation": "迷信(めいしん)"
+        ]
     },
     {
         "name": "abaku",
         "trans": [
+            "暴(あば)く",
             "② 他动1  挖，掘；揭发，揭露"
-        ],
-        "notation": "暴(あば)く"
+        ]
     },
     {
         "name": "ketsujo",
         "trans": [
+            "欠如(けつじょ)",
             "① 名·自动3  缺少，缺乏"
-        ],
-        "notation": "欠如(けつじょ)"
+        ]
     },
     {
         "name": "kaijo",
         "trans": [
+            "解除(かいじょ)",
             "① 名·他动3  废除；解除"
-        ],
-        "notation": "解除(かいじょ)"
+        ]
     },
     {
         "name": "saboru",
         "trans": [
+            "サボる",
             "② 自他动1  怠工；旷课，旷工"
-        ],
-        "notation": "サボる"
+        ]
     },
     {
         "name": "kontena-",
         "trans": [
+            "コンテナー",
             "① 名  集装箱，货柜"
-        ],
-        "notation": "コンテナー"
+        ]
     },
     {
         "name": "juuji",
         "trans": [
+            "従事(じゅうじ)",
             "① 名·自动3  从事"
-        ],
-        "notation": "従事(じゅうじ)"
+        ]
     },
     {
         "name": "hajiru",
         "trans": [
+            "恥(は)じる",
             "② 自他动2  羞愧，惭愧；败坏名誉"
-        ],
-        "notation": "恥(は)じる"
+        ]
     },
     {
         "name": "nenshou",
         "trans": [
+            "年少(ねんしょう)",
             "⓪ 名·ナ形  年少，年轻"
-        ],
-        "notation": "年少(ねんしょう)"
+        ]
     },
     {
         "name": "ho-mushikku",
         "trans": [
+            "ホームシック",
             "④ 名  想家，思乡"
-        ],
-        "notation": "ホームシック"
+        ]
     },
     {
         "name": "yueni",
         "trans": [
+            "ゆえに",
             "② 接续  故而，所以"
-        ],
-        "notation": "ゆえに"
+        ]
     },
     {
         "name": "ran'you",
         "trans": [
+            "濫用(らんよう)",
             "⓪ 名·他动3  滥用"
-        ],
-        "notation": "濫用(らんよう)"
+        ]
     },
     {
         "name": "unsou",
         "trans": [
+            "運送(うんそう)",
             "⓪ 名·他动3  运送，运输"
-        ],
-        "notation": "運送(うんそう)"
+        ]
     },
     {
         "name": "itoshii",
         "trans": [
+            "愛(いと)しい",
             "③ イ形  可爱的；可怜的"
-        ],
-        "notation": "愛(いと)しい"
+        ]
     },
     {
         "name": "kyuubou",
         "trans": [
+            "窮乏(きゅうぼう)",
             "⓪ 名·自动3  贫穷，贫困"
-        ],
-        "notation": "窮乏(きゅうぼう)"
+        ]
     },
     {
         "name": "shushi",
         "trans": [
+            "趣旨(しゅし)",
             "① 名  宗旨；主旨"
-        ],
-        "notation": "趣旨(しゅし)"
+        ]
     },
     {
         "name": "goshigoshi",
         "trans": [
+            "ごしごし",
             "① 副  使劲地（搓、擦）"
-        ],
-        "notation": "ごしごし"
+        ]
     },
     {
         "name": "samurai",
         "trans": [
+            "侍(さむらい)",
             "⓪ 名  武士；有骨气的人"
-        ],
-        "notation": "侍(さむらい)"
+        ]
     },
     {
         "name": "tousei",
         "trans": [
+            "統制(とうせい)",
             "⓪ 名·他动3  统制；统一管理"
-        ],
-        "notation": "統制(とうせい)"
+        ]
     },
     {
         "name": "tsutsushinde",
         "trans": [
+            "謹(つつし)んで",
             "③ 副  恭谨地"
-        ],
-        "notation": "謹(つつし)んで"
+        ]
     },
     {
         "name": "kyousei",
         "trans": [
+            "矯正(きょうせい)",
             "⓪ 名·他动3  矫正，纠正"
-        ],
-        "notation": "矯正(きょうせい)"
+        ]
     },
     {
         "name": "shicchou",
         "trans": [
+            "失調(しっちょう)",
             "⓪ 名·自动3  失调，不平衡"
-        ],
-        "notation": "失調(しっちょう)"
+        ]
     },
     {
         "name": "atakku",
         "trans": [
+            "アタック",
             "② 名·自他动3  攻击，进攻；挑战"
-        ],
-        "notation": "アタック"
+        ]
     },
     {
         "name": "ougon",
         "trans": [
+            "黄金(おうごん)",
             "⓪ 名  黄金；金钱"
-        ],
-        "notation": "黄金(おうごん)"
+        ]
     },
     {
         "name": "go-ruin",
         "trans": [
+            "ゴールイン",
             "③ 名·自动3  到达终点；进球；达到目的"
-        ],
-        "notation": "ゴールイン"
+        ]
     },
     {
         "name": "kanesonaeru",
         "trans": [
+            "兼(か)ね備(そな)える",
             "⑤ 他动2  （二者）兼备"
-        ],
-        "notation": "兼(か)ね備(そな)える"
+        ]
     },
     {
         "name": "zahyou",
         "trans": [
+            "座標(ざひょう)",
             "⓪ 名  （数学）坐标"
-        ],
-        "notation": "座標(ざひょう)"
+        ]
     },
     {
         "name": "tayou",
         "trans": [
+            "多様(たよう)",
             "⓪ 名·ナ形  各式各样，多种多样"
-        ],
-        "notation": "多様(たよう)"
+        ]
     },
     {
         "name": "suritsubusu",
         "trans": [
+            "擂(す)り潰(つぶ)す",
             "④ 他动1  研磨；损毁；挥霍"
-        ],
-        "notation": "擂(す)り潰(つぶ)す"
+        ]
     },
     {
         "name": "teichaku",
         "trans": [
+            "定着(ていちゃく)",
             "⓪ 名·自动3  扎根，固定，定居"
-        ],
-        "notation": "定着(ていちゃく)"
+        ]
     },
     {
         "name": "hason",
         "trans": [
+            "破損(はそん)",
             "⓪ 名·自他动3  破损，损坏"
-        ],
-        "notation": "破損(はそん)"
+        ]
     },
     {
         "name": "toriwake",
         "trans": [
+            "とりわけ",
             "⓪ 副  尤其，特别"
-        ],
-        "notation": "とりわけ"
+        ]
     },
     {
         "name": "hitonami",
         "trans": [
+            "人並(ひとな)み",
             "⓪ 名·ナ形  普通，一般"
-        ],
-        "notation": "人並(ひとな)み"
+        ]
     },
     {
         "name": "horumon",
         "trans": [
+            "ホルモン",
             "① 名  荷尔蒙，激素"
-        ],
-        "notation": "ホルモン"
+        ]
     },
     {
         "name": "muchakucha",
         "trans": [
+            "無茶苦茶(むちゃくちゃ)",
             "⓪ 名·ナ形  毫无道理；混乱；格外，过分"
-        ],
-        "notation": "無茶苦茶(むちゃくちゃ)"
+        ]
     },
     {
         "name": "riten",
         "trans": [
+            "利点(りてん)",
             "⓪ 名  长处，优点"
-        ],
-        "notation": "利点(りてん)"
+        ]
     },
     {
         "name": "arikata",
         "trans": [
+            "あり方(かた)",
             "③ 名  应有的状态，理想的状态"
-        ],
-        "notation": "あり方(かた)"
+        ]
     },
     {
         "name": "kishimu",
         "trans": [
+            "軋(きし)む",
             "② 自动1  嘎吱嘎吱作响"
-        ],
-        "notation": "軋(きし)む"
+        ]
     },
     {
         "name": "ikubun",
         "trans": [
+            "幾分(いくぶん)",
             "⓪ 名·副  一部分；少许，一点儿"
-        ],
-        "notation": "幾分(いくぶん)"
+        ]
     },
     {
         "name": "enshutsu",
         "trans": [
+            "演出(えんしゅつ)",
             "⓪ 名·他动3  导演；组织安排"
-        ],
-        "notation": "演出(えんしゅつ)"
+        ]
     },
     {
         "name": "kodawaru",
         "trans": [
+            "拘(こだわ)る",
             "③ 自动1  拘泥；讲究"
-        ],
-        "notation": "拘(こだわ)る"
+        ]
     },
     {
         "name": "kukaku",
         "trans": [
+            "区画(くかく)",
             "⓪ 名·他动3  区划，划分"
-        ],
-        "notation": "区画(くかく)"
+        ]
     },
     {
         "name": "jougi",
         "trans": [
+            "定規(じょうぎ)",
             "① 名  尺；尺度，标准"
-        ],
-        "notation": "定規(じょうぎ)"
+        ]
     },
     {
         "name": "soreha",
         "trans": [
+            "それは",
             "⓪ 叹  那可真是"
-        ],
-        "notation": "それは"
+        ]
     },
     {
         "name": "negirau",
         "trans": [
+            "労(ねぎら)う",
             "③ 他动1  慰劳，犒劳"
-        ],
-        "notation": "労(ねぎら)う"
+        ]
     },
     {
         "name": "chouin",
         "trans": [
+            "調印(ちょういん)",
             "⓪ 名·自动3  签订，签署"
-        ],
-        "notation": "調印(ちょういん)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "説(と)く",
             "① 他动1  解释，说明；劝说；提倡"
-        ],
-        "notation": "説(と)く"
+        ]
     },
     {
         "name": "tehazu",
         "trans": [
+            "手筈(てはず)",
             "① 名  程序，步骤，事前的准备"
-        ],
-        "notation": "手筈(てはず)"
+        ]
     },
     {
         "name": "nenji",
         "trans": [
+            "年次(ねんじ)",
             "① 名  年份，年度"
-        ],
-        "notation": "年次(ねんじ)"
+        ]
     },
     {
         "name": "harebareshii",
         "trans": [
+            "晴(は)れ晴(ば)れしい",
             "⑤ イ形  愉快的；明朗的；晴朗的"
-        ],
-        "notation": "晴(は)れ晴(ば)れしい"
+        ]
     },
     {
         "name": "puraido",
         "trans": [
+            "プライド",
             "⓪ 名  自尊心"
-        ],
-        "notation": "プライド"
+        ]
     },
     {
         "name": "mikai",
         "trans": [
+            "未開(みかい)",
             "⓪ 名  未开化，未开垦"
-        ],
-        "notation": "未開(みかい)"
+        ]
     },
     {
         "name": "moru",
         "trans": [
+            "漏(も)る",
             "① 自动1  漏，漏出，透出"
-        ],
-        "notation": "漏(も)る"
+        ]
     },
     {
         "name": "ichiren",
         "trans": [
+            "一連(いちれん)",
             "⓪ 名  一连串，一系列"
-        ],
-        "notation": "一連(いちれん)"
+        ]
     },
     {
         "name": "koukai",
         "trans": [
+            "後悔(こうかい)",
             "① 名·他动3  后悔"
-        ],
-        "notation": "後悔(こうかい)"
+        ]
     },
     {
         "name": "oshiyoseru",
         "trans": [
+            "押(お)し寄(よ)せる",
             "④ 自他动2  蜂拥而至；推到一边"
-        ],
-        "notation": "押(お)し寄(よ)せる"
+        ]
     },
     {
         "name": "kyoufu",
         "trans": [
+            "恐怖(きょうふ)",
             "① 名·自动3  恐怖，恐惧"
-        ],
-        "notation": "恐怖(きょうふ)"
+        ]
     },
     {
         "name": "shitto",
         "trans": [
+            "嫉妬(しっと)",
             "⓪ 名·他动3  嫉妒"
-        ],
-        "notation": "嫉妬(しっと)"
+        ]
     },
     {
         "name": "koumuru",
         "trans": [
+            "被(こうむ)る",
             "③ 他动1  蒙受，遭受；招致"
-        ],
-        "notation": "被(こうむ)る"
+        ]
     },
     {
         "name": "seiken",
         "trans": [
+            "政権(せいけん)",
             "⓪ 名  政权"
-        ],
-        "notation": "政権(せいけん)"
+        ]
     },
     {
         "name": "tojou",
         "trans": [
+            "途上(とじょう)",
             "⓪ 名  中途，途中"
-        ],
-        "notation": "途上(とじょう)"
+        ]
     },
     {
         "name": "shikarubeki",
         "trans": [
+            "しかるべき",
             "④ 连语  适当的，应有的，应当的"
-        ],
-        "notation": "しかるべき"
+        ]
     },
     {
         "name": "pafo-mansu",
         "trans": [
+            "パフォーマンス",
             "② 名  表演；效果，性能"
-        ],
-        "notation": "パフォーマンス"
+        ]
     },
     {
         "name": "asagata",
         "trans": [
+            "朝方(あさがた)",
             "② 名  早晨，清晨"
-        ],
-        "notation": "朝方(あさがた)"
+        ]
     },
     {
         "name": "kaijuu",
         "trans": [
+            "怪獣(かいじゅう)",
             "⓪ 名  怪兽"
-        ],
-        "notation": "怪獣(かいじゅう)"
+        ]
     },
     {
         "name": "shinayaka",
         "trans": [
+            "しなやか",
             "② ナ形  柔软的；柔和的，优美的"
-        ],
-        "notation": "しなやか"
+        ]
     },
     {
         "name": "ochido",
         "trans": [
+            "落(お)ち度(ど)",
             "① 名  过失，过错，疏忽，失误"
-        ],
-        "notation": "落(お)ち度(ど)"
+        ]
     },
     {
         "name": "kyacchi",
         "trans": [
+            "キャッチ",
             "① 名·他动3  捕捉，接收；接球"
-        ],
-        "notation": "キャッチ"
+        ]
     },
     {
         "name": "kotsukotsu",
         "trans": [
+            "こつこつ",
             "① 副  孜孜不倦，勤勉地"
-        ],
-        "notation": "こつこつ"
+        ]
     },
     {
         "name": "seihou",
         "trans": [
+            "製法(せいほう)",
             "⓪ 名  制法，做法"
-        ],
-        "notation": "製法(せいほう)"
+        ]
     },
     {
         "name": "tandoku",
         "trans": [
+            "単独(たんどく)",
             "⓪ 名·ナ形  单独，独自"
-        ],
-        "notation": "単独(たんどく)"
+        ]
     },
     {
         "name": "sureru",
         "trans": [
+            "擦(す)れる",
             "② 自动2  摩擦；磨损；久经世故，变得圆滑"
-        ],
-        "notation": "擦(す)れる"
+        ]
     },
     {
         "name": "douteki",
         "trans": [
+            "動的(どうてき)",
             "⓪ ナ形  具有动感的，生动的，活泼的"
-        ],
-        "notation": "動的(どうてき)"
+        ]
     },
     {
         "name": "teibou",
         "trans": [
+            "堤防(ていぼう)",
             "⓪ 名  堤，坝，堤防"
-        ],
-        "notation": "堤防(ていぼう)"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "慣(な)らす",
             "② 他动1  使习惯，使适应"
-        ],
-        "notation": "慣(な)らす"
+        ]
     },
     {
         "name": "hakugai",
         "trans": [
+            "迫害(はくがい)",
             "⓪ 名·他动3  迫害，虐待"
-        ],
-        "notation": "迫害(はくがい)"
+        ]
     },
     {
         "name": "bunan",
         "trans": [
+            "無難(ぶなん)",
             "⓪ 名·ナ形  无灾无难，平安；没有缺点，无可非议"
-        ],
-        "notation": "無難(ぶなん)"
+        ]
     },
     {
         "name": "mojimoji",
         "trans": [
+            "もじもじ",
             "① 副·自动3  扭扭捏捏"
-        ],
-        "notation": "もじもじ"
+        ]
     },
     {
         "name": "yangu",
         "trans": [
+            "ヤング",
             "① 名  年轻人，年轻一代"
-        ],
-        "notation": "ヤング"
+        ]
     },
     {
         "name": "ada",
         "trans": [
+            "仇(あだ)",
             "② 名  仇人；仇恨；危害"
-        ],
-        "notation": "仇(あだ)"
+        ]
     },
     {
         "name": "umekomu",
         "trans": [
+            "埋(う)め込(こ)む",
             "③ 他动1  埋进，埋入"
-        ],
-        "notation": "埋(う)め込(こ)む"
+        ]
     },
     {
         "name": "kengen",
         "trans": [
+            "権限(けんげん)",
             "③ 名  权限，职权范围"
-        ],
-        "notation": "権限(けんげん)"
+        ]
     },
     {
         "name": "sanbashi",
         "trans": [
+            "桟橋(さんばし)",
             "⓪ 名  码头，栈桥"
-        ],
-        "notation": "桟橋(さんばし)"
+        ]
     },
     {
         "name": "kukkiri",
         "trans": [
+            "くっきり",
             "③ 副·自动3  特别鲜明，清楚"
-        ],
-        "notation": "くっきり"
+        ]
     },
     {
         "name": "sutorobo",
         "trans": [
+            "ストロボ",
             "⓪ 名  闪光灯"
-        ],
-        "notation": "ストロボ"
+        ]
     },
     {
         "name": "dasaku",
         "trans": [
+            "駄作(ださく)",
             "⓪ 名  拙劣的作品，无价值的作品"
-        ],
-        "notation": "駄作(ださく)"
+        ]
     },
     {
         "name": "dounika",
         "trans": [
+            "どうにか",
             "① 副·自动3  想办法；总算，勉强"
-        ],
-        "notation": "どうにか"
+        ]
     },
     {
         "name": "hassan",
         "trans": [
+            "発散(はっさん)",
             "⓪ 名·自他动3  散发；发散，消散"
-        ],
-        "notation": "発散(はっさん)"
+        ]
     },
     {
         "name": "henkei",
         "trans": [
+            "変形(へんけい)",
             "⓪ 名·自他动3  变形"
-        ],
-        "notation": "変形(へんけい)"
+        ]
     },
     {
         "name": "yotte",
         "trans": [
+            "よって",
             "⓪ 接续  故而，因此"
-        ],
-        "notation": "よって"
+        ]
     },
     {
         "name": "in'you",
         "trans": [
+            "飲用(いんよう)",
             "⓪ 名·他动3  饮用，喝"
-        ],
-        "notation": "飲用(いんよう)"
+        ]
     },
     {
         "name": "katagawari",
         "trans": [
+            "肩代(かたが)わり",
             "③ 名·他动3  （债务、负担等）转移，更替"
-        ],
-        "notation": "肩代(かたが)わり"
+        ]
     },
     {
         "name": "shitagaeru",
         "trans": [
+            "従(したが)える",
             "⓪ 他动2  率领，带着；征服"
-        ],
-        "notation": "従(したが)える"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "起源(きげん)",
             "① 名  起源"
-        ],
-        "notation": "起源(きげん)"
+        ]
     },
     {
         "name": "jiku",
         "trans": [
+            "軸(じく)",
             "② 名  轴；核心，中心"
-        ],
-        "notation": "軸(じく)"
+        ]
     },
     {
         "name": "sendatte",
         "trans": [
+            "先(せん)だって",
             "⓪ 名·副  前几天，前些日子"
-        ],
-        "notation": "先(せん)だって"
+        ]
     },
     {
         "name": "tanaoroshi",
         "trans": [
+            "棚卸(たなおろ)し",
             "⓪ 名·自他动3  盘点，盘货"
-        ],
-        "notation": "棚卸(たなおろ)し"
+        ]
     },
     {
         "name": "sha-pu",
         "trans": [
+            "シャープ",
             "① ナ形  敏锐的；锋利的；清晰的"
-        ],
-        "notation": "シャープ"
+        ]
     },
     {
         "name": "tsuneru",
         "trans": [
+            "抓(つね)る",
             "② 他动1  掐，拧"
-        ],
-        "notation": "抓(つね)る"
+        ]
     },
     {
         "name": "hisshuu",
         "trans": [
+            "必修(ひっしゅう)",
             "⓪ 名  必修"
-        ],
-        "notation": "必修(ひっしゅう)"
+        ]
     },
     {
         "name": "boutou",
         "trans": [
+            "冒頭(ぼうとう)",
             "⓪ 名  （文章、讲话等的）开头部分"
-        ],
-        "notation": "冒頭(ぼうとう)"
+        ]
     },
     {
         "name": "isuwaru",
         "trans": [
+            "居座(いすわ)る",
             "③ 自动1  赖着不走；留任，蝉联"
-        ],
-        "notation": "居座(いすわ)る"
+        ]
     },
     {
         "name": "kanmuri",
         "trans": [
+            "冠(かんむり)",
             "⓪ 名  冠，帽子"
-        ],
-        "notation": "冠(かんむり)"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "興業(こうぎょう)",
             "⓪ 名  振兴事业"
-        ],
-        "notation": "興業(こうぎょう)"
+        ]
     },
     {
         "name": "samayou",
         "trans": [
+            "さまよう",
             "③ 自动1  彷徨，徘徊；犹豫不决"
-        ],
-        "notation": "さまよう"
+        ]
     },
     {
         "name": "seisai",
         "trans": [
+            "精細(せいさい)",
             "⓪ 名·ナ形  详细，周详，细致"
-        ],
-        "notation": "精細(せいさい)"
+        ]
     },
     {
         "name": "tekishutsu",
         "trans": [
+            "摘出(てきしゅつ)",
             "⓪ 名·他动3  摘除，取出；指出"
-        ],
-        "notation": "摘出(てきしゅつ)"
+        ]
     },
     {
         "name": "shonbori",
         "trans": [
+            "しょんぼり",
             "③ 副·自动3  无精打采，垂头丧气"
-        ],
-        "notation": "しょんぼり"
+        ]
     },
     {
         "name": "chochiku",
         "trans": [
+            "貯蓄(ちょちく)",
             "⓪ 名·他动3  储蓄，积蓄"
-        ],
-        "notation": "貯蓄(ちょちく)"
+        ]
     },
     {
         "name": "nobanashi",
         "trans": [
+            "野放(のばな)し",
             "② 名  放养（牲畜）；放任自流"
-        ],
-        "notation": "野放(のばな)し"
+        ]
     },
     {
         "name": "hiideru",
         "trans": [
+            "秀(ひい)でる",
             "③ 自动2  优秀，卓越；擅长，突出"
-        ],
-        "notation": "秀(ひい)でる"
+        ]
     },
     {
         "name": "bottou",
         "trans": [
+            "没頭(ぼっとう)",
             "⓪ 名·自动3  埋头，专心致志"
-        ],
-        "notation": "没頭(ぼっとう)"
+        ]
     },
     {
         "name": "mouten",
         "trans": [
+            "盲点(もうてん)",
             "① 名  盲点；漏洞"
-        ],
-        "notation": "盲点(もうてん)"
+        ]
     },
     {
         "name": "imanishite",
         "trans": [
+            "今(いま)にして",
             "① 连语  现在，如今"
-        ],
-        "notation": "今(いま)にして"
+        ]
     },
     {
         "name": "kuraimakkusu",
         "trans": [
+            "クライマックス",
             "④ 名  顶点，最高峰"
-        ],
-        "notation": "クライマックス"
+        ]
     },
     {
         "name": "shingi",
         "trans": [
+            "審議(しんぎ)",
             "① 名·他动3  审议"
-        ],
-        "notation": "審議(しんぎ)"
+        ]
     },
     {
         "name": "kojireru",
         "trans": [
+            "拗(こじ)れる",
             "③ 自动2  别扭；复杂化，恶化"
-        ],
-        "notation": "拗(こじ)れる"
+        ]
     },
     {
         "name": "tabou",
         "trans": [
+            "多忙(たぼう)",
             "⓪ 名·ナ形  繁忙，忙碌"
-        ],
-        "notation": "多忙(たぼう)"
+        ]
     },
     {
         "name": "fukin",
         "trans": [
+            "布巾(ふきん)",
             "② 名  抹布"
-        ],
-        "notation": "布巾(ふきん)"
+        ]
     },
     {
         "name": "dodai",
         "trans": [
+            "土台(どだい)",
             "⓪ 名·副  根基，基础；本来"
-        ],
-        "notation": "土台(どだい)"
+        ]
     },
     {
         "name": "bakuzen",
         "trans": [
+            "漠然(ばくぜん)",
             "⓪ ナ形  含糊的，笼统的，暧昧的"
-        ],
-        "notation": "漠然(ばくぜん)"
+        ]
     },
     {
         "name": "hoon",
         "trans": [
+            "保温(ほおん)",
             "⓪ 名·自动3  保温"
-        ],
-        "notation": "保温(ほおん)"
+        ]
     },
     {
         "name": "manzara",
         "trans": [
+            "まんざら",
             "⓪ 副  （后接否定）并非完全，未必一定"
-        ],
-        "notation": "まんざら"
+        ]
     },
     {
         "name": "etsuran",
         "trans": [
+            "閲覧(えつらん)",
             "⓪ 名·他动3  阅览"
-        ],
-        "notation": "閲覧(えつらん)"
+        ]
     },
     {
         "name": "kyatatsu",
         "trans": [
+            "脚立(きゃたつ)",
             "⓪ 名  人字梯"
-        ],
-        "notation": "脚立(きゃたつ)"
+        ]
     },
     {
         "name": "satoru",
         "trans": [
+            "悟(さと)る",
             "⓪ 他动1  知晓，领悟；察觉，发觉"
-        ],
-        "notation": "悟(さと)る"
+        ]
     },
     {
         "name": "kontorasuto",
         "trans": [
+            "コントラスト",
             "① 名  对比，对照"
-        ],
-        "notation": "コントラスト"
+        ]
     },
     {
         "name": "settai",
         "trans": [
+            "接待(せったい)",
             "① 名·他动3  接待，招待"
-        ],
-        "notation": "接待(せったい)"
+        ]
     },
     {
         "name": "tende",
         "trans": [
+            "てんで",
             "⓪ 副  完全，丝毫"
-        ],
-        "notation": "てんで"
+        ]
     },
     {
         "name": "chin'age",
         "trans": [
+            "賃上(ちんあ)げ",
             "⓪ 名·自动3  涨工资，加薪"
-        ],
-        "notation": "賃上(ちんあ)げ"
+        ]
     },
     {
         "name": "hitorimi",
         "trans": [
+            "独(ひと)り身(み)",
             "③ 名  单身，独身"
-        ],
-        "notation": "独(ひと)り身(み)"
+        ]
     },
     {
         "name": "todokooru",
         "trans": [
+            "滞(とどこお)る",
             "⓪ 自动1  堵塞；拖延，延误；拖欠"
-        ],
-        "notation": "滞(とどこお)る"
+        ]
     },
     {
         "name": "nankyoku",
         "trans": [
+            "難局(なんきょく)",
             "⓪ 名  困难局面"
-        ],
-        "notation": "難局(なんきょく)"
+        ]
     },
     {
         "name": "fuhai",
         "trans": [
+            "腐敗(ふはい)",
             "⓪ 名·自动3  腐坏，腐烂；腐败，堕落"
-        ],
-        "notation": "腐敗(ふはい)"
+        ]
     },
     {
         "name": "potto",
         "trans": [
+            "ぽっと",
             "⓪ 副·自动3  迷糊；突然燃烧；脸变红"
-        ],
-        "notation": "ぽっと"
+        ]
     },
     {
         "name": "manbiki",
         "trans": [
+            "万引(まんび)き",
             "⓪ 名·他动3  偷盗商店物品"
-        ],
-        "notation": "万引(まんび)き"
+        ]
     },
     {
         "name": "ri-do",
         "trans": [
+            "リード",
             "① 自他动3  领导，带领；领先"
-        ],
-        "notation": "リード"
+        ]
     },
     {
         "name": "abekobe",
         "trans": [
+            "あべこべ",
             "⓪ 名·ナ形  （顺序、位置等）相反，颠倒"
-        ],
-        "notation": "あべこべ"
+        ]
     },
     {
         "name": "kiyo",
         "trans": [
+            "寄与(きよ)",
             "① 名·自动3  贡献，有助于"
-        ],
-        "notation": "寄与(きよ)"
+        ]
     },
     {
         "name": "kokutei",
         "trans": [
+            "国定(こくてい)",
             "⓪ 名  国家规定"
-        ],
-        "notation": "国定(こくてい)"
+        ]
     },
     {
         "name": "kasamu",
         "trans": [
+            "嵩(かさ)む",
             "⓪ 自动1  体积增大，数量增多"
-        ],
-        "notation": "嵩(かさ)む"
+        ]
     },
     {
         "name": "eri-to",
         "trans": [
+            "エリート",
             "② 名  精英，尖子"
-        ],
-        "notation": "エリート"
+        ]
     },
     {
         "name": "shitsunen",
         "trans": [
+            "失念(しつねん)",
             "⓪ 名·他动3  忘记，遗忘"
-        ],
-        "notation": "失念(しつねん)"
+        ]
     },
     {
         "name": "surudoi",
         "trans": [
+            "鋭(するど)い",
             "③ イ形  锋利的；尖锐的；敏锐的"
-        ],
-        "notation": "鋭(するど)い"
+        ]
     },
     {
         "name": "chikusan",
         "trans": [
+            "畜産(ちくさん)",
             "⓪ 名  畜产，畜牧"
-        ],
-        "notation": "畜産(ちくさん)"
+        ]
     },
     {
         "name": "torauma",
         "trans": [
+            "トラウマ",
             "⓪ 名  心灵创伤，心理阴影"
-        ],
-        "notation": "トラウマ"
+        ]
     },
     {
         "name": "namihazureru",
         "trans": [
+            "並外(なみはず)れる",
             "⓪ 自动2  超出常规，不寻常"
-        ],
-        "notation": "並外(なみはず)れる"
+        ]
     },
     {
         "name": "ban'nin",
         "trans": [
+            "番人(ばんにん)",
             "③ 名  值班人，看守人"
-        ],
-        "notation": "番人(ばんにん)"
+        ]
     },
     {
         "name": "mikomi",
         "trans": [
+            "見込(みこ)み",
             "⓪ 名  希望；可能性；预料"
-        ],
-        "notation": "見込(みこ)み"
+        ]
     },
     {
         "name": "kareru",
         "trans": [
+            "嗄(か)れる",
             "⓪ 自动2  （声音）嘶哑"
-        ],
-        "notation": "嗄(か)れる"
+        ]
     },
     {
         "name": "uchiage",
         "trans": [
+            "打(う)ち上(あ)げ",
             "⓪ 名  发射；演出结束，比赛结束"
-        ],
-        "notation": "打(う)ち上(あ)げ"
+        ]
     },
     {
         "name": "geraku",
         "trans": [
+            "下落(げらく)",
             "⓪ 名·自动3  （物价等）下跌，降落；（等级等）降低"
-        ],
-        "notation": "下落(げらく)"
+        ]
     },
     {
         "name": "omakeni",
         "trans": [
+            "おまけに",
             "⓪ 接续  加之，而且"
-        ],
-        "notation": "おまけに"
+        ]
     },
     {
         "name": "kokkei",
         "trans": [
+            "滑稽(こっけい)",
             "⓪ 名·ナ形  滑稽，诙谐"
-        ],
-        "notation": "滑稽(こっけい)"
+        ]
     },
     {
         "name": "samagawari",
         "trans": [
+            "様変(さまが)わり",
             "③ 名·自动3  情况发生变化；行情突变"
-        ],
-        "notation": "様変(さまが)わり"
+        ]
     },
     {
         "name": "soru",
         "trans": [
+            "反(そ)る",
             "① 自动1  翘，弯曲；身子向后弯"
-        ],
-        "notation": "反(そ)る"
+        ]
     },
     {
         "name": "taimusa-bisu",
         "trans": [
+            "タイムサービス",
             "④ 名  限时特卖"
-        ],
-        "notation": "タイムサービス"
+        ]
     },
     {
         "name": "doutoku",
         "trans": [
+            "道徳(どうとく)",
             "⓪ 名  道德"
-        ],
-        "notation": "道徳(どうとく)"
+        ]
     },
     {
         "name": "nagomu",
         "trans": [
+            "和(なご)む",
             "② 自动1  平静下来，温和起来"
-        ],
-        "notation": "和(なご)む"
+        ]
     },
     {
         "name": "han'nou",
         "trans": [
+            "反応(はんのう)",
             "⓪ 名·自动3  反应；反响"
-        ],
-        "notation": "反応(はんのう)"
+        ]
     },
     {
         "name": "mottenohoka",
         "trans": [
+            "もってのほか",
             "③ 名·ナ形  荒谬，岂有此理"
-        ],
-        "notation": "もってのほか"
+        ]
     },
     {
         "name": "horu",
         "trans": [
+            "彫(ほ)る",
             "① 他动1  雕刻，篆刻"
-        ],
-        "notation": "彫(ほ)る"
+        ]
     },
     {
         "name": "shougi",
         "trans": [
+            "将棋(しょうぎ)",
             "⓪ 名  日本象棋"
-        ],
-        "notation": "将棋(しょうぎ)"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "当(あ)たり",
             "⓪ 名  命中，打中；中奖，中签；成功；待人处事；感觉"
-        ],
-        "notation": "当(あ)たり"
+        ]
     },
     {
         "name": "gainen",
         "trans": [
+            "概念(がいねん)",
             "① 名  概念"
-        ],
-        "notation": "概念(がいねん)"
+        ]
     },
     {
         "name": "imashimeru",
         "trans": [
+            "戒(いまし)める",
             "④ 他动2  劝诫，劝告；禁止，戒；警惕"
-        ],
-        "notation": "戒(いまし)める"
+        ]
     },
     {
         "name": "kizashi",
         "trans": [
+            "兆(きざ)し",
             "⓪ 名  兆头，征兆；苗头，眉目"
-        ],
-        "notation": "兆(きざ)し"
+        ]
     },
     {
         "name": "jiei",
         "trans": [
+            "自営(じえい)",
             "⓪ 名·他动3  个体经营，独立经营"
-        ],
-        "notation": "自営(じえい)"
+        ]
     },
     {
         "name": "kusuguru",
         "trans": [
+            "くすぐる",
             "⓪ 他动1  使发痒；逗笑；激起，引发"
-        ],
-        "notation": "くすぐる"
+        ]
     },
     {
         "name": "seisaku",
         "trans": [
+            "政策(せいさく)",
             "⓪ 名  政策"
-        ],
-        "notation": "政策(せいさく)"
+        ]
     },
     {
         "name": "chuugaeri",
         "trans": [
+            "宙返(ちゅうがえ)り",
             "③ 名·自动3  翻跟头"
-        ],
-        "notation": "宙返(ちゅうがえ)り"
+        ]
     },
     {
         "name": "tsuraneru",
         "trans": [
+            "連(つら)ねる",
             "③ 他动2  排列成行；罗列；连同"
-        ],
-        "notation": "連(つら)ねる"
+        ]
     },
     {
         "name": "tairu",
         "trans": [
+            "タイル",
             "① 名  瓷砖，花砖"
-        ],
-        "notation": "タイル"
+        ]
     },
     {
         "name": "tojimari",
         "trans": [
+            "戸締(とじま)り",
             "② 名·自动3  锁门，锁紧门户"
-        ],
-        "notation": "戸締(とじま)り"
+        ]
     },
     {
         "name": "nayamashii",
         "trans": [
+            "悩(なや)ましい",
             "④ イ形  烦恼的，苦恼的"
-        ],
-        "notation": "悩(なや)ましい"
+        ]
     },
     {
         "name": "hatan",
         "trans": [
+            "破綻(はたん)",
             "⓪ 名·自动3  （谈判）破裂；失败；破产"
-        ],
-        "notation": "破綻(はたん)"
+        ]
     },
     {
         "name": "houkai",
         "trans": [
+            "崩壊(ほうかい)",
             "⓪ 名·自动3  崩溃，垮台"
-        ],
-        "notation": "崩壊(ほうかい)"
+        ]
     },
     {
         "name": "hyottosuruto",
         "trans": [
+            "ひょっとすると",
             "⓪ 副  或许，说不定"
-        ],
-        "notation": "ひょっとすると"
+        ]
     },
     {
         "name": "mine",
         "trans": [
+            "峰(みね)",
             "② 名  山峰；刀背；凸起部分"
-        ],
-        "notation": "峰(みね)"
+        ]
     },
     {
         "name": "shutsudai",
         "trans": [
+            "出題(しゅつだい)",
             "⓪ 名·自他动3  （考试、诗歌等）出题"
-        ],
-        "notation": "出題(しゅつだい)"
+        ]
     },
     {
         "name": "yorikakaru",
         "trans": [
+            "寄(よ)り掛(か)かる",
             "④ 自动1  依靠，依赖"
-        ],
-        "notation": "寄(よ)り掛(か)かる"
+        ]
     },
     {
         "name": "utsushi",
         "trans": [
+            "写(うつ)し",
             "③ 名  副本，抄本"
-        ],
-        "notation": "写(うつ)し"
+        ]
     },
     {
         "name": "keta",
         "trans": [
+            "桁(けた)",
             "⓪ 名  （数字的）位数"
-        ],
-        "notation": "桁(けた)"
+        ]
     },
     {
         "name": "shikiru",
         "trans": [
+            "仕切(しき)る",
             "② 他动1  隔开，间隔；掌管，全权处理"
-        ],
-        "notation": "仕切(しき)る"
+        ]
     },
     {
         "name": "sanpuku",
         "trans": [
+            "山腹(さんぷく)",
             "⓪ 名  山腰"
-        ],
-        "notation": "山腹(さんぷく)"
+        ]
     },
     {
         "name": "konpurekkusu",
         "trans": [
+            "コンプレックス",
             "④ 名  情结；自卑感"
-        ],
-        "notation": "コンプレックス"
+        ]
     },
     {
         "name": "tsugeru",
         "trans": [
+            "告(つ)げる",
             "⓪ 他动2  告知，通知；宣告"
-        ],
-        "notation": "告(つ)げる"
+        ]
     },
     {
         "name": "dotanba",
         "trans": [
+            "土壇場(どたんば)",
             "⓪ 名  绝境，最后关头"
-        ],
-        "notation": "土壇場(どたんば)"
+        ]
     },
     {
         "name": "shugei",
         "trans": [
+            "手芸(しゅげい)",
             "⓪ 名  手工艺，手艺"
-        ],
-        "notation": "手芸(しゅげい)"
+        ]
     },
     {
         "name": "nozomu",
         "trans": [
+            "臨(のぞ)む",
             "⓪ 自动1  面临；出席，参加"
-        ],
-        "notation": "臨(のぞ)む"
+        ]
     },
     {
         "name": "haizoku",
         "trans": [
+            "配属(はいぞく)",
             "⓪ 名·他动3  分配，调配"
-        ],
-        "notation": "配属(はいぞく)"
+        ]
     },
     {
         "name": "funtou",
         "trans": [
+            "奮闘(ふんとう)",
             "⓪ 名·自动3  奋斗；奋战"
-        ],
-        "notation": "奮闘(ふんとう)"
+        ]
     },
     {
         "name": "hometataeru",
         "trans": [
+            "褒(ほ)め称(たた)える",
             "⑤ 他动2  极力称赞，盛赞 "
-        ],
-        "notation": "褒(ほ)め称(たた)える"
+        ]
     },
     {
         "name": "gishi",
         "trans": [
+            "技師(ぎし)",
             "① 名  工程师，技师"
-        ],
-        "notation": "技師(ぎし)"
+        ]
     },
     {
         "name": "jiga",
         "trans": [
+            "自我(じが)",
             "① 名  自己，自我"
-        ],
-        "notation": "自我(じが)"
+        ]
     },
     {
         "name": "kasuru",
         "trans": [
+            "課(か)する",
             "② 他动3  使负担；使担任，使做某事"
-        ],
-        "notation": "課(か)する"
+        ]
     },
     {
         "name": "socchoku",
         "trans": [
+            "率直(そっちょく)",
             "⓪ ナ形  坦率的，爽快的"
-        ],
-        "notation": "率直(そっちょく)"
+        ]
     },
     {
         "name": "kousui",
         "trans": [
+            "香水(こうすい)",
             "⓪ 名  香水"
-        ],
-        "notation": "香水(こうすい)"
+        ]
     },
     {
         "name": "amanjiru",
         "trans": [
+            "甘(あま)んじる",
             "④ 自动2  甘愿，情愿；满足，忍受"
-        ],
-        "notation": "甘(あま)んじる"
+        ]
     },
     {
         "name": "settou",
         "trans": [
+            "窃盗(せっとう)",
             "⓪ 名·他动3  盗窃，偷盗"
-        ],
-        "notation": "窃盗(せっとう)"
+        ]
     },
     {
         "name": "fubi",
         "trans": [
+            "不備(ふび)",
             "① 名·ナ形  不完备，不齐全"
-        ],
-        "notation": "不備(ふび)"
+        ]
     },
     {
         "name": "hitasura",
         "trans": [
+            "ひたすら",
             "⓪ 副  只顾，一味，一个劲儿地"
-        ],
-        "notation": "ひたすら"
+        ]
     },
     {
         "name": "ho-su",
         "trans": [
+            "ホース",
             " ① 名  软管，胶皮管"
-        ],
-        "notation": "ホース"
+        ]
     },
     {
         "name": "renmei",
         "trans": [
+            "連盟(れんめい)",
             "⓪ 名  联盟，联合会"
-        ],
-        "notation": "連盟(れんめい)"
+        ]
     },
     {
         "name": "ureeru",
         "trans": [
+            "憂(うれ)える",
             "③ 他动2  忧虑，担心"
-        ],
-        "notation": "憂(うれ)える"
+        ]
     },
     {
         "name": "kingan",
         "trans": [
+            "近眼(きんがん)",
             "⓪ 名  近视眼"
-        ],
-        "notation": "近眼(きんがん)"
+        ]
     },
     {
         "name": "shakou",
         "trans": [
+            "社交(しゃこう)",
             "⓪ 名  社交，交际"
-        ],
-        "notation": "社交(しゃこう)"
+        ]
     },
     {
         "name": "kawasu",
         "trans": [
+            "交(か)わす",
             "⓪ 他动1  交，交换；交错，交叉"
-        ],
-        "notation": "交(か)わす"
+        ]
     },
     {
         "name": "attoho-mu",
         "trans": [
+            "アットホーム",
             "④ ナ形  舒适的，无拘无束的"
-        ],
-        "notation": "アットホーム"
+        ]
     },
     {
         "name": "seishi",
         "trans": [
+            "制止(せいし)",
             "⓪ 名·他动3  制止，阻止"
-        ],
-        "notation": "制止(せいし)"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "馴(な)らす",
             "② 他动1  驯服，驯养"
-        ],
-        "notation": "馴(な)らす"
+        ]
     },
     {
         "name": "zougen",
         "trans": [
+            "増減(ぞうげん)",
             "⓪ 名·自他动3  增减，增加和减少"
-        ],
-        "notation": "増減(ぞうげん)"
+        ]
     },
     {
         "name": "shutsudou",
         "trans": [
+            "出動(しゅつどう)",
             "⓪ 名·自动3  出动"
-        ],
-        "notation": "出動(しゅつどう)"
+        ]
     },
     {
         "name": "hadasamui",
         "trans": [
+            "肌寒(はださむ)い",
             "④ イ形  略感寒意的；毛骨悚然的"
-        ],
-        "notation": "肌寒(はださむ)い"
+        ]
     },
     {
         "name": "deban",
         "trans": [
+            "出番(でばん)",
             "⓪ 名  值班；出场"
-        ],
-        "notation": "出番(でばん)"
+        ]
     },
     {
         "name": "ho-muresu",
         "trans": [
+            "ホームレス",
             "① 名  无家可归的人"
-        ],
-        "notation": "ホームレス"
+        ]
     },
     {
         "name": "moyoosu",
         "trans": [
+            "催(もよお)す",
             "③ 他动1  举行，举办；感觉（要⋯⋯）"
-        ],
-        "notation": "催(もよお)す"
+        ]
     },
     {
         "name": "sanpi",
         "trans": [
+            "賛否(さんぴ)",
             "① 名  赞成与否"
-        ],
-        "notation": "賛否(さんぴ)"
+        ]
     },
     {
         "name": "koukai",
         "trans": [
+            "公開(こうかい)",
             "⓪ 名·他动3  公开"
-        ],
-        "notation": "公開(こうかい)"
+        ]
     },
     {
         "name": "sarau",
         "trans": [
+            "攫(さら)う",
             "⓪ 他动1  掠夺，夺取；赢得，取得"
-        ],
-        "notation": "攫(さら)う"
+        ]
     },
     {
         "name": "oogara",
         "trans": [
+            "大柄(おおがら)",
             "⓪ 名·ナ形  大花纹；体格大，骨架大"
-        ],
-        "notation": "大柄(おおがら)"
+        ]
     },
     {
         "name": "bakuha",
         "trans": [
+            "爆破(ばくは)",
             "⓪ 名·他动3  爆破，炸毁"
-        ],
-        "notation": "爆破(ばくは)"
+        ]
     },
     {
         "name": "ayakaru",
         "trans": [
+            "あやかる",
             "③ 自动1  相似，效仿；跟着沾光"
-        ],
-        "notation": "あやかる"
+        ]
     },
     {
         "name": "kishitsu",
         "trans": [
+            "気質(きしつ)",
             "⓪ 名  秉性，性格"
-        ],
-        "notation": "気質(きしつ)"
+        ]
     },
     {
         "name": "oshiego",
         "trans": [
+            "教(おし)え子(ご)",
             "⓪ 名  学生，徒弟"
-        ],
-        "notation": "教(おし)え子(ご)"
+        ]
     },
     {
         "name": "kuchizusamu",
         "trans": [
+            "口(くち)ずさむ",
             "④ 他动1  吟，诵；哼唱"
-        ],
-        "notation": "口(くち)ずさむ"
+        ]
     },
     {
         "name": "shitashirabe",
         "trans": [
+            "下調(したしら)べ",
             "③ 名·他动3  预先调查；预习"
-        ],
-        "notation": "下調(したしら)べ"
+        ]
     },
     {
         "name": "tenshon",
         "trans": [
+            "テンション",
             "① 名  紧张，兴奋"
-        ],
-        "notation": "テンション"
+        ]
     },
     {
         "name": "sateha",
         "trans": [
+            "さては",
             "① 接续·叹  还有，再加上；这样说来；原来是"
-        ],
-        "notation": "さては"
+        ]
     },
     {
         "name": "irie",
         "trans": [
+            "入(い)り江(え)",
             "⓪ 名  海湾，河口湾"
-        ],
-        "notation": "入(い)り江(え)"
+        ]
     },
     {
         "name": "daihon",
         "trans": [
+            "台本(だいほん)",
             "⓪ 名  剧本，脚本"
-        ],
-        "notation": "台本(だいほん)"
+        ]
     },
     {
         "name": "sureau",
         "trans": [
+            "擦(す)れ合(あ)う",
             "③ 自动1  互相摩擦；闹矛盾"
-        ],
-        "notation": "擦(す)れ合(あ)う"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "試行(しこう)",
             "⓪ 名·他动3  试行，试验"
-        ],
-        "notation": "試行(しこう)"
+        ]
     },
     {
         "name": "chuukei",
         "trans": [
+            "中継(ちゅうけい)",
             "⓪ 名·他动3  中转；转播"
-        ],
-        "notation": "中継(ちゅうけい)"
+        ]
     },
     {
         "name": "torimazeru",
         "trans": [
+            "取(と)り混(ま)ぜる",
             "④ 他动2  掺杂，混合"
-        ],
-        "notation": "取(と)り混(ま)ぜる"
+        ]
     },
     {
         "name": "ba-ko-do",
         "trans": [
+            "バーコード",
             "③ 名  条形码"
-        ],
-        "notation": "バーコード"
+        ]
     },
     {
         "name": "fushi",
         "trans": [
+            "節(ふし)",
             "② 名  竹节；关节；地方，点；曲调"
-        ],
-        "notation": "節(ふし)"
+        ]
     },
     {
         "name": "megumu",
         "trans": [
+            "恵(めぐ)む",
             "⓪ 他动1  怜恤，施恩惠，救济"
-        ],
-        "notation": "恵(めぐ)む"
+        ]
     },
     {
         "name": "iken",
         "trans": [
+            "異見(いけん)",
             "⓪ 名  异议，不同见解"
-        ],
-        "notation": "異見(いけん)"
+        ]
     },
     {
         "name": "jizai",
         "trans": [
+            "自在(じざい)",
             "⓪ 名·ナ形  自由自在，随意"
-        ],
-        "notation": "自在(じざい)"
+        ]
     },
     {
         "name": "katachidukuru",
         "trans": [
+            "形作(かたちづく)る",
             "⑤ 他动1  形成，构成"
-        ],
-        "notation": "形作(かたちづく)る"
+        ]
     },
     {
         "name": "ate",
         "trans": [
+            "当(あ)て",
             "⓪ 名  目的，目标；期待，指望"
-        ],
-        "notation": "当(あ)て"
+        ]
     },
     {
         "name": "kaisei",
         "trans": [
+            "快晴(かいせい)",
             "⓪ 名  晴朗的天气"
-        ],
-        "notation": "快晴(かいせい)"
+        ]
     },
     {
         "name": "imanimo",
         "trans": [
+            "今(いま)にも",
             "① 副  眼看就要，马上"
-        ],
-        "notation": "今(いま)にも"
+        ]
     },
     {
         "name": "jiten",
         "trans": [
+            "自転(じてん)",
             "⓪ 名·自动3  自转"
-        ],
-        "notation": "自転(じてん)"
+        ]
     },
     {
         "name": "orijinaru",
         "trans": [
+            "オリジナル",
             "② 名·ナ形  原创，独创"
-        ],
-        "notation": "オリジナル"
+        ]
     },
     {
         "name": "kenasu",
         "trans": [
+            "貶(けな)す",
             "⓪ 他动1  贬低，诋毁，诽谤"
-        ],
-        "notation": "貶(けな)す"
+        ]
     },
     {
         "name": "gyoushuku",
         "trans": [
+            "凝縮(ぎょうしゅく)",
             "⓪ 名·自动3  凝结"
-        ],
-        "notation": "凝縮(ぎょうしゅく)"
+        ]
     },
     {
         "name": "taidan",
         "trans": [
+            "対談(たいだん)",
             "⓪ 名·自动3  对谈，会谈"
-        ],
-        "notation": "対談(たいだん)"
+        ]
     },
     {
         "name": "kureguremo",
         "trans": [
+            "くれぐれも",
             "③ 副  反复，周到，仔细"
-        ],
-        "notation": "くれぐれも"
+        ]
     },
     {
         "name": "sekimu",
         "trans": [
+            "責務(せきむ)",
             "① 名  责任与义务，职责"
-        ],
-        "notation": "責務(せきむ)"
+        ]
     },
     {
         "name": "tsubomi",
         "trans": [
+            "蕾(つぼみ)",
             "③ 名  花蕾；未成年"
-        ],
-        "notation": "蕾(つぼみ)"
+        ]
     },
     {
         "name": "tojiru",
         "trans": [
+            "綴(と)じる",
             "② 他动2  订上；缝在一起"
-        ],
-        "notation": "綴(と)じる"
+        ]
     },
     {
         "name": "ibento",
         "trans": [
+            "イベント",
             "⓪ 名  活动，节目；事件"
-        ],
-        "notation": "イベント"
+        ]
     },
     {
         "name": "zouki",
         "trans": [
+            "雑木(ぞうき)",
             "⓪ 名  杂样的树木，不成材的树木"
-        ],
-        "notation": "雑木(ぞうき)"
+        ]
     },
     {
         "name": "nomikomu",
         "trans": [
+            "飲(の)み込(こ)む",
             "③ 他动1  咽下；理解，领会"
-        ],
-        "notation": "飲(の)み込(こ)む"
+        ]
     },
     {
         "name": "hitsuzen",
         "trans": [
+            "必然(ひつぜん)",
             "⓪ 名  必然"
-        ],
-        "notation": "必然(ひつぜん)"
+        ]
     },
     {
         "name": "juuyaku",
         "trans": [
+            "重役(じゅうやく)",
             "⓪ 名  重要角色，要职"
-        ],
-        "notation": "重役(じゅうやく)"
+        ]
     },
     {
         "name": "moreru",
         "trans": [
+            "漏(も)れる",
             "② 自动2  漏；泄露；遗漏；吐露"
-        ],
-        "notation": "漏(も)れる"
+        ]
     },
     {
         "name": "ensen",
         "trans": [
+            "沿線(えんせん)",
             "⓪ 名  （铁路）沿线"
-        ],
-        "notation": "沿線(えんせん)"
+        ]
     },
     {
         "name": "madashimo",
         "trans": [
+            "未(ま)だしも",
             "① 副  还算可以，还好"
-        ],
-        "notation": "未(ま)だしも"
+        ]
     },
     {
         "name": "tomadou",
         "trans": [
+            "戸惑(とまど)う",
             "③ 自动1  困惑，不知所措，踌躇"
-        ],
-        "notation": "戸惑(とまど)う"
+        ]
     },
     {
         "name": "shinkoku",
         "trans": [
+            "申告(しんこく)",
             "⓪ 名·他动3  申报，报告，呈报"
-        ],
-        "notation": "申告(しんこく)"
+        ]
     },
     {
         "name": "amakuchi",
         "trans": [
+            "甘口(あまくち)",
             "⓪ 名·ナ形  甜味的；喜欢吃甜的（人）；甜言蜜语"
-        ],
-        "notation": "甘口(あまくち)"
+        ]
     },
     {
         "name": "kanyuu",
         "trans": [
+            "加入(かにゅう)",
             "⓪ 名·自动3  加入，参加"
-        ],
-        "notation": "加入(かにゅう)"
+        ]
     },
     {
         "name": "umetateru",
         "trans": [
+            "埋(う)め立(た)てる",
             "④ 他动2  填海造地"
-        ],
-        "notation": "埋(う)め立(た)てる"
+        ]
     },
     {
         "name": "keiretsu",
         "trans": [
+            "系列(けいれつ)",
             "⓪ 名  系列，系统，体系"
-        ],
-        "notation": "系列(けいれつ)"
+        ]
     },
     {
         "name": "jouka",
         "trans": [
+            "浄化(じょうか)",
             "① 名·他动3  净化；纯洁化"
-        ],
-        "notation": "浄化(じょうか)"
+        ]
     },
     {
         "name": "kirihiraku",
         "trans": [
+            "切(き)り開(ひら)く",
             "④ 他动1  开拓，开辟；开垦"
-        ],
-        "notation": "切(き)り開(ひら)く"
+        ]
     },
     {
         "name": "saikuru",
         "trans": [
+            "サイクル",
             "① 名  周期，循环"
-        ],
-        "notation": "サイクル"
+        ]
     },
     {
         "name": "sotomawari",
         "trans": [
+            "外回(そとまわ)り",
             "③ 名  周围；外勤"
-        ],
-        "notation": "外回(そとまわ)り"
+        ]
     },
     {
         "name": "sumiyaka",
         "trans": [
+            "速(すみ)やか",
             "② ナ形  迅速的，及时的"
-        ],
-        "notation": "速(すみ)やか"
+        ]
     },
     {
         "name": "tebiki",
         "trans": [
+            "手引(てび)き",
             "① 名·他动3  入门书；辅导，启蒙；引荐；向导"
-        ],
-        "notation": "手引(てび)き"
+        ]
     },
     {
         "name": "hanataba",
         "trans": [
+            "花束(はなたば)",
             "② 名  花束"
-        ],
-        "notation": "花束(はなたば)"
+        ]
     },
     {
         "name": "naganaga",
         "trans": [
+            "長々(ながなが)",
             "③ 副  冗长，长时间；（身体伸展得）长长地"
-        ],
-        "notation": "長々(ながなが)"
+        ]
     },
     {
         "name": "bougai",
         "trans": [
+            "妨害(ぼうがい)",
             "⓪ 名·他动3  妨碍，干扰"
-        ],
-        "notation": "妨害(ぼうがい)"
+        ]
     },
     {
         "name": "michibata",
         "trans": [
+            "道端(みちばた)",
             "⓪ 名  路边，路旁"
-        ],
-        "notation": "道端(みちばた)"
+        ]
     },
     {
         "name": "susugu",
         "trans": [
+            "濯(すす)ぐ",
             "⓪ 他动1  洗，涮；漱口；洗掉，雪除"
-        ],
-        "notation": "濯(すす)ぐ"
+        ]
     },
     {
         "name": "pi-a-ru",
         "trans": [
+            "ピーアール",
             "③ 名  宣传活动，广告活动"
-        ],
-        "notation": "ピーアール"
+        ]
     },
     {
         "name": "jushin",
         "trans": [
+            "受診(じゅしん)",
             "⓪ 名·自他动3  就诊，接受诊断"
-        ],
-        "notation": "受診(じゅしん)"
+        ]
     },
     {
         "name": "ichikabachika",
         "trans": [
+            "一(いち)か八(ばち)か",
             "④ 连语  碰运气，听天由命"
-        ],
-        "notation": "一(いち)か八(ばち)か"
+        ]
     },
     {
         "name": "kijitsu",
         "trans": [
+            "期日(きじつ)",
             "① 名  日期，期限"
-        ],
-        "notation": "期日(きじつ)"
+        ]
     },
     {
         "name": "seppaku",
         "trans": [
+            "切迫(せっぱく)",
             "⓪ 名·自动3  逼近，迫近；（事态）紧迫，紧张"
-        ],
-        "notation": "切迫(せっぱく)"
+        ]
     },
     {
         "name": "kougoni",
         "trans": [
+            "交互(こうご)に",
             "① 副  互相，交替"
-        ],
-        "notation": "交互(こうご)に"
+        ]
     },
     {
         "name": "kuma",
         "trans": [
+            "隈(くま)",
             "② 名  隐蔽的角落；黑眼圈"
-        ],
-        "notation": "隈(くま)"
+        ]
     },
     {
         "name": "suingu",
         "trans": [
+            "スイング",
             "② 名·他动3  舞动，挥动，摇动"
-        ],
-        "notation": "スイング"
+        ]
     },
     {
         "name": "habamu",
         "trans": [
+            "阻(はば)む",
             "② 他动1  阻止，阻碍，阻挡"
-        ],
-        "notation": "阻(はば)む"
+        ]
     },
     {
         "name": "jizoku",
         "trans": [
+            "持続(じぞく)",
             "⓪ 名·自他动3  持续，保持，维持"
-        ],
-        "notation": "持続(じぞく)"
+        ]
     },
     {
         "name": "toutatsu",
         "trans": [
+            "到達(とうたつ)",
             "⓪ 名·自动3  到达，达到"
-        ],
-        "notation": "到達(とうたつ)"
+        ]
     },
     {
         "name": "hisashii",
         "trans": [
+            "久(ひさ)しい",
             "③ イ形  好久，许久的"
-        ],
-        "notation": "久(ひさ)しい"
+        ]
     },
     {
         "name": "pojishon",
         "trans": [
+            "ポジション",
             "② 名  地位，职位"
-        ],
-        "notation": "ポジション"
+        ]
     },
     {
         "name": "oogosho",
         "trans": [
+            "大御所(おおごしょ)",
             "⓪ 名  权威，泰斗"
-        ],
-        "notation": "大御所(おおごしょ)"
+        ]
     },
     {
         "name": "toubun",
         "trans": [
+            "当分(とうぶん)",
             "⓪ 副  暂时，一时，目前"
-        ],
-        "notation": "当分(とうぶん)"
+        ]
     },
     {
         "name": "shazai",
         "trans": [
+            "謝罪(しゃざい)",
             "⓪ 名·自他动3  谢罪，道歉"
-        ],
-        "notation": "謝罪(しゃざい)"
+        ]
     },
     {
         "name": "teppai",
         "trans": [
+            "撤廃(てっぱい)",
             "⓪ 名·他动3  取消，撤销"
-        ],
-        "notation": "撤廃(てっぱい)"
+        ]
     },
     {
         "name": "amaeru",
         "trans": [
+            "甘(あま)える",
             "⓪ 自动2  撒娇；趁⋯⋯机会，承蒙"
-        ],
-        "notation": "甘(あま)える"
+        ]
     },
     {
         "name": "kenzai",
         "trans": [
+            "健在(けんざい)",
             "⓪ 名·ナ形  健在"
-        ],
-        "notation": "健在(けんざい)"
+        ]
     },
     {
         "name": "sendai",
         "trans": [
+            "先代(せんだい)",
             "⓪ 名  上一代，上一辈；上一个时代"
-        ],
-        "notation": "先代(せんだい)"
+        ]
     },
     {
         "name": "karakau",
         "trans": [
+            "からかう",
             "③ 他动1  嘲笑，戏弄"
-        ],
-        "notation": "からかう"
+        ]
     },
     {
         "name": "joukuu",
         "trans": [
+            "上空(じょうくう)",
             "⓪ 名  上空，高空"
-        ],
-        "notation": "上空(じょうくう)"
+        ]
     },
     {
         "name": "chi-muwa-ku",
         "trans": [
+            "チームワーク",
             "④ 名  团队合作"
-        ],
-        "notation": "チームワーク"
+        ]
     },
     {
         "name": "sasayaka",
         "trans": [
+            "ささやか",
             "② ナ形  细小的；简单的，微薄的"
-        ],
-        "notation": "ささやか"
+        ]
     },
     {
         "name": "onkei",
         "trans": [
+            "恩恵(おんけい)",
             "⓪ 名  恩惠，恩情"
-        ],
-        "notation": "恩恵(おんけい)"
+        ]
     },
     {
         "name": "tamashii",
         "trans": [
+            "魂(たましい)",
             "① 名  灵魂；精神"
-        ],
-        "notation": "魂(たましい)"
+        ]
     },
     {
         "name": "nijimu",
         "trans": [
+            "滲(にじ)む",
             "② 自动1  （颜色、墨等）洇，渗；渗出，浸出"
-        ],
-        "notation": "滲(にじ)む"
+        ]
     },
     {
         "name": "chokkan",
         "trans": [
+            "直感(ちょっかん)",
             "⓪ 名·他动3  直觉，直接的感觉"
-        ],
-        "notation": "直感(ちょっかん)"
+        ]
     },
     {
         "name": "hacchuu",
         "trans": [
+            "発注(はっちゅう)",
             "⓪ 名·他动3  订货，订购"
-        ],
-        "notation": "発注(はっちゅう)"
+        ]
     },
     {
         "name": "houmuru",
         "trans": [
+            "葬(ほうむ)る",
             "③ 他动1  埋葬；遮掩，掩埋"
-        ],
-        "notation": "葬(ほうむ)る"
+        ]
     },
     {
         "name": "munen",
         "trans": [
+            "無念(むねん)",
             "⓪ 名·ナ形  毫无牵挂；懊悔，悔恨"
-        ],
-        "notation": "無念(むねん)"
+        ]
     },
     {
         "name": "joumu",
         "trans": [
+            "常務(じょうむ)",
             "① 名  日常事务；常务董事"
-        ],
-        "notation": "常務(じょうむ)"
+        ]
     },
     {
         "name": "ikichigau/yukichigau",
         "trans": [
+            "行(いきちがう/ゆ)き違(ちが)う",
             "④ 自动1  走岔开；出现矛盾，有差错"
-        ],
-        "notation": "行(いきちがう/ゆ)き違(ちが)う"
+        ]
     },
     {
         "name": "gisei",
         "trans": [
+            "犠牲(ぎせい)",
             "⓪ 名  牺牲"
-        ],
-        "notation": "犠牲(ぎせい)"
+        ]
     },
     {
         "name": "souritsu",
         "trans": [
+            "創立(そうりつ)",
             "⓪ 名·他动3  创立，创办"
-        ],
-        "notation": "創立(そうりつ)"
+        ]
     },
     {
         "name": "guzutsuku",
         "trans": [
+            "ぐずつく",
             "⓪ 自动1  磨蹭，拖延；阴天；（身体）不舒服"
-        ],
-        "notation": "ぐずつく"
+        ]
     },
     {
         "name": "koromogae",
         "trans": [
+            "衣替(ころもが)え",
             "⓪ 名  换季，换衣服"
-        ],
-        "notation": "衣替(ころもが)え"
+        ]
     },
     {
         "name": "seichou",
         "trans": [
+            "清聴(せいちょう)",
             "⓪ 名·他动3  倾听，垂听"
-        ],
-        "notation": "清聴(せいちょう)"
+        ]
     },
     {
         "name": "kaerimiru",
         "trans": [
+            "省(かえり)みる",
             "④ 他动2  反省，反躬自问"
-        ],
-        "notation": "省(かえり)みる"
+        ]
     },
     {
         "name": "jippi",
         "trans": [
+            "実費(じっぴ)",
             "⓪ 名  实际费用，成本"
-        ],
-        "notation": "実費(じっぴ)"
+        ]
     },
     {
         "name": "taimureko-da-",
         "trans": [
+            "タイムレコーダー",
             "⑤ 名  打卡器"
-        ],
-        "notation": "タイムレコーダー"
+        ]
     },
     {
         "name": "noridasu",
         "trans": [
+            "乗(の)り出(だ)す",
             "③ 自他动1  乘（船等）出去；崭露头角；开始进行"
-        ],
-        "notation": "乗(の)り出(だ)す"
+        ]
     },
     {
         "name": "toukyuu",
         "trans": [
+            "等級(とうきゅう)",
             "⓪ 名  等级"
-        ],
-        "notation": "等級(とうきゅう)"
+        ]
     },
     {
         "name": "biryoku",
         "trans": [
+            "微力(びりょく)",
             "⓪ 名·ナ形  绵薄之力"
-        ],
-        "notation": "微力(びりょく)"
+        ]
     },
     {
         "name": "nechinechi",
         "trans": [
+            "ねちねち",
             "① 副·自动3  黏糊糊；絮絮叨叨，不干脆"
-        ],
-        "notation": "ねちねち"
+        ]
     },
     {
         "name": "furasutore-shon",
         "trans": [
+            "フラストレーション",
             "⑤ 名  失意，受挫，挫折，沮丧"
-        ],
-        "notation": "フラストレーション"
+        ]
     },
     {
         "name": "matomari",
         "trans": [
+            "まとまり",
             "⓪ 名  解决；一贯，连贯；统一"
-        ],
-        "notation": "まとまり"
+        ]
     },
     {
         "name": "oshitsukegamashii",
         "trans": [
+            "押(お)し付(つ)けがましい",
             "⑦ イ形  强加于人的，命令式的，强逼着"
-        ],
-        "notation": "押(お)し付(つ)けがましい"
+        ]
     },
     {
         "name": "rinen",
         "trans": [
+            "理念(りねん)",
             "① 名  理念；最高境界，根本想法"
-        ],
-        "notation": "理念(りねん)"
+        ]
     },
     {
         "name": "ishoku",
         "trans": [
+            "移植(いしょく)",
             "⓪ 名·他动3  移植，移种"
-        ],
-        "notation": "移植(いしょく)"
+        ]
     },
     {
         "name": "kimatte",
         "trans": [
+            "決(き)まって",
             "⓪ 副  一定，必定"
-        ],
-        "notation": "決(き)まって"
+        ]
     },
     {
         "name": "shimatsu",
         "trans": [
+            "始末(しまつ)",
             "① 名·他动3  事情的原委；情形，情况；处理，应付；节约"
-        ],
-        "notation": "始末(しまつ)"
+        ]
     },
     {
         "name": "sen'nyuu",
         "trans": [
+            "潜入(せんにゅう)",
             "⓪ 名·自动3  潜入"
-        ],
-        "notation": "潜入(せんにゅう)"
+        ]
     },
     {
         "name": "api-ru",
         "trans": [
+            "アピール",
             "② 自他动3  呼吁，要求；有魅力，有吸引力，打动人心"
-        ],
-        "notation": "アピール"
+        ]
     },
     {
         "name": "kango",
         "trans": [
+            "看護(かんご)",
             "① 名·他动3  护理，看护"
-        ],
-        "notation": "看護(かんご)"
+        ]
     },
     {
         "name": "saigetsu",
         "trans": [
+            "歳月(さいげつ)",
             "① 名  岁月"
-        ],
-        "notation": "歳月(さいげつ)"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "織(お)る",
             "① 他动1  织，编织"
-        ],
-        "notation": "織(お)る"
+        ]
     },
     {
         "name": "kyuukutsu",
         "trans": [
+            "窮屈(きゅうくつ)",
             "① 名·ナ形  狭窄；受束缚，不自由；死板"
-        ],
-        "notation": "窮屈(きゅうくつ)"
+        ]
     },
     {
         "name": "jokou",
         "trans": [
+            "徐行(じょこう)",
             "⓪ 名·自动3  慢行"
-        ],
-        "notation": "徐行(じょこう)"
+        ]
     },
     {
         "name": "kuruu",
         "trans": [
+            "狂(くる)う",
             "② 自动1  精神失常；沉迷；出故障；打乱"
-        ],
-        "notation": "狂(くる)う"
+        ]
     },
     {
         "name": "taitou",
         "trans": [
+            "対等(たいとう)",
             "⓪ 名·ナ形  对等，平等"
-        ],
-        "notation": "対等(たいとう)"
+        ]
     },
     {
         "name": "torai",
         "trans": [
+            "トライ",
             "② 名·自动3  尝试"
-        ],
-        "notation": "トライ"
+        ]
     },
     {
         "name": "sokusuru",
         "trans": [
+            "即(そく)する",
             "③ 自动3  就，结合（情况）"
-        ],
-        "notation": "即(そく)する"
+        ]
     },
     {
         "name": "natsuba",
         "trans": [
+            "夏場(なつば)",
             "⓪ 名  夏季，夏天"
-        ],
-        "notation": "夏場(なつば)"
+        ]
     },
     {
         "name": "hanjou",
         "trans": [
+            "繁盛(はんじょう)",
             "① 名·自动3  繁荣，昌盛"
-        ],
-        "notation": "繁盛(はんじょう)"
+        ]
     },
     {
         "name": "arakajime",
         "trans": [
+            "予(あらかじ)め",
             "⓪ 副  预先，事先"
-        ],
-        "notation": "予(あらかじ)め"
+        ]
     },
     {
         "name": "metsubou",
         "trans": [
+            "滅亡(めつぼう)",
             "⓪ 名·自动3  灭亡"
-        ],
-        "notation": "滅亡(めつぼう)"
+        ]
     },
     {
         "name": "utsuwa",
         "trans": [
+            "器(うつわ)",
             "⓪ 名  容器，器皿；才干"
-        ],
-        "notation": "器(うつわ)"
+        ]
     },
     {
         "name": "kanawanai",
         "trans": [
+            "かなわない",
             "④ 连语  敌不过，比不上；吃不消，受不了"
-        ],
-        "notation": "かなわない"
+        ]
     },
     {
         "name": "shikake",
         "trans": [
+            "仕掛(しか)け",
             "⓪ 名  开始做；做到中途；结构，装置，机关；手法，招数"
-        ],
-        "notation": "仕掛(しか)け"
+        ]
     },
     {
         "name": "kokon",
         "trans": [
+            "古今(ここん)",
             "① 名  古今，从古至今"
-        ],
-        "notation": "古今(ここん)"
+        ]
     },
     {
         "name": "nengoro",
         "trans": [
+            "懇(ねんご)ろ",
             "⓪ ナ形  恳切的；殷勤的；亲密的"
-        ],
-        "notation": "懇(ねんご)ろ"
+        ]
     },
     {
         "name": "sakazuki",
         "trans": [
+            "杯(さかずき)",
             "⓪ 名  酒杯"
-        ],
-        "notation": "杯(さかずき)"
+        ]
     },
     {
         "name": "dainashi",
         "trans": [
+            "台無(だいな)し",
             "⓪ 名  弄坏，糟蹋"
-        ],
-        "notation": "台無(だいな)し"
+        ]
     },
     {
         "name": "hisomu",
         "trans": [
+            "潜(ひそ)む",
             "② 自动1  隐藏，潜藏；（心理）潜在"
-        ],
-        "notation": "潜(ひそ)む"
+        ]
     },
     {
         "name": "teimei",
         "trans": [
+            "低迷(ていめい)",
             "⓪ 名·自动3  低迷"
-        ],
-        "notation": "低迷(ていめい)"
+        ]
     },
     {
         "name": "jari",
         "trans": [
+            "砂利(じゃり)",
             "⓪ 名  小石头，砂砾；小孩子"
-        ],
-        "notation": "砂利(じゃり)"
+        ]
     },
     {
         "name": "motte",
         "trans": [
+            "もって",
             "① 连语  以，用；因为，根据；到（期限）"
-        ],
-        "notation": "もって"
+        ]
     },
     {
         "name": "ba-jon'appu",
         "trans": [
+            "バージョンアップ",
             " ⑤ 名  版本升级，修改程序"
-        ],
-        "notation": "バージョンアップ"
+        ]
     },
     {
         "name": "hougaku",
         "trans": [
+            "方角(ほうがく)",
             "⓪ 名  方向，方位"
-        ],
-        "notation": "方角(ほうがく)"
+        ]
     },
     {
         "name": "ogosoka",
         "trans": [
+            "厳(おごそ)か",
             "② ナ形  庄严的，庄重的"
-        ],
-        "notation": "厳(おごそ)か"
+        ]
     },
     {
         "name": "mimoto",
         "trans": [
+            "身元(みもと)",
             "⓪ 名  出身，来历；身世"
-        ],
-        "notation": "身元(みもと)"
+        ]
     },
     {
         "name": "rifuresshu",
         "trans": [
+            "リフレッシュ",
             "③ 名·自他动3  重新振作，恢复精神"
-        ],
-        "notation": "リフレッシュ"
+        ]
     },
     {
         "name": "kidoru",
         "trans": [
+            "気取(きど)る",
             "⓪ 自他动1  装模作样；以⋯⋯自居"
-        ],
-        "notation": "気取(きど)る"
+        ]
     },
     {
         "name": "shiten",
         "trans": [
+            "視点(してん)",
             "⓪ 名  视点，角度"
-        ],
-        "notation": "視点(してん)"
+        ]
     },
     {
         "name": "an'un",
         "trans": [
+            "暗雲(あんうん)",
             "⓪ 名  乌云；形势险恶"
-        ],
-        "notation": "暗雲(あんうん)"
+        ]
     },
     {
         "name": "kanjin",
         "trans": [
+            "肝心(かんじん)",
             "⓪ 名·ナ形  重要，紧要"
-        ],
-        "notation": "肝心(かんじん)"
+        ]
     },
     {
         "name": "saibou",
         "trans": [
+            "細胞(さいぼう)",
             "⓪ 名  细胞"
-        ],
-        "notation": "細胞(さいぼう)"
+        ]
     },
     {
         "name": "chokkei",
         "trans": [
+            "直径(ちょっけい)",
             "⓪ 名  直径"
-        ],
-        "notation": "直径(ちょっけい)"
+        ]
     },
     {
         "name": "iza",
         "trans": [
+            "いざ",
             "① 叹·副  喂，哎；一旦"
-        ],
-        "notation": "いざ"
+        ]
     },
     {
         "name": "kijutsu",
         "trans": [
+            "記述(きじゅつ)",
             "⓪ 名·他动3  记述"
-        ],
-        "notation": "記述(きじゅつ)"
+        ]
     },
     {
         "name": "shitadori",
         "trans": [
+            "下取(したど)り",
             "⓪ 名·他动3  以旧换新"
-        ],
-        "notation": "下取(したど)り"
+        ]
     },
     {
         "name": "choueki",
         "trans": [
+            "懲役(ちょうえき)",
             "⓪ 名  徒刑，刑役"
-        ],
-        "notation": "懲役(ちょうえき)"
+        ]
     },
     {
         "name": "hamabe",
         "trans": [
+            "浜辺(はまべ)",
             "⓪ 名  海滨，湖边"
-        ],
-        "notation": "浜辺(はまべ)"
+        ]
     },
     {
         "name": "karamu",
         "trans": [
+            "絡(から)む",
             "② 自动1  缠住；胡搅蛮缠，无理取闹；密切相关"
-        ],
-        "notation": "絡(から)む"
+        ]
     },
     {
         "name": "mashi",
         "trans": [
+            "増(ま)し",
             "⓪ 名·ナ形  胜过，强于"
-        ],
-        "notation": "増(ま)し"
+        ]
     },
     {
         "name": "rimokon",
         "trans": [
+            "リモコン",
             "⓪ 名  遥控器"
-        ],
-        "notation": "リモコン"
+        ]
     },
     {
         "name": "jikyuu",
         "trans": [
+            "自給(じきゅう)",
             "⓪ 名·他动3  自给，满足自己的需要"
-        ],
-        "notation": "自給(じきゅう)"
+        ]
     },
     {
         "name": "ironaoshi",
         "trans": [
+            "色直(いろなお)し",
             "③ 名·自动3  婚礼上换衣服"
-        ],
-        "notation": "色直(いろなお)し"
+        ]
     },
     {
         "name": "sorenari",
         "trans": [
+            "それなり",
             "⓪ 名·副  没有下文；与之相应的"
-        ],
-        "notation": "それなり"
+        ]
     },
     {
         "name": "kizuna",
         "trans": [
+            "絆(きずな)",
             "⓪ 名  纽带，羁绊"
-        ],
-        "notation": "絆(きずな)"
+        ]
     },
     {
         "name": "suuchi",
         "trans": [
+            "数値(すうち)",
             "① 名  数值"
-        ],
-        "notation": "数値(すうち)"
+        ]
     },
     {
         "name": "tsuiseki",
         "trans": [
+            "追跡(ついせき)",
             "⓪ 名·他动3  追踪，追捕"
-        ],
-        "notation": "追跡(ついせき)"
+        ]
     },
     {
         "name": "hidori",
         "trans": [
+            "日取(ひど)り",
             "⓪ 名  日期，日子；日程"
-        ],
-        "notation": "日取(ひど)り"
+        ]
     },
     {
         "name": "kasuka",
         "trans": [
+            "かすか",
             "① ナ形  模糊的，微弱的"
-        ],
-        "notation": "かすか"
+        ]
     },
     {
         "name": "mohan",
         "trans": [
+            "模範(もはん)",
             "⓪ 名  模范"
-        ],
-        "notation": "模範(もはん)"
+        ]
     },
     {
         "name": "endan",
         "trans": [
+            "演壇(えんだん)",
             "⓪ 名  讲台，讲坛"
-        ],
-        "notation": "演壇(えんだん)"
+        ]
     },
     {
         "name": "ken'yaku",
         "trans": [
+            "倹約(けんやく)",
             "⓪ 名·他动3  节俭，节省"
-        ],
-        "notation": "倹約(けんやく)"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "選考(せんこう)",
             "⓪ 名·他动3  甄选，选拔"
-        ],
-        "notation": "選考(せんこう)"
+        ]
     },
     {
         "name": "patoro-ru",
         "trans": [
+            "パトロール",
             "③ 名·自动3  巡逻，巡视"
-        ],
-        "notation": "パトロール"
+        ]
     },
     {
         "name": "shuppin",
         "trans": [
+            "出品(しゅっぴん)",
             "⓪ 名·他动3  展出，展销"
-        ],
-        "notation": "出品(しゅっぴん)"
+        ]
     },
     {
         "name": "touhou",
         "trans": [
+            "当方(とうほう)",
             "① 名  我们，我方"
-        ],
-        "notation": "当方(とうほう)"
+        ]
     },
     {
         "name": "fukahi",
         "trans": [
+            "不可避(ふかひ)",
             "② 名·ナ形  不可避免，不能避开"
-        ],
-        "notation": "不可避(ふかひ)"
+        ]
     },
     {
         "name": "misshuu",
         "trans": [
+            "密集(みっしゅう)",
             "⓪ 名·自动3  密集，稠密"
-        ],
-        "notation": "密集(みっしゅう)"
+        ]
     },
     {
         "name": "ayabumu",
         "trans": [
+            "危(あや)ぶむ",
             "③ 他动1  担心，担忧；怀疑，不相信"
-        ],
-        "notation": "危(あや)ぶむ"
+        ]
     },
     {
         "name": "kan'you",
         "trans": [
+            "寛容(かんよう)",
             "⓪ 名·ナ形  宽容"
-        ],
-        "notation": "寛容(かんよう)"
+        ]
     },
     {
         "name": "ooyake",
         "trans": [
+            "公(おおやけ)",
             "⓪ 名  公家，公共；公开"
-        ],
-        "notation": "公(おおやけ)"
+        ]
     },
     {
         "name": "shippitsu",
         "trans": [
+            "執筆(しっぴつ)",
             "⓪ 名·自他动3  执笔，写作，撰稿"
-        ],
-        "notation": "執筆(しっぴつ)"
+        ]
     },
     {
         "name": "teusu",
         "trans": [
+            "手薄(てうす)",
             "⓪ 名·ナ形  缺少，不足；不充分"
-        ],
-        "notation": "手薄(てうす)"
+        ]
     },
     {
         "name": "kuchibashiru",
         "trans": [
+            "口走(くちばし)る",
             "④ 他动1  说漏嘴，顺口说出；说胡话"
-        ],
-        "notation": "口走(くちばし)る"
+        ]
     },
     {
         "name": "konshinkai",
         "trans": [
+            "懇親会(こんしんかい)",
             "③ 名  联欢会，联谊会"
-        ],
-        "notation": "懇親会(こんしんかい)"
+        ]
     },
     {
         "name": "tanken",
         "trans": [
+            "探検(たんけん)",
             "⓪ 名·他动3  探险"
-        ],
-        "notation": "探検(たんけん)"
+        ]
     },
     {
         "name": "tokushuu",
         "trans": [
+            "特集(とくしゅう)",
             "⓪ 名·他动3  专刊，专辑"
-        ],
-        "notation": "特集(とくしゅう)"
+        ]
     },
     {
         "name": "pa-tona-",
         "trans": [
+            "パートナー",
             "① 名  伙伴，合伙人"
-        ],
-        "notation": "パートナー"
+        ]
     },
     {
         "name": "shiiru",
         "trans": [
+            "強(し)いる",
             "② 他动2  强迫，迫使"
-        ],
-        "notation": "強(し)いる"
+        ]
     },
     {
         "name": "houbi",
         "trans": [
+            "褒美(ほうび)",
             "⓪ 名·他动3  奖赏，奖励"
-        ],
-        "notation": "褒美(ほうび)"
+        ]
     },
     {
         "name": "mendan",
         "trans": [
+            "面談(めんだん)",
             "⓪ 名·自动3  面谈"
-        ],
-        "notation": "面談(めんだん)"
+        ]
     },
     {
         "name": "jouyaku",
         "trans": [
+            "条約(じょうやく)",
             "⓪ 名  条约"
-        ],
-        "notation": "条約(じょうやく)"
+        ]
     },
     {
         "name": "kenbun",
         "trans": [
+            "見聞(けんぶん)",
             "⓪ 名·他动3  见闻，见识"
-        ],
-        "notation": "見聞(けんぶん)"
+        ]
     },
     {
         "name": "tsunedune",
         "trans": [
+            "常々(つねづね)",
             "② 名·副  平素；经常，常常"
-        ],
-        "notation": "常々(つねづね)"
+        ]
     },
     {
         "name": "ikkatsu",
         "trans": [
+            "一括(いっかつ)",
             "⓪ 名·他动3  统一，总括"
-        ],
-        "notation": "一括(いっかつ)"
+        ]
     },
     {
         "name": "kisei",
         "trans": [
+            "既成(きせい)",
             "⓪ 名  既成，现有，原有"
-        ],
-        "notation": "既成(きせい)"
+        ]
     },
     {
         "name": "sairen",
         "trans": [
+            "サイレン",
             "① 名  汽笛，警笛"
-        ],
-        "notation": "サイレン"
+        ]
     },
     {
         "name": "seitei",
         "trans": [
+            "制定(せいてい)",
             "⓪ 名·他动3  制定（法律、规则等）"
-        ],
-        "notation": "制定(せいてい)"
+        ]
     },
     {
         "name": "namanurui",
         "trans": [
+            "生温(なまぬる)い",
             "④ イ形  微温的；不严格的，不够彻底的"
-        ],
-        "notation": "生温(なまぬる)い"
+        ]
     },
     {
         "name": "chisei",
         "trans": [
+            "知性(ちせい)",
             "① 名  才智，智力；理智"
-        ],
-        "notation": "知性(ちせい)"
+        ]
     },
     {
         "name": "tougekou",
         "trans": [
+            "登下校(とうげこう)",
             "③ 名·自动3  上下学"
-        ],
-        "notation": "登下校(とうげこう)"
+        ]
     },
     {
         "name": "nenchaku",
         "trans": [
+            "粘着(ねんちゃく)",
             "⓪ 名·自动3  黏着，黏住"
-        ],
-        "notation": "粘着(ねんちゃく)"
+        ]
     },
     {
         "name": "fuchi/fuji",
         "trans": [
+            "不治(ふち/ふじ)",
             "② 名  不治（之症），治不好"
-        ],
-        "notation": "不治(ふち/ふじ)"
+        ]
     },
     {
         "name": "hamaru",
         "trans": [
+            "嵌(はま)る",
             "⓪ 自动1  套上；吻合；陷入；中圈套"
-        ],
-        "notation": "嵌(はま)る"
+        ]
     },
     {
         "name": "houken",
         "trans": [
+            "封建(ほうけん)",
             "⓪ 名  封建"
-        ],
-        "notation": "封建(ほうけん)"
+        ]
     },
     {
         "name": "mania",
         "trans": [
+            "マニア",
             "① 名  ⋯⋯迷，爱好者"
-        ],
-        "notation": "マニア"
+        ]
     },
     {
         "name": "shudou",
         "trans": [
+            "主導(しゅどう)",
             "⓪ 名·他动3  主导；主动"
-        ],
-        "notation": "主導(しゅどう)"
+        ]
     },
     {
         "name": "ryoukyoku",
         "trans": [
+            "両極(りょうきょく)",
             "⓪ 名  两极；两个极端"
-        ],
-        "notation": "両極(りょうきょく)"
+        ]
     },
     {
         "name": "amaru",
         "trans": [
+            "余(あま)る",
             "② 自动1  多余；力不能及，承担不了"
-        ],
-        "notation": "余(あま)る"
+        ]
     },
     {
         "name": "oosuji",
         "trans": [
+            "大筋(おおすじ)",
             "⓪ 名  梗概，概要"
-        ],
-        "notation": "大筋(おおすじ)"
+        ]
     },
     {
         "name": "kousai",
         "trans": [
+            "交際(こうさい)",
             "⓪ 名·自动3  交际，交往，应酬"
-        ],
-        "notation": "交際(こうさい)"
+        ]
     },
     {
         "name": "kawase",
         "trans": [
+            "為替(かわせ)",
             "⓪ 名  汇兑，汇款"
-        ],
-        "notation": "為替(かわせ)"
+        ]
     },
     {
         "name": "sousai",
         "trans": [
+            "相殺(そうさい)",
             "⓪ 名·他动3  （债权和债务）相抵；（功和过）相抵，抵销"
-        ],
-        "notation": "相殺(そうさい)"
+        ]
     },
     {
         "name": "kusuburu",
         "trans": [
+            "燻(くすぶ)る",
             "③ 自动1  熏黑；闷在家；纠缠不休"
-        ],
-        "notation": "燻(くすぶ)る"
+        ]
     },
     {
         "name": "shinpojiumu",
         "trans": [
+            "シンポジウム",
             "④ 名  研讨会，座谈会"
-        ],
-        "notation": "シンポジウム"
+        ]
     },
     {
         "name": "tobiiri",
         "trans": [
+            "飛(と)び入(い)り",
             "⓪ 名·自动3  中途临时参加（的人）"
-        ],
-        "notation": "飛(と)び入(い)り"
+        ]
     },
     {
         "name": "dandori",
         "trans": [
+            "段取(だんど)り",
             "④ 名  安排；打算，计划"
-        ],
-        "notation": "段取(だんど)り"
+        ]
     },
     {
         "name": "hirou",
         "trans": [
+            "疲労(ひろう)",
             "⓪ 名·自动3  疲劳，疲乏"
-        ],
-        "notation": "疲労(ひろう)"
+        ]
     },
     {
         "name": "isoiso",
         "trans": [
+            "いそいそ",
             "① 副·自动3  兴高采烈地，欢欣雀跃地"
-        ],
-        "notation": "いそいそ"
+        ]
     },
     {
         "name": "teokure",
         "trans": [
+            "手遅(ておく)れ",
             "② 名  为时已晚，耽误"
-        ],
-        "notation": "手遅(ておく)れ"
+        ]
     },
     {
         "name": "haichi",
         "trans": [
+            "配置(はいち)",
             "⓪ 名·他动3  配置，布置"
-        ],
-        "notation": "配置(はいち)"
+        ]
     },
     {
         "name": "fuyou",
         "trans": [
+            "不要(ふよう)",
             "⓪ 名·ナ形  不需要；不用"
-        ],
-        "notation": "不要(ふよう)"
+        ]
     },
     {
         "name": "shazetsu",
         "trans": [
+            "謝絶(しゃぜつ)",
             "⓪ 名·他动3  谢绝，拒绝"
-        ],
-        "notation": "謝絶(しゃぜつ)"
+        ]
     },
     {
         "name": "hariau",
         "trans": [
+            "張(は)り合(あ)う",
             "③ 自他动1  竞争，争夺"
-        ],
-        "notation": "張(は)り合(あ)う"
+        ]
     },
     {
         "name": "chuudan",
         "trans": [
+            "中断(ちゅうだん)",
             "⓪ 名·自他动3  中断，断开,中止"
-        ],
-        "notation": "中断(ちゅうだん)"
+        ]
     },
     {
         "name": "keiro",
         "trans": [
+            "経路(けいろ)",
             "① 名  路径，途径"
-        ],
-        "notation": "経路(けいろ)"
+        ]
     },
     {
         "name": "gaisetsu",
         "trans": [
+            "概説(がいせつ)",
             "⓪ 名·他动3  概说，概要"
-        ],
-        "notation": "概説(がいせつ)"
+        ]
     },
     {
         "name": "tedika",
         "trans": [
+            "手近(てぢか)",
             "⓪ 名·ナ形  身边，手边；常见"
-        ],
-        "notation": "手近(てぢか)"
+        ]
     },
     {
         "name": "o-sodokkusu",
         "trans": [
+            "オーソドックス",
             "④ ナ形  正统的"
-        ],
-        "notation": "オーソドックス"
+        ]
     },
     {
         "name": "hokaku",
         "trans": [
+            "捕獲(ほかく)",
             "⓪ 名·他动3  捕获"
-        ],
-        "notation": "捕獲(ほかく)"
+        ]
     },
     {
         "name": "kanketsu",
         "trans": [
+            "簡潔(かんけつ)",
             "⓪ 名·ナ形  简洁，简明"
-        ],
-        "notation": "簡潔(かんけつ)"
+        ]
     },
     {
         "name": "shikikin",
         "trans": [
+            "敷金(しききん)",
             "② 名  （租房）押金；保证金"
-        ],
-        "notation": "敷金(しききん)"
+        ]
     },
     {
         "name": "kouho",
         "trans": [
+            "候補(こうほ)",
             "① 名  候选人"
-        ],
-        "notation": "候補(こうほ)"
+        ]
     },
     {
         "name": "imaya",
         "trans": [
+            "今(いま)や",
             "① 副  现在正是；马上，眼看就；现在已经"
-        ],
-        "notation": "今(いま)や"
+        ]
     },
     {
         "name": "senpaku",
         "trans": [
+            "浅薄(せんぱく)",
             "⓪ 名·ナ形  浅薄，肤浅"
-        ],
-        "notation": "浅薄(せんぱく)"
+        ]
     },
     {
         "name": "kizou",
         "trans": [
+            "寄贈(きぞう)",
             "⓪ 名·他动3  赠送，捐赠"
-        ],
-        "notation": "寄贈(きぞう)"
+        ]
     },
     {
         "name": "furi-ta-",
         "trans": [
+            "フリーター",
             " ② 名  自由职业者"
-        ],
-        "notation": "フリーター"
+        ]
     },
     {
         "name": "daikou",
         "trans": [
+            "代行(だいこう)",
             "⓪ 名·他动3  代理，代办"
-        ],
-        "notation": "代行(だいこう)"
+        ]
     },
     {
         "name": "douride",
         "trans": [
+            "道理(どうり)で",
             "③ 副  怪不得，难怪"
-        ],
-        "notation": "道理(どうり)で"
+        ]
     },
     {
         "name": "anji",
         "trans": [
+            "暗示(あんじ)",
             "⓪ 名·他动3  提示，暗示"
-        ],
-        "notation": "暗示(あんじ)"
+        ]
     },
     {
         "name": "kakou",
         "trans": [
+            "下降(かこう)",
             "⓪ 名·自动3  下降"
-        ],
-        "notation": "下降(かこう)"
+        ]
     },
     {
         "name": "sayou",
         "trans": [
+            "作用(さよう)",
             "① 名·自动3  作用；起作用"
-        ],
-        "notation": "作用(さよう)"
+        ]
     },
     {
         "name": "zeppan",
         "trans": [
+            "絶版(ぜっぱん)",
             "⓪ 名  绝版"
-        ],
-        "notation": "絶版(ぜっぱん)"
+        ]
     },
     {
         "name": "hiyakasu",
         "trans": [
+            "冷(ひ)やかす",
             "③ 他动1  戏弄，嘲弄；只逛不买"
-        ],
-        "notation": "冷(ひ)やかす"
+        ]
     },
     {
         "name": "hontai",
         "trans": [
+            "本体(ほんたい)",
             "① 名  本来面目，真相；主体"
-        ],
-        "notation": "本体(ほんたい)"
+        ]
     },
     {
         "name": "o-ba-",
         "trans": [
+            "オーバー",
             "① 自他动3·ナ形  超过；过分，夸张"
-        ],
-        "notation": "オーバー"
+        ]
     },
     {
         "name": "shuueki",
         "trans": [
+            "収益(しゅうえき)",
             "⓪ 名  收益"
-        ],
-        "notation": "収益(しゅうえき)"
+        ]
     },
     {
         "name": "kotei",
         "trans": [
+            "固定(こてい)",
             "⓪ 名·自他动3  固定"
-        ],
-        "notation": "固定(こてい)"
+        ]
     },
     {
         "name": "kemuru",
         "trans": [
+            "煙(けむ)る",
             "⓪ 自动1  冒烟；（烟雾）朦胧"
-        ],
-        "notation": "煙(けむ)る"
+        ]
     },
     {
         "name": "apo",
         "trans": [
+            "アポ",
             "① 名  约会，约定"
-        ],
-        "notation": "アポ"
+        ]
     },
     {
         "name": "ouja",
         "trans": [
+            "王者(おうじゃ)",
             "① 名  王者；最有实力的人"
-        ],
-        "notation": "王者(おうじゃ)"
+        ]
     },
     {
         "name": "kengyou",
         "trans": [
+            "兼業(けんぎょう)",
             "⓪ 名·他动3  副业，兼营"
-        ],
-        "notation": "兼業(けんぎょう)"
+        ]
     },
     {
         "name": "shushou",
         "trans": [
+            "首相(しゅしょう)",
             "⓪ 名  首相"
-        ],
-        "notation": "首相(しゅしょう)"
+        ]
     },
     {
         "name": "karareru",
         "trans": [
+            "駆(か)られる",
             "④ 自动2  受⋯⋯驱使"
-        ],
-        "notation": "駆(か)られる"
+        ]
     },
     {
         "name": "zetsubou",
         "trans": [
+            "絶望(ぜつぼう)",
             "⓪ 名·自动3  绝望，失望"
-        ],
-        "notation": "絶望(ぜつぼう)"
+        ]
     },
     {
         "name": "dankou",
         "trans": [
+            "断行(だんこう)",
             "⓪ 名·他动3  断然实行，坚决实行"
-        ],
-        "notation": "断行(だんこう)"
+        ]
     },
     {
         "name": "toubou",
         "trans": [
+            "逃亡(とうぼう)",
             "⓪ 名·自动3  逃亡，逃跑"
-        ],
-        "notation": "逃亡(とうぼう)"
+        ]
     },
     {
         "name": "hatsuiku",
         "trans": [
+            "発育(はついく)",
             "⓪ 名·自动3  发育，成长"
-        ],
-        "notation": "発育(はついく)"
+        ]
     },
     {
         "name": "sarau",
         "trans": [
+            "浚(さら)う",
             "⓪ 他动1  疏浚（河、沟）"
-        ],
-        "notation": "浚(さら)う"
+        ]
     },
     {
         "name": "fuchou",
         "trans": [
+            "不調(ふちょう)",
             "⓪ 名·ナ形  （谈判等）破裂；状态不佳"
-        ],
-        "notation": "不調(ふちょう)"
+        ]
     },
     {
         "name": "mari",
         "trans": [
+            "鞠(まり)",
             "② 名  球"
-        ],
-        "notation": "鞠(まり)"
+        ]
     },
     {
         "name": "ikoi",
         "trans": [
+            "憩(いこ)い",
             "⓪ 名  休息，休憩"
-        ],
-        "notation": "憩(いこ)い"
+        ]
     },
     {
         "name": "kyoukou",
         "trans": [
+            "強硬(きょうこう)",
             "⓪ 名·ナ形  强硬"
-        ],
-        "notation": "強硬(きょうこう)"
+        ]
     },
     {
         "name": "nageku",
         "trans": [
+            "嘆(なげ)く",
             "② 自他动1  叹息，叹气；悲叹；慨叹"
-        ],
-        "notation": "嘆(なげ)く"
+        ]
     },
     {
         "name": "sekushon",
         "trans": [
+            "セクション",
             "① 名  部门；（报纸等的）版面，栏目"
-        ],
-        "notation": "セクション"
+        ]
     },
     {
         "name": "tegakari",
         "trans": [
+            "手掛(てが)かり",
             "② 名  线索，头绪"
-        ],
-        "notation": "手掛(てが)かり"
+        ]
     },
     {
         "name": "shozoku",
         "trans": [
+            "所属(しょぞく)",
             "⓪ 名·自动3  所属，附属"
-        ],
-        "notation": "所属(しょぞく)"
+        ]
     },
     {
         "name": "chintai",
         "trans": [
+            "賃貸(ちんたい)",
             "⓪ 名·他动3  出租，出赁"
-        ],
-        "notation": "賃貸(ちんたい)"
+        ]
     },
     {
         "name": "bareru",
         "trans": [
+            "ばれる",
             "② 自动2  败露，暴露"
-        ],
-        "notation": "ばれる"
+        ]
     },
     {
         "name": "tokkyo",
         "trans": [
+            "特許(とっきょ)",
             "① 名·他动3  特别许可，专利"
-        ],
-        "notation": "特許(とっきょ)"
+        ]
     },
     {
         "name": "nasake",
         "trans": [
+            "情(なさ)け",
             "① 名  仁慈，情义；爱情，恋情"
-        ],
-        "notation": "情(なさ)け"
+        ]
     },
     {
         "name": "hinketsu",
         "trans": [
+            "貧血(ひんけつ)",
             "⓪ 名·自动3  贫血"
-        ],
-        "notation": "貧血(ひんけつ)"
+        ]
     },
     {
         "name": "ro-puue-",
         "trans": [
+            "ロープウエー",
             "⑤ 名  空中索道"
-        ],
-        "notation": "ロープウエー"
+        ]
     },
     {
         "name": "munashii",
         "trans": [
+            "空(むな)しい",
             "③ イ形  空虚的，空洞的；枉然的，徒然的"
-        ],
-        "notation": "空(むな)しい"
+        ]
     },
     {
         "name": "oyakoukou",
         "trans": [
+            "親孝行(おやこうこう)",
             "③ 名·ナ形·自动3  孝敬父母"
-        ],
-        "notation": "親孝行(おやこうこう)"
+        ]
     },
     {
         "name": "kurumi",
         "trans": [
+            "胡桃(くるみ)",
             "⓪ 名  核桃"
-        ],
-        "notation": "胡桃(くるみ)"
+        ]
     },
     {
         "name": "shouyo",
         "trans": [
+            "賞与(しょうよ)",
             "① 名  奖金，红利"
-        ],
-        "notation": "賞与(しょうよ)"
+        ]
     },
     {
         "name": "konpasu",
         "trans": [
+            "コンパス",
             "① 名  圆规；罗盘；步幅"
-        ],
-        "notation": "コンパス"
+        ]
     },
     {
         "name": "ikkokumohayaku",
         "trans": [
+            "一刻(いっこく)も早(はや)く",
             "⑥ 副  尽快，火速"
-        ],
-        "notation": "一刻(いっこく)も早(はや)く"
+        ]
     },
     {
         "name": "sakari",
         "trans": [
+            "盛(さか)り",
             "⓪ 名  鼎盛时期，最佳状态；壮年，精力充沛"
-        ],
-        "notation": "盛(さか)り"
+        ]
     },
     {
         "name": "zutsuu",
         "trans": [
+            "頭痛(ずつう)",
             "⓪ 名  头痛；烦恼，担忧"
-        ],
-        "notation": "頭痛(ずつう)"
+        ]
     },
     {
         "name": "dohyou",
         "trans": [
+            "土俵(どひょう)",
             "⓪ 名  相扑比赛场"
-        ],
-        "notation": "土俵(どひょう)"
+        ]
     },
     {
         "name": "busho",
         "trans": [
+            "部署(ぶしょ)",
             "① 名  工作岗位"
-        ],
-        "notation": "部署(ぶしょ)"
+        ]
     },
     {
         "name": "kaimamiru",
         "trans": [
+            "垣間見(かいまみ)る",
             "④ 他动2  窥视，偷看"
-        ],
-        "notation": "垣間見(かいまみ)る"
+        ]
     },
     {
         "name": "amado",
         "trans": [
+            "雨戸(あまど)",
             "② 名  防雨门，护窗板"
-        ],
-        "notation": "雨戸(あまど)"
+        ]
     },
     {
         "name": "gyakujou",
         "trans": [
+            "逆上(ぎゃくじょう)",
             "⓪ 名·自动3  （因激愤、悲痛等）血充上头，勃然大怒"
-        ],
-        "notation": "逆上(ぎゃくじょう)"
+        ]
     },
     {
         "name": "zesei",
         "trans": [
+            "是正(ぜせい)",
             "⓪ 名·他动3  订正，更正；改正；纠正"
-        ],
-        "notation": "是正(ぜせい)"
+        ]
     },
     {
         "name": "tsubame",
         "trans": [
+            "燕(つばめ)",
             "⓪ 名  燕子"
-        ],
-        "notation": "燕(つばめ)"
+        ]
     },
     {
         "name": "shitoyaka",
         "trans": [
+            "淑(しと)やか",
             "② ナ形  端庄的，贤淑的"
-        ],
-        "notation": "淑(しと)やか"
+        ]
     },
     {
         "name": "panku",
         "trans": [
+            "パンク",
             "⓪ 名·自动3  爆胎；胀破；拥挤不堪；破产"
-        ],
-        "notation": "パンク"
+        ]
     },
     {
         "name": "houshuu",
         "trans": [
+            "報酬(ほうしゅう)",
             "⓪ 名  报酬"
-        ],
-        "notation": "報酬(ほうしゅう)"
+        ]
     },
     {
         "name": "moritsuke",
         "trans": [
+            "盛(も)り付(つ)け",
             "⓪ 名  把食物放入盘中，装盘摆设"
-        ],
-        "notation": "盛(も)り付(つ)け"
+        ]
     },
     {
         "name": "ouchaku",
         "trans": [
+            "横着(おうちゃく)",
             "③ 名·ナ形·自动3  偷懒，耍滑头；厚脸皮"
-        ],
-        "notation": "横着(おうちゃく)"
+        ]
     },
     {
         "name": "danzen",
         "trans": [
+            "断然(だんぜん)",
             "⓪ 副  断然；显然；决（不）"
-        ],
-        "notation": "断然(だんぜん)"
+        ]
     },
     {
         "name": "kireme",
         "trans": [
+            "切(き)れ目(め)",
             "③ 名  断开处，裂缝；间隔；段落"
-        ],
-        "notation": "切(き)れ目(め)"
+        ]
     },
     {
         "name": "shotei",
         "trans": [
+            "所定(しょてい)",
             "⓪ 名  指定，规定"
-        ],
-        "notation": "所定(しょてい)"
+        ]
     },
     {
         "name": "dassen",
         "trans": [
+            "脱線(だっせん)",
             "⓪ 名·自动3  脱轨；离题"
-        ],
-        "notation": "脱線(だっせん)"
+        ]
     },
     {
         "name": "hensei",
         "trans": [
+            "編成(へんせい)",
             "⓪ 名·他动3  编成，组成"
-        ],
-        "notation": "編成(へんせい)"
+        ]
     },
     {
         "name": "moppara",
         "trans": [
+            "専(もっぱ)ら",
             "⓪ 名·副  专门；主要；净"
-        ],
-        "notation": "専(もっぱ)ら"
+        ]
     },
     {
         "name": "missetsu",
         "trans": [
+            "密接(みっせつ)",
             "⓪ 名·ナ形·自动3  密切；紧挨"
-        ],
-        "notation": "密接(みっせつ)"
+        ]
     },
     {
         "name": "arukari",
         "trans": [
+            "アルカリ",
             "⓪ 名  （化学用语）碱，强碱"
-        ],
-        "notation": "アルカリ"
+        ]
     },
     {
         "name": "kyuusai",
         "trans": [
+            "救済(きゅうさい)",
             "⓪ 名·他动3  救济"
-        ],
-        "notation": "救済(きゅうさい)"
+        ]
     },
     {
         "name": "sushidume",
         "trans": [
+            "すし詰(づ)め",
             "⓪ 名·ナ形  拥挤不堪"
-        ],
-        "notation": "すし詰(づ)め"
+        ]
     },
     {
         "name": "shioreru",
         "trans": [
+            "萎(しお)れる",
             "⓪ 自动2  枯萎；灰心丧气，意志消沉，沮丧"
-        ],
-        "notation": "萎(しお)れる"
+        ]
     },
     {
         "name": "tokken",
         "trans": [
+            "特権(とっけん)",
             "⓪ 名  特权"
-        ],
-        "notation": "特権(とっけん)"
+        ]
     },
     {
         "name": "hakkutsu",
         "trans": [
+            "発掘(はっくつ)",
             "⓪ 名·他动3  发掘，挖掘"
-        ],
-        "notation": "発掘(はっくつ)"
+        ]
     },
     {
         "name": "houshi",
         "trans": [
+            "奉仕(ほうし)",
             "① 名·自动3  （义务）服务，效劳；廉价销售商品"
-        ],
-        "notation": "奉仕(ほうし)"
+        ]
     },
     {
         "name": "memori",
         "trans": [
+            "目盛(めも)り",
             "③ 名  刻度，度数"
-        ],
-        "notation": "目盛(めも)り"
+        ]
     },
     {
         "name": "tegatai",
         "trans": [
+            "手堅(てがた)い",
             "③ イ形  踏实的，靠得住的；（行情）稳定的"
-        ],
-        "notation": "手堅(てがた)い"
+        ]
     },
     {
         "name": "jinryoku",
         "trans": [
+            "尽力(じんりょく)",
             "① 名·自动3  尽力，努力"
-        ],
-        "notation": "尽力(じんりょく)"
+        ]
     },
     {
         "name": "chouhou",
         "trans": [
+            "重宝(ちょうほう)",
             "① ナ形·他动3  便利的，实用的；珍视，爱惜"
-        ],
-        "notation": "重宝(ちょうほう)"
+        ]
     },
     {
         "name": "bakkunanba-",
         "trans": [
+            "バックナンバー",
             "④ 名  过期杂志；车牌号"
-        ],
-        "notation": "バックナンバー"
+        ]
     },
     {
         "name": "tasuuketsu",
         "trans": [
+            "多数決(たすうけつ)",
             "② 名  多数表决，多数决定"
-        ],
-        "notation": "多数決(たすうけつ)"
+        ]
     },
     {
         "name": "utsurikawaru",
         "trans": [
+            "移(うつ)り変(か)わる",
             "⑤ 自动1  变迁，变化"
-        ],
-        "notation": "移(うつ)り変(か)わる"
+        ]
     },
     {
         "name": "hibi",
         "trans": [
+            "皹(ひび)",
             "② 名  皲裂；裂痕；不和"
-        ],
-        "notation": "皹(ひび)"
+        ]
     },
     {
         "name": "mangetsu",
         "trans": [
+            "満月(まんげつ)",
             "① 名  满月，圆月"
-        ],
-        "notation": "満月(まんげつ)"
+        ]
     },
     {
         "name": "shippei",
         "trans": [
+            "疾病(しっぺい)",
             "⓪ 名  疾病"
-        ],
-        "notation": "疾病(しっぺい)"
+        ]
     },
     {
         "name": "suponsa-",
         "trans": [
+            "スポンサー",
             "② 名  赞助者，广告主"
-        ],
-        "notation": "スポンサー"
+        ]
     },
     {
         "name": "torinozoku",
         "trans": [
+            "取(と)り除(のぞ)く",
             "⓪ 他动1  除掉，去掉；拆掉"
-        ],
-        "notation": "取(と)り除(のぞ)く"
+        ]
     },
     {
         "name": "tainou",
         "trans": [
+            "滞納(たいのう)",
             "⓪ 名·他动3  滞纳，拖欠，逾期未缴"
-        ],
-        "notation": "滞納(たいのう)"
+        ]
     },
     {
         "name": "fujun",
         "trans": [
+            "不順(ふじゅん)",
             "⓪ 名·ナ形  不顺，异常；不合理，没有道理"
-        ],
-        "notation": "不順(ふじゅん)"
+        ]
     },
     {
         "name": "itareritsukuseri",
         "trans": [
+            "至(いた)れり尽(つ)くせり",
             "⑦ 连语  尽善尽美，无微不至"
-        ],
-        "notation": "至(いた)れり尽(つ)くせり"
+        ]
     },
     {
         "name": "sagi",
         "trans": [
+            "詐欺(さぎ)",
             "① 名  诈骗，欺诈"
-        ],
-        "notation": "詐欺(さぎ)"
+        ]
     },
     {
         "name": "nadameru",
         "trans": [
+            "宥(なだ)める",
             "③ 他动2  抚慰，安抚；劝解"
-        ],
-        "notation": "宥(なだ)める"
+        ]
     },
     {
         "name": "soroban",
         "trans": [
+            "算盤(そろばん)",
             "⓪ 名  算盘；利害得失的计算"
-        ],
-        "notation": "算盤(そろばん)"
+        ]
     },
     {
         "name": "kake",
         "trans": [
+            "掛(か)け",
             "② 名  悬挂物；赊账；欠款"
-        ],
-        "notation": "掛(か)け"
+        ]
     },
     {
         "name": "kimei",
         "trans": [
+            "記名(きめい)",
             "⓪ 名·自动3  记名，签名"
-        ],
-        "notation": "記名(きめい)"
+        ]
     },
     {
         "name": "shibai",
         "trans": [
+            "芝居(しばい)",
             "⓪ 名  戏剧；演技；把戏"
-        ],
-        "notation": "芝居(しばい)"
+        ]
     },
     {
         "name": "ayafuya",
         "trans": [
+            "あやふや",
             "⓪ ナ形  含糊不清的，模棱两可的"
-        ],
-        "notation": "あやふや"
+        ]
     },
     {
         "name": "koumyou",
         "trans": [
+            "功名(こうみょう)",
             "⓪ 名  功名"
-        ],
-        "notation": "功名(こうみょう)"
+        ]
     },
     {
         "name": "supuringu",
         "trans": [
+            "スプリング",
             "③ 名  春天；弹簧，弹力"
-        ],
-        "notation": "スプリング"
+        ]
     },
     {
         "name": "sonomono",
         "trans": [
+            "そのもの",
             "④ 名  事物本身"
-        ],
-        "notation": "そのもの"
+        ]
     },
     {
         "name": "tenka",
         "trans": [
+            "天下(てんか)",
             "① 名  天下"
-        ],
-        "notation": "天下(てんか)"
+        ]
     },
     {
         "name": "kegarawashii",
         "trans": [
+            "汚(けが)らわしい",
             "⑤ イ形  污秽的，肮脏的；卑鄙的"
-        ],
-        "notation": "汚(けが)らわしい"
+        ]
     },
     {
         "name": "hatsubyou",
         "trans": [
+            "発病(はつびょう)",
             "⓪ 名·自动3  发病，得病"
-        ],
-        "notation": "発病(はつびょう)"
+        ]
     },
     {
         "name": "burando",
         "trans": [
+            "ブランド",
             "⓪ 名  品牌，商标"
-        ],
-        "notation": "ブランド"
+        ]
     },
     {
         "name": "ryoushi",
         "trans": [
+            "漁師(りょうし)",
             "① 名  渔民，渔夫"
-        ],
-        "notation": "漁師(りょうし)"
+        ]
     },
     {
         "name": "ketsubou",
         "trans": [
+            "欠乏(けつぼう)",
             "⓪ 名·自动3  缺少，不足"
-        ],
-        "notation": "欠乏(けつぼう)"
+        ]
     },
     {
         "name": "neduyoi",
         "trans": [
+            "根強(ねづよ)い",
             "③ イ形  根深蒂固的；坚忍不拔的，顽强的"
-        ],
-        "notation": "根強(ねづよ)い"
+        ]
     },
     {
         "name": "ookata",
         "trans": [
+            "大方(おおかた)",
             "⓪ 名·副  大部分；一般人；大致"
-        ],
-        "notation": "大方(おおかた)"
+        ]
     },
     {
         "name": "ko-do",
         "trans": [
+            "コード",
             "① 名  规则；符号，代码；编码"
-        ],
-        "notation": "コード"
+        ]
     },
     {
         "name": "sanaka",
         "trans": [
+            "最中(さなか)",
             "① 名  最高潮，最盛期"
-        ],
-        "notation": "最中(さなか)"
+        ]
     },
     {
         "name": "seiyaku",
         "trans": [
+            "制約(せいやく)",
             "⓪ 名·他动3  制约，限制"
-        ],
-        "notation": "制約(せいやく)"
+        ]
     },
     {
         "name": "ayumu",
         "trans": [
+            "歩(あゆ)む",
             "② 自动1  走；发展，前进"
-        ],
-        "notation": "歩(あゆ)む"
+        ]
     },
     {
         "name": "tsuke",
         "trans": [
+            "付(つ)け",
             "② 名  账单；赊账"
-        ],
-        "notation": "付(つ)け"
+        ]
     },
     {
         "name": "fuhyou",
         "trans": [
+            "不評(ふひょう)",
             "⓪ 名  声誉不好，评价低"
-        ],
-        "notation": "不評(ふひょう)"
+        ]
     },
     {
         "name": "shousan",
         "trans": [
+            "勝算(しょうさん)",
             "⓪ 名  胜算"
-        ],
-        "notation": "勝算(しょうさん)"
+        ]
     },
     {
         "name": "tagui",
         "trans": [
+            "類(たぐい)",
             "① 名  同类；匹敌"
-        ],
-        "notation": "類(たぐい)"
+        ]
     },
     {
         "name": "hitosuji",
         "trans": [
+            "一筋(ひとすじ)",
             "② 名·ナ形  一条，一根；一心一意"
-        ],
-        "notation": "一筋(ひとすじ)"
+        ]
     },
     {
         "name": "ippen",
         "trans": [
+            "一変(いっぺん)",
             "⓪ 名·自他动3  完全改变，突然改变"
-        ],
-        "notation": "一変(いっぺん)"
+        ]
     },
     {
         "name": "kyouhaku",
         "trans": [
+            "脅迫(きょうはく)",
             "⓪ 名·他动3  威胁，恐吓，胁迫"
-        ],
-        "notation": "脅迫(きょうはく)"
+        ]
     },
     {
         "name": "sakiokuri",
         "trans": [
+            "先送(さきおく)り",
             "⓪ 名·他动3  延缓，推后"
-        ],
-        "notation": "先送(さきおく)り"
+        ]
     },
     {
         "name": "tenraku",
         "trans": [
+            "転落(てんらく)",
             "⓪ 名·自动3  跌落，滚下；落魄，沦落"
-        ],
-        "notation": "転落(てんらく)"
+        ]
     },
     {
         "name": "shosen",
         "trans": [
+            "所詮(しょせん)",
             "⓪ 副  归根到底，终归"
-        ],
-        "notation": "所詮(しょせん)"
+        ]
     },
     {
         "name": "seishi",
         "trans": [
+            "生死(せいし)",
             "① 名  生死"
-        ],
-        "notation": "生死(せいし)"
+        ]
     },
     {
         "name": "tan'nou",
         "trans": [
+            "堪能(たんのう)",
             "⓪ 名·ナ形·自他动3  擅长；十分满足"
-        ],
-        "notation": "堪能(たんのう)"
+        ]
     },
     {
         "name": "pare-do",
         "trans": [
+            "パレード",
             "② 名·自动3  阅兵式；盛装游行"
-        ],
-        "notation": "パレード"
+        ]
     },
     {
         "name": "hossa",
         "trans": [
+            "発作(ほっさ)",
             "⓪ 名·自动3  （疾病）发作"
-        ],
-        "notation": "発作(ほっさ)"
+        ]
     },
     {
         "name": "toboshii",
         "trans": [
+            "乏(とぼ)しい",
             "③ イ形  缺乏的，不足的；贫穷的，贫困的，贫乏的"
-        ],
-        "notation": "乏(とぼ)しい"
+        ]
     },
     {
         "name": "atsukai",
         "trans": [
+            "扱(あつか)い",
             "⓪ 名  操作；对待；处理；经营"
-        ],
-        "notation": "扱(あつか)い"
+        ]
     },
     {
         "name": "shadan",
         "trans": [
+            "遮断(しゃだん)",
             "⓪ 名·他动3  截断，切断，隔绝"
-        ],
-        "notation": "遮断(しゃだん)"
+        ]
     },
     {
         "name": "kenshiki",
         "trans": [
+            "見識(けんしき)",
             "⓪ 名  见地，见识，鉴赏力"
-        ],
-        "notation": "見識(けんしき)"
+        ]
     },
     {
         "name": "sousaku",
         "trans": [
+            "捜索(そうさく)",
             "⓪ 名·他动3  搜索，搜寻"
-        ],
-        "notation": "捜索(そうさく)"
+        ]
     },
     {
         "name": "katayoru",
         "trans": [
+            "偏(かたよ)る",
             "③ 自动1  不均衡，偏向一方；偏颇，偏袒"
-        ],
-        "notation": "偏(かたよ)る"
+        ]
     },
     {
         "name": "tsubo",
         "trans": [
+            "壺(つぼ)",
             "⓪ 名  坛子；穴位；关键，要点"
-        ],
-        "notation": "壺(つぼ)"
+        ]
     },
     {
         "name": "taiji",
         "trans": [
+            "退治(たいじ)",
             "⓪ 名·他动3  扑灭，消灭；打退"
-        ],
-        "notation": "退治(たいじ)"
+        ]
     },
     {
         "name": "koubai",
         "trans": [
+            "勾配(こうばい)",
             "⓪ 名  斜坡，坡度"
-        ],
-        "notation": "勾配(こうばい)"
+        ]
     },
     {
         "name": "taihi",
         "trans": [
+            "対比(たいひ)",
             "⓪ 名·他动3  对比，对照"
-        ],
-        "notation": "対比(たいひ)"
+        ]
     },
     {
         "name": "moroni",
         "trans": [
+            "もろに",
             "① 副  全面；迎面，直接"
-        ],
-        "notation": "もろに"
+        ]
     },
     {
         "name": "doriru",
         "trans": [
+            "ドリル",
             "① 名  钢钻，钻孔器；训练，练习"
-        ],
-        "notation": "ドリル"
+        ]
     },
     {
         "name": "joukigen",
         "trans": [
+            "上機嫌(じょうきげん)",
             "③ 名·ナ形  心情愉快"
-        ],
-        "notation": "上機嫌(じょうきげん)"
+        ]
     },
     {
         "name": "fuyukitodoki",
         "trans": [
+            "不行(ふゆ)き届(とど)き",
             "④ 名·ナ形  （招待）不周到，疏忽"
-        ],
-        "notation": "不行(ふゆ)き届(とど)き"
+        ]
     },
     {
         "name": "ijiwaru",
         "trans": [
+            "意地悪(いじわる)",
             "③ 名·ナ形  使坏，刁难，捉弄"
-        ],
-        "notation": "意地悪(いじわる)"
+        ]
     },
     {
         "name": "kisou",
         "trans": [
+            "競(きそ)う",
             "② 他动1  竞争，竞赛"
-        ],
-        "notation": "競(きそ)う"
+        ]
     },
     {
         "name": "ketsui",
         "trans": [
+            "決意(けつい)",
             "① 名·自他动3  决意，决心"
-        ],
-        "notation": "決意(けつい)"
+        ]
     },
     {
         "name": "shougou",
         "trans": [
+            "照合(しょうごう)",
             "⓪ 名·他动3  对照，核对"
-        ],
-        "notation": "照合(しょうごう)"
+        ]
     },
     {
         "name": "chuukoku",
         "trans": [
+            "忠告(ちゅうこく)",
             "⓪ 名·自他动3  忠告，劝告"
-        ],
-        "notation": "忠告(ちゅうこく)"
+        ]
     },
     {
         "name": "hinjaku",
         "trans": [
+            "貧弱(ひんじゃく)",
             "⓪ 名·ナ形  贫乏，贫弱；寒碜"
-        ],
-        "notation": "貧弱(ひんじゃく)"
+        ]
     },
     {
         "name": "toritateru",
         "trans": [
+            "取(と)り立(た)てる",
             "④ 他动2  索取，催收；提拔；特别提及"
-        ],
-        "notation": "取(と)り立(た)てる"
+        ]
     },
     {
         "name": "hanpatsu",
         "trans": [
+            "反発(はんぱつ)",
             "⓪ 名·自他动3  排斥；反感，抗拒；（行情）回升"
-        ],
-        "notation": "反発(はんぱつ)"
+        ]
     },
     {
         "name": "bouraku",
         "trans": [
+            "暴落(ぼうらく)",
             "⓪ 名·自动3  暴跌"
-        ],
-        "notation": "暴落(ぼうらく)"
+        ]
     },
     {
         "name": "arerugi-",
         "trans": [
+            "アレルギー",
             "③ 名  过敏，过敏反应"
-        ],
-        "notation": "アレルギー"
+        ]
     },
     {
         "name": "kokochi",
         "trans": [
+            "心地(ここち)",
             "⓪ 名  心情，心境，感觉"
-        ],
-        "notation": "心地(ここち)"
+        ]
     },
     {
         "name": "omomuku",
         "trans": [
+            "赴(おもむ)く",
             "③ 自动1  前往，奔赴；趋向，倾向"
-        ],
-        "notation": "赴(おもむ)く"
+        ]
     },
     {
         "name": "kasen",
         "trans": [
+            "河川(かせん)",
             "① 名  河川"
-        ],
-        "notation": "河川(かせん)"
+        ]
     },
     {
         "name": "kontoro-ru",
         "trans": [
+            "コントロール",
             "④ 名·他动3  控制，操纵，管理"
-        ],
-        "notation": "コントロール"
+        ]
     },
     {
         "name": "jouyou",
         "trans": [
+            "常用(じょうよう)",
             "⓪ 名·他动3  常用，经常使用"
-        ],
-        "notation": "常用(じょうよう)"
+        ]
     },
     {
         "name": "sokubaku",
         "trans": [
+            "束縛(そくばく)",
             "⓪ 名·他动3  束缚，限制"
-        ],
-        "notation": "束縛(そくばく)"
+        ]
     },
     {
         "name": "hyousuru",
         "trans": [
+            "表(ひょう)する",
             "③ 他动3  表示，表达"
-        ],
-        "notation": "表(ひょう)する"
+        ]
     },
     {
         "name": "ryoushiki",
         "trans": [
+            "良識(りょうしき)",
             "⓪ 名  明智，正确的判断"
-        ],
-        "notation": "良識(りょうしき)"
+        ]
     },
     {
         "name": "inki",
         "trans": [
+            "陰気(いんき)",
             "⓪ ナ形  忧郁的，阴郁的；阴沉的，阴暗的"
-        ],
-        "notation": "陰気(いんき)"
+        ]
     },
     {
         "name": "kifuku",
         "trans": [
+            "起伏(きふく)",
             "⓪ 名·自动3  起伏；浮沉，起落"
-        ],
-        "notation": "起伏(きふく)"
+        ]
     },
     {
         "name": "saiken",
         "trans": [
+            "再建(さいけん)",
             "⓪ 名·他动3  重建"
-        ],
-        "notation": "再建(さいけん)"
+        ]
     },
     {
         "name": "anzuru",
         "trans": [
+            "案(あん)ずる",
             "③ 他动3  担心，挂念"
-        ],
-        "notation": "案(あん)ずる"
+        ]
     },
     {
         "name": "jirenma",
         "trans": [
+            "ジレンマ",
             "② 名  进退维谷，困境"
-        ],
-        "notation": "ジレンマ"
+        ]
     },
     {
         "name": "dattai",
         "trans": [
+            "脱退(だったい)",
             "⓪ 名·自动3  脱离，退出"
-        ],
-        "notation": "脱退(だったい)"
+        ]
     },
     {
         "name": "tegiwa",
         "trans": [
+            "手際(てぎわ)",
             "⓪ 名  （处理事物的）手法，技巧；手腕，本领"
-        ],
-        "notation": "手際(てぎわ)"
+        ]
     },
     {
         "name": "fukkyuu",
         "trans": [
+            "復旧(ふっきゅう)",
             "⓪ 名·自他动3  复原，修复"
-        ],
-        "notation": "復旧(ふっきゅう)"
+        ]
     },
     {
         "name": "sorehasateoki",
         "trans": [
+            "それはさておき",
             "④ 副  那个暂且不提，闲话休提"
-        ],
-        "notation": "それはさておき"
+        ]
     },
     {
         "name": "matomo",
         "trans": [
+            "まとも",
             "⓪ 名·ナ形  正面；正经，认真"
-        ],
-        "notation": "まとも"
+        ]
     },
     {
         "name": "mondou",
         "trans": [
+            "問答(もんどう)",
             "③ 名·自动3  问答；讨论，商量"
-        ],
-        "notation": "問答(もんどう)"
+        ]
     },
     {
         "name": "un'nun",
         "trans": [
+            "云々(うんぬん)",
             "③ 名·他动3  说三道四，说长道短；云云，等等"
-        ],
-        "notation": "云々(うんぬん)"
+        ]
     },
     {
         "name": "shoukai",
         "trans": [
+            "照会(しょうかい)",
             "⓪ 名·他动3  询问，查询"
-        ],
-        "notation": "照会(しょうかい)"
+        ]
     },
     {
         "name": "kutsugaesu",
         "trans": [
+            "覆(くつがえ)す",
             "③ 他动1  打翻；推翻(政权、学说)"
-        ],
-        "notation": "覆(くつがえ)す"
+        ]
     },
     {
         "name": "chissoku",
         "trans": [
+            "窒息(ちっそく)",
             "⓪ 名·自动3  窒息"
-        ],
-        "notation": "窒息(ちっそく)"
+        ]
     },
     {
         "name": "nekku",
         "trans": [
+            "ネック",
             "① 名  颈部；衣领；障碍，瓶颈"
-        ],
-        "notation": "ネック"
+        ]
     },
     {
         "name": "hyouhon",
         "trans": [
+            "標本(ひょうほん)",
             "⓪ 名  标本；样本"
-        ],
-        "notation": "標本(ひょうほん)"
+        ]
     },
     {
         "name": "hokyuu",
         "trans": [
+            "補給(ほきゅう)",
             "⓪ 名·他动3  补给，补充"
-        ],
-        "notation": "補給(ほきゅう)"
+        ]
     },
     {
         "name": "narabini",
         "trans": [
+            "並(なら)びに",
             "⓪ 接续  和，以及"
-        ],
-        "notation": "並(なら)びに"
+        ]
     },
     {
         "name": "ousei",
         "trans": [
+            "旺盛(おうせい)",
             "⓪ 名·ナ形  旺盛，充沛"
-        ],
-        "notation": "旺盛(おうせい)"
+        ]
     },
     {
         "name": "kyouka",
         "trans": [
+            "強化(きょうか)",
             "① 名·他动3  强化，加强"
-        ],
-        "notation": "強化(きょうか)"
+        ]
     },
     {
         "name": "shitsuyou",
         "trans": [
+            "執拗(しつよう)",
             "⓪ 名·ナ形  纠缠不休；执拗，固执"
-        ],
-        "notation": "執拗(しつよう)"
+        ]
     },
     {
         "name": "zoushin",
         "trans": [
+            "増進(ぞうしん)",
             "⓪ 名·自他动3  增进，增加"
-        ],
-        "notation": "増進(ぞうしん)"
+        ]
     },
     {
         "name": "mukuu",
         "trans": [
+            "報(むく)う",
             "② 自他动1  报偿，报答"
-        ],
-        "notation": "報(むく)う"
+        ]
     },
     {
         "name": "tanteki",
         "trans": [
+            "端的(たんてき)",
             "⓪ ナ形  直率的，直截了当的；明显的，清楚的"
-        ],
-        "notation": "端的(たんてき)"
+        ]
     },
     {
         "name": "barome-ta-",
         "trans": [
+            "バロメーター",
             "③ 名  气压计；标志，指标"
-        ],
-        "notation": "バロメーター"
+        ]
     },
     {
         "name": "fureau",
         "trans": [
+            "触(ふ)れ合(あ)う",
             "③ 自动1  互相接触；互相挨着"
-        ],
-        "notation": "触(ふ)れ合(あ)う"
+        ]
     },
     {
         "name": "mizuke",
         "trans": [
+            "水気(みずけ)",
             "⓪ 名  水分"
-        ],
-        "notation": "水気(みずけ)"
+        ]
     },
     {
         "name": "tokiori",
         "trans": [
+            "時折(ときおり)",
             "⓪ 副  有时，偶尔"
-        ],
-        "notation": "時折(ときおり)"
+        ]
     },
     {
         "name": "enpou",
         "trans": [
+            "遠方(えんぽう)",
             "⓪ 名  远方，远处"
-        ],
-        "notation": "遠方(えんぽう)"
+        ]
     },
     {
         "name": "kyasha",
         "trans": [
+            "華奢(きゃしゃ)",
             "⓪ ナ形  苗条的，纤细的；纤弱的，不结实的"
-        ],
-        "notation": "華奢(きゃしゃ)"
+        ]
     },
     {
         "name": "konma",
         "trans": [
+            "コンマ",
             "① 名  逗号；小数点"
-        ],
-        "notation": "コンマ"
+        ]
     },
     {
         "name": "shuusei",
         "trans": [
+            "修正(しゅうせい)",
             "⓪ 名·他动3  修正，改正"
-        ],
-        "notation": "修正(しゅうせい)"
+        ]
     },
     {
         "name": "kasumu",
         "trans": [
+            "霞(かす)む",
             "⓪ 自动1  云雾朦胧；眼睛模糊，看不清楚；暗淡，不醒目"
-        ],
-        "notation": "霞(かす)む"
+        ]
     },
     {
         "name": "tanpaku",
         "trans": [
+            "淡泊(たんぱく)",
             "① 名·ナ形  淡；坦率，爽直；淡泊"
-        ],
-        "notation": "淡泊(たんぱく)"
+        ]
     },
     {
         "name": "baibai",
         "trans": [
+            "売買(ばいばい)",
             "① 名·他动3  买卖"
-        ],
-        "notation": "売買(ばいばい)"
+        ]
     },
     {
         "name": "ichiran",
         "trans": [
+            "一覧(いちらん)",
             "⓪ 名·他动3  一览表，便览；一览，一看"
-        ],
-        "notation": "一覧(いちらん)"
+        ]
     },
     {
         "name": "kaitei",
         "trans": [
+            "改訂(かいてい)",
             "⓪ 名·他动3  修订"
-        ],
-        "notation": "改訂(かいてい)"
+        ]
     },
     {
         "name": "moteru",
         "trans": [
+            "持(も)てる",
             "② 自动2  能有，拥有；受欢迎，受捧"
-        ],
-        "notation": "持(も)てる"
+        ]
     },
     {
         "name": "kouseki",
         "trans": [
+            "鉱石(こうせき)",
             "⓪ 名  矿石"
-        ],
-        "notation": "鉱石(こうせき)"
+        ]
     },
     {
         "name": "chomei",
         "trans": [
+            "著名(ちょめい)",
             "⓪ 名·ナ形  著名，有名"
-        ],
-        "notation": "著名(ちょめい)"
+        ]
     },
     {
         "name": "douyou",
         "trans": [
+            "動揺(どうよう)",
             "⓪ 名·自动3  颠簸，摆动；动摇，不安"
-        ],
-        "notation": "動揺(どうよう)"
+        ]
     },
     {
         "name": "nariyuki",
         "trans": [
+            "成(な)り行(ゆ)き",
             "⓪ 名  动向，趋势"
-        ],
-        "notation": "成(な)り行(ゆ)き"
+        ]
     },
     {
         "name": "shinbouduyoi",
         "trans": [
+            "辛抱強(しんぼうづよ)い",
             "⑥ イ形  有耐心的，忍耐力强的"
-        ],
-        "notation": "辛抱強(しんぼうづよ)い"
+        ]
     },
     {
         "name": "fo-maru",
         "trans": [
+            "フォーマル",
             "① ナ形  正式的"
-        ],
-        "notation": "フォーマル"
+        ]
     },
     {
         "name": "micchaku",
         "trans": [
+            "密着(みっちゃく)",
             "⓪ 名·自动3  贴近，紧贴"
-        ],
-        "notation": "密着(みっちゃく)"
+        ]
     },
     {
         "name": "arisama",
         "trans": [
+            "有様(ありさま)",
             "② 名  样子，光景，状态"
-        ],
-        "notation": "有様(ありさま)"
+        ]
     },
     {
         "name": "ginmi",
         "trans": [
+            "吟味(ぎんみ)",
             "① 名·他动3  斟酌，考虑，考量"
-        ],
-        "notation": "吟味(ぎんみ)"
+        ]
     },
     {
         "name": "bikutomo",
         "trans": [
+            "びくとも",
             "① 副  （后接否定）纹丝不动，毫不动摇"
-        ],
-        "notation": "びくとも"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "回送(かいそう)",
             "⓪ 名·他动3  转寄（信件）；调回，开回（空车等）；运送"
-        ],
-        "notation": "回送(かいそう)"
+        ]
     },
     {
         "name": "kone",
         "trans": [
+            "コネ",
             "② 名  后门，特殊关系"
-        ],
-        "notation": "コネ"
+        ]
     },
     {
         "name": "jouriku",
         "trans": [
+            "上陸(じょうりく)",
             "⓪ 名·自动3  登陆，登岸"
-        ],
-        "notation": "上陸(じょうりく)"
+        ]
     },
     {
         "name": "zoukyou",
         "trans": [
+            "増強(ぞうきょう)",
             "⓪ 名·他动3  增强，加强"
-        ],
-        "notation": "増強(ぞうきょう)"
+        ]
     },
     {
         "name": "guchagucha",
         "trans": [
+            "ぐちゃぐちゃ",
             "① 副·ナ形  黏黏糊糊；乱七八糟；嘀嘀咕咕"
-        ],
-        "notation": "ぐちゃぐちゃ"
+        ]
     },
     {
         "name": "chuushou",
         "trans": [
+            "中傷(ちゅうしょう)",
             "⓪ 名·他动3  中伤，诽谤"
-        ],
-        "notation": "中傷(ちゅうしょう)"
+        ]
     },
     {
         "name": "dote",
         "trans": [
+            "土手(どて)",
             "⓪ 名  堤坝，河堤"
-        ],
-        "notation": "土手(どて)"
+        ]
     },
     {
         "name": "hate",
         "trans": [
+            "果(は)て",
             "② 名  边际，尽头；结果"
-        ],
-        "notation": "果(は)て"
+        ]
     },
     {
         "name": "boudou",
         "trans": [
+            "暴動(ぼうどう)",
             "⓪ 名  暴动"
-        ],
-        "notation": "暴動(ぼうどう)"
+        ]
     },
     {
         "name": "arakata",
         "trans": [
+            "あらかた",
             "⓪ 副  大部分，大致，大体上"
-        ],
-        "notation": "あらかた"
+        ]
     },
     {
         "name": "ayamachi",
         "trans": [
+            "過(あやま)ち",
             "③ 名  错误，过失"
-        ],
-        "notation": "過(あやま)ち"
+        ]
     },
     {
         "name": "gaitou",
         "trans": [
+            "該当(がいとう)",
             "⓪ 名·自动3  符合，适合"
-        ],
-        "notation": "該当(がいとう)"
+        ]
     },
     {
         "name": "sakugo",
         "trans": [
+            "錯誤(さくご)",
             "① 名  错误；不符合，错谬"
-        ],
-        "notation": "錯誤(さくご)"
+        ]
     },
     {
         "name": "kyougou",
         "trans": [
+            "競合(きょうごう)",
             "⓪ 名·自动3  竞争"
-        ],
-        "notation": "競合(きょうごう)"
+        ]
     },
     {
         "name": "yuusuru",
         "trans": [
+            "有(ゆう)する",
             "③ 他动3  有，拥有"
-        ],
-        "notation": "有(ゆう)する"
+        ]
     },
     {
         "name": "shimi",
         "trans": [
+            "染(し)み",
             "⓪ 名  污垢，污痕；污点；色斑"
-        ],
-        "notation": "染(し)み"
+        ]
     },
     {
         "name": "serufusa-bisu",
         "trans": [
+            "セルフサービス",
             "④ 名  自助，自选"
-        ],
-        "notation": "セルフサービス"
+        ]
     },
     {
         "name": "tarumi",
         "trans": [
+            "弛(たる)み",
             "⓪ 名  松弛；松懈"
-        ],
-        "notation": "弛(たる)み"
+        ]
     },
     {
         "name": "tekisei",
         "trans": [
+            "適性(てきせい)",
             "⓪ 名  适应性"
-        ],
-        "notation": "適性(てきせい)"
+        ]
     },
     {
         "name": "moroi",
         "trans": [
+            "脆(もろ)い",
             "② イ形  易碎的；脆弱的；没有持久力的"
-        ],
-        "notation": "脆(もろ)い"
+        ]
     },
     {
         "name": "ninmei",
         "trans": [
+            "任命(にんめい)",
             "⓪ 名·他动3  任命"
-        ],
-        "notation": "任命(にんめい)"
+        ]
     },
     {
         "name": "hakunetsu",
         "trans": [
+            "白熱(はくねつ)",
             "⓪ 名·自动3  白炽；白热化，最热烈"
-        ],
-        "notation": "白熱(はくねつ)"
+        ]
     },
     {
         "name": "fushouji",
         "trans": [
+            "不祥事(ふしょうじ)",
             "② 名  不好的事，不正当的事"
-        ],
-        "notation": "不祥事(ふしょうじ)"
+        ]
     },
     {
         "name": "mitsudo",
         "trans": [
+            "密度(みつど)",
             "① 名  密度；（文章、讲话等的）充实程度"
-        ],
-        "notation": "密度(みつど)"
+        ]
     },
     {
         "name": "boyakeru",
         "trans": [
+            "ぼやける",
             "③ 自动2  模糊，不清楚"
-        ],
-        "notation": "ぼやける"
+        ]
     },
     {
         "name": "iseki",
         "trans": [
+            "移籍(いせき)",
             "⓪ 名·自动3  转移户籍；（运动员）转队"
-        ],
-        "notation": "移籍(いせき)"
+        ]
     },
     {
         "name": "kyuuji",
         "trans": [
+            "給仕(きゅうじ)",
             "① 名·自动3  服务人员；伺候（吃饭）"
-        ],
-        "notation": "給仕(きゅうじ)"
+        ]
     },
     {
         "name": "jigen",
         "trans": [
+            "次元(じげん)",
             "⓪ 名  次元，维度；着眼点，立场"
-        ],
-        "notation": "次元(じげん)"
+        ]
     },
     {
         "name": "sesou",
         "trans": [
+            "世相(せそう)",
             "⓪ 名  世态，社会情况"
-        ],
-        "notation": "世相(せそう)"
+        ]
     },
     {
         "name": "hitaru",
         "trans": [
+            "浸(ひた)る",
             "⓪ 自动1  浸，泡；沉浸，沉醉"
-        ],
-        "notation": "浸(ひた)る"
+        ]
     },
     {
         "name": "touryuumon",
         "trans": [
+            "登竜門(とうりゅうもん)",
             "③ 名  飞黄腾达的门路"
-        ],
-        "notation": "登竜門(とうりゅうもん)"
+        ]
     },
     {
         "name": "hitoichibai",
         "trans": [
+            "人一倍(ひといちばい)",
             "⓪ 名·副  比别人加倍"
-        ],
-        "notation": "人一倍(ひといちばい)"
+        ]
     },
     {
         "name": "bure-ku",
         "trans": [
+            "ブレーク",
             "② 名·自动3  休息；受欢迎"
-        ],
-        "notation": "ブレーク"
+        ]
     },
     {
         "name": "mura",
         "trans": [
+            "斑(むら)",
             "② 名  不均匀，有斑点；易变"
-        ],
-        "notation": "斑(むら)"
+        ]
     },
     {
         "name": "hanahada",
         "trans": [
+            "甚(はなは)だ",
             "⓪ 副  很，甚，极其"
-        ],
-        "notation": "甚(はなは)だ"
+        ]
     },
     {
         "name": "rirakkusu",
         "trans": [
+            "リラックス",
             "② 名·自动3  放松，轻松"
-        ],
-        "notation": "リラックス"
+        ]
     },
     {
         "name": "unpan",
         "trans": [
+            "運搬(うんぱん)",
             "⓪ 名·他动3  搬运，运输"
-        ],
-        "notation": "運搬(うんぱん)"
+        ]
     },
     {
         "name": "gekiyasu",
         "trans": [
+            "激安(げきやす)",
             "⓪ 名  非常便宜，折扣很低"
-        ],
-        "notation": "激安(げきやす)"
+        ]
     },
     {
         "name": "shuuto",
         "trans": [
+            "舅(しゅうと)",
             "⓪ 名  公公；岳父"
-        ],
-        "notation": "舅(しゅうと)"
+        ]
     },
     {
         "name": "neru",
         "trans": [
+            "練(ね)る",
             "① 他动1  推敲，斟酌；锻炼；搅拌"
-        ],
-        "notation": "練(ね)る"
+        ]
     },
     {
         "name": "soutai",
         "trans": [
+            "相対(そうたい)",
             "⓪ 名  相对"
-        ],
-        "notation": "相対(そうたい)"
+        ]
     },
     {
         "name": "hensen",
         "trans": [
+            "変遷(へんせん)",
             "⓪ 名·自动3  变迁"
-        ],
-        "notation": "変遷(へんせん)"
+        ]
     },
     {
         "name": "menkai",
         "trans": [
+            "面会(めんかい)",
             "⓪ 名·自动3  见面，会面"
-        ],
-        "notation": "面会(めんかい)"
+        ]
     },
     {
         "name": "oyagokoro",
         "trans": [
+            "親心(おやごころ)",
             "③ 名  父母的慈爱；（父母般的）亲切关怀"
-        ],
-        "notation": "親心(おやごころ)"
+        ]
     },
     {
         "name": "natsuku",
         "trans": [
+            "懐(なつ)く",
             "② 自动1  亲近，喜欢"
-        ],
-        "notation": "懐(なつ)く"
+        ]
     },
     {
         "name": "kougai",
         "trans": [
+            "口外(こうがい)",
             "⓪ 名·他动3  说出，泄露"
-        ],
-        "notation": "口外(こうがい)"
+        ]
     },
     {
         "name": "sokushin",
         "trans": [
+            "促進(そくしん)",
             "⓪ 名·他动3  促进"
-        ],
-        "notation": "促進(そくしん)"
+        ]
     },
     {
         "name": "tousotsu",
         "trans": [
+            "統率(とうそつ)",
             "⓪ 名·他动3  统率"
-        ],
-        "notation": "統率(とうそつ)"
+        ]
     },
     {
         "name": "shiruba-shi-to",
         "trans": [
+            "シルバーシート",
             " ⑤ 名  老弱病残孕专座"
-        ],
-        "notation": "シルバーシート"
+        ]
     },
     {
         "name": "totsujo",
         "trans": [
+            "突如(とつじょ)",
             "① 副·ナ形  突然，突如其来"
-        ],
-        "notation": "突如(とつじょ)"
+        ]
     },
     {
         "name": "bosshuu",
         "trans": [
+            "没収(ぼっしゅう)",
             "⓪ 名·他动3  没收，查抄"
-        ],
-        "notation": "没収(ぼっしゅう)"
+        ]
     },
     {
         "name": "mofuku",
         "trans": [
+            "喪服(もふく)",
             "⓪ 名  丧服"
-        ],
-        "notation": "喪服(もふく)"
+        ]
     },
     {
         "name": "arenji",
         "trans": [
+            "アレンジ",
             "② 名·他动3  布置；改编；安排"
-        ],
-        "notation": "アレンジ"
+        ]
     },
     {
         "name": "kainyuu",
         "trans": [
+            "介入(かいにゅう)",
             "⓪ 名·自动3  介入，插手，干涉"
-        ],
-        "notation": "介入(かいにゅう)"
+        ]
     },
     {
         "name": "tenjiru",
         "trans": [
+            "転(てん)じる",
             "⓪ 自他动2  改变，转换；迁居"
-        ],
-        "notation": "転(てん)じる"
+        ]
     },
     {
         "name": "sanka",
         "trans": [
+            "傘下(さんか)",
             "① 名  系统下，旗帜下，隶属于"
-        ],
-        "notation": "傘下(さんか)"
+        ]
     },
     {
         "name": "tachioujou",
         "trans": [
+            "立(た)ち往生(おうじょう)",
             "③ 名·自动3  进退维谷；动弹不得"
-        ],
-        "notation": "立(た)ち往生(おうじょう)"
+        ]
     },
     {
         "name": "haifu",
         "trans": [
+            "配付(はいふ)",
             "⓪ 名·他动3  分发，分配（给每个人）"
-        ],
-        "notation": "配付(はいふ)"
+        ]
     },
     {
         "name": "shuutaisei",
         "trans": [
+            "集大成(しゅうたいせい)",
             "③ 名·他动3  集大成"
-        ],
-        "notation": "集大成(しゅうたいせい)"
+        ]
     },
     {
         "name": "tsugunau",
         "trans": [
+            "償(つぐな)う",
             "③ 他动1  补偿，赔偿"
-        ],
-        "notation": "償(つぐな)う"
+        ]
     },
     {
         "name": "hitoribocchi",
         "trans": [
+            "一人(ひとり)ぼっち",
             "④ 名  孤身一人，孤零零一个人"
-        ],
-        "notation": "一人(ひとり)ぼっち"
+        ]
     },
     {
         "name": "bochi",
         "trans": [
+            "墓地(ぼち)",
             "① 名  墓地"
-        ],
-        "notation": "墓地(ぼち)"
+        ]
     },
     {
         "name": "itadaki",
         "trans": [
+            "頂(いただき)",
             "⓪ 名  顶，上部；山顶；赢定了"
-        ],
-        "notation": "頂(いただき)"
+        ]
     },
     {
         "name": "kaihi",
         "trans": [
+            "回避(かいひ)",
             "① 名·他动3  回避，逃避"
-        ],
-        "notation": "回避(かいひ)"
+        ]
     },
     {
         "name": "sassato",
         "trans": [
+            "さっさと",
             "① 副  赶快，迅速地，痛快地"
-        ],
-        "notation": "さっさと"
+        ]
     },
     {
         "name": "kousaku",
         "trans": [
+            "工作(こうさく)",
             "⓪ 名·他动3  制作；修理；活动，工作"
-        ],
-        "notation": "工作(こうさく)"
+        ]
     },
     {
         "name": "zandaka",
         "trans": [
+            "残高(ざんだか)",
             "① 名  余额，结余"
-        ],
-        "notation": "残高(ざんだか)"
+        ]
     },
     {
         "name": "kyouju",
         "trans": [
+            "享受(きょうじゅ)",
             "① 名·他动3  享受"
-        ],
-        "notation": "享受(きょうじゅ)"
+        ]
     },
     {
         "name": "zenmetsu",
         "trans": [
+            "全滅(ぜんめつ)",
             "⓪ 名·自他动3  全歼，全军覆没"
-        ],
-        "notation": "全滅(ぜんめつ)"
+        ]
     },
     {
         "name": "shiite",
         "trans": [
+            "強(し)いて",
             "① 副  强逼，强迫，勉强"
-        ],
-        "notation": "強(し)いて"
+        ]
     },
     {
         "name": "taibu",
         "trans": [
+            "大部(たいぶ)",
             "① 名  大部头（指图书的页数或卷数多）；大部分"
-        ],
-        "notation": "大部(たいぶ)"
+        ]
     },
     {
         "name": "tossa",
         "trans": [
+            "とっさ",
             "⓪ 名  瞬间，刹那间，立刻"
-        ],
-        "notation": "とっさ"
+        ]
     },
     {
         "name": "furi-zu",
         "trans": [
+            "フリーズ",
             "② 名·自动3  冷冻，冻结；死机"
-        ],
-        "notation": "フリーズ"
+        ]
     },
     {
         "name": "ryoushou",
         "trans": [
+            "了承(りょうしょう)",
             "⓪ 名·他动3  知悉，了解；同意；谅解"
-        ],
-        "notation": "了承(りょうしょう)"
+        ]
     },
     {
         "name": "sarasu",
         "trans": [
+            "晒(さら)す",
             "⓪ 他动1  暴晒；暴露；置身于"
-        ],
-        "notation": "晒(さら)す"
+        ]
     },
     {
         "name": "outen",
         "trans": [
+            "横転(おうてん)",
             "⓪ 名·自动3  翻滚；向左右旋转"
-        ],
-        "notation": "横転(おうてん)"
+        ]
     },
     {
         "name": "karisuma",
         "trans": [
+            "カリスマ",
             "⓪ 名  超凡的资质或能力"
-        ],
-        "notation": "カリスマ"
+        ]
     },
     {
         "name": "shinshutsu",
         "trans": [
+            "進出(しんしゅつ)",
             "⓪ 名·自动3  进入，打入"
-        ],
-        "notation": "進出(しんしゅつ)"
+        ]
     },
     {
         "name": "ansei",
         "trans": [
+            "安静(あんせい)",
             "⓪ 名·ナ形  病人静养；安静"
-        ],
-        "notation": "安静(あんせい)"
+        ]
     },
     {
         "name": "koukou",
         "trans": [
+            "煌々(こうこう)",
             "⓪ 副·ナ形  亮堂堂，闪闪发光"
-        ],
-        "notation": "煌々(こうこう)"
+        ]
     },
     {
         "name": "zenpan",
         "trans": [
+            "全般(ぜんぱん)",
             "⓪ 名  全体，整体，总体"
-        ],
-        "notation": "全般(ぜんぱん)"
+        ]
     },
     {
         "name": "chinden",
         "trans": [
+            "沈殿(ちんでん)",
             "⓪ 名·自动3  沉淀"
-        ],
-        "notation": "沈殿(ちんでん)"
+        ]
     },
     {
         "name": "nendo",
         "trans": [
+            "粘土(ねんど)",
             "① 名  黏土"
-        ],
-        "notation": "粘土(ねんど)"
+        ]
     },
     {
         "name": "hashiwatashi",
         "trans": [
+            "橋渡(はしわた)し",
             "③ 名  架桥；当中间人"
-        ],
-        "notation": "橋渡(はしわた)し"
+        ]
     },
     {
         "name": "kussuru",
         "trans": [
+            "屈(くっ)する",
             "⓪ 自动3  屈服，屈从"
-        ],
-        "notation": "屈(くっ)する"
+        ]
     },
     {
         "name": "fubuki",
         "trans": [
+            "吹雪(ふぶき)",
             "① 名  暴风雪"
-        ],
-        "notation": "吹雪(ふぶき)"
+        ]
     },
     {
         "name": "ponpu",
         "trans": [
+            "ポンプ",
             " ① 名  水泵"
-        ],
-        "notation": "ポンプ"
+        ]
     },
     {
         "name": "miryou",
         "trans": [
+            "魅了(みりょう)",
             "⓪ 名·他动3  使人入迷"
-        ],
-        "notation": "魅了(みりょう)"
+        ]
     },
     {
         "name": "inochitori",
         "trans": [
+            "命取(いのちと)り",
             "③ 名  要命的东西；致命伤"
-        ],
-        "notation": "命取(いのちと)り"
+        ]
     },
     {
         "name": "kyoujiru",
         "trans": [
+            "興(きょう)じる",
             "⓪ 自动2  有兴趣，感兴趣"
-        ],
-        "notation": "興(きょう)じる"
+        ]
     },
     {
         "name": "o-na-",
         "trans": [
+            "オーナー",
             "① 名  物主，所有者"
-        ],
-        "notation": "オーナー"
+        ]
     },
     {
         "name": "gensaku",
         "trans": [
+            "原作(げんさく)",
             "⓪ 名  原作，原著"
-        ],
-        "notation": "原作(げんさく)"
+        ]
     },
     {
         "name": "jishu",
         "trans": [
+            "自主(じしゅ)",
             "① 名  自主，独立自主"
-        ],
-        "notation": "自主(じしゅ)"
+        ]
     },
     {
         "name": "sokumen",
         "trans": [
+            "側面(そくめん)",
             "⓪ 名  侧面，间接；一面，片面"
-        ],
-        "notation": "側面(そくめん)"
+        ]
     },
     {
         "name": "kakageru",
         "trans": [
+            "掲(かか)げる",
             "⓪ 他动2  高举，悬挂；刊登，登载；提出"
-        ],
-        "notation": "掲(かか)げる"
+        ]
     },
     {
         "name": "tantei",
         "trans": [
+            "探偵(たんてい)",
             "⓪ 名·他动3  侦探，侦查"
-        ],
-        "notation": "探偵(たんてい)"
+        ]
     },
     {
         "name": "dowasure",
         "trans": [
+            "度忘(どわす)れ",
             "② 名·自他动3  突然忘记，一时想不起来"
-        ],
-        "notation": "度忘(どわす)れ"
+        ]
     },
     {
         "name": "binwan",
         "trans": [
+            "敏腕(びんわん)",
             "⓪ 名·ナ形  有能力，能干"
-        ],
-        "notation": "敏腕(びんわん)"
+        ]
     },
     {
         "name": "purezen",
         "trans": [
+            "プレゼン",
             "⓪ 名  公开演示，展示，陈述"
-        ],
-        "notation": "プレゼン"
+        ]
     },
     {
         "name": "oomune",
         "trans": [
+            "概(おおむ)ね",
             "⓪ 名·副  大概，概要；大部分"
-        ],
-        "notation": "概(おおむ)ね"
+        ]
     },
     {
         "name": "miren",
         "trans": [
+            "未練(みれん)",
             "① 名·ナ形  依恋，恋恋不舍"
-        ],
-        "notation": "未練(みれん)"
+        ]
     },
     {
         "name": "kugiri",
         "trans": [
+            "区切(くぎ)り",
             "③ 名  （文章或事情的）段落，阶段"
-        ],
-        "notation": "区切(くぎ)り"
+        ]
     },
     {
         "name": "kogecha",
         "trans": [
+            "焦(こ)げ茶(ちゃ)",
             "⓪ 名  深棕色，深咖啡色"
-        ],
-        "notation": "焦(こ)げ茶(ちゃ)"
+        ]
     },
     {
         "name": "shuuchi",
         "trans": [
+            "周知(しゅうち)",
             "① 名·自他动3  周知，众所周知"
-        ],
-        "notation": "周知(しゅうち)"
+        ]
     },
     {
         "name": "isamashii",
         "trans": [
+            "勇(いさ)ましい",
             "④ イ形  勇敢的；活泼的，生机勃勃的"
-        ],
-        "notation": "勇(いさ)ましい"
+        ]
     },
     {
         "name": "daiben",
         "trans": [
+            "代弁(だいべん)",
             "⓪ 名·他动3  替人偿还；代办；代为辩解，陈述"
-        ],
-        "notation": "代弁(だいべん)"
+        ]
     },
     {
         "name": "tegotae",
         "trans": [
+            "手(て)ごたえ",
             "② 名  手感；反应，效果"
-        ],
-        "notation": "手(て)ごたえ"
+        ]
     },
     {
         "name": "hatsumimi",
         "trans": [
+            "初耳(はつみみ)",
             "⓪ 名  初次听到"
-        ],
-        "notation": "初耳(はつみみ)"
+        ]
     },
     {
         "name": "housha",
         "trans": [
+            "放射(ほうしゃ)",
             "⓪ 名·他动3  放射，辐射"
-        ],
-        "notation": "放射(ほうしゃ)"
+        ]
     },
     {
         "name": "aritoarayuru",
         "trans": [
+            "ありとあらゆる",
             "① 连体  所有，一切；各种"
-        ],
-        "notation": "ありとあらゆる"
+        ]
     },
     {
         "name": "hoyou",
         "trans": [
+            "保養(ほよう)",
             "⓪ 名·自动3  休养，疗养；消遣"
-        ],
-        "notation": "保養(ほよう)"
+        ]
     },
     {
         "name": "hitomakase",
         "trans": [
+            "人任(ひとまか)せ",
             "③ 名  委托给别人"
-        ],
-        "notation": "人任(ひとまか)せ"
+        ]
     },
     {
         "name": "haibun",
         "trans": [
+            "配分(はいぶん)",
             "⓪ 名·他动3  分配"
-        ],
-        "notation": "配分(はいぶん)"
+        ]
     },
     {
         "name": "tougou",
         "trans": [
+            "統合(とうごう)",
             "⓪ 名·他动3  合并，统一"
-        ],
-        "notation": "統合(とうごう)"
+        ]
     },
     {
         "name": "arinomama",
         "trans": [
+            "ありのまま",
             "⑤ 名·ナ形·副  据实，如实，实事求是"
-        ],
-        "notation": "ありのまま"
+        ]
     },
     {
         "name": "tsuyoki",
         "trans": [
+            "強気(つよき)",
             "⓪ 名·ナ形  强硬，坚决；行情看涨"
-        ],
-        "notation": "強気(つよき)"
+        ]
     },
     {
         "name": "taimuri-",
         "trans": [
+            "タイムリー",
             "① ナ形  适时的，正合时宜的"
-        ],
-        "notation": "タイムリー"
+        ]
     },
     {
         "name": "seiyaku",
         "trans": [
+            "誓約(せいやく)",
             "⓪ 名·他动3  誓约，起誓"
-        ],
-        "notation": "誓約(せいやく)"
+        ]
     },
     {
         "name": "shitabi",
         "trans": [
+            "下火(したび)",
             "⓪ 名  火势减弱；势力衰退"
-        ],
-        "notation": "下火(したび)"
+        ]
     },
     {
         "name": "izatonaruto/izatonareba/izatonattara",
         "trans": [
+            "いざとなると/いざとなれば/いざとなったら",
             " ① 连语  一到关键时刻；一旦发生问题，一旦情况紧急"
-        ],
-        "notation": "いざとなると/いざとなれば/いざとなったら"
+        ]
     },
     {
         "name": "konki",
         "trans": [
+            "根気(こんき)",
             "⓪ 名  耐性，毅力"
-        ],
-        "notation": "根気(こんき)"
+        ]
     },
     {
         "name": "kumen",
         "trans": [
+            "工面(くめん)",
             "① 名·他动3  筹措，筹划；筹款"
-        ],
-        "notation": "工面(くめん)"
+        ]
     },
     {
         "name": "katawara",
         "trans": [
+            "傍(かたわ)ら",
             "⓪ 名  旁边；一边⋯⋯一边⋯⋯"
-        ],
-        "notation": "傍(かたわ)ら"
+        ]
     },
     {
         "name": "anko-ru",
         "trans": [
+            "アンコール",
             "③ 名·他动3  要求重演，再来一个"
-        ],
-        "notation": "アンコール"
+        ]
     },
     {
         "name": "utsuro",
         "trans": [
+            "虚(うつ)ろ",
             "⓪ 名·ナ形  空洞；空虚，发呆"
-        ],
-        "notation": "虚(うつ)ろ"
+        ]
     },
     {
         "name": "rinkaku",
         "trans": [
+            "輪郭(りんかく)",
             "⓪ 名  轮廓；概要，梗概"
-        ],
-        "notation": "輪郭(りんかく)"
+        ]
     },
     {
         "name": "mitsuyu",
         "trans": [
+            "密輸(みつゆ)",
             "⓪ 名·他动3  （进出口）走私"
-        ],
-        "notation": "密輸(みつゆ)"
+        ]
     },
     {
         "name": "henchou",
         "trans": [
+            "偏重(へんちょう)",
             "⓪ 名·他动3  偏重"
-        ],
-        "notation": "偏重(へんちょう)"
+        ]
     },
     {
         "name": "hinpan",
         "trans": [
+            "頻繁(ひんぱん)",
             "⓪ 名·ナ形  频繁，屡次"
-        ],
-        "notation": "頻繁(ひんぱん)"
+        ]
     },
     {
         "name": "oogesa",
         "trans": [
+            "大(おお)げさ",
             "⓪ ナ形  夸大的，夸张的"
-        ],
-        "notation": "大(おお)げさ"
+        ]
     },
     {
         "name": "dorojiai",
         "trans": [
+            "泥仕合(どろじあい)",
             "③ 名  互相揭短"
-        ],
-        "notation": "泥仕合(どろじあい)"
+        ]
     },
     {
         "name": "choushuu",
         "trans": [
+            "徴収(ちょうしゅう)",
             "⓪ 名·他动3  征收（钱）"
-        ],
-        "notation": "徴収(ちょうしゅう)"
+        ]
     },
     {
         "name": "soudai",
         "trans": [
+            "壮大(そうだい)",
             "⓪ 名·ナ形  雄壮，宏大"
-        ],
-        "notation": "壮大(そうだい)"
+        ]
     },
     {
         "name": "zure",
         "trans": [
+            "ずれ",
             "② 名  分歧，差异，不一致，偏差"
-        ],
-        "notation": "ずれ"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "孵(かえ)る",
             "① 自动1  孵化"
-        ],
-        "notation": "孵(かえ)る"
+        ]
     },
     {
         "name": "sanshou",
         "trans": [
+            "参照(さんしょう)",
             "⓪ 名·他动3  参照，参阅"
-        ],
-        "notation": "参照(さんしょう)"
+        ]
     },
     {
         "name": "gensou",
         "trans": [
+            "幻想(げんそう)",
             "⓪ 名·他动3  幻想，空想"
-        ],
-        "notation": "幻想(げんそう)"
+        ]
     },
     {
         "name": "omomuki",
         "trans": [
+            "趣(おもむき)",
             "④ 名  要点，主要内容；情趣，风趣；韵味；听说的内容、情况"
-        ],
-        "notation": "趣(おもむき)"
+        ]
     },
     {
         "name": "iyake",
         "trans": [
+            "嫌気(いやけ)",
             "⓪ 名  讨厌，厌烦"
-        ],
-        "notation": "嫌気(いやけ)"
+        ]
     },
     {
         "name": "kikinogasu",
         "trans": [
+            "聞(き)き逃(のが)す",
             "④ 他动1  听漏"
-        ],
-        "notation": "聞(き)き逃(のが)す"
+        ]
     },
     {
         "name": "shougai",
         "trans": [
+            "生涯(しょうがい)",
             "① 名  一生，终生"
-        ],
-        "notation": "生涯(しょうがい)"
+        ]
     },
     {
         "name": "yuruyaka",
         "trans": [
+            "緩(ゆる)やか",
             "② ナ形  缓慢的，缓和的；宽松的，宽大的；舒畅的"
-        ],
-        "notation": "緩(ゆる)やか"
+        ]
     },
     {
         "name": "moumokuteki",
         "trans": [
+            "盲目的(もうもくてき)",
             "⓪ ナ形  盲目的"
-        ],
-        "notation": "盲目的(もうもくてき)"
+        ]
     },
     {
         "name": "honchoushi",
         "trans": [
+            "本調子(ほんちょうし)",
             "③ 名  正常状态，常态"
-        ],
-        "notation": "本調子(ほんちょうし)"
+        ]
     },
     {
         "name": "kujikeru",
         "trans": [
+            "挫(くじ)ける",
             "③ 自动2  挫伤，扭了；沮丧，消沉"
-        ],
-        "notation": "挫(くじ)ける"
+        ]
     },
     {
         "name": "furidashi",
         "trans": [
+            "振(ふ)り出(だ)し",
             "⓪ 名  出发点，原点；开端，最初"
-        ],
-        "notation": "振(ふ)り出(だ)し"
+        ]
     },
     {
         "name": "bariafuri-",
         "trans": [
+            "バリアフリー",
             "⑤ 名  无障碍式"
-        ],
-        "notation": "バリアフリー"
+        ]
     },
     {
         "name": "teppen",
         "trans": [
+            "天辺(てっぺん)",
             "③ 名  顶峰，顶点"
-        ],
-        "notation": "天辺(てっぺん)"
+        ]
     },
     {
         "name": "tan'nen",
         "trans": [
+            "丹念(たんねん)",
             "① 名·ナ形  精心，细心"
-        ],
-        "notation": "丹念(たんねん)"
+        ]
     },
     {
         "name": "koeru",
         "trans": [
+            "肥(こ)える",
             "② 自动2  肥胖；肥沃；富裕；鉴赏力强"
-        ],
-        "notation": "肥(こ)える"
+        ]
     },
     {
         "name": "sekkai",
         "trans": [
+            "切開(せっかい)",
             "① 名·他动3  （医学用语）切开，开刀"
-        ],
-        "notation": "切開(せっかい)"
+        ]
     },
     {
         "name": "jogai",
         "trans": [
+            "除外(じょがい)",
             "⓪ 名·他动3  除外，免除，不在此限"
-        ],
-        "notation": "除外(じょがい)"
+        ]
     },
     {
         "name": "koyomi",
         "trans": [
+            "暦(こよみ)",
             "③ 名  日历"
-        ],
-        "notation": "暦(こよみ)"
+        ]
     },
     {
         "name": "gunji",
         "trans": [
+            "軍事(ぐんじ)",
             "① 名  军事"
-        ],
-        "notation": "軍事(ぐんじ)"
+        ]
     },
     {
         "name": "saranaru",
         "trans": [
+            "更(さら)なる",
             "① 连体  更加，进一步"
-        ],
-        "notation": "更(さら)なる"
+        ]
     },
     {
         "name": "kansan",
         "trans": [
+            "換算(かんさん)",
             "⓪ 名·他动3  换算，折合"
-        ],
-        "notation": "換算(かんさん)"
+        ]
     },
     {
         "name": "onwa",
         "trans": [
+            "温和(おんわ)",
             "⓪ 名·ナ形  温暖；温和，温柔"
-        ],
-        "notation": "温和(おんわ)"
+        ]
     },
     {
         "name": "udemae",
         "trans": [
+            "腕前(うでまえ)",
             "⓪ 名  能力，本事"
-        ],
-        "notation": "腕前(うでまえ)"
+        ]
     },
     {
         "name": "aware",
         "trans": [
+            "哀(あわ)れ",
             "① 名·ナ形  悲哀；可怜；凄惨；情趣"
-        ],
-        "notation": "哀(あわ)れ"
+        ]
     },
     {
         "name": "jikani",
         "trans": [
+            "直(じか)に",
             "① 副  直接，亲自；贴身"
-        ],
-        "notation": "直(じか)に"
+        ]
     },
     {
         "name": "juunan",
         "trans": [
+            "柔軟(じゅうなん)",
             "⓪ ナ形  柔软的；灵活的"
-        ],
-        "notation": "柔軟(じゅうなん)"
+        ]
     },
     {
         "name": "rire-",
         "trans": [
+            "リレー",
             "⓪ 名  接力，传递"
-        ],
-        "notation": "リレー"
+        ]
     },
     {
         "name": "henpin",
         "trans": [
+            "返品(へんぴん)",
             "⓪ 名·自他动3  退货"
-        ],
-        "notation": "返品(へんぴん)"
+        ]
     },
     {
         "name": "pinkarakirimade",
         "trans": [
+            "ピンからキリまで",
             "① 惯  从开头到末尾；从最好的到最坏的"
-        ],
-        "notation": "ピンからキリまで"
+        ]
     },
     {
         "name": "sukoyaka",
         "trans": [
+            "健(すこ)やか",
             "② ナ形  健壮的，健康的"
-        ],
-        "notation": "健(すこ)やか"
+        ]
     },
     {
         "name": "nagisa",
         "trans": [
+            "渚(なぎさ)",
             "⓪ 名  海滨，岸边"
-        ],
-        "notation": "渚(なぎさ)"
+        ]
     },
     {
         "name": "toutotsu",
         "trans": [
+            "唐突(とうとつ)",
             "⓪ 名·ナ形  唐突，冒昧，贸然"
-        ],
-        "notation": "唐突(とうとつ)"
+        ]
     },
     {
         "name": "tsubura",
         "trans": [
+            "つぶら",
             "⓪ ナ形  圆的，圆溜溜的"
-        ],
-        "notation": "つぶら"
+        ]
     },
     {
         "name": "tanka",
         "trans": [
+            "担架(たんか)",
             "① 名  担架"
-        ],
-        "notation": "担架(たんか)"
+        ]
     },
     {
         "name": "zonzai",
         "trans": [
+            "ぞんざい",
             "⓪ ナ形  草率的，粗糙的；粗鲁的"
-        ],
-        "notation": "ぞんざい"
+        ]
     },
     {
         "name": "souryou",
         "trans": [
+            "送料(そうりょう)",
             "① 名  运费，邮费"
-        ],
-        "notation": "送料(そうりょう)"
+        ]
     },
     {
         "name": "zubunure",
         "trans": [
+            "ずぶぬれ",
             "⓪ 名  全身湿透"
-        ],
-        "notation": "ずぶぬれ"
+        ]
     },
     {
         "name": "sakkon",
         "trans": [
+            "昨今(さっこん)",
             "① 名  近来，最近"
-        ],
-        "notation": "昨今(さっこん)"
+        ]
     },
     {
         "name": "kouraku",
         "trans": [
+            "行楽(こうらく)",
             "⓪ 名  游玩，出游"
-        ],
-        "notation": "行楽(こうらく)"
+        ]
     },
     {
         "name": "daishikyuu",
         "trans": [
+            "大至急(だいしきゅう)",
             "③ 副  非常紧急，十万火急"
-        ],
-        "notation": "大至急(だいしきゅう)"
+        ]
     },
     {
         "name": "kyouryoku",
         "trans": [
+            "協力(きょうりょく)",
             "⓪ 名·自动3  协力，共同努力；合作，配合"
-        ],
-        "notation": "協力(きょうりょく)"
+        ]
     },
     {
         "name": "enman",
         "trans": [
+            "円満(えんまん)",
             "⓪ 名·ナ形  圆满，美满"
-        ],
-        "notation": "円満(えんまん)"
+        ]
     },
     {
         "name": "itade",
         "trans": [
+            "痛手(いたで)",
             "⓪ 名  重伤，重创；沉重打击"
-        ],
-        "notation": "痛手(いたで)"
+        ]
     },
     {
         "name": "shikeru",
         "trans": [
+            "湿気(しけ)る",
             "② 自动1  受潮，潮湿"
-        ],
-        "notation": "湿気(しけ)る"
+        ]
     },
     {
         "name": "chippoke",
         "trans": [
+            "ちっぽけ",
             "③ ナ形  特别小的，极小的"
-        ],
-        "notation": "ちっぽけ"
+        ]
     },
     {
         "name": "horyo",
         "trans": [
+            "捕虜(ほりょ)",
             "① 名  俘虏"
-        ],
-        "notation": "捕虜(ほりょ)"
+        ]
     },
     {
         "name": "bujoku",
         "trans": [
+            "侮辱(ぶじょく)",
             "⓪ 名·他动3  侮辱，凌辱"
-        ],
-        "notation": "侮辱(ぶじょく)"
+        ]
     },
     {
         "name": "hayameni",
         "trans": [
+            "早(はや)めに",
             "⓪ 副  提前，早些"
-        ],
-        "notation": "早(はや)めに"
+        ]
     },
     {
         "name": "temawashi",
         "trans": [
+            "手回(てまわ)し",
             "② 名·他动3  准备，安排；用手摇"
-        ],
-        "notation": "手回(てまわ)し"
+        ]
     },
     {
         "name": "tsuiteha",
         "trans": [
+            "ついては",
             "① 接续  因此，因而，于是"
-        ],
-        "notation": "ついては"
+        ]
     },
     {
         "name": "taibou",
         "trans": [
+            "待望(たいぼう)",
             "⓪ 名·他动3  期望，期待"
-        ],
-        "notation": "待望(たいぼう)"
+        ]
     },
     {
         "name": "senpou",
         "trans": [
+            "先方(せんぽう)",
             "⓪ 名  对方；前方，远方"
-        ],
-        "notation": "先方(せんぽう)"
+        ]
     },
     {
         "name": "shinchoku",
         "trans": [
+            "進捗(しんちょく)",
             "⓪ 名·自动3  进展"
-        ],
-        "notation": "進捗(しんちょく)"
+        ]
     },
     {
         "name": "konwaku",
         "trans": [
+            "困惑(こんわく)",
             "⓪ 名·自动3  困惑，为难，不知所措"
-        ],
-        "notation": "困惑(こんわく)"
+        ]
     },
     {
         "name": "tekigi",
         "trans": [
+            "適宜(てきぎ)",
             "① 副·ナ形  适宜，适当；酌情"
-        ],
-        "notation": "適宜(てきぎ)"
+        ]
     },
     {
         "name": "kessoku",
         "trans": [
+            "結束(けっそく)",
             "⓪ 名·自他动3  捆扎；团结"
-        ],
-        "notation": "結束(けっそく)"
+        ]
     },
     {
         "name": "kawarukawaru",
         "trans": [
+            "代(か)わる代(か)わる",
             "④ 副  轮流，轮换；轮班"
-        ],
-        "notation": "代(か)わる代(か)わる"
+        ]
     },
     {
         "name": "obekka",
         "trans": [
+            "おべっか",
             "② 名  奉承，谄媚，恭维"
-        ],
-        "notation": "おべっか"
+        ]
     },
     {
         "name": "ittai",
         "trans": [
+            "一帯(いったい)",
             "⓪ 名  附近一带；一条（山脉） "
-        ],
-        "notation": "一帯(いったい)"
+        ]
     },
     {
         "name": "toutoi",
         "trans": [
+            "尊(とうと)い",
             "③ イ形  珍贵的，宝贵的；值得尊敬的"
-        ],
-        "notation": "尊(とうと)い"
+        ]
     },
     {
         "name": "fushin",
         "trans": [
+            "不審(ふしん)",
             "⓪ 名·ナ形  可疑，怀疑；不清楚"
-        ],
-        "notation": "不審(ふしん)"
+        ]
     },
     {
         "name": "toppi",
         "trans": [
+            "突飛(とっぴ)",
             "⓪ ナ形  离奇的，古怪的"
-        ],
-        "notation": "突飛(とっぴ)"
+        ]
     },
     {
         "name": "seremoni-",
         "trans": [
+            "セレモニー",
             "① 名  仪式，典礼"
-        ],
-        "notation": "セレモニー"
+        ]
     },
     {
         "name": "shuuyou",
         "trans": [
+            "収容(しゅうよう)",
             "⓪ 名·他动3  收容，容纳"
-        ],
-        "notation": "収容(しゅうよう)"
+        ]
     },
     {
         "name": "nameru",
         "trans": [
+            "嘗(な)める",
             "② 他动2  舔；尝（味道）；经历；轻视；烧光"
-        ],
-        "notation": "嘗(な)める"
+        ]
     },
     {
         "name": "kouyou",
         "trans": [
+            "効用(こうよう)",
             "⓪ 名  用途，用处；功效"
-        ],
-        "notation": "効用(こうよう)"
+        ]
     },
     {
         "name": "kyohi",
         "trans": [
+            "拒否(きょひ)",
             "① 名·他动3  拒绝，否决"
-        ],
-        "notation": "拒否(きょひ)"
+        ]
     },
     {
         "name": "uyokyokusetsu",
         "trans": [
+            "紆余曲折(うよきょくせつ)",
             "① 名·自动3  周折，波折，曲折，弯弯曲曲"
-        ],
-        "notation": "紆余曲折(うよきょくせつ)"
+        ]
     },
     {
         "name": "awasete",
         "trans": [
+            "合(あ)わせて",
             "② 副  共计；同时"
-        ],
-        "notation": "合(あ)わせて"
+        ]
     },
     {
         "name": "harewataru",
         "trans": [
+            "晴(は)れ渡(わた)る",
             "④ 自动1  完全放晴；心情舒畅"
-        ],
-        "notation": "晴(は)れ渡(わた)る"
+        ]
     },
     {
         "name": "zankin",
         "trans": [
+            "残金(ざんきん)",
             "① 名  余额，余款；余下的欠款"
-        ],
-        "notation": "残金(ざんきん)"
+        ]
     },
     {
         "name": "hikkirinashini",
         "trans": [
+            "ひっきりなしに",
             "⑤ 副  接连不断地，不停地"
-        ],
-        "notation": "ひっきりなしに"
+        ]
     },
     {
         "name": "taiman",
         "trans": [
+            "怠慢(たいまん)",
             "⓪ 名·ナ形  懈怠，怠慢，玩忽（职守）"
-        ],
-        "notation": "怠慢(たいまん)"
+        ]
     },
     {
         "name": "kari",
         "trans": [
+            "仮(かり)",
             "⓪ 名  临时，暂时；假的；假设"
-        ],
-        "notation": "仮(かり)"
+        ]
     },
     {
         "name": "bouzen",
         "trans": [
+            "呆然(ぼうぜん)",
             "⓪ ナ形  发呆的，发愣的"
-        ],
-        "notation": "呆然(ぼうぜん)"
+        ]
     },
     {
         "name": "iyami",
         "trans": [
+            "嫌味(いやみ)",
             "③ 名·ナ形  挖苦，讽刺"
-        ],
-        "notation": "嫌味(いやみ)"
+        ]
     },
     {
         "name": "kyokugen",
         "trans": [
+            "極限(きょくげん)",
             "⓪ 名  极限"
-        ],
-        "notation": "極限(きょくげん)"
+        ]
     },
     {
         "name": "shichi",
         "trans": [
+            "質(しち)",
             "② 名  典当的东西，抵押品"
-        ],
-        "notation": "質(しち)"
+        ]
     },
     {
         "name": "dankai",
         "trans": [
+            "団塊(だんかい)",
             "⓪ 名  块儿，团"
-        ],
-        "notation": "団塊(だんかい)"
+        ]
     },
     {
         "name": "torimidasu",
         "trans": [
+            "取(と)り乱(みだ)す",
             "④ 自他动1  弄得乱七八糟；慌张，慌乱"
-        ],
-        "notation": "取(と)り乱(みだ)す"
+        ]
     },
     {
         "name": "temijika",
         "trans": [
+            "手短(てみじか)",
             "⓪ ナ形  简单的，简略的"
-        ],
-        "notation": "手短(てみじか)"
+        ]
     },
     {
         "name": "bachigai",
         "trans": [
+            "場違(ばちが)い",
             "② 名·ナ形  不合时宜"
-        ],
-        "notation": "場違(ばちが)い"
+        ]
     },
     {
         "name": "fukugou",
         "trans": [
+            "複合(ふくごう)",
             "⓪ 名·自他动3  复合，合成"
-        ],
-        "notation": "複合(ふくごう)"
+        ]
     },
     {
         "name": "houkatsuteki",
         "trans": [
+            "包括的(ほうかつてき)",
             "⓪ ナ形  总括的，综合的"
-        ],
-        "notation": "包括的(ほうかつてき)"
+        ]
     },
     {
         "name": "kagamu",
         "trans": [
+            "屈(かが)む",
             "⓪ 自动1  弯腰；蹲，蹲下"
-        ],
-        "notation": "屈(かが)む"
+        ]
     },
     {
         "name": "miharashi",
         "trans": [
+            "見晴(みは)らし",
             "⓪ 名  眺望；景致"
-        ],
-        "notation": "見晴(みは)らし"
+        ]
     },
     {
         "name": "kakimawasu",
         "trans": [
+            "掻(か)き回(まわ)す",
             "⓪ 他动1  搅拌；乱翻，乱弄；搅乱"
-        ],
-        "notation": "掻(か)き回(まわ)す"
+        ]
     },
     {
         "name": "uwayaku",
         "trans": [
+            "上役(うわやく)",
             "⓪ 名  上级，上司"
-        ],
-        "notation": "上役(うわやく)"
+        ]
     },
     {
         "name": "kamubakku",
         "trans": [
+            "カムバック",
             "① 名·自动3  恢复（原位），东山再起"
-        ],
-        "notation": "カムバック"
+        ]
     },
     {
         "name": "yurayura",
         "trans": [
+            "ゆらゆら",
             "① 副·自动3  晃动，摇曳，摇摇晃晃"
-        ],
-        "notation": "ゆらゆら"
+        ]
     },
     {
         "name": "gekirei",
         "trans": [
+            "激励(げきれい)",
             "⓪ 名·他动3  激励，鼓励"
-        ],
-        "notation": "激励(げきれい)"
+        ]
     },
     {
         "name": "sekkyou",
         "trans": [
+            "説教(せっきょう)",
             "③ 名·自他动3  说教；教诲"
-        ],
-        "notation": "説教(せっきょう)"
+        ]
     },
     {
         "name": "choutatsu",
         "trans": [
+            "調達(ちょうたつ)",
             "⓪ 名·他动3  筹措，筹备"
-        ],
-        "notation": "調達(ちょうたつ)"
+        ]
     },
     {
         "name": "todomeru",
         "trans": [
+            "留(とど)める",
             "③ 他动2  留下，保留"
-        ],
-        "notation": "留(とど)める"
+        ]
     },
     {
         "name": "horobiru",
         "trans": [
+            "滅(ほろ)びる",
             "③ 自动2  灭亡，灭绝"
-        ],
-        "notation": "滅(ほろ)びる"
+        ]
     },
     {
         "name": "bunpu",
         "trans": [
+            "分布(ぶんぷ)",
             "⓪ 名·自他动3  分布"
-        ],
-        "notation": "分布(ぶんぷ)"
+        ]
     },
     {
         "name": "ryouhan",
         "trans": [
+            "量販(りょうはん)",
             "⓪ 名·他动3  量贩，大量销售"
-        ],
-        "notation": "量販(りょうはん)"
+        ]
     },
     {
         "name": "ansatsu",
         "trans": [
+            "暗殺(あんさつ)",
             "⓪ 名·他动3  暗杀，行刺"
-        ],
-        "notation": "暗殺(あんさつ)"
+        ]
     },
     {
         "name": "un'you",
         "trans": [
+            "運用(うんよう)",
             "⓪ 名·他动3  运用，活用"
-        ],
-        "notation": "運用(うんよう)"
+        ]
     },
     {
         "name": "hissori",
         "trans": [
+            "ひっそり",
             "③ 副·自动3  偷偷地，悄悄地；鸦雀无声"
-        ],
-        "notation": "ひっそり"
+        ]
     },
     {
         "name": "kyanpe-n",
         "trans": [
+            "キャンペーン",
             "③ 名  宣传活动，运动"
-        ],
-        "notation": "キャンペーン"
+        ]
     },
     {
         "name": "goudou",
         "trans": [
+            "合同(ごうどう)",
             "⓪ 名·自他动3  联合，合并"
-        ],
-        "notation": "合同(ごうどう)"
+        ]
     },
     {
         "name": "shutoshite",
         "trans": [
+            "主(しゅ)として",
             "① 副  主要是"
-        ],
-        "notation": "主(しゅ)として"
+        ]
     },
     {
         "name": "suponji",
         "trans": [
+            "スポンジ",
             "⓪ 名  海绵，海绵状物体"
-        ],
-        "notation": "スポンジ"
+        ]
     },
     {
         "name": "narenareshii",
         "trans": [
+            "馴(な)れ馴(な)れしい",
             "⑤ イ形  过分亲昵的，熟不拘礼的"
-        ],
-        "notation": "馴(な)れ馴(な)れしい"
+        ]
     },
     {
         "name": "songen",
         "trans": [
+            "尊厳(そんげん)",
             "⓪ 名  尊严"
-        ],
-        "notation": "尊厳(そんげん)"
+        ]
     },
     {
         "name": "tairo",
         "trans": [
+            "退路(たいろ)",
             "① 名  退路，后路"
-        ],
-        "notation": "退路(たいろ)"
+        ]
     },
     {
         "name": "tsurisen",
         "trans": [
+            "釣(つ)り銭(せん)",
             "⓪ 名  找的零钱，零头"
-        ],
-        "notation": "釣(つ)り銭(せん)"
+        ]
     },
     {
         "name": "tenpu",
         "trans": [
+            "添付(てんぷ)",
             "① 名·他动3  添上，附上"
-        ],
-        "notation": "添付(てんぷ)"
+        ]
     },
     {
         "name": "toutei",
         "trans": [
+            "到底(とうてい)",
             "⓪ 副  （后接否定）无论如何也，怎么也"
-        ],
-        "notation": "到底(とうてい)"
+        ]
     },
     {
         "name": "hiseisanteki",
         "trans": [
+            "非生産的(ひせいさんてき)",
             "⓪ ナ形  非建设性的（意见）"
-        ],
-        "notation": "非生産的(ひせいさんてき)"
+        ]
     },
     {
         "name": "irasuto",
         "trans": [
+            "イラスト",
             "⓪ 名  插图，图解"
-        ],
-        "notation": "イラスト"
+        ]
     },
     {
         "name": "kakkiteki",
         "trans": [
+            "画期的(かっきてき)",
             "⓪ ナ形  划时期的，划时代的"
-        ],
-        "notation": "画期的(かっきてき)"
+        ]
     },
     {
         "name": "kessai",
         "trans": [
+            "決済(けっさい)",
             "① 名·他动3  结算，结账"
-        ],
-        "notation": "決済(けっさい)"
+        ]
     },
     {
         "name": "tenten",
         "trans": [
+            "転々(てんてん)",
             "⓪ 副·自动3  辗转；翻来覆去，辗转反侧"
-        ],
-        "notation": "転々(てんてん)"
+        ]
     },
     {
         "name": "saijou",
         "trans": [
+            "最上(さいじょう)",
             "⓪ 名  最上面；最高，至上"
-        ],
-        "notation": "最上(さいじょう)"
+        ]
     },
     {
         "name": "jinsoku",
         "trans": [
+            "迅速(じんそく)",
             "⓪ 名·ナ形  迅速"
-        ],
-        "notation": "迅速(じんそく)"
+        ]
     },
     {
         "name": "soudou",
         "trans": [
+            "騒動(そうどう)",
             "① 名·自动3  骚动；暴乱"
-        ],
-        "notation": "騒動(そうどう)"
+        ]
     },
     {
         "name": "doboku",
         "trans": [
+            "土木(どぼく)",
             "① 名  土木工程"
-        ],
-        "notation": "土木(どぼく)"
+        ]
     },
     {
         "name": "tsukurou",
         "trans": [
+            "繕(つくろ)う",
             "③ 他动1  修补，修缮；整理，修饰；敷衍"
-        ],
-        "notation": "繕(つくろ)う"
+        ]
     },
     {
         "name": "haiboku",
         "trans": [
+            "敗北(はいぼく)",
             "⓪ 名·自动3  败北，打败仗"
-        ],
-        "notation": "敗北(はいぼく)"
+        ]
     },
     {
         "name": "fukkou",
         "trans": [
+            "復興(ふっこう)",
             "⓪ 名·自他动3  复兴，重建"
-        ],
-        "notation": "復興(ふっこう)"
+        ]
     },
     {
         "name": "izen",
         "trans": [
+            "依然(いぜん)",
             "⓪ 副  依然，仍然"
-        ],
-        "notation": "依然(いぜん)"
+        ]
     },
     {
         "name": "kimagure",
         "trans": [
+            "気(き)まぐれ",
             "⓪ 名·ナ形  反复无常；一时冲动，心血来潮"
-        ],
-        "notation": "気(き)まぐれ"
+        ]
     },
     {
         "name": "danko",
         "trans": [
+            "断固(だんこ)",
             "① 副·ナ形  断然，毅然；坚决"
-        ],
-        "notation": "断固(だんこ)"
+        ]
     },
     {
         "name": "kenshou",
         "trans": [
+            "健勝(けんしょう)",
             "⓪ 名·ナ形  健康，强壮"
-        ],
-        "notation": "健勝(けんしょう)"
+        ]
     },
     {
         "name": "zatsu",
         "trans": [
+            "雑(ざつ)",
             "① 名·ナ形  混乱；杂类，杂项；粗糙，粗率"
-        ],
-        "notation": "雑(ざつ)"
+        ]
     },
     {
         "name": "seisou",
         "trans": [
+            "正装(せいそう)",
             "⓪ 名·自动3  正装"
-        ],
-        "notation": "正装(せいそう)"
+        ]
     },
     {
         "name": "tsukinami",
         "trans": [
+            "月並(つきな)み",
             "⓪ 名·ナ形  每月例行；平凡，平庸"
-        ],
-        "notation": "月並(つきな)み"
+        ]
     },
     {
         "name": "shizumarikaeru",
         "trans": [
+            "静(しず)まり返(かえ)る",
             "⑤ 自动1  鸦雀无声，万籁俱寂"
-        ],
-        "notation": "静(しず)まり返(かえ)る"
+        ]
     },
     {
         "name": "dokusen",
         "trans": [
+            "独占(どくせん)",
             "⓪ 名·他动3  独占，垄断"
-        ],
-        "notation": "独占(どくせん)"
+        ]
     },
     {
         "name": "hitoshii",
         "trans": [
+            "等(ひと)しい",
             "③ イ形  相等的；等同于"
-        ],
-        "notation": "等(ひと)しい"
+        ]
     },
     {
         "name": "housaku",
         "trans": [
+            "方策(ほうさく)",
             "⓪ 名  方法，策略"
-        ],
-        "notation": "方策(ほうさく)"
+        ]
     },
     {
         "name": "mabara",
         "trans": [
+            "まばら",
             "⓪ ナ形  稀疏的，零散的，零星的"
-        ],
-        "notation": "まばら"
+        ]
     },
     {
         "name": "sawaru",
         "trans": [
+            "障(さわ)る",
             "⓪ 自动1  妨碍，阻碍；不利，有坏影响"
-        ],
-        "notation": "障(さわ)る"
+        ]
     },
     {
         "name": "oohaba",
         "trans": [
+            "大幅(おおはば)",
             "⓪ ナ形  大幅度的，大范围的"
-        ],
-        "notation": "大幅(おおはば)"
+        ]
     },
     {
         "name": "kyuukyoku",
         "trans": [
+            "究極(きゅうきょく)",
             "⓪ 名·自动3  最终，终极"
-        ],
-        "notation": "究極(きゅうきょく)"
+        ]
     },
     {
         "name": "koushi",
         "trans": [
+            "行使(こうし)",
             "① 名·他动3  行使，使用"
-        ],
-        "notation": "行使(こうし)"
+        ]
     },
     {
         "name": "shuju",
         "trans": [
+            "種々(しゅじゅ)",
             "① 名·ナ形·副  种种，各种"
-        ],
-        "notation": "種々(しゅじゅ)"
+        ]
     },
     {
         "name": "komame",
         "trans": [
+            "こまめ",
             "① ナ形  忠实的，诚恳的，勤恳的"
-        ],
-        "notation": "こまめ"
+        ]
     },
     {
         "name": "seitou",
         "trans": [
+            "正当(せいとう)",
             "⓪ 名·ナ形  正当，合理，合法"
-        ],
-        "notation": "正当(せいとう)"
+        ]
     },
     {
         "name": "danmen",
         "trans": [
+            "断面(だんめん)",
             "③ 名  断面，截面"
-        ],
-        "notation": "断面(だんめん)"
+        ]
     },
     {
         "name": "karoujite",
         "trans": [
+            "辛(かろ)うじて",
             "② 副  好不容易才，勉强"
-        ],
-        "notation": "辛(かろ)うじて"
+        ]
     },
     {
         "name": "jogen",
         "trans": [
+            "助言(じょげん)",
             "⓪ 名·自动3  从旁教导，建议，出主意"
-        ],
-        "notation": "助言(じょげん)"
+        ]
     },
     {
         "name": "kuyokuyo",
         "trans": [
+            "くよくよ",
             "① 副·自动3  闷闷不乐，耿耿于怀"
-        ],
-        "notation": "くよくよ"
+        ]
     },
     {
         "name": "chiteki",
         "trans": [
+            "知的(ちてき)",
             "⓪ ナ形  智慧的，智力的；理性的，理智的"
-        ],
-        "notation": "知的(ちてき)"
+        ]
     },
     {
         "name": "tenken",
         "trans": [
+            "点検(てんけん)",
             "⓪ 名·他动3  检查"
-        ],
-        "notation": "点検(てんけん)"
+        ]
     },
     {
         "name": "nebari",
         "trans": [
+            "粘(ねば)り",
             "③ 名  黏性，黏度；毅力，坚韧不拔"
-        ],
-        "notation": "粘(ねば)り"
+        ]
     },
     {
         "name": "fushin",
         "trans": [
+            "不信(ふしん)",
             "⓪ 名  不诚实；不相信，怀疑"
-        ],
-        "notation": "不信(ふしん)"
+        ]
     },
     {
         "name": "gyutto",
         "trans": [
+            "ぎゅっと",
             "⓪ 副  紧紧地（勒、关闭、拉、按等）"
-        ],
-        "notation": "ぎゅっと"
+        ]
     },
     {
         "name": "myaku",
         "trans": [
+            "脈(みゃく)",
             "② 名  脉搏；联系；希望"
-        ],
-        "notation": "脈(みゃく)"
+        ]
     },
     {
         "name": "itaku",
         "trans": [
+            "委託(いたく)",
             "⓪ 名·他动3  委托，托付"
-        ],
-        "notation": "委託(いたく)"
+        ]
     },
     {
         "name": "kakubetsu",
         "trans": [
+            "格別(かくべつ)",
             "⓪ 副·ナ形  特别，格外；姑且不论"
-        ],
-        "notation": "格別(かくべつ)"
+        ]
     },
     {
         "name": "gen'eki",
         "trans": [
+            "現役(げんえき)",
             "⓪ 名  现役；应届生"
-        ],
-        "notation": "現役(げんえき)"
+        ]
     },
     {
         "name": "katsute",
         "trans": [
+            "かつて",
             "① 副  曾经，过去"
-        ],
-        "notation": "かつて"
+        ]
     },
     {
         "name": "shidoromodoro",
         "trans": [
+            "しどろもどろ",
             "④ ナ形  乱七八糟的，语无伦次的"
-        ],
-        "notation": "しどろもどろ"
+        ]
     },
     {
         "name": "sekku",
         "trans": [
+            "節句(せっく)",
             "⓪ 名  传统节日"
-        ],
-        "notation": "節句(せっく)"
+        ]
     },
     {
         "name": "torokeru",
         "trans": [
+            "とろける",
             "③ 自动2  溶化；陶醉，心旷神怡"
-        ],
-        "notation": "とろける"
+        ]
     },
     {
         "name": "hanran",
         "trans": [
+            "氾濫(はんらん)",
             "⓪ 名·自动3  泛滥"
-        ],
-        "notation": "氾濫(はんらん)"
+        ]
     },
     {
         "name": "oshikomu",
         "trans": [
+            "押(お)し込(こ)む",
             "③ 自他动1  闯进，硬挤进去；抢劫；硬塞，塞入"
-        ],
-        "notation": "押(お)し込(こ)む"
+        ]
     },
     {
         "name": "hon'ne",
         "trans": [
+            "本音(ほんね)",
             "⓪ 名  真心话"
-        ],
-        "notation": "本音(ほんね)"
+        ]
     },
     {
         "name": "fufuku",
         "trans": [
+            "不服(ふふく)",
             "⓪ 名·ナ形  不答应，不服从；抗议；不满"
-        ],
-        "notation": "不服(ふふく)"
+        ]
     },
     {
         "name": "hairetsu",
         "trans": [
+            "配列(はいれつ)",
             "⓪ 名·他动3  排列"
-        ],
-        "notation": "配列(はいれつ)"
+        ]
     },
     {
         "name": "shintei",
         "trans": [
+            "進呈(しんてい)",
             "⓪ 名·他动3  赠送，奉送"
-        ],
-        "notation": "進呈(しんてい)"
+        ]
     },
     {
         "name": "uyamau",
         "trans": [
+            "敬(うやま)う",
             "③ 他动1  尊敬，敬重"
-        ],
-        "notation": "敬(うやま)う"
+        ]
     },
     {
         "name": "doukou",
         "trans": [
+            "動向(どうこう)",
             "⓪ 名  动向"
-        ],
-        "notation": "動向(どうこう)"
+        ]
     },
     {
         "name": "senketsu",
         "trans": [
+            "先決(せんけつ)",
             "⓪ 名·他动3  先决，首先解决"
-        ],
-        "notation": "先決(せんけつ)"
+        ]
     },
     {
         "name": "gongodoudan",
         "trans": [
+            "言語道断(ごんごどうだん)",
             "① 名·ナ形  岂有此理，荒谬至极"
-        ],
-        "notation": "言語道断(ごんごどうだん)"
+        ]
     },
     {
         "name": "kanshou",
         "trans": [
+            "干渉(かんしょう)",
             "⓪ 名·自动3  干涉"
-        ],
-        "notation": "干渉(かんしょう)"
+        ]
     },
     {
         "name": "izure",
         "trans": [
+            "いずれ",
             "⓪ 代·副  哪个，哪个方面；反正；不久，改日"
-        ],
-        "notation": "いずれ"
+        ]
     },
     {
         "name": "shutsugan",
         "trans": [
+            "出願(しゅつがん)",
             "⓪ 名·自他动3  申请，申报志愿"
-        ],
-        "notation": "出願(しゅつがん)"
+        ]
     },
     {
         "name": "docchimichi",
         "trans": [
+            "どっち道(みち)",
             "⓪ 副  反正，总之，总而言之"
-        ],
-        "notation": "どっち道(みち)"
+        ]
     },
     {
         "name": "ooraka",
         "trans": [
+            "おおらか",
             "② ナ形  落落大方的，豁达的，胸襟开阔的"
-        ],
-        "notation": "おおらか"
+        ]
     },
     {
         "name": "kinmotsu",
         "trans": [
+            "禁物(きんもつ)",
             "⓪ 名  严禁的事物；切忌的事物"
-        ],
-        "notation": "禁物(きんもつ)"
+        ]
     },
     {
         "name": "areru",
         "trans": [
+            "荒(あ)れる",
             "⓪ 自动2  波涛汹涌；荒芜，荒废；胡闹，荒唐；变粗糙"
-        ],
-        "notation": "荒(あ)れる"
+        ]
     },
     {
         "name": "houwa",
         "trans": [
+            "飽和(ほうわ)",
             "⓪ 名·自动3  饱和，极限"
-        ],
-        "notation": "飽和(ほうわ)"
+        ]
     },
     {
         "name": "fusessei",
         "trans": [
+            "不摂生(ふせっせい)",
             "② 名·ナ形  不养生，不注意健康，没有节制"
-        ],
-        "notation": "不摂生(ふせっせい)"
+        ]
     },
     {
         "name": "hahen",
         "trans": [
+            "破片(はへん)",
             "⓪ 名  碎片"
-        ],
-        "notation": "破片(はへん)"
+        ]
     },
     {
         "name": "nenpi",
         "trans": [
+            "燃費(ねんぴ)",
             "⓪ 名  汽车耗油量"
-        ],
-        "notation": "燃費(ねんぴ)"
+        ]
     },
     {
         "name": "an'nojou",
         "trans": [
+            "案(あん)の定(じょう)",
             "③ 副  果然，果如所料"
-        ],
-        "notation": "案(あん)の定(じょう)"
+        ]
     },
     {
         "name": "nagoyaka",
         "trans": [
+            "和(なご)やか",
             "② ナ形  平静的，温和的；和睦的，平和的；和谐的"
-        ],
-        "notation": "和(なご)やか"
+        ]
     },
     {
         "name": "tontonbyoushi",
         "trans": [
+            "とんとん拍子(びょうし)",
             "⑤ 名·ナ形  一帆风顺，顺顺当当"
-        ],
-        "notation": "とんとん拍子(びょうし)"
+        ]
     },
     {
         "name": "tsurikawa",
         "trans": [
+            "吊革(つりかわ)",
             "⓪ 名  吊环，拉手"
-        ],
-        "notation": "吊革(つりかわ)"
+        ]
     },
     {
         "name": "tanshinfunin",
         "trans": [
+            "単身赴任(たんしんふにん)",
             "⑤ 名·自动3  单身赴任"
-        ],
-        "notation": "単身赴任(たんしんふにん)"
+        ]
     },
     {
         "name": "iyaiya",
         "trans": [
+            "いやいや",
             "⓪ 名·副  摇头，不乐意；不情愿地，勉强地"
-        ],
-        "notation": "いやいや"
+        ]
     },
     {
         "name": "zenrei",
         "trans": [
+            "前例(ぜんれい)",
             "⓪ 名  前例，先例"
-        ],
-        "notation": "前例(ぜんれい)"
+        ]
     },
     {
         "name": "shinbou",
         "trans": [
+            "辛抱(しんぼう)",
             "① 名·自他动3  忍受，忍耐；耐心工作"
-        ],
-        "notation": "辛抱(しんぼう)"
+        ]
     },
     {
         "name": "konpou",
         "trans": [
+            "梱包(こんぽう)",
             "⓪ 名·他动3  包装，捆扎"
-        ],
-        "notation": "梱包(こんぽう)"
+        ]
     },
     {
         "name": "kinkou",
         "trans": [
+            "均衡(きんこう)",
             "⓪ 名·自动3  均衡，平衡"
-        ],
-        "notation": "均衡(きんこう)"
+        ]
     },
     {
         "name": "oshitsukeru",
         "trans": [
+            "押(お)し付(つ)ける",
             "④ 他动2  压住，按住；强加于人，硬推给别人"
-        ],
-        "notation": "押(お)し付(つ)ける"
+        ]
     },
     {
         "name": "engei",
         "trans": [
+            "演芸(えんげい)",
             "⓪ 名  文艺表演"
-        ],
-        "notation": "演芸(えんげい)"
+        ]
     },
     {
         "name": "anzan",
         "trans": [
+            "暗算(あんざん)",
             "⓪ 名·他动3  心算，在头脑中计算"
-        ],
-        "notation": "暗算(あんざん)"
+        ]
     },
     {
         "name": "wara",
         "trans": [
+            "藁(わら)",
             "① 名  稻草，麦秆"
-        ],
-        "notation": "藁(わら)"
+        ]
     },
     {
         "name": "shichaku",
         "trans": [
+            "試着(しちゃく)",
             "⓪ 名·他动3  试穿（衣服）"
-        ],
-        "notation": "試着(しちゃく)"
+        ]
     },
     {
         "name": "kabau",
         "trans": [
+            "庇(かば)う",
             "② 他动1  保护，庇护，包庇"
-        ],
-        "notation": "庇(かば)う"
+        ]
     },
     {
         "name": "hen'you",
         "trans": [
+            "変容(へんよう)",
             "⓪ 名·自动3  变样，改观"
-        ],
-        "notation": "変容(へんよう)"
+        ]
     },
     {
         "name": "pinpin",
         "trans": [
+            "ぴんぴん",
             "① 副·自动3  活蹦乱跳；精神抖擞，健朗"
-        ],
-        "notation": "ぴんぴん"
+        ]
     },
     {
         "name": "denrai",
         "trans": [
+            "伝来(でんらい)",
             "⓪ 名·自动3  （从国外）传来，传入；祖传"
-        ],
-        "notation": "伝来(でんらい)"
+        ]
     },
     {
         "name": "chinretsu",
         "trans": [
+            "陳列(ちんれつ)",
             "⓪ 名·他动3  陈列，展览"
-        ],
-        "notation": "陳列(ちんれつ)"
+        ]
     },
     {
         "name": "gyotto",
         "trans": [
+            "ぎょっと",
             "⓪ 副·自动3  吓了一跳，大吃一惊"
-        ],
-        "notation": "ぎょっと"
+        ]
     },
     {
         "name": "sonzoku",
         "trans": [
+            "存続(そんぞく)",
             "⓪ 名·自他动3  长存，延续"
-        ],
-        "notation": "存続(そんぞく)"
+        ]
     },
     {
         "name": "sunpou",
         "trans": [
+            "寸法(すんぽう)",
             "⓪ 名  尺寸；计划；情况"
-        ],
-        "notation": "寸法(すんぽう)"
+        ]
     },
     {
         "name": "sanjou",
         "trans": [
+            "参上(さんじょう)",
             "⓪ 名·自动3  拜访，造访"
-        ],
-        "notation": "参上(さんじょう)"
+        ]
     },
     {
         "name": "kenchi",
         "trans": [
+            "見地(けんち)",
             "① 名  见地，立场，观点"
-        ],
-        "notation": "見地(けんち)"
+        ]
     },
     {
         "name": "gutto",
         "trans": [
+            "ぐっと",
             "⓪ 副  一口气；更加；怔住；深受感动"
-        ],
-        "notation": "ぐっと"
+        ]
     },
     {
         "name": "kirabiyaka",
         "trans": [
+            "煌(きら)びやか",
             "③ ナ形  光辉灿烂的，光彩夺目的"
-        ],
-        "notation": "煌(きら)びやか"
+        ]
     },
     {
         "name": "kanbashii",
         "trans": [
+            "芳(かんば)しい",
             "④ イ形  芬芳的；优秀的，声誉好的"
-        ],
-        "notation": "芳(かんば)しい"
+        ]
     },
     {
         "name": "okkuu",
         "trans": [
+            "億劫(おっくう)",
             "③ 名·ナ形  嫌麻烦，懒得动"
-        ],
-        "notation": "億劫(おっくう)"
+        ]
     },
     {
         "name": "infure",
         "trans": [
+            "インフレ",
             "⓪ 名  通货膨胀"
-        ],
-        "notation": "インフレ"
+        ]
     },
     {
         "name": "shitateru",
         "trans": [
+            "仕立(した)てる",
             "③ 他动2  缝制衣服；培养；准备；乔装，扮作"
-        ],
-        "notation": "仕立(した)てる"
+        ]
     },
     {
         "name": "honba",
         "trans": [
+            "本場(ほんば)",
             "⓪ 名  发源地，原产地"
-        ],
-        "notation": "本場(ほんば)"
+        ]
     },
     {
         "name": "toriyoseru",
         "trans": [
+            "取(と)り寄(よ)せる",
             "④ 他动2  让人寄来，订购"
-        ],
-        "notation": "取(と)り寄(よ)せる"
+        ]
     },
     {
         "name": "bussou",
         "trans": [
+            "物騒(ぶっそう)",
             "③ 名·ナ形  不安定，不太平；危险"
-        ],
-        "notation": "物騒(ぶっそう)"
+        ]
     },
     {
         "name": "hande",
         "trans": [
+            "ハンデ",
             "① 名  障碍，不利条件"
-        ],
-        "notation": "ハンデ"
+        ]
     },
     {
         "name": "tsutsuku",
         "trans": [
+            "突(つつ)く",
             "② 他动1  捅，戳；欺负；怂恿，挑唆"
-        ],
-        "notation": "突(つつ)く"
+        ]
     },
     {
         "name": "chouda",
         "trans": [
+            "長蛇(ちょうだ)",
             "① 名  长蛇；排成很长的队伍"
-        ],
-        "notation": "長蛇(ちょうだ)"
+        ]
     },
     {
         "name": "zousan",
         "trans": [
+            "増産(ぞうさん)",
             "⓪ 名·他动3  增产"
-        ],
-        "notation": "増産(ぞうさん)"
+        ]
     },
     {
         "name": "joujou",
         "trans": [
+            "上場(じょうじょう)",
             "⓪ 名·他动3  上市，开始交易"
-        ],
-        "notation": "上場(じょうじょう)"
+        ]
     },
     {
         "name": "kokoroatari",
         "trans": [
+            "心当(こころあ)たり",
             "④ 名  猜想得到；线索"
-        ],
-        "notation": "心当(こころあ)たり"
+        ]
     },
     {
         "name": "tohaie",
         "trans": [
+            "とはいえ",
             "① 接续  虽说如此，尽管那样"
-        ],
-        "notation": "とはいえ"
+        ]
     },
     {
         "name": "orikaeshi",
         "trans": [
+            "折(お)り返(かえ)し",
             "⓪ 名·副  翻折；返回，折回；立即，尽快"
-        ],
-        "notation": "折(お)り返(かえ)し"
+        ]
     },
     {
         "name": "kiwamete",
         "trans": [
+            "極(きわ)めて",
             "② 副  极其，非常"
-        ],
-        "notation": "極(きわ)めて"
+        ]
     },
     {
         "name": "iriyou",
         "trans": [
+            "入(い)り用(よう)",
             "⓪ 名·ナ形  需要；必要的费用"
-        ],
-        "notation": "入(い)り用(よう)"
+        ]
     },
     {
         "name": "juyo",
         "trans": [
+            "授与(じゅよ)",
             "① 名·他动3  授予"
-        ],
-        "notation": "授与(じゅよ)"
+        ]
     },
     {
         "name": "nandemokandemo",
         "trans": [
+            "なんでもかんでも",
             "⑤ 连语  全部，一切；一定，无论如何"
-        ],
-        "notation": "なんでもかんでも"
+        ]
     },
     {
         "name": "muyami",
         "trans": [
+            "無闇(むやみ)",
             "① ナ形  胡乱的，随便的；过分的，过度的"
-        ],
-        "notation": "無闇(むやみ)"
+        ]
     },
     {
         "name": "fuhon'i",
         "trans": [
+            "不本意(ふほんい)",
             "② 名·ナ形  非本意，不情愿"
-        ],
-        "notation": "不本意(ふほんい)"
+        ]
     },
     {
         "name": "bapponteki",
         "trans": [
+            "抜本的(ばっぽんてき)",
             "⓪ ナ形  根本的，彻底的"
-        ],
-        "notation": "抜本的(ばっぽんてき)"
+        ]
     },
     {
         "name": "karekore",
         "trans": [
+            "かれこれ",
             "① 副  这样那样，多方；大概，差不多"
-        ],
-        "notation": "かれこれ"
+        ]
     },
     {
         "name": "himeru",
         "trans": [
+            "秘(ひ)める",
             "② 他动2  隐藏，隐瞒"
-        ],
-        "notation": "秘(ひ)める"
+        ]
     },
     {
         "name": "doudou",
         "trans": [
+            "堂々(どうどう)",
             "③ 副·ナ形  威严庄重；堂堂正正；威风凛凛"
-        ],
-        "notation": "堂々(どうどう)"
+        ]
     },
     {
         "name": "saisei",
         "trans": [
+            "再生(さいせい)",
             "⓪ 名·自他动3  再生，新生；重新播放"
-        ],
-        "notation": "再生(さいせい)"
+        ]
     },
     {
         "name": "teguchi",
         "trans": [
+            "手口(てぐち)",
             "① 名  （做坏事的）手法，手段"
-        ],
-        "notation": "手口(てぐち)"
+        ]
     },
     {
         "name": "setai",
         "trans": [
+            "世帯(せたい)",
             "② 名  家庭，户"
-        ],
-        "notation": "世帯(せたい)"
+        ]
     },
     {
         "name": "yurugasu",
         "trans": [
+            "揺(ゆ)るがす",
             "③ 他动1  动摇，震撼"
-        ],
-        "notation": "揺(ゆ)るがす"
+        ]
     },
     {
         "name": "tankyuu",
         "trans": [
+            "探究(たんきゅう)",
             "⓪ 名·他动3  探寻，探索"
-        ],
-        "notation": "探究(たんきゅう)"
+        ]
     },
     {
         "name": "botsuraku",
         "trans": [
+            "没落(ぼつらく)",
             "⓪ 名·自动3  没落，衰败"
-        ],
-        "notation": "没落(ぼつらく)"
+        ]
     },
     {
         "name": "kanguru",
         "trans": [
+            "勘(かん)ぐる",
             "③ 他动1  乱猜测，猜疑"
-        ],
-        "notation": "勘(かん)ぐる"
+        ]
     },
     {
         "name": "shikku",
         "trans": [
+            "シック",
             "① ナ形  时髦的，高雅的"
-        ],
-        "notation": "シック"
+        ]
     },
     {
         "name": "ichimokusan'ni",
         "trans": [
+            "一目散(いちもくさん)に",
             "③ 副  一溜烟儿地，飞快地(跑)"
-        ],
-        "notation": "一目散(いちもくさん)に"
+        ]
     },
     {
         "name": "tousaku",
         "trans": [
+            "盗作(とうさく)",
             "⓪ 名·他动3  剽窃，抄袭"
-        ],
-        "notation": "盗作(とうさく)"
+        ]
     },
     {
         "name": "byoutou",
         "trans": [
+            "病棟(びょうとう)",
             "⓪ 名  病房大楼"
-        ],
-        "notation": "病棟(びょうとう)"
+        ]
     },
     {
         "name": "giwaku",
         "trans": [
+            "疑惑(ぎわく)",
             "⓪ 名  疑惑，疑心，猜疑"
-        ],
-        "notation": "疑惑(ぎわく)"
+        ]
     },
     {
         "name": "hodoku",
         "trans": [
+            "解(ほど)く",
             "② 他动1  解开（绳子）；拆开（衣服等）"
-        ],
-        "notation": "解(ほど)く"
+        ]
     },
     {
         "name": "oshimazu",
         "trans": [
+            "惜(お)しまず",
             "② 副  不惜，毫不吝惜"
-        ],
-        "notation": "惜(お)しまず"
+        ]
     },
     {
         "name": "rokotsu",
         "trans": [
+            "露骨(ろこつ)",
             "⓪ 名·ナ形  露骨，毫不顾忌"
-        ],
-        "notation": "露骨(ろこつ)"
+        ]
     },
     {
         "name": "katagata",
         "trans": [
+            "方々(かたがた)",
             "① 名  到处，各处"
-        ],
-        "notation": "方々(かたがた)"
+        ]
     },
     {
         "name": "toppyoushimonai",
         "trans": [
+            "突拍子(とっぴょうし)もない",
             "⑦ 连语  越出常轨，出奇，异常"
-        ],
-        "notation": "突拍子(とっぴょうし)もない"
+        ]
     },
     {
         "name": "busshoku",
         "trans": [
+            "物色(ぶっしょく)",
             "⓪ 名·他动3  物色，寻找；选择"
-        ],
-        "notation": "物色(ぶっしょく)"
+        ]
     },
     {
         "name": "kamaeru",
         "trans": [
+            "構(かま)える",
             "③ 自他动2  修建；自立门户；摆出姿势；准备好；假托"
-        ],
-        "notation": "構(かま)える"
+        ]
     },
     {
         "name": "hariai",
         "trans": [
+            "張(は)り合(あ)い",
             "⓪ 名  竞争，对立；有劲头"
-        ],
-        "notation": "張(は)り合(あ)い"
+        ]
     },
     {
         "name": "tenbou",
         "trans": [
+            "展望(てんぼう)",
             "⓪ 名·他动3  眺望，展望"
-        ],
-        "notation": "展望(てんぼう)"
+        ]
     },
     {
         "name": "chinmoku",
         "trans": [
+            "沈黙(ちんもく)",
             "⓪ 名·自动3  沉默，默不作声"
-        ],
-        "notation": "沈黙(ちんもく)"
+        ]
     },
     {
         "name": "shuei",
         "trans": [
+            "守衛(しゅえい)",
             "⓪ 名  门卫，保安"
-        ],
-        "notation": "守衛(しゅえい)"
+        ]
     },
     {
         "name": "kiriageru",
         "trans": [
+            "切(き)り上(あ)げる",
             "④ 他动2  结束，告一段落；（把零数当做1）进到前一位"
-        ],
-        "notation": "切(き)り上(あ)げる"
+        ]
     },
     {
         "name": "ichiritsu",
         "trans": [
+            "一律(いちりつ)",
             "⓪ 名·ナ形  一律，一概"
-        ],
-        "notation": "一律(いちりつ)"
+        ]
     },
     {
         "name": "obitadashii",
         "trans": [
+            "夥(おびただ)しい",
             "⑤ イ形  大量的；非常，很"
-        ],
-        "notation": "夥(おびただ)しい"
+        ]
     },
     {
         "name": "kyuuchi",
         "trans": [
+            "窮地(きゅうち)",
             "① 名  困境，窘境"
-        ],
-        "notation": "窮地(きゅうち)"
+        ]
     },
     {
         "name": "zen'iki",
         "trans": [
+            "全域(ぜんいき)",
             "⓪ 名  整个地区，整个领域"
-        ],
-        "notation": "全域(ぜんいき)"
+        ]
     },
     {
         "name": "kuraisuru",
         "trans": [
+            "位(くらい)する",
             "⓪ 自动3  位于，居于"
-        ],
-        "notation": "位(くらい)する"
+        ]
     },
     {
         "name": "bunpai",
         "trans": [
+            "分配(ぶんぱい)",
             "⓪ 名·他动3  分配，分发"
-        ],
-        "notation": "分配(ぶんぱい)"
+        ]
     },
     {
         "name": "shitsugi",
         "trans": [
+            "質疑(しつぎ)",
             "② 名·自动3  质疑，疑问"
-        ],
-        "notation": "質疑(しつぎ)"
+        ]
     },
     {
         "name": "kandou",
         "trans": [
+            "勘当(かんどう)",
             "⓪ 名·他动3  断绝（父子、师徒）关系"
-        ],
-        "notation": "勘当(かんどう)"
+        ]
     },
     {
         "name": "honmyou",
         "trans": [
+            "本名(ほんみょう)",
             "① 名  本名，真名"
-        ],
-        "notation": "本名(ほんみょう)"
+        ]
     },
     {
         "name": "shinobu",
         "trans": [
+            "偲(しの)ぶ",
             "② 他动1  追忆，缅怀；欣赏"
-        ],
-        "notation": "偲(しの)ぶ"
+        ]
     },
     {
         "name": "takumi",
         "trans": [
+            "巧(たく)み",
             "⓪ ナ形  巧妙的，精巧的"
-        ],
-        "notation": "巧(たく)み"
+        ]
     },
     {
         "name": "genchi",
         "trans": [
+            "現地(げんち)",
             "① 名  现场；当地"
-        ],
-        "notation": "現地(げんち)"
+        ]
     },
     {
         "name": "inpei",
         "trans": [
+            "隠蔽(いんぺい)",
             "⓪ 名·他动3  掩盖，隐瞒，隐藏"
-        ],
-        "notation": "隠蔽(いんぺい)"
+        ]
     },
     {
         "name": "seiton",
         "trans": [
+            "整頓(せいとん)",
             "⓪ 名·他动3  整顿，整理"
-        ],
-        "notation": "整頓(せいとん)"
+        ]
     },
     {
         "name": "tsumamu",
         "trans": [
+            "撮(つま)む",
             "⓪ 他动1  捏；夹起；摘取"
-        ],
-        "notation": "撮(つま)む"
+        ]
     },
     {
         "name": "shikkaku",
         "trans": [
+            "失格(しっかく)",
             "⓪ 名·自动3  失去资格"
-        ],
-        "notation": "失格(しっかく)"
+        ]
     },
     {
         "name": "tonda",
         "trans": [
+            "とんだ",
             "⓪ 连体  意想不到；不可挽回"
-        ],
-        "notation": "とんだ"
+        ]
     },
     {
         "name": "konagona",
         "trans": [
+            "粉々(こなごな)",
             "⓪ ナ形  粉碎的，稀巴烂的"
-        ],
-        "notation": "粉々(こなごな)"
+        ]
     },
     {
         "name": "kanmuryou",
         "trans": [
+            "感無量(かんむりょう)",
             "① ナ形  感慨万千的"
-        ],
-        "notation": "感無量(かんむりょう)"
+        ]
     },
     {
         "name": "hyoito",
         "trans": [
+            "ひょいと",
             "① 副  突然，忽然；无意中；轻松地"
-        ],
-        "notation": "ひょいと"
+        ]
     },
     {
         "name": "hon'nou",
         "trans": [
+            "本能(ほんのう)",
             "① 名  本能"
-        ],
-        "notation": "本能(ほんのう)"
+        ]
     },
     {
         "name": "purosesu",
         "trans": [
+            "プロセス",
             "② 名  过程；程序，流程"
-        ],
-        "notation": "プロセス"
+        ]
     },
     {
         "name": "hansoku",
         "trans": [
+            "反則(はんそく)",
             "⓪ 名·自动3  犯规，违规"
-        ],
-        "notation": "反則(はんそく)"
+        ]
     },
     {
         "name": "ganrai",
         "trans": [
+            "元来(がんらい)",
             "① 副  本来，原来"
-        ],
-        "notation": "元来(がんらい)"
+        ]
     },
     {
         "name": "iyasu",
         "trans": [
+            "癒(いや)す",
             "② 他动1  治疗，医治"
-        ],
-        "notation": "癒(いや)す"
+        ]
     },
     {
         "name": "kakusa",
         "trans": [
+            "格差(かくさ)",
             "① 名  差距，差别"
-        ],
-        "notation": "格差(かくさ)"
+        ]
     },
     {
         "name": "sakai",
         "trans": [
+            "境(さかい)",
             "② 名  交界，分界；境界"
-        ],
-        "notation": "境(さかい)"
+        ]
     },
     {
         "name": "kessai",
         "trans": [
+            "決裁(けっさい)",
             "① 名·他动3  裁决；审批，批准"
-        ],
-        "notation": "決裁(けっさい)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "進行(しんこう)",
             "⓪ 名·自动3  前进；进展，进行；（病情）恶化"
-        ],
-        "notation": "進行(しんこう)"
+        ]
     },
     {
         "name": "omouzonbun",
         "trans": [
+            "思(おも)う存分(ぞんぶん)",
             "② 副  尽情地，肆意地"
-        ],
-        "notation": "思(おも)う存分(ぞんぶん)"
+        ]
     },
     {
         "name": "saisan",
         "trans": [
+            "採算(さいさん)",
             "⓪ 名  （收支）核算"
-        ],
-        "notation": "採算(さいさん)"
+        ]
     },
     {
         "name": "shoukyo",
         "trans": [
+            "消去(しょうきょ)",
             "① 名·他动3  删除，消除"
-        ],
-        "notation": "消去(しょうきょ)"
+        ]
     },
     {
         "name": "tedori",
         "trans": [
+            "手取(てど)り",
             "③ 名  纯收入，净收入"
-        ],
-        "notation": "手取(てど)り"
+        ]
     },
     {
         "name": "bakuro",
         "trans": [
+            "暴露(ばくろ)",
             "① 名·自他动3  暴露，揭露，泄露"
-        ],
-        "notation": "暴露(ばくろ)"
+        ]
     },
     {
         "name": "kakimidasu",
         "trans": [
+            "かき乱(みだ)す",
             "④ 他动1  弄乱；扰乱"
-        ],
-        "notation": "かき乱(みだ)す"
+        ]
     },
     {
         "name": "koujo",
         "trans": [
+            "控除(こうじょ)",
             "① 名·他动3  扣除"
-        ],
-        "notation": "控除(こうじょ)"
+        ]
     },
     {
         "name": "uragaeshi",
         "trans": [
+            "裏返(うらがえ)し",
             "③ 名  表里相反；反证"
-        ],
-        "notation": "裏返(うらがえ)し"
+        ]
     },
     {
         "name": "gizou",
         "trans": [
+            "偽造(ぎぞう)",
             "⓪ 名·他动3  伪造，假造"
-        ],
-        "notation": "偽造(ぎぞう)"
+        ]
     },
     {
         "name": "saitaku",
         "trans": [
+            "採択(さいたく)",
             "⓪ 名·他动3  采纳，通过；选择，选定"
-        ],
-        "notation": "採択(さいたく)"
+        ]
     },
     {
         "name": "tsurutsuru",
         "trans": [
+            "つるつる",
             "① 副·ナ形·自动3  滑溜溜，光滑；吸食食物的声音"
-        ],
-        "notation": "つるつる"
+        ]
     },
     {
         "name": "touzai",
         "trans": [
+            "東西(とうざい)",
             "① 名  （方向上的）东西；方向，事理"
-        ],
-        "notation": "東西(とうざい)"
+        ]
     },
     {
         "name": "shoutai",
         "trans": [
+            "正体(しょうたい)",
             "① 名  真面目，原形；意识"
-        ],
-        "notation": "正体(しょうたい)"
+        ]
     },
     {
         "name": "kyouyu",
         "trans": [
+            "教諭(きょうゆ)",
             "⓪ 名  教诲，教导；（幼儿园、中小学的）正规教师"
-        ],
-        "notation": "教諭(きょうゆ)"
+        ]
     },
     {
         "name": "hanarebanare",
         "trans": [
+            "離(はな)れ離(ばな)れ",
             "④ 名·ナ形  分散，离散"
-        ],
-        "notation": "離(はな)れ離(ばな)れ"
+        ]
     },
     {
         "name": "iyani",
         "trans": [
+            "いやに",
             "② 副  特别，非常，过于"
-        ],
-        "notation": "いやに"
+        ]
     },
     {
         "name": "karute",
         "trans": [
+            "カルテ",
             "① 名  病历卡，诊断记录"
-        ],
-        "notation": "カルテ"
+        ]
     },
     {
         "name": "sakkyuu/soukyuu",
         "trans": [
+            "早急(さっきゅう/そうきゅう)",
             "⓪ 名·ナ形  紧急，火速"
-        ],
-        "notation": "早急(さっきゅう/そうきゅう)"
+        ]
     },
     {
         "name": "osekkai",
         "trans": [
+            "お節介(せっかい)",
             "② 名·ナ形  多管闲事"
-        ],
-        "notation": "お節介(せっかい)"
+        ]
     },
     {
         "name": "kousoku",
         "trans": [
+            "拘束(こうそく)",
             "⓪ 名·他动3  拘束，束缚，限制"
-        ],
-        "notation": "拘束(こうそく)"
+        ]
     },
     {
         "name": "torawareru",
         "trans": [
+            "捕(と)らわれる",
             "④ 自动2  被逮捕；受限制"
-        ],
-        "notation": "捕(と)らわれる"
+        ]
     },
     {
         "name": "kyakkou",
         "trans": [
+            "脚光(きゃっこう)",
             "⓪ 名  舞台上照亮脚部的灯光；登场，受人瞩目"
-        ],
-        "notation": "脚光(きゃっこう)"
+        ]
     },
     {
         "name": "haretsu",
         "trans": [
+            "破裂(はれつ)",
             "⓪ 名·自动3  破裂；（谈判）破裂"
-        ],
-        "notation": "破裂(はれつ)"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "フル",
             "① 名·ナ形  充分；全部"
-        ],
-        "notation": "フル"
+        ]
     },
     {
         "name": "wataridori",
         "trans": [
+            "渡(わたりど)り鳥()",
             "③ 名  候鸟；到处奔走谋生的人"
-        ],
-        "notation": "渡(わたりど)り鳥()"
+        ]
     },
     {
         "name": "iyarashii",
         "trans": [
+            "嫌(いや)らしい",
             "④ イ形  令人讨厌的；下流的，卑鄙的"
-        ],
-        "notation": "嫌(いや)らしい"
+        ]
     },
     {
         "name": "rosu",
         "trans": [
+            "ロス",
             "① 名·他动3  浪费，损耗"
-        ],
-        "notation": "ロス"
+        ]
     },
     {
         "name": "fukumen",
         "trans": [
+            "覆面(ふくめん)",
             "⓪ 名·自动3  蒙面；匿名"
-        ],
-        "notation": "覆面(ふくめん)"
+        ]
     },
     {
         "name": "sekkin",
         "trans": [
+            "接近(せっきん)",
             "⓪ 名·自动3  接近；关系密切"
-        ],
-        "notation": "接近(せっきん)"
+        ]
     },
     {
         "name": "kencho",
         "trans": [
+            "顕著(けんちょ)",
             "① ナ形  显著的，明显的"
-        ],
-        "notation": "顕著(けんちょ)"
+        ]
     },
     {
         "name": "kakutaru",
         "trans": [
+            "確(かく)たる",
             "① 连体  确切的，确凿的"
-        ],
-        "notation": "確(かく)たる"
+        ]
     },
     {
         "name": "sattou",
         "trans": [
+            "殺到(さっとう)",
             "⓪ 名·自动3  蜂拥而至"
-        ],
-        "notation": "殺到(さっとう)"
+        ]
     },
     {
         "name": "oroka",
         "trans": [
+            "愚(おろ)か",
             "① ナ形  愚蠢的，糊涂的"
-        ],
-        "notation": "愚(おろ)か"
+        ]
     },
     {
         "name": "ganjou",
         "trans": [
+            "頑丈(がんじょう)",
             "⓪ ナ形  结实的，坚固的；健壮的"
-        ],
-        "notation": "頑丈(がんじょう)"
+        ]
     },
     {
         "name": "iryuu",
         "trans": [
+            "慰留(いりゅう)",
             "⓪ 名·他动3  挽留"
-        ],
-        "notation": "慰留(いりゅう)"
+        ]
     },
     {
         "name": "togu",
         "trans": [
+            "研(と)ぐ",
             "① 他动1  磨光，磨快；擦亮；淘（米）"
-        ],
-        "notation": "研(と)ぐ"
+        ]
     },
     {
         "name": "saizen",
         "trans": [
+            "最善(さいぜん)",
             "⓪ 名  最好，最佳；全力"
-        ],
-        "notation": "最善(さいぜん)"
+        ]
     },
     {
         "name": "koutai",
         "trans": [
+            "交替(こうたい)",
             "⓪ 名·自动3  交替，轮流"
-        ],
-        "notation": "交替(こうたい)"
+        ]
     },
     {
         "name": "kessan",
         "trans": [
+            "決算(けっさん)",
             "① 名·他动3  结算，清账"
-        ],
-        "notation": "決算(けっさん)"
+        ]
     },
     {
         "name": "kanchi",
         "trans": [
+            "関知(かんち)",
             "① 名·自动3  与⋯⋯有关；知道"
-        ],
-        "notation": "関知(かんち)"
+        ]
     },
     {
         "name": "honoka",
         "trans": [
+            "仄(ほの)か",
             "① ナ形  隐约的，模糊的；略微的"
-        ],
-        "notation": "仄(ほの)か"
+        ]
     },
     {
         "name": "kashimashii",
         "trans": [
+            "姦(かしま)しい",
             "④ イ形  吵闹的，喧闹的"
-        ],
-        "notation": "姦(かしま)しい"
+        ]
     },
     {
         "name": "uwagaki",
         "trans": [
+            "上書(うわが)き",
             "⓪ 名·自他动3  在表面写；（在电脑原有文件上）保存，数据覆盖，替换"
-        ],
-        "notation": "上書(うわが)き"
+        ]
     },
     {
         "name": "kounai",
         "trans": [
+            "構内(こうない)",
             "① 名  某范围之内"
-        ],
-        "notation": "構内(こうない)"
+        ]
     },
     {
         "name": "occhokochoi",
         "trans": [
+            "おっちょこちょい",
             "⑤ 名·ナ形  轻浮，冒失"
-        ],
-        "notation": "おっちょこちょい"
+        ]
     },
     {
         "name": "gangan",
         "trans": [
+            "がんがん",
             "① 副  （头疼、耳鸣）强烈；喋喋不休"
-        ],
-        "notation": "がんがん"
+        ]
     },
     {
         "name": "sappuukei",
         "trans": [
+            "殺風景(さっぷうけい)",
             "③ 名·ナ形  煞风景，扫兴"
-        ],
-        "notation": "殺風景(さっぷうけい)"
+        ]
     },
     {
         "name": "kanreki",
         "trans": [
+            "還暦(かんれき)",
             "⓪ 名  花甲，满六十岁"
-        ],
-        "notation": "還暦(かんれき)"
+        ]
     },
     {
         "name": "kessei",
         "trans": [
+            "結成(けっせい)",
             "⓪ 名·他动3  结成，组成"
-        ],
-        "notation": "結成(けっせい)"
+        ]
     },
     {
         "name": "kaimu",
         "trans": [
+            "皆無(かいむ)",
             "① 名·ナ形  完全没有"
-        ],
-        "notation": "皆無(かいむ)"
+        ]
     },
     {
         "name": "kabureru",
         "trans": [
+            "気触(かぶ)れる",
             "⓪ 自动2  皮肤红肿，发炎；着迷，热衷于"
-        ],
-        "notation": "気触(かぶ)れる"
+        ]
     },
     {
         "name": "irai",
         "trans": [
+            "依頼(いらい)",
             "⓪ 名·他动3  委托，托付；依靠"
-        ],
-        "notation": "依頼(いらい)"
+        ]
     },
     {
         "name": "gouhi",
         "trans": [
+            "合否(ごうひ)",
             "① 名  合格与否"
-        ],
-        "notation": "合否(ごうひ)"
+        ]
     },
     {
         "name": "kontei",
         "trans": [
+            "根底(こんてい)",
             "⓪ 名  根本，基础"
-        ],
-        "notation": "根底(こんてい)"
+        ]
     },
     {
         "name": "ichiji",
         "trans": [
+            "一時(いちじ)",
             "② 名  一个时期；一时，临时"
-        ],
-        "notation": "一時(いちじ)"
+        ]
     },
     {
         "name": "hyottoshite",
         "trans": [
+            "ひょっとして",
             "⓪ 副  说不定，也许，万一"
-        ],
-        "notation": "ひょっとして"
+        ]
     },
     {
         "name": "kesson",
         "trans": [
+            "欠損(けっそん)",
             "⓪ 名·自动3  缺损；亏损，损失"
-        ],
-        "notation": "欠損(けっそん)"
+        ]
     },
     {
         "name": "gacchi",
         "trans": [
+            "合致(がっち)",
             "⓪ 名·自动3  一致，吻合"
-        ],
-        "notation": "合致(がっち)"
+        ]
     },
     {
         "name": "satei",
         "trans": [
+            "査定(さてい)",
             "⓪ 名·他动3  核定，审定，评定"
-        ],
-        "notation": "査定(さてい)"
+        ]
     },
     {
         "name": "irusu",
         "trans": [
+            "居留守(いるす)",
             "⓪ 名  假装不在家"
-        ],
-        "notation": "居留守(いるす)"
+        ]
     },
     {
         "name": "kizuku",
         "trans": [
+            "築(きず)く",
             "② 他动1  修建；建立"
-        ],
-        "notation": "築(きず)く"
+        ]
     },
     {
         "name": "kecchaku",
         "trans": [
+            "決着(けっちゃく)",
             "⓪ 名·自动3  了结，解决"
-        ],
-        "notation": "決着(けっちゃく)"
+        ]
     },
     {
         "name": "omokage",
         "trans": [
+            "面影(おもかげ)",
             "⓪ 名  相貌，模样；迹象，风貌"
-        ],
-        "notation": "面影(おもかげ)"
+        ]
     },
     {
         "name": "gouben",
         "trans": [
+            "合弁(ごうべん)",
             "⓪ 名  合办，合资"
-        ],
-        "notation": "合弁(ごうべん)"
+        ]
     },
     {
         "name": "funpatsu",
         "trans": [
+            "奮発(ふんぱつ)",
             "⓪ 名·自他动3  发奋；（一狠心）豁出去拿出钱"
-        ],
-        "notation": "奮発(ふんぱつ)"
+        ]
     },
     {
         "name": "tazusawaru",
         "trans": [
+            "携(たずさ)わる",
             "④ 自动1  参与，从事"
-        ],
-        "notation": "携(たずさ)わる"
+        ]
     },
     {
         "name": "sadou",
         "trans": [
+            "作動(さどう)",
             "⓪ 名·自动3  发动，启动"
-        ],
-        "notation": "作動(さどう)"
+        ]
     },
     {
         "name": "iyagarase",
         "trans": [
+            "嫌(いや)がらせ",
             "⓪ 名  找人麻烦，讨人嫌"
-        ],
-        "notation": "嫌(いや)がらせ"
+        ]
     },
     {
         "name": "choutei",
         "trans": [
+            "調停(ちょうてい)",
             "⓪ 名·他动3  调停，调解"
-        ],
-        "notation": "調停(ちょうてい)"
+        ]
     },
     {
         "name": "seiryoku",
         "trans": [
+            "精力(せいりょく)",
             "① 名  精力"
-        ],
-        "notation": "精力(せいりょく)"
+        ]
     },
     {
         "name": "kankan",
         "trans": [
+            "かんかん",
             "① 副  （阳光、火焰）强烈；大发雷霆"
-        ],
-        "notation": "かんかん"
+        ]
     },
     {
         "name": "chuutohanpa",
         "trans": [
+            "中途半端(ちゅうとはんぱ)",
             "④ 名·ナ形  半途而废；不完整；不彻底"
-        ],
-        "notation": "中途半端(ちゅうとはんぱ)"
+        ]
     },
     {
         "name": "isshin",
         "trans": [
+            "一心(いっしん)",
             "③ 名·副  同心；一心，专心"
-        ],
-        "notation": "一心(いっしん)"
+        ]
     },
     {
         "name": "konjou",
         "trans": [
+            "根性(こんじょう)",
             "① 名  性情，秉性；毅力，骨气"
-        ],
-        "notation": "根性(こんじょう)"
+        ]
     },
     {
         "name": "shutsuen",
         "trans": [
+            "出演(しゅつえん)",
             "⓪ 名·自动3  演出，登台表演"
-        ],
-        "notation": "出演(しゅつえん)"
+        ]
     },
     {
         "name": "kiwameru",
         "trans": [
+            "究(きわ)める",
             "③ 他动2  钻研，探求"
-        ],
-        "notation": "究(きわ)める"
+        ]
     },
     {
         "name": "omoitsuki",
         "trans": [
+            "思(おも)い付(つ)き",
             "⓪ 名  偶然的想法；主意"
-        ],
-        "notation": "思(おも)い付(つ)き"
+        ]
     },
     {
         "name": "fungai",
         "trans": [
+            "憤慨(ふんがい)",
             "⓪ 名·自他动3  愤慨，气愤"
-        ],
-        "notation": "憤慨(ふんがい)"
+        ]
     },
     {
         "name": "kanroku",
         "trans": [
+            "貫禄(かんろく)",
             "⓪ 名  威严，威信"
-        ],
-        "notation": "貫禄(かんろく)"
+        ]
     },
     {
         "name": "oboe",
         "trans": [
+            "覚(おぼ)え",
             "③ 名  记忆；经验；信心；信任"
-        ],
-        "notation": "覚(おぼ)え"
+        ]
     },
     {
         "name": "tsurareru",
         "trans": [
+            "釣(つ)られる",
             "⓪ 自动2  受到引诱；受到影响"
-        ],
-        "notation": "釣(つ)られる"
+        ]
     },
     {
         "name": "kakusaku",
         "trans": [
+            "画策(かくさく)",
             "⓪ 名·他动3  策划，谋划"
-        ],
-        "notation": "画策(かくさく)"
+        ]
     },
     {
         "name": "inshitsu",
         "trans": [
+            "陰湿(いんしつ)",
             "⓪ 名·ナ形  阴湿，阴暗；阴郁"
-        ],
-        "notation": "陰湿(いんしつ)"
+        ]
     },
     {
         "name": "tekikaku",
         "trans": [
+            "的確(てきかく)",
             "⓪ ナ形  正确的，准确的"
-        ],
-        "notation": "的確(てきかく)"
+        ]
     },
     {
         "name": "gappei",
         "trans": [
+            "合併(がっぺい)",
             "⓪ 名·自他动3  合并"
-        ],
-        "notation": "合併(がっぺい)"
+        ]
     },
     {
         "name": "kiwameru",
         "trans": [
+            "極(きわ)める",
             "③ 他动2  达到极限，极尽"
-        ],
-        "notation": "極(きわ)める"
+        ]
     },
     {
         "name": "fukusayou",
         "trans": [
+            "副作用(ふくさよう)",
             "③ 名  副作用"
-        ],
-        "notation": "副作用(ふくさよう)"
+        ]
     },
     {
         "name": "gatten",
         "trans": [
+            "合点(がってん)",
             "③ 名·自动3  认可，同意"
-        ],
-        "notation": "合点(がってん)"
+        ]
     },
     {
         "name": "oteage",
         "trans": [
+            "お手上(てあ)げ",
             "⓪ 名  束手无策，毫无办法"
-        ],
-        "notation": "お手上(てあ)げ"
+        ]
     },
     {
         "name": "chakujitsu",
         "trans": [
+            "着実(ちゃくじつ)",
             "⓪ 名·ナ形  踏实，牢靠"
-        ],
-        "notation": "着実(ちゃくじつ)"
+        ]
     },
     {
         "name": "guratsuku",
         "trans": [
+            "ぐらつく",
             "⓪ 自动1  摇晃；（想法）动摇"
-        ],
-        "notation": "ぐらつく"
+        ]
     }
 ]

--- a/assets/dicts/Jap_High-Frequency_N2.json
+++ b/assets/dicts/Jap_High-Frequency_N2.json
@@ -2,17501 +2,17501 @@
     {
         "name": "tamesu",
         "trans": [
+            "試(ため)す",
             "② 他动1  尝试，试验"
-        ],
-        "notation": "試(ため)す"
+        ]
     },
     {
         "name": "tamerau",
         "trans": [
+            "躊躇(ためら)う",
             "③ 自他动1  踌躇；犹豫"
-        ],
-        "notation": "躊躇(ためら)う"
+        ]
     },
     {
         "name": "niburu",
         "trans": [
+            "鈍(にぶ)る",
             "② 自动1  变钝；变得迟钝；变弱"
-        ],
-        "notation": "鈍(にぶ)る"
+        ]
     },
     {
         "name": "kuusou",
         "trans": [
+            "空想(くうそう)",
             "⓪ 名·他动3  空想，幻想"
-        ],
-        "notation": "空想(くうそう)"
+        ]
     },
     {
         "name": "kugi",
         "trans": [
+            "釘(くぎ)",
             "⓪ 名  钉子"
-        ],
-        "notation": "釘(くぎ)"
+        ]
     },
     {
         "name": "tamotsu",
         "trans": [
+            "保(たも)つ",
             "② 他动1  保持，维持；保住"
-        ],
-        "notation": "保(たも)つ"
+        ]
     },
     {
         "name": "kuguru",
         "trans": [
+            "潜(くぐ)る",
             "② 自动1  钻过，通过；钻空子"
-        ],
-        "notation": "潜(くぐ)る"
+        ]
     },
     {
         "name": "kusai",
         "trans": [
+            "～臭(くさ)い",
             " 接尾  有……的味道；给人某种感觉"
-        ],
-        "notation": "～臭(くさ)い"
+        ]
     },
     {
         "name": "tayori",
         "trans": [
+            "頼(たよ)り",
             "① 名  依靠，依赖"
-        ],
-        "notation": "頼(たよ)り"
+        ]
     },
     {
         "name": "tayorinai",
         "trans": [
+            "頼(たよ)りない",
             "④ イ形  无依无靠的；没把握的，不可靠的"
-        ],
-        "notation": "頼(たよ)りない"
+        ]
     },
     {
         "name": "kuji",
         "trans": [
+            "くじ",
             " ① 名  签；抽签"
-        ],
-        "notation": "くじ"
+        ]
     },
     {
         "name": "kujou",
         "trans": [
+            "苦情(くじょう)",
             "⓪ 名  牢骚，抱怨；请求，要求"
-        ],
-        "notation": "苦情(くじょう)"
+        ]
     },
     {
         "name": "kuchisaki",
         "trans": [
+            "口先(くちさき)",
             "⓪ 名  嘴边；口头上的"
-        ],
-        "notation": "口先(くちさき)"
+        ]
     },
     {
         "name": "taiko",
         "trans": [
+            "太鼓(たいこ)",
             "⓪ 名  鼓，大鼓"
-        ],
-        "notation": "太鼓(たいこ)"
+        ]
     },
     {
         "name": "teishi",
         "trans": [
+            "停止(ていし)",
             "⓪ 名·自他动3  停下，停止"
-        ],
-        "notation": "停止(ていし)"
+        ]
     },
     {
         "name": "kushin",
         "trans": [
+            "苦心(くしん)",
             "② 名·自动3  费心思，煞费苦心"
-        ],
-        "notation": "苦心(くしん)"
+        ]
     },
     {
         "name": "kuchiburi",
         "trans": [
+            "口(くち)ぶり",
             "⓪ 名  口吻，口气"
-        ],
-        "notation": "口(くち)ぶり"
+        ]
     },
     {
         "name": "gutai",
         "trans": [
+            "具体(ぐたい)",
             "⓪ 名  具体"
-        ],
-        "notation": "具体(ぐたい)"
+        ]
     },
     {
         "name": "kutakuta",
         "trans": [
+            "くたくた",
             " ⓪ ナ形  筋疲力尽的，疲惫不堪的"
-        ],
-        "notation": "くたくた"
+        ]
     },
     {
         "name": "taisho",
         "trans": [
+            "対処(たいしょ)",
             "① 名·自动3  对待，处理，应对"
-        ],
-        "notation": "対処(たいしょ)"
+        ]
     },
     {
         "name": "taisou",
         "trans": [
+            "大層(たいそう)",
             "① 副·ナ形  很，非常；夸张"
-        ],
-        "notation": "大層(たいそう)"
+        ]
     },
     {
         "name": "kure",
         "trans": [
+            "暮(く)れ",
             "⓪ 名  黄昏；年底"
-        ],
-        "notation": "暮(く)れ"
+        ]
     },
     {
         "name": "kessaku",
         "trans": [
+            "傑作(けっさく)",
             "⓪ 名  杰作"
-        ],
-        "notation": "傑作(けっさく)"
+        ]
     },
     {
         "name": "kenchou",
         "trans": [
+            "県庁(けんちょう)",
             "① 名  县政府"
-        ],
-        "notation": "県庁(けんちょう)"
+        ]
     },
     {
         "name": "genshi",
         "trans": [
+            "原始(げんし)",
             "① 名  原始；不发达"
-        ],
-        "notation": "原始(げんし)"
+        ]
     },
     {
         "name": "genjuu",
         "trans": [
+            "現住(げんじゅう)",
             "⓪ 名  现在居住（的地方），现地址"
-        ],
-        "notation": "現住(げんじゅう)"
+        ]
     },
     {
         "name": "kouon",
         "trans": [
+            "高温(こうおん)",
             "⓪ 名  高温"
-        ],
-        "notation": "高温(こうおん)"
+        ]
     },
     {
         "name": "kesshou",
         "trans": [
+            "決勝(けっしょう)",
             "⓪ 名  决胜负，决赛"
-        ],
-        "notation": "決勝(けっしょう)"
+        ]
     },
     {
         "name": "damu",
         "trans": [
+            "ダム",
             "① 名  水坝；水库"
-        ],
-        "notation": "ダム"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "高価(こうか)",
             "① 名·ナ形  高价，大价钱"
-        ],
-        "notation": "高価(こうか)"
+        ]
     },
     {
         "name": "shisen",
         "trans": [
+            "視線(しせん)",
             "⓪ 名  视线"
-        ],
-        "notation": "視線(しせん)"
+        ]
     },
     {
         "name": "kentou",
         "trans": [
+            "見当(けんとう)",
             "③ 名  估计，推测；方向；大约，左右"
-        ],
-        "notation": "見当(けんとう)"
+        ]
     },
     {
         "name": "jizen",
         "trans": [
+            "事前(じぜん)",
             "⓪ 名  事先"
-        ],
-        "notation": "事前(じぜん)"
+        ]
     },
     {
         "name": "koui",
         "trans": [
+            "好意(こうい)",
             "① 名  好意，美意"
-        ],
-        "notation": "好意(こうい)"
+        ]
     },
     {
         "name": "gen'ni",
         "trans": [
+            "現(げん)に",
             "① 副  实际；亲眼"
-        ],
-        "notation": "現(げん)に"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "弾(たま)",
             "② 名  子弹，炮弹；订书钉"
-        ],
-        "notation": "弾(たま)"
+        ]
     },
     {
         "name": "kenbikyou",
         "trans": [
+            "顕微鏡(けんびきょう)",
             "⓪ 名  显微镜"
-        ],
-        "notation": "顕微鏡(けんびきょう)"
+        ]
     },
     {
         "name": "genbun",
         "trans": [
+            "原文(げんぶん)",
             "⓪ 名  原文"
-        ],
-        "notation": "原文(げんぶん)"
+        ]
     },
     {
         "name": "ojigi",
         "trans": [
+            "お辞儀(じぎ)",
             "⓪ 名·自动3  行礼，鞠躬"
-        ],
-        "notation": "お辞儀(じぎ)"
+        ]
     },
     {
         "name": "genjou",
         "trans": [
+            "現状(げんじょう)",
             "⓪ 名  现状"
-        ],
-        "notation": "現状(げんじょう)"
+        ]
     },
     {
         "name": "kataru",
         "trans": [
+            "語(かた)る",
             "⓪ 他动1  谈，说，讲述"
-        ],
-        "notation": "語(かた)る"
+        ]
     },
     {
         "name": "kenzen",
         "trans": [
+            "健全(けんぜん)",
             "⓪ ナ形  健康的，健全的；完善的"
-        ],
-        "notation": "健全(けんぜん)"
+        ]
     },
     {
         "name": "gensoku",
         "trans": [
+            "原則(げんそく)",
             "⓪ 名  原则"
-        ],
-        "notation": "原則(げんそく)"
+        ]
     },
     {
         "name": "go",
         "trans": [
+            "碁(ご)",
             "① 名  围棋"
-        ],
-        "notation": "碁(ご)"
+        ]
     },
     {
         "name": "koishii",
         "trans": [
+            "恋(こい)しい",
             "③ イ形  爱慕的，思慕的，怀念的"
-        ],
-        "notation": "恋(こい)しい"
+        ]
     },
     {
         "name": "kehai",
         "trans": [
+            "気配(けはい)",
             "① 名  情形，样子；迹象，苗头；行情"
-        ],
-        "notation": "気配(けはい)"
+        ]
     },
     {
         "name": "gehin",
         "trans": [
+            "下品(げひん)",
             "② ナ形  卑鄙的，下流的，粗俗的"
-        ],
-        "notation": "下品(げひん)"
+        ]
     },
     {
         "name": "kuufuku",
         "trans": [
+            "空腹(くうふく)",
             "⓪ 名  饿肚子；空腹"
-        ],
-        "notation": "空腹(くうふく)"
+        ]
     },
     {
         "name": "kenkai",
         "trans": [
+            "見解(けんかい)",
             "⓪ 名  见解，看法"
-        ],
-        "notation": "見解(けんかい)"
+        ]
     },
     {
         "name": "tekisetsu",
         "trans": [
+            "適切(てきせつ)",
             "⓪ 名·ナ形  合适，恰当，妥当"
-        ],
-        "notation": "適切(てきせつ)"
+        ]
     },
     {
         "name": "genkai",
         "trans": [
+            "限界(げんかい)",
             "⓪ 名  极限，界限"
-        ],
-        "notation": "限界(げんかい)"
+        ]
     },
     {
         "name": "kashi",
         "trans": [
+            "歌詞(かし)",
             "① 名  歌词"
-        ],
-        "notation": "歌詞(かし)"
+        ]
     },
     {
         "name": "kougi",
         "trans": [
+            "抗議(こうぎ)",
             "① 名·自他动3  抗议"
-        ],
-        "notation": "抗議(こうぎ)"
+        ]
     },
     {
         "name": "kenpou",
         "trans": [
+            "憲法(けんぽう)",
             "① 名  宪法"
-        ],
-        "notation": "憲法(けんぽう)"
+        ]
     },
     {
         "name": "genri",
         "trans": [
+            "原理(げんり)",
             "① 名  原理"
-        ],
-        "notation": "原理(げんり)"
+        ]
     },
     {
         "name": "koukuu",
         "trans": [
+            "航空(こうくう)",
             "⓪ 名  航空"
-        ],
-        "notation": "航空(こうくう)"
+        ]
     },
     {
         "name": "sakugen",
         "trans": [
+            "削減(さくげん)",
             "⓪ 名·他动3  削减，缩减，减少"
-        ],
-        "notation": "削減(さくげん)"
+        ]
     },
     {
         "name": "koukei",
         "trans": [
+            "光景(こうけい)",
             "⓪ 名  光景，情景，景象"
-        ],
-        "notation": "光景(こうけい)"
+        ]
     },
     {
         "name": "gentei",
         "trans": [
+            "限定(げんてい)",
             "⓪ 名·他动3  限定，限制"
-        ],
-        "notation": "限定(げんてい)"
+        ]
     },
     {
         "name": "gendo",
         "trans": [
+            "限度(げんど)",
             "① 名  限度，界限"
-        ],
-        "notation": "限度(げんど)"
+        ]
     },
     {
         "name": "koukou",
         "trans": [
+            "孝行(こうこう)",
             "① 名·ナ形·自动3  孝顺，孝敬"
-        ],
-        "notation": "孝行(こうこう)"
+        ]
     },
     {
         "name": "genten",
         "trans": [
+            "減点(げんてん)",
             "⓪ 名·自动3  减分，扣分"
-        ],
-        "notation": "減点(げんてん)"
+        ]
     },
     {
         "name": "koui",
         "trans": [
+            "行為(こうい)",
             "① 名  行为，举动"
-        ],
-        "notation": "行為(こうい)"
+        ]
     },
     {
         "name": "kousa",
         "trans": [
+            "交差(こうさ)",
             "⓪ 名·自动3  交叉"
-        ],
-        "notation": "交差(こうさ)"
+        ]
     },
     {
         "name": "zashiki",
         "trans": [
+            "座敷(ざしき)",
             "③ 名  （日式）铺着席子的房间"
-        ],
-        "notation": "座敷(ざしき)"
+        ]
     },
     {
         "name": "koukishin",
         "trans": [
+            "好奇心(こうきしん)",
             "③ 名  好奇心"
-        ],
-        "notation": "好奇心(こうきしん)"
+        ]
     },
     {
         "name": "idaku",
         "trans": [
+            "抱(いだ)く",
             "② 他动1  抱，搂；（心中）怀有"
-        ],
-        "notation": "抱(いだ)く"
+        ]
     },
     {
         "name": "sashidasu",
         "trans": [
+            "差(さ)し出(だ)す",
             "③ 他动1  提交；寄出；伸出"
-        ],
-        "notation": "差(さ)し出(だ)す"
+        ]
     },
     {
         "name": "sashitsukae",
         "trans": [
+            "差(さ)し支(つか)え",
             "⓪ 名  妨碍，不方便"
-        ],
-        "notation": "差(さ)し支(つか)え"
+        ]
     },
     {
         "name": "kenri",
         "trans": [
+            "権利(けんり)",
             "① 名  权利"
-        ],
-        "notation": "権利(けんり)"
+        ]
     },
     {
         "name": "kouza",
         "trans": [
+            "口座(こうざ)",
             "⓪ 名  （银行）账户，账号"
-        ],
-        "notation": "口座(こうざ)"
+        ]
     },
     {
         "name": "shison",
         "trans": [
+            "子孫(しそん)",
             "① 名  子孙，后代"
-        ],
-        "notation": "子孫(しそん)"
+        ]
     },
     {
         "name": "shidaini",
         "trans": [
+            "次第(しだい)に",
             "⓪ 副  逐渐，渐渐地，慢慢地"
-        ],
-        "notation": "次第(しだい)に"
+        ]
     },
     {
         "name": "ketsudan",
         "trans": [
+            "決断(けつだん)",
             "⓪ 名·自他动3  决断，当机立断"
-        ],
-        "notation": "決断(けつだん)"
+        ]
     },
     {
         "name": "fukou",
         "trans": [
+            "不幸(ふこう)",
             "② 名·ナ形  不幸，厄运"
-        ],
-        "notation": "不幸(ふこう)"
+        ]
     },
     {
         "name": "gensan",
         "trans": [
+            "原産(げんさん)",
             "⓪ 名  原产"
-        ],
-        "notation": "原産(げんさん)"
+        ]
     },
     {
         "name": "koushiki",
         "trans": [
+            "公式(こうしき)",
             "⓪ 名  正式；（数学）公式"
-        ],
-        "notation": "公式(こうしき)"
+        ]
     },
     {
         "name": "sanso",
         "trans": [
+            "酸素(さんそ)",
             "① 名  氧"
-        ],
-        "notation": "酸素(さんそ)"
+        ]
     },
     {
         "name": "jitaku",
         "trans": [
+            "自宅(じたく)",
             "⓪ 名  自己家，自己的房子"
-        ],
-        "notation": "自宅(じたく)"
+        ]
     },
     {
         "name": "shitamawaru",
         "trans": [
+            "下回(したまわ)る",
             "⓪ 自动1  在……以下；低于"
-        ],
-        "notation": "下回(したまわ)る"
+        ]
     },
     {
         "name": "chiribameru",
         "trans": [
+            "ちりばめる",
             " ④ 他动2  镶嵌，点缀"
-        ],
-        "notation": "ちりばめる"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "裂(さ)く",
             "① 他动1  撕开；劈开，分开；匀出，腾出"
-        ],
-        "notation": "裂(さ)く"
+        ]
     },
     {
         "name": "shitamachi",
         "trans": [
+            "下町(したまち)",
             "⓪ 名  工商业者居住区"
-        ],
-        "notation": "下町(したまち)"
+        ]
     },
     {
         "name": "shidai",
         "trans": [
+            "次第(しだい)",
             "⓪ 名  顺序；事情的经过，缘由"
-        ],
-        "notation": "次第(しだい)"
+        ]
     },
     {
         "name": "tsure",
         "trans": [
+            "連(つ)れ",
             "⓪ 名  同伴，伴侣，伙伴"
-        ],
-        "notation": "連(つ)れ"
+        ]
     },
     {
         "name": "jitai",
         "trans": [
+            "事態(じたい)",
             "① 名  事态，局势"
-        ],
-        "notation": "事態(じたい)"
+        ]
     },
     {
         "name": "sakuin",
         "trans": [
+            "索引(さくいん)",
             "⓪ 名  索引"
-        ],
-        "notation": "索引(さくいん)"
+        ]
     },
     {
         "name": "sakebi",
         "trans": [
+            "叫(さけ)び",
             "③ 名  叫喊，呼声"
-        ],
-        "notation": "叫(さけ)び"
+        ]
     },
     {
         "name": "shirigomi",
         "trans": [
+            "尻込(しりご)み",
             "③ 名·自动3  后退；踌躇，犹豫"
-        ],
-        "notation": "尻込(しりご)み"
+        ]
     },
     {
         "name": "suitai",
         "trans": [
+            "衰退(すいたい)",
             "⓪ 名·自动3  衰退，衰落，衰弱"
-        ],
-        "notation": "衰退(すいたい)"
+        ]
     },
     {
         "name": "kouken",
         "trans": [
+            "貢献(こうけん)",
             "⓪ 名·自动3  贡献"
-        ],
-        "notation": "貢献(こうけん)"
+        ]
     },
     {
         "name": "nukeochiru",
         "trans": [
+            "抜(ぬ)け落(お)ちる",
             "④ 自动2  脱落；遗漏"
-        ],
-        "notation": "抜(ぬ)け落(お)ちる"
+        ]
     },
     {
         "name": "shichou",
         "trans": [
+            "視聴(しちょう)",
             "⓪ 名·他动3  视听；收看；关注"
-        ],
-        "notation": "視聴(しちょう)"
+        ]
     },
     {
         "name": "shitsuon",
         "trans": [
+            "室温(しつおん)",
             "⓪ 名  室温，室内温度"
-        ],
-        "notation": "室温(しつおん)"
+        ]
     },
     {
         "name": "sutereotaipu",
         "trans": [
+            "ステレオタイプ",
             "⑤ 名  （印刷用语）铅版；老一套，模式化观念"
-        ],
-        "notation": "ステレオタイプ"
+        ]
     },
     {
         "name": "kougeki",
         "trans": [
+            "攻撃(こうげき)",
             "⓪ 名·他动3  攻击，进攻；抨击"
-        ],
-        "notation": "攻撃(こうげき)"
+        ]
     },
     {
         "name": "puroro-gu",
         "trans": [
+            "プロローグ",
             "③ 名  序言；开端，开头"
-        ],
-        "notation": "プロローグ"
+        ]
     },
     {
         "name": "segumente-shon",
         "trans": [
+            "セグメンテーション",
             "⑤ 名  区分市场"
-        ],
-        "notation": "セグメンテーション"
+        ]
     },
     {
         "name": "kouso",
         "trans": [
+            "控訴(こうそ)",
             "① 名·自动3  上诉"
-        ],
-        "notation": "控訴(こうそ)"
+        ]
     },
     {
         "name": "sensabanbetsu",
         "trans": [
+            "千差万別(せんさばんべつ)",
             "① 名·ナ形  千差万别"
-        ],
-        "notation": "千差万別(せんさばんべつ)"
+        ]
     },
     {
         "name": "manben'naku",
         "trans": [
+            "まんべんなく",
             " ⑤ 副  普遍；平均，一视同仁"
-        ],
-        "notation": "まんべんなく"
+        ]
     },
     {
         "name": "gyougi",
         "trans": [
+            "行儀(ぎょうぎ)",
             "⓪ 名  举止；礼貌"
-        ],
-        "notation": "行儀(ぎょうぎ)"
+        ]
     },
     {
         "name": "shizumaru",
         "trans": [
+            "静(しず)まる",
             "③ 自动1  平静；平息"
-        ],
-        "notation": "静(しず)まる"
+        ]
     },
     {
         "name": "shizumeru",
         "trans": [
+            "沈(しず)める",
             "⓪ 他动2  使下沉；使降落"
-        ],
-        "notation": "沈(しず)める"
+        ]
     },
     {
         "name": "sakusei",
         "trans": [
+            "作成(さくせい)",
             "⓪ 名·他动3  写成；制作"
-        ],
-        "notation": "作成(さくせい)"
+        ]
     },
     {
         "name": "shichou",
         "trans": [
+            "市長(しちょう)",
             "② 名  市长"
-        ],
-        "notation": "市長(しちょう)"
+        ]
     },
     {
         "name": "sasayaku",
         "trans": [
+            "ささやく",
             " ③ 自动1  小声说话，窃窃私语"
-        ],
-        "notation": "ささやく"
+        ]
     },
     {
         "name": "sansei",
         "trans": [
+            "酸性(さんせい)",
             "⓪ 名  酸性"
-        ],
-        "notation": "酸性(さんせい)"
+        ]
     },
     {
         "name": "shi-ru",
         "trans": [
+            "シール",
             "① 名  密封条；贴纸"
-        ],
-        "notation": "シール"
+        ]
     },
     {
         "name": "shikirini",
         "trans": [
+            "頻(しき)りに",
             "⓪ 副  频繁，屡次；强烈"
-        ],
-        "notation": "頻(しき)りに"
+        ]
     },
     {
         "name": "sanchi",
         "trans": [
+            "山地(さんち)",
             "① 名  山地，山区"
-        ],
-        "notation": "山地(さんち)"
+        ]
     },
     {
         "name": "shuusoku",
         "trans": [
+            "終息(しゅうそく)",
             "⓪ 名·自动3  结束；平息；根除"
-        ],
-        "notation": "終息(しゅうそく)"
+        ]
     },
     {
         "name": "sakumotsu",
         "trans": [
+            "作物(さくもつ)",
             "② 名  农作物"
-        ],
-        "notation": "作物(さくもつ)"
+        ]
     },
     {
         "name": "kenen",
         "trans": [
+            "懸念(けねん)",
             "⓪ 名·他动3  担心，忧虑"
-        ],
-        "notation": "懸念(けねん)"
+        ]
     },
     {
         "name": "oritatamu",
         "trans": [
+            "折(お)り畳(たた)む",
             "⓪ 他动1  叠，折叠"
-        ],
-        "notation": "折(お)り畳(たた)む"
+        ]
     },
     {
         "name": "sanchou",
         "trans": [
+            "山頂(さんちょう)",
             "⓪ 名  山顶，山峰"
-        ],
-        "notation": "山頂(さんちょう)"
+        ]
     },
     {
         "name": "shitsugai",
         "trans": [
+            "室外(しつがい)",
             "② 名  室外，户外"
-        ],
-        "notation": "室外(しつがい)"
+        ]
     },
     {
         "name": "jikkuri",
         "trans": [
+            "じっくり",
             " ③ 副·自动3  慢慢地，仔细地，不慌不忙地，踏踏实实地"
-        ],
-        "notation": "じっくり"
+        ]
     },
     {
         "name": "shinjou",
         "trans": [
+            "信条(しんじょう)",
             "⓪ 名  信条；信念"
-        ],
-        "notation": "信条(しんじょう)"
+        ]
     },
     {
         "name": "orimono",
         "trans": [
+            "織物(おりもの)",
             "⓪ 名  纺织品"
-        ],
-        "notation": "織物(おりもの)"
+        ]
     },
     {
         "name": "shibomu",
         "trans": [
+            "萎(しぼ)む",
             "⓪ 自动1  枯萎，凋谢"
-        ],
-        "notation": "萎(しぼ)む"
+        ]
     },
     {
         "name": "jisoku",
         "trans": [
+            "時速(じそく)",
             "① 名  时速"
-        ],
-        "notation": "時速(じそく)"
+        ]
     },
     {
         "name": "onshitsu",
         "trans": [
+            "温室(おんしつ)",
             "⓪ 名  温室，暖房"
-        ],
-        "notation": "温室(おんしつ)"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "占(し)める",
             "② 他动2  占，占据，占有；占领"
-        ],
-        "notation": "占(し)める"
+        ]
     },
     {
         "name": "chousen",
         "trans": [
+            "挑戦(ちょうせん)",
             "⓪ 名·自动3  挑战"
-        ],
-        "notation": "挑戦(ちょうせん)"
+        ]
     },
     {
         "name": "odokasu",
         "trans": [
+            "脅(おど)かす",
             "⓪ 他动1  威胁，恐吓；吓唬"
-        ],
-        "notation": "脅(おど)かす"
+        ]
     },
     {
         "name": "otoshimono",
         "trans": [
+            "落(お)とし物(もの)",
             "⓪ 名  遗失的物品，失物"
-        ],
-        "notation": "落(お)とし物(もの)"
+        ]
     },
     {
         "name": "tadashi",
         "trans": [
+            "但(ただ)し",
             "① 接续  但，但是"
-        ],
-        "notation": "但(ただ)し"
+        ]
     },
     {
         "name": "obi",
         "trans": [
+            "帯(おび)",
             "① 名  腰带；带子"
-        ],
-        "notation": "帯(おび)"
+        ]
     },
     {
         "name": "omairi",
         "trans": [
+            "お参(まい)り",
             "⓪ 名·自动3  参拜神佛"
-        ],
-        "notation": "お参(まい)り"
+        ]
     },
     {
         "name": "sentan",
         "trans": [
+            "先端(せんたん)",
             "⓪ 名  顶端；前沿，尖端"
-        ],
-        "notation": "先端(せんたん)"
+        ]
     },
     {
         "name": "omake",
         "trans": [
+            "おまけ",
             " ⓪ 名  赠品；附加的东西"
-        ],
-        "notation": "おまけ"
+        ]
     },
     {
         "name": "suigai",
         "trans": [
+            "水害(すいがい)",
             "⓪ 名  洪水，水灾"
-        ],
-        "notation": "水害(すいがい)"
+        ]
     },
     {
         "name": "chouka",
         "trans": [
+            "超過(ちょうか)",
             "⓪ 名·自动3  超过，超越"
-        ],
-        "notation": "超過(ちょうか)"
+        ]
     },
     {
         "name": "izakaya",
         "trans": [
+            "居酒屋(いざかや)",
             "⓪ 名  日式小酒馆"
-        ],
-        "notation": "居酒屋(いざかや)"
+        ]
     },
     {
         "name": "chintsuuzai",
         "trans": [
+            "鎮痛剤(ちんつうざい)",
             "③ 名  止痛药"
-        ],
-        "notation": "鎮痛剤(ちんつうざい)"
+        ]
     },
     {
         "name": "omoiukabu",
         "trans": [
+            "思(おも)い浮(う)かぶ",
             "⑤ 自动1  想起来，回忆起来 "
-        ],
-        "notation": "思(おも)い浮(う)かぶ"
+        ]
     },
     {
         "name": "omoikiri",
         "trans": [
+            "思(おも)い切(き)り",
             "⓪ 名·副  死心，断念；狠狠地，尽情地"
-        ],
-        "notation": "思(おも)い切(き)り"
+        ]
     },
     {
         "name": "katamuku",
         "trans": [
+            "傾(かたむ)く",
             "③ 自动1  倾斜；有……倾向，倾向于"
-        ],
-        "notation": "傾(かたむ)く"
+        ]
     },
     {
         "name": "saimatsu",
         "trans": [
+            "歳末(さいまつ)",
             "⓪ 名  年终，年底"
-        ],
-        "notation": "歳末(さいまつ)"
+        ]
     },
     {
         "name": "fuicchi",
         "trans": [
+            "不一致(ふいっち)",
             "② 名  不一致，不符合"
-        ],
-        "notation": "不一致(ふいっち)"
+        ]
     },
     {
         "name": "hekomu",
         "trans": [
+            "凹(へこ)む",
             "⓪ 自动1  凹下，陷下；屈服，认输"
-        ],
-        "notation": "凹(へこ)む"
+        ]
     },
     {
         "name": "yakunin",
         "trans": [
+            "役人(やくにん)",
             "⓪ 名  官员，公务员"
-        ],
-        "notation": "役人(やくにん)"
+        ]
     },
     {
         "name": "minwa",
         "trans": [
+            "民話(みんわ)",
             "⓪ 名  民间故事，民间传说"
-        ],
-        "notation": "民話(みんわ)"
+        ]
     },
     {
         "name": "ganbou",
         "trans": [
+            "願望(がんぼう)",
             "⓪ 名·他动3  愿望，心愿"
-        ],
-        "notation": "願望(がんぼう)"
+        ]
     },
     {
         "name": "sekenbanashi",
         "trans": [
+            "世間話(せけんばなし)",
             "④ 名  闲话；聊天，闲聊"
-        ],
-        "notation": "世間話(せけんばなし)"
+        ]
     },
     {
         "name": "eitan",
         "trans": [
+            "詠嘆(えいたん)",
             "⓪ 名·自动3  感叹，赞叹"
-        ],
-        "notation": "詠嘆(えいたん)"
+        ]
     },
     {
         "name": "odoroki",
         "trans": [
+            "驚(おどろ)き",
             "④ 名  惊讶，吃惊；震惊"
-        ],
-        "notation": "驚(おどろ)き"
+        ]
     },
     {
         "name": "onoono",
         "trans": [
+            "各(かく)々",
             "② 名·副  各个；各自"
-        ],
-        "notation": "各(かく)々"
+        ]
     },
     {
         "name": "ikidoori",
         "trans": [
+            "憤(いきどお)り",
             "⓪ 名  愤怒，愤慨"
-        ],
-        "notation": "憤(いきどお)り"
+        ]
     },
     {
         "name": "shiwayose",
         "trans": [
+            "しわ寄(よ)せ",
             "⓪ 名·他动3  不良影响的后果；不良影响波及"
-        ],
-        "notation": "しわ寄(よ)せ"
+        ]
     },
     {
         "name": "shinka",
         "trans": [
+            "深化(しんか)",
             "① 名·自动3  深化，加深"
-        ],
-        "notation": "深化(しんか)"
+        ]
     },
     {
         "name": "jinzai",
         "trans": [
+            "人材(じんざい)",
             "⓪ 名  人才"
-        ],
-        "notation": "人材(じんざい)"
+        ]
     },
     {
         "name": "taki",
         "trans": [
+            "滝(たき)",
             "⓪ 名  瀑布"
-        ],
-        "notation": "滝(たき)"
+        ]
     },
     {
         "name": "kanmei",
         "trans": [
+            "感銘(かんめい)",
             "⓪ 名·自动3  感人肺腑，铭刻于心"
-        ],
-        "notation": "感銘(かんめい)"
+        ]
     },
     {
         "name": "jun'nou",
         "trans": [
+            "順応(じゅんのう)",
             "⓪ 名·自动3  顺应，适应"
-        ],
-        "notation": "順応(じゅんのう)"
+        ]
     },
     {
         "name": "shuusei",
         "trans": [
+            "習性(しゅうせい)",
             "⓪ 名  习性，习惯"
-        ],
-        "notation": "習性(しゅうせい)"
+        ]
     },
     {
         "name": "keido",
         "trans": [
+            "軽度(けいど)",
             "① 名  轻度，轻微"
-        ],
-        "notation": "軽度(けいど)"
+        ]
     },
     {
         "name": "kouryuu",
         "trans": [
+            "拘留(こうりゅう)",
             "⓪ 名·他动3  拘留，拘役；扣押"
-        ],
-        "notation": "拘留(こうりゅう)"
+        ]
     },
     {
         "name": "nin'i",
         "trans": [
+            "任意(にんい)",
             "① 名·ナ形  任意，随意"
-        ],
-        "notation": "任意(にんい)"
+        ]
     },
     {
         "name": "kiso",
         "trans": [
+            "起訴(きそ)",
             "① 名·他动3  起诉，提起公诉"
-        ],
-        "notation": "起訴(きそ)"
+        ]
     },
     {
         "name": "maneru",
         "trans": [
+            "真似(まね)る",
             "⓪ 他动2  模仿，效仿"
-        ],
-        "notation": "真似(まね)る"
+        ]
     },
     {
         "name": "shitei",
         "trans": [
+            "指定(してい)",
             "⓪ 名·他动3  指定"
-        ],
-        "notation": "指定(してい)"
+        ]
     },
     {
         "name": "migara",
         "trans": [
+            "身柄(みがら)",
             "⓪ 名  本人；身份"
-        ],
-        "notation": "身柄(みがら)"
+        ]
     },
     {
         "name": "jenda-",
         "trans": [
+            "ジェンダー",
             "① 名  性别，男女差异"
-        ],
-        "notation": "ジェンダー"
+        ]
     },
     {
         "name": "ihou",
         "trans": [
+            "違法(いほう)",
             "⓪ 名  违法"
-        ],
-        "notation": "違法(いほう)"
+        ]
     },
     {
         "name": "kansei",
         "trans": [
+            "感性(かんせい)",
             "① 名  感性"
-        ],
-        "notation": "感性(かんせい)"
+        ]
     },
     {
         "name": "minshuu",
         "trans": [
+            "民衆(みんしゅう)",
             "⓪ 名  民众，大众，群众"
-        ],
-        "notation": "民衆(みんしゅう)"
+        ]
     },
     {
         "name": "furumai",
         "trans": [
+            "振(ふ)る舞(ま)い",
             "⓪ 名  行为，举止；请客，招待"
-        ],
-        "notation": "振(ふ)る舞(ま)い"
+        ]
     },
     {
         "name": "ikichigai/yukichigai",
         "trans": [
+            "行(いきちがい/ゆ)き違(ちが)い",
             "⓪ 名  走岔；产生龃龉，弄错"
-        ],
-        "notation": "行(いきちがい/ゆ)き違(ちが)い"
+        ]
     },
     {
         "name": "juukou",
         "trans": [
+            "重厚(じゅうこう)",
             "⓪ 名·ナ形  沉着，稳重"
-        ],
-        "notation": "重厚(じゅうこう)"
+        ]
     },
     {
         "name": "houru",
         "trans": [
+            "放(ほう)る",
             "⓪ 他动1  扔，抛；放弃，放下，弃而不顾，不加理睬"
-        ],
-        "notation": "放(ほう)る"
+        ]
     },
     {
         "name": "setsudo",
         "trans": [
+            "節度(せつど)",
             "① 名  节制，分寸；规范"
-        ],
-        "notation": "節度(せつど)"
+        ]
     },
     {
         "name": "senobi",
         "trans": [
+            "背伸(せの)び",
             "① 名·自动3  踮起脚；伸懒腰；逞能，逞强"
-        ],
-        "notation": "背伸(せの)び"
+        ]
     },
     {
         "name": "semina-",
         "trans": [
+            "セミナー",
             "① 名  研讨会，小组讨论"
-        ],
-        "notation": "セミナー"
+        ]
     },
     {
         "name": "shohousen",
         "trans": [
+            "処方箋(しょほうせん)",
             "⓪ 名  处方笺，药方"
-        ],
-        "notation": "処方箋(しょほうせん)"
+        ]
     },
     {
         "name": "shomin",
         "trans": [
+            "庶民(しょみん)",
             "① 名  老百姓，平民，群众"
-        ],
-        "notation": "庶民(しょみん)"
+        ]
     },
     {
         "name": "sensa-",
         "trans": [
+            "センサー",
             "① 名  传感器，感应装置"
-        ],
-        "notation": "センサー"
+        ]
     },
     {
         "name": "zensoku",
         "trans": [
+            "喘息(ぜんそく)",
             "⓪ 名  哮喘"
-        ],
-        "notation": "喘息(ぜんそく)"
+        ]
     },
     {
         "name": "senchaku",
         "trans": [
+            "先着(せんちゃく)",
             "⓪ 名·自动3  先到，先抵达"
-        ],
-        "notation": "先着(せんちゃく)"
+        ]
     },
     {
         "name": "shuuwai",
         "trans": [
+            "収賄(しゅうわい)",
             "⓪ 名·自他动3  受贿"
-        ],
-        "notation": "収賄(しゅうわい)"
+        ]
     },
     {
         "name": "inisharu",
         "trans": [
+            "イニシャル",
             "② 名  单词或名字的首字母"
-        ],
-        "notation": "イニシャル"
+        ]
     },
     {
         "name": "inta-nshippu",
         "trans": [
+            "インターンシップ",
             "⑥ 名  实习"
-        ],
-        "notation": "インターンシップ"
+        ]
     },
     {
         "name": "uradukeru",
         "trans": [
+            "裏付(うらづ)ける",
             "④ 他动2  证实，印证，证明"
-        ],
-        "notation": "裏付(うらづ)ける"
+        ]
     },
     {
         "name": "enshi",
         "trans": [
+            "遠視(えんし)",
             "⓪ 名  远视 "
-        ],
-        "notation": "遠視(えんし)"
+        ]
     },
     {
         "name": "ranshi",
         "trans": [
+            "乱視(らんし)",
             "⓪ 名  散光"
-        ],
-        "notation": "乱視(らんし)"
+        ]
     },
     {
         "name": "oshikakeru",
         "trans": [
+            "押(お)しかける",
             "④ 自动2  蜂拥而至，闯进；不请自来"
-        ],
-        "notation": "押(お)しかける"
+        ]
     },
     {
         "name": "ochikakaru",
         "trans": [
+            "落(お)ちかかる",
             "④ 自动1  眼看要落下，就要掉下来"
-        ],
-        "notation": "落(お)ちかかる"
+        ]
     },
     {
         "name": "onomatope",
         "trans": [
+            "オノマトペ",
             " ③ 名  拟声词，象声词"
-        ],
-        "notation": "オノマトペ"
+        ]
     },
     {
         "name": "onwa",
         "trans": [
+            "穏和(おんわ)",
             "⓪ 名·ナ形  （气候）温和；（性格）稳重，平和"
-        ],
-        "notation": "穏和(おんわ)"
+        ]
     },
     {
         "name": "ga-dore-ru",
         "trans": [
+            "ガードレール",
             "④ 名  公路上的护栏"
-        ],
-        "notation": "ガードレール"
+        ]
     },
     {
         "name": "kaishou",
         "trans": [
+            "解消(かいしょう)",
             "⓪ 名·自他动3  解除，取消"
-        ],
-        "notation": "解消(かいしょう)"
+        ]
     },
     {
         "name": "shitsugen",
         "trans": [
+            "湿原(しつげん)",
             "⓪ 名  沼泽地"
-        ],
-        "notation": "湿原(しつげん)"
+        ]
     },
     {
         "name": "kanau",
         "trans": [
+            "叶(かな)う",
             "② 自动1  能实现，能如愿以偿"
-        ],
-        "notation": "叶(かな)う"
+        ]
     },
     {
         "name": "joukoku",
         "trans": [
+            "上告(じょうこく)",
             "⓪ 名·他动3  上报，呈报；上诉"
-        ],
-        "notation": "上告(じょうこく)"
+        ]
     },
     {
         "name": "shousai",
         "trans": [
+            "詳細(しょうさい)",
             "⓪ 名·ナ形  详细"
-        ],
-        "notation": "詳細(しょうさい)"
+        ]
     },
     {
         "name": "hoshuteki",
         "trans": [
+            "保守的(ほしゅてき)",
             "⓪ ナ形  保守的，因循守旧的"
-        ],
-        "notation": "保守的(ほしゅてき)"
+        ]
     },
     {
         "name": "yoshuu",
         "trans": [
+            "予習(よしゅう)",
             "⓪ 名·他动3  预习"
-        ],
-        "notation": "予習(よしゅう)"
+        ]
     },
     {
         "name": "ukiyoe",
         "trans": [
+            "浮世絵(うきよえ)",
             "③ 名  浮世绘，风俗画"
-        ],
-        "notation": "浮世絵(うきよえ)"
+        ]
     },
     {
         "name": "hahen",
         "trans": [
+            "破片(はへん)",
             "⓪ 名  碎片"
-        ],
-        "notation": "破片(はへん)"
+        ]
     },
     {
         "name": "tensai",
         "trans": [
+            "天才(てんさい)",
             "⓪ 名  天才"
-        ],
-        "notation": "天才(てんさい)"
+        ]
     },
     {
         "name": "somaru",
         "trans": [
+            "染(そ)まる",
             "⓪ 自动1  染上；沾染，受（坏）影响"
-        ],
-        "notation": "染(そ)まる"
+        ]
     },
     {
         "name": "jinmashin",
         "trans": [
+            "蕁麻疹(じんましん)",
             "③ 名  荨麻疹"
-        ],
-        "notation": "蕁麻疹(じんましん)"
+        ]
     },
     {
         "name": "zukizuki",
         "trans": [
+            "ずきずき",
             " ① 副·自动3  跳痛，一跳一跳地疼"
-        ],
-        "notation": "ずきずき"
+        ]
     },
     {
         "name": "shoppingusenta-",
         "trans": [
+            "ショッピングセンター",
             "⑥ 名  商业区，购物中心"
-        ],
-        "notation": "ショッピングセンター"
+        ]
     },
     {
         "name": "shoppingumo-ru",
         "trans": [
+            "ショッピングモール",
             "⑥ 名  商场，大型购物中心"
-        ],
-        "notation": "ショッピングモール"
+        ]
     },
     {
         "name": "shinsotsu",
         "trans": [
+            "新卒(しんそつ)",
             "⓪ 名  应届毕业生"
-        ],
-        "notation": "新卒(しんそつ)"
+        ]
     },
     {
         "name": "sutamina",
         "trans": [
+            "スタミナ",
             "⓪ 名  持久力，耐力；精力；体力"
-        ],
-        "notation": "スタミナ"
+        ]
     },
     {
         "name": "supaisu",
         "trans": [
+            "スパイス",
             "② 名  调味品，香料"
-        ],
-        "notation": "スパイス"
+        ]
     },
     {
         "name": "subesube",
         "trans": [
+            "すべすべ",
             " ① 副·ナ形  光滑，滑溜溜"
-        ],
-        "notation": "すべすべ"
+        ]
     },
     {
         "name": "shoudaku",
         "trans": [
+            "承諾(しょうだく)",
             "⓪ 名·他动3  同意，应允，允许"
-        ],
-        "notation": "承諾(しょうだく)"
+        ]
     },
     {
         "name": "seiryoku",
         "trans": [
+            "勢力(せいりょく)",
             "① 名  势力，权势，力量，实力"
-        ],
-        "notation": "勢力(せいりょく)"
+        ]
     },
     {
         "name": "shougai",
         "trans": [
+            "傷害(しょうがい)",
             "⓪ 名·他动3  伤害，加害"
-        ],
-        "notation": "傷害(しょうがい)"
+        ]
     },
     {
         "name": "seitai",
         "trans": [
+            "生態(せいたい)",
             "⓪ 名  生态；生活状态"
-        ],
-        "notation": "生態(せいたい)"
+        ]
     },
     {
         "name": "suto-ka-",
         "trans": [
+            "ストーカー",
             "⓪ 名  跟踪狂，骚扰者"
-        ],
-        "notation": "ストーカー"
+        ]
     },
     {
         "name": "shoudou",
         "trans": [
+            "衝動(しょうどう)",
             "⓪ 名  冲动；打击，震惊"
-        ],
-        "notation": "衝動(しょうどう)"
+        ]
     },
     {
         "name": "shokudou",
         "trans": [
+            "食道(しょくどう)",
             "⓪ 名  食道，食管"
-        ],
-        "notation": "食道(しょくどう)"
+        ]
     },
     {
         "name": "sumie",
         "trans": [
+            "墨絵(すみえ)",
             "⓪ 名  水墨画"
-        ],
-        "notation": "墨絵(すみえ)"
+        ]
     },
     {
         "name": "suma-zu",
         "trans": [
+            "スムーズ",
             "② ナ形  平滑的，光滑的；顺利的，流畅的，顺畅的"
-        ],
-        "notation": "スムーズ"
+        ]
     },
     {
         "name": "surikaeru",
         "trans": [
+            "すり替(か)える",
             "③ 他动2  顶替，偷换，调包"
-        ],
-        "notation": "すり替(か)える"
+        ]
     },
     {
         "name": "suriru",
         "trans": [
+            "スリル",
             "① 名  惊险，刺激性，紧张感"
-        ],
-        "notation": "スリル"
+        ]
     },
     {
         "name": "seien",
         "trans": [
+            "声援(せいえん)",
             "⓪ 名·他动3  声援，助威；支援，支持 "
-        ],
-        "notation": "声援(せいえん)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "清算(せいさん)",
             "⓪ 名·他动3  结算，清算；了结，结束"
-        ],
-        "notation": "清算(せいさん)"
+        ]
     },
     {
         "name": "shuukatsu",
         "trans": [
+            "就活(しゅうかつ)",
             "⓪ 名  求职"
-        ],
-        "notation": "就活(しゅうかつ)"
+        ]
     },
     {
         "name": "shokuchuudoku",
         "trans": [
+            "食中毒(しょくちゅうどく)",
             "③ 名  食物中毒"
-        ],
-        "notation": "食中毒(しょくちゅうどく)"
+        ]
     },
     {
         "name": "shunou",
         "trans": [
+            "首脳(しゅのう)",
             "⓪ 名  首脑，首领，领导人物"
-        ],
-        "notation": "首脳(しゅのう)"
+        ]
     },
     {
         "name": "seidai",
         "trans": [
+            "盛大(せいだい)",
             "⓪ ナ形  盛大的，隆重的，宏大的"
-        ],
-        "notation": "盛大(せいだい)"
+        ]
     },
     {
         "name": "seimitsu",
         "trans": [
+            "精密(せいみつ)",
             "⓪ 名·ナ形  精密，精细；精确"
-        ],
-        "notation": "精密(せいみつ)"
+        ]
     },
     {
         "name": "kousotsu",
         "trans": [
+            "高卒(こうそつ)",
             "⓪ 名  高中毕业"
-        ],
-        "notation": "高卒(こうそつ)"
+        ]
     },
     {
         "name": "ottori",
         "trans": [
+            "おっとり",
             " ③ 副·自动3  稳重，文静，大方"
-        ],
-        "notation": "おっとり"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "声明(せいめい)",
             "⓪ 名·自他动3  声明"
-        ],
-        "notation": "声明(せいめい)"
+        ]
     },
     {
         "name": "kon'yaku",
         "trans": [
+            "婚約(こんやく)",
             "⓪ 名·自动3  婚约；订婚"
-        ],
-        "notation": "婚約(こんやく)"
+        ]
     },
     {
         "name": "shinryou",
         "trans": [
+            "診療(しんりょう)",
             "⓪ 名·他动3  诊疗，诊治"
-        ],
-        "notation": "診療(しんりょう)"
+        ]
     },
     {
         "name": "shinro",
         "trans": [
+            "進路(しんろ)",
             "① 名  前进的方向；前途"
-        ],
-        "notation": "進路(しんろ)"
+        ]
     },
     {
         "name": "ido",
         "trans": [
+            "緯度(いど)",
             "① 名  纬度"
-        ],
-        "notation": "緯度(いど)"
+        ]
     },
     {
         "name": "tsukitsukeru",
         "trans": [
+            "突(つ)きつける",
             "④ 他动2  摆在面前；（以强硬的态度）提出"
-        ],
-        "notation": "突(つ)きつける"
+        ]
     },
     {
         "name": "okuru",
         "trans": [
+            "贈(おく)る",
             "⓪ 他动1  赠送；授予"
-        ],
-        "notation": "贈(おく)る"
+        ]
     },
     {
         "name": "kagu",
         "trans": [
+            "嗅(か)ぐ",
             "⓪ 他动1  闻，嗅"
-        ],
-        "notation": "嗅(か)ぐ"
+        ]
     },
     {
         "name": "kakawaru",
         "trans": [
+            "関(かか)わる",
             "③ 自动1  关系到；有牵连"
-        ],
-        "notation": "関(かか)わる"
+        ]
     },
     {
         "name": "tsukitsumeru",
         "trans": [
+            "突(つ)き詰(つ)める",
             "④ 他动2  追究到底；反复思考"
-        ],
-        "notation": "突(つ)き詰(つ)める"
+        ]
     },
     {
         "name": "sen'nyuukan",
         "trans": [
+            "先入観(せんにゅうかん)",
             "③ 名  先入之见，成见"
-        ],
-        "notation": "先入観(せんにゅうかん)"
+        ]
     },
     {
         "name": "zouwai",
         "trans": [
+            "贈賄(ぞうわい)",
             "⓪ 名·自动3  行贿"
-        ],
-        "notation": "贈賄(ぞうわい)"
+        ]
     },
     {
         "name": "sogai",
         "trans": [
+            "阻害(そがい)",
             "⓪ 名·他动3  阻碍，妨碍"
-        ],
-        "notation": "阻害(そがい)"
+        ]
     },
     {
         "name": "koumyou",
         "trans": [
+            "巧妙(こうみょう)",
             "⓪ 名·ナ形  巧妙"
-        ],
-        "notation": "巧妙(こうみょう)"
+        ]
     },
     {
         "name": "seiriteki",
         "trans": [
+            "生理的(せいりてき)",
             "⓪ ナ形  生理上的"
-        ],
-        "notation": "生理的(せいりてき)"
+        ]
     },
     {
         "name": "zubanukeru",
         "trans": [
+            "ずば抜(ぬ)ける",
             "④ 自动2  出众，出类拔萃"
-        ],
-        "notation": "ずば抜(ぬ)ける"
+        ]
     },
     {
         "name": "kokutai",
         "trans": [
+            "国体(こくたい)",
             "⓪ 名  国体，国家体制"
-        ],
-        "notation": "国体(こくたい)"
+        ]
     },
     {
         "name": "sen'nen",
         "trans": [
+            "専念(せんねん)",
             "③ 名·自他动3  一心一意地做"
-        ],
-        "notation": "専念(せんねん)"
+        ]
     },
     {
         "name": "soumushou",
         "trans": [
+            "総務省(そうむしょう)",
             "③ 名  （日本政府机构）总务省"
-        ],
-        "notation": "総務省(そうむしょう)"
+        ]
     },
     {
         "name": "kainushi",
         "trans": [
+            "飼(か)い主(ぬし)",
             "① 名  饲养主，主人，所有者"
-        ],
-        "notation": "飼(か)い主(ぬし)"
+        ]
     },
     {
         "name": "kourei",
         "trans": [
+            "恒例(こうれい)",
             "⓪ 名  惯例，常例，常规"
-        ],
-        "notation": "恒例(こうれい)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "絶(た)つ",
             "① 他动1  绝，断绝；结束"
-        ],
-        "notation": "絶(た)つ"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "断(た)つ",
             "① 他动1  切，断；断绝，截断"
-        ],
-        "notation": "断(た)つ"
+        ]
     },
     {
         "name": "toozakeru",
         "trans": [
+            "遠(とお)ざける",
             "④ 他动2  躲开，避开；疏远；节制"
-        ],
-        "notation": "遠(とお)ざける"
+        ]
     },
     {
         "name": "shihou",
         "trans": [
+            "司法(しほう)",
             "① 名  司法"
-        ],
-        "notation": "司法(しほう)"
+        ]
     },
     {
         "name": "kaoku",
         "trans": [
+            "家屋(かおく)",
             "① 名  房屋，住房"
-        ],
-        "notation": "家屋(かおく)"
+        ]
     },
     {
         "name": "doraggusutoa",
         "trans": [
+            "ドラッグストア",
             "⑥ 名  药妆店，杂货店"
-        ],
-        "notation": "ドラッグストア"
+        ]
     },
     {
         "name": "nageyari",
         "trans": [
+            "投(な)げやり",
             "⓪ 名·ナ形  不认真，马虎，敷衍，草率"
-        ],
-        "notation": "投(な)げやり"
+        ]
     },
     {
         "name": "tozasu",
         "trans": [
+            "閉(と)ざす",
             "② 他动1  关闭；封锁；憋在心里"
-        ],
-        "notation": "閉(と)ざす"
+        ]
     },
     {
         "name": "donaritsukeru",
         "trans": [
+            "怒鳴(どな)りつける",
             "⑤ 他动2  大声训斥，大声叱责"
-        ],
-        "notation": "怒鳴(どな)りつける"
+        ]
     },
     {
         "name": "chigin",
         "trans": [
+            "地銀(ちぎん)",
             "⓪ 名  地方银行"
-        ],
-        "notation": "地銀(ちぎん)"
+        ]
     },
     {
         "name": "chikuseki",
         "trans": [
+            "蓄積(ちくせき)",
             "⓪ 名·自他动3  积蓄，积累，积攒"
-        ],
-        "notation": "蓄積(ちくせき)"
+        ]
     },
     {
         "name": "chikei",
         "trans": [
+            "地形(ちけい)",
             "⓪ 名  地形，地势"
-        ],
-        "notation": "地形(ちけい)"
+        ]
     },
     {
         "name": "tousho",
         "trans": [
+            "投書(とうしょ)",
             "⓪ 名·自他动3  投稿，寄稿；（向机关）写信"
-        ],
-        "notation": "投書(とうしょ)"
+        ]
     },
     {
         "name": "koubashii",
         "trans": [
+            "香(こう)ばしい",
             "④ イ形  香的，芳香的"
-        ],
-        "notation": "香(こう)ばしい"
+        ]
     },
     {
         "name": "touchou",
         "trans": [
+            "盗聴(とうちょう)",
             "⓪ 名·他动3  偷听，窃听"
-        ],
-        "notation": "盗聴(とうちょう)"
+        ]
     },
     {
         "name": "chihou",
         "trans": [
+            "地方(ちほう)",
             "② 名  地方，地区；外地"
-        ],
-        "notation": "地方(ちほう)"
+        ]
     },
     {
         "name": "shibia",
         "trans": [
+            "シビア",
             "① ナ形  严厉的，苛刻的，毫不留情的"
-        ],
-        "notation": "シビア"
+        ]
     },
     {
         "name": "shuugiin",
         "trans": [
+            "衆議院(しゅうぎいん)",
             "③ 名  众议院"
-        ],
-        "notation": "衆議院(しゅうぎいん)"
+        ]
     },
     {
         "name": "tsukitobasu",
         "trans": [
+            "突(つ)き飛(と)ばす",
             "④ 他动1  撞出很远，撞到一旁，用力猛撞"
-        ],
-        "notation": "突(つ)き飛(と)ばす"
+        ]
     },
     {
         "name": "ubau",
         "trans": [
+            "奪(うば)う",
             "② 他动1  夺，抢夺；（强烈地）吸引住"
-        ],
-        "notation": "奪(うば)う"
+        ]
     },
     {
         "name": "tsukihanasu",
         "trans": [
+            "突(つ)き放(はな)す",
             "④ 他动1  推开；甩开，抛弃"
-        ],
-        "notation": "突(つ)き放(はな)す"
+        ]
     },
     {
         "name": "se-fu",
         "trans": [
+            "セーフ",
             "① 名  安全；（棒球）安全进垒"
-        ],
-        "notation": "セーフ"
+        ]
     },
     {
         "name": "seken",
         "trans": [
+            "世間(せけん)",
             "① 名  世间，社会；交际，社交范围"
-        ],
-        "notation": "世間(せけん)"
+        ]
     },
     {
         "name": "setsuden",
         "trans": [
+            "節電(せつでん)",
             "⓪ 名·自动3  省电，节电"
-        ],
-        "notation": "節電(せつでん)"
+        ]
     },
     {
         "name": "kakuritsu",
         "trans": [
+            "確率(かくりつ)",
             "⓪ 名  概率；可能性"
-        ],
-        "notation": "確率(かくりつ)"
+        ]
     },
     {
         "name": "chuuzetsu",
         "trans": [
+            "中絶(ちゅうぜつ)",
             "⓪ 名·自他动3  中止，暂时中断"
-        ],
-        "notation": "中絶(ちゅうぜつ)"
+        ]
     },
     {
         "name": "chouonpa",
         "trans": [
+            "超音波(ちょうおんぱ)",
             "③ 名  超音波，超声波"
-        ],
-        "notation": "超音波(ちょうおんぱ)"
+        ]
     },
     {
         "name": "datsuzei",
         "trans": [
+            "脱税(だつぜい)",
             "⓪ 名·自动3  偷税，漏税"
-        ],
-        "notation": "脱税(だつぜい)"
+        ]
     },
     {
         "name": "tokonoma",
         "trans": [
+            "床(とこ)の間(ま)",
             "⓪ 名  壁龛，神龛"
-        ],
-        "notation": "床(とこ)の間(ま)"
+        ]
     },
     {
         "name": "jikaku",
         "trans": [
+            "自覚(じかく)",
             "⓪ 名·他动3  自知，认识到；觉醒，自觉"
-        ],
-        "notation": "自覚(じかく)"
+        ]
     },
     {
         "name": "tsukaikiru",
         "trans": [
+            "使(つか)い切(き)る",
             "④ 他动1  用完，花光"
-        ],
-        "notation": "使(つか)い切(き)る"
+        ]
     },
     {
         "name": "tsudumi",
         "trans": [
+            "鼓(つづみ)",
             "⓪ 名  鼓，小鼓"
-        ],
-        "notation": "鼓(つづみ)"
+        ]
     },
     {
         "name": "shippori",
         "trans": [
+            "しっぽり",
             " ③ 副  湿漉漉，湿淋淋；亲密无间，情意绵绵"
-        ],
-        "notation": "しっぽり"
+        ]
     },
     {
         "name": "shinryaku",
         "trans": [
+            "侵略(しんりゃく)",
             "⓪ 名·自他动3  侵略"
-        ],
-        "notation": "侵略(しんりゃく)"
+        ]
     },
     {
         "name": "shinayaka",
         "trans": [
+            "しなやか",
             " ② ナ形  柔软的；柔和的，优美的"
-        ],
-        "notation": "しなやか"
+        ]
     },
     {
         "name": "tanpakushitsu",
         "trans": [
+            "蛋白質(たんぱくしつ)",
             "④ 名  蛋白质"
-        ],
-        "notation": "蛋白質(たんぱくしつ)"
+        ]
     },
     {
         "name": "danran",
         "trans": [
+            "団(だん)らん",
             "⓪ 名·自动3  团圆，团聚"
-        ],
-        "notation": "団(だん)らん"
+        ]
     },
     {
         "name": "chigiru",
         "trans": [
+            "ちぎる",
             " ② 他动1  撕，撕碎；掐下，摘取"
-        ],
-        "notation": "ちぎる"
+        ]
     },
     {
         "name": "taitou",
         "trans": [
+            "台頭(たいとう)",
             "⓪ 名·自动3  抬头，得势，兴起"
-        ],
-        "notation": "台頭(たいとう)"
+        ]
     },
     {
         "name": "kigae",
         "trans": [
+            "着替(きが)え",
             "⓪ 名·自动3  换的衣服；换衣服"
-        ],
-        "notation": "着替(きが)え"
+        ]
     },
     {
         "name": "dainamikku",
         "trans": [
+            "ダイナミック",
             "④ ナ形  动态的，有生气的"
-        ],
-        "notation": "ダイナミック"
+        ]
     },
     {
         "name": "baitarithi-",
         "trans": [
+            "バイタリティー",
             "③ 名  活力，生气，生命力"
-        ],
-        "notation": "バイタリティー"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "謀(はか)る",
             "② 他动1  策划；谋算，欺骗"
-        ],
-        "notation": "謀(はか)る"
+        ]
     },
     {
         "name": "taira",
         "trans": [
+            "平(たい)ら",
             "⓪ ナ形  平的，平坦的；心平气和的，坦然的"
-        ],
-        "notation": "平(たい)ら"
+        ]
     },
     {
         "name": "kaishaku",
         "trans": [
+            "解釈(かいしゃく)",
             "① 名·他动3  解释，说明"
-        ],
-        "notation": "解釈(かいしゃく)"
+        ]
     },
     {
         "name": "sankou",
         "trans": [
+            "参考(さんこう)",
             "⓪ 名·他动3  参考，借鉴"
-        ],
-        "notation": "参考(さんこう)"
+        ]
     },
     {
         "name": "tsumekakeru",
         "trans": [
+            "詰(つ)めかける",
             "④ 自动2  拥上来，蜂拥而至"
-        ],
-        "notation": "詰(つ)めかける"
+        ]
     },
     {
         "name": "dhisupure-",
         "trans": [
+            "ディスプレー",
             "① 名·他动3  陈列，展示 "
-        ],
-        "notation": "ディスプレー"
+        ]
     },
     {
         "name": "tekunikku",
         "trans": [
+            "テクニック",
             "① 名  技巧，技艺；艺术上的手法"
-        ],
-        "notation": "テクニック"
+        ]
     },
     {
         "name": "tekozuru",
         "trans": [
+            "手(て)こずる",
             "③ 自动1  棘手，难对付"
-        ],
-        "notation": "手(て)こずる"
+        ]
     },
     {
         "name": "tesaguri",
         "trans": [
+            "手探(てさぐ)り",
             "② 名·他动3  摸，摸索；试探"
-        ],
-        "notation": "手探(てさぐ)り"
+        ]
     },
     {
         "name": "tairiku",
         "trans": [
+            "大陸(たいりく)",
             "⓪ 名  大陆"
-        ],
-        "notation": "大陸(たいりく)"
+        ]
     },
     {
         "name": "daun",
         "trans": [
+            "ダウン",
             "① 名·自他动3  降低，下降；倒下；病倒"
-        ],
-        "notation": "ダウン"
+        ]
     },
     {
         "name": "jisshuu",
         "trans": [
+            "実習(じっしゅう)",
             "⓪ 名·他动3  实习"
-        ],
-        "notation": "実習(じっしゅう)"
+        ]
     },
     {
         "name": "tenka",
         "trans": [
+            "添加(てんか)",
             "⓪ 名·他动3  添加，加上"
-        ],
-        "notation": "添加(てんか)"
+        ]
     },
     {
         "name": "nusumidori",
         "trans": [
+            "盗(ぬす)み撮(ど)り",
             "⓪ 名  偷拍"
-        ],
-        "notation": "盗(ぬす)み撮(ど)り"
+        ]
     },
     {
         "name": "tounyoubyou",
         "trans": [
+            "糖尿病(とうにょうびょう)",
             "⓪ 名  糖尿病"
-        ],
-        "notation": "糖尿病(とうにょうびょう)"
+        ]
     },
     {
         "name": "tane",
         "trans": [
+            "種(たね)",
             "① 名  种子；原因，根源；材料，话题"
-        ],
-        "notation": "種(たね)"
+        ]
     },
     {
         "name": "bouken",
         "trans": [
+            "冒険(ぼうけん)",
             "⓪ 名·自动3  冒险"
-        ],
-        "notation": "冒険(ぼうけん)"
+        ]
     },
     {
         "name": "ta-minarukea",
         "trans": [
+            "ターミナルケア",
             "⑥ 名  临终看护；临终关怀"
-        ],
-        "notation": "ターミナルケア"
+        ]
     },
     {
         "name": "take",
         "trans": [
+            "丈(たけ)",
             "② 名  尺寸，长短；身长"
-        ],
-        "notation": "丈(たけ)"
+        ]
     },
     {
         "name": "dashikiru",
         "trans": [
+            "出(だ)し切(き)る",
             "③ 他动1  全部拿出，尽力"
-        ],
-        "notation": "出(だ)し切(き)る"
+        ]
     },
     {
         "name": "tazusaeru",
         "trans": [
+            "携(たずさ)える",
             "④ 他动2  携带，拿；携手，偕同"
-        ],
-        "notation": "携(たずさ)える"
+        ]
     },
     {
         "name": "tereru",
         "trans": [
+            "照(て)れる",
             "② 自动2  害羞，难为情"
-        ],
-        "notation": "照(て)れる"
+        ]
     },
     {
         "name": "daisotsu",
         "trans": [
+            "大卒(だいそつ)",
             "⓪ 名  大学毕业；大学毕业生"
-        ],
-        "notation": "大卒(だいそつ)"
+        ]
     },
     {
         "name": "kaitsuu",
         "trans": [
+            "開通(かいつう)",
             "⓪ 名·自他动3  开通，通车；通行"
-        ],
-        "notation": "開通(かいつう)"
+        ]
     },
     {
         "name": "gouman",
         "trans": [
+            "傲慢(ごうまん)",
             "⓪ 名·ナ形  傲慢，骄傲"
-        ],
-        "notation": "傲慢(ごうまん)"
+        ]
     },
     {
         "name": "doku",
         "trans": [
+            "毒(どく)",
             "② 名  毒，毒药；有害；恶毒"
-        ],
-        "notation": "毒(どく)"
+        ]
     },
     {
         "name": "dokuta-",
         "trans": [
+            "ドクター",
             "① 名  医生；博士"
-        ],
-        "notation": "ドクター"
+        ]
     },
     {
         "name": "tokuchuu",
         "trans": [
+            "特注(とくちゅう)",
             "⓪ 名·他动3  特别订货"
-        ],
-        "notation": "特注(とくちゅう)"
+        ]
     },
     {
         "name": "sashisemaru",
         "trans": [
+            "差(さ)し迫(せま)る",
             "④ 自动1  迫近，逼近"
-        ],
-        "notation": "差(さ)し迫(せま)る"
+        ]
     },
     {
         "name": "rengou",
         "trans": [
+            "連合(れんごう)",
             "⓪ 名·自他动3  联合，团结起来"
-        ],
-        "notation": "連合(れんごう)"
+        ]
     },
     {
         "name": "tsukamitoru",
         "trans": [
+            "掴(つか)み取(と)る",
             "④ 他动1  抓取，拿到；掌握，理解"
-        ],
-        "notation": "掴(つか)み取(と)る"
+        ]
     },
     {
         "name": "tobiokiru",
         "trans": [
+            "飛(と)び起(お)きる",
             "④ 自动2  （从床上）一跃而起"
-        ],
-        "notation": "飛(と)び起(お)きる"
+        ]
     },
     {
         "name": "tobioriru",
         "trans": [
+            "飛(と)び降(お)りる",
             "④ 自动2  （从高处或行驶中的车辆上）跳下"
-        ],
-        "notation": "飛(と)び降(お)りる"
+        ]
     },
     {
         "name": "wabiru",
         "trans": [
+            "詫(わ)びる",
             "⓪ 他动2  道歉，谢罪"
-        ],
-        "notation": "詫(わ)びる"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "遭(あ)う",
             "① 自动1  遭遇，碰上"
-        ],
-        "notation": "遭(あ)う"
+        ]
     },
     {
         "name": "shibaru",
         "trans": [
+            "縛(しば)る",
             "② 他动1  捆，绑；束缚，限制"
-        ],
-        "notation": "縛(しば)る"
+        ]
     },
     {
         "name": "nameraka",
         "trans": [
+            "滑(なめ)らか",
             "② ナ形  光滑的，滑溜溜的；流利的，流畅的"
-        ],
-        "notation": "滑(なめ)らか"
+        ]
     },
     {
         "name": "nyuansu",
         "trans": [
+            "ニュアンス",
             "① 名  语气，语感；细微的差异"
-        ],
-        "notation": "ニュアンス"
+        ]
     },
     {
         "name": "nyuukoku",
         "trans": [
+            "入国(にゅうこく)",
             "⓪ 名·自动3  入境"
-        ],
-        "notation": "入国(にゅうこく)"
+        ]
     },
     {
         "name": "rensou",
         "trans": [
+            "連想(れんそう)",
             "⓪ 名·他动3  联想"
-        ],
-        "notation": "連想(れんそう)"
+        ]
     },
     {
         "name": "nejiru",
         "trans": [
+            "捻(ねじ)る",
             "② 他动1  拧，扭"
-        ],
-        "notation": "捻(ねじ)る"
+        ]
     },
     {
         "name": "nettowa-ku",
         "trans": [
+            "ネットワーク",
             "④ 名  网络"
-        ],
-        "notation": "ネットワーク"
+        ]
     },
     {
         "name": "nen",
         "trans": [
+            "念(ねん)",
             "① 名  念，念头；夙愿；注意，用心 "
-        ],
-        "notation": "念(ねん)"
+        ]
     },
     {
         "name": "nenkyuu",
         "trans": [
+            "年休(ねんきゅう)",
             "⓪ 名  年假，带薪休假"
-        ],
-        "notation": "年休(ねんきゅう)"
+        ]
     },
     {
         "name": "nenza",
         "trans": [
+            "捻挫(ねんざ)",
             "⓪ 名·自他动3  扭伤，挫伤"
-        ],
-        "notation": "捻挫(ねんざ)"
+        ]
     },
     {
         "name": "noushi",
         "trans": [
+            "脳死(のうし)",
             "① 名  脑组织坏死，脑死亡"
-        ],
-        "notation": "脳死(のうし)"
+        ]
     },
     {
         "name": "nozoku",
         "trans": [
+            "覗(のぞ)く",
             "⓪ 自他动1  露出；窥视；看一看"
-        ],
-        "notation": "覗(のぞ)く"
+        ]
     },
     {
         "name": "pa-kingu",
         "trans": [
+            "パーキング",
             "① 名  停车；停车场"
-        ],
-        "notation": "パーキング"
+        ]
     },
     {
         "name": "kouken",
         "trans": [
+            "貢献(こうけん)",
             "⓪ 名·自动3  贡献"
-        ],
-        "notation": "貢献(こうけん)"
+        ]
     },
     {
         "name": "shikii",
         "trans": [
+            "敷居(しきい)",
             "⓪ 名  门槛，门坎"
-        ],
-        "notation": "敷居(しきい)"
+        ]
     },
     {
         "name": "pa-kingueria",
         "trans": [
+            "パーキングエリア",
             "⑥ 名  停车区域，停车场"
-        ],
-        "notation": "パーキングエリア"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "肺(はい)",
             "⓪ 名  肺，肺脏"
-        ],
-        "notation": "肺(はい)"
+        ]
     },
     {
         "name": "pakupaku",
         "trans": [
+            "ぱくぱく",
             " ① 副·自动3  嘴一张一合的样子；大吃特吃；裂开，开绽"
-        ],
-        "notation": "ぱくぱく"
+        ]
     },
     {
         "name": "shigeki",
         "trans": [
+            "刺激(しげき)",
             "⓪ 名·他动3  （物理的、生理的）刺激；（心理上的）刺激，使兴奋"
-        ],
-        "notation": "刺激(しげき)"
+        ]
     },
     {
         "name": "hatarakikakeru",
         "trans": [
+            "働(はたら)きかける",
             "⑥ 自他动2  推动，发动；开始工作"
-        ],
-        "notation": "働(はたら)きかける"
+        ]
     },
     {
         "name": "batsu",
         "trans": [
+            "罰(ばつ)",
             "① 名  惩罚，处罚"
-        ],
-        "notation": "罰(ばつ)"
+        ]
     },
     {
         "name": "hakka-",
         "trans": [
+            "ハッカー",
             "① 名  黑客（秘密窥视或改变他人计算机系统信息）"
-        ],
-        "notation": "ハッカー"
+        ]
     },
     {
         "name": "kousou",
         "trans": [
+            "構想(こうそう)",
             "⓪ 名·他动3  设想（方案、计划）；构思（作品）"
-        ],
-        "notation": "構想(こうそう)"
+        ]
     },
     {
         "name": "pakku",
         "trans": [
+            "パック",
             "① 名·他动3  包装；做面膜"
-        ],
-        "notation": "パック"
+        ]
     },
     {
         "name": "hakkou",
         "trans": [
+            "発酵(はっこう)",
             "⓪ 名·自动3  发酵"
-        ],
-        "notation": "発酵(はっこう)"
+        ]
     },
     {
         "name": "tomosuruto",
         "trans": [
+            "ともすると",
             " ① 副  常常，动辄，每每"
-        ],
-        "notation": "ともすると"
+        ]
     },
     {
         "name": "renzoku",
         "trans": [
+            "連続(れんぞく)",
             "⓪ 名·自他动3  连续，接连不断"
-        ],
-        "notation": "連続(れんぞく)"
+        ]
     },
     {
         "name": "dorai",
         "trans": [
+            "ドライ",
             "② ナ形  干燥的；理智的，冷冰冰的"
-        ],
-        "notation": "ドライ"
+        ]
     },
     {
         "name": "touhi",
         "trans": [
+            "逃避(とうひ)",
             "⓪ 名·自动3  躲避，逃避"
-        ],
-        "notation": "逃避(とうひ)"
+        ]
     },
     {
         "name": "hasshin",
         "trans": [
+            "発信(はっしん)",
             "⓪ 名·自他动3  发信，发报"
-        ],
-        "notation": "発信(はっしん)"
+        ]
     },
     {
         "name": "patto",
         "trans": [
+            "ぱっと",
             " ⓪ 副·自动3  突然，一下子；显眼，出色"
-        ],
-        "notation": "ぱっと"
+        ]
     },
     {
         "name": "hanashikakeru",
         "trans": [
+            "話(はな)しかける",
             "⑤ 自他动2  搭话，攀谈；刚说，开始说"
-        ],
-        "notation": "話(はな)しかける"
+        ]
     },
     {
         "name": "paneru",
         "trans": [
+            "パネル",
             "① 名  油画板；告示板"
-        ],
-        "notation": "パネル"
+        ]
     },
     {
         "name": "mousaikekkan",
         "trans": [
+            "毛細血管(もうさいけっかん)",
             "⑤ 名  毛细血管"
-        ],
-        "notation": "毛細血管(もうさいけっかん)"
+        ]
     },
     {
         "name": "moushiwakenai",
         "trans": [
+            "申(もう)し訳(わけ)ない",
             "⑥ イ形  实在抱歉，十分对不起"
-        ],
-        "notation": "申(もう)し訳(わけ)ない"
+        ]
     },
     {
         "name": "mouretsu",
         "trans": [
+            "猛烈(もうれつ)",
             "⓪ 名·ナ形  猛烈，凶猛，激烈"
-        ],
-        "notation": "猛烈(もうれつ)"
+        ]
     },
     {
         "name": "motarekakaru",
         "trans": [
+            "凭(もた)れ掛(か)かる",
             " ⑤ 自动1  凭靠，靠；依靠，依赖"
-        ],
-        "notation": "凭(もた)れ掛(か)かる"
+        ]
     },
     {
         "name": "yakuzai",
         "trans": [
+            "薬剤(やくざい)",
             "⓪ 名  药剂，药品"
-        ],
-        "notation": "薬剤(やくざい)"
+        ]
     },
     {
         "name": "habikoru",
         "trans": [
+            "蔓延(はびこ)る",
             "③ 自动1  蔓延，弥漫"
-        ],
-        "notation": "蔓延(はびこ)る"
+        ]
     },
     {
         "name": "hamidasu",
         "trans": [
+            "食(は)み出(だ)す",
             "③ 自动1  露出；超出（限度）"
-        ],
-        "notation": "食(は)み出(だ)す"
+        ]
     },
     {
         "name": "akireru",
         "trans": [
+            "呆(あき)れる",
             "⓪ 自动2  惊呆，吃惊，惊讶"
-        ],
-        "notation": "呆(あき)れる"
+        ]
     },
     {
         "name": "geta",
         "trans": [
+            "下駄(げた)",
             "⓪ 名  木屐"
-        ],
-        "notation": "下駄(げた)"
+        ]
     },
     {
         "name": "mokuzen",
         "trans": [
+            "目前(もくぜん)",
             "⓪ 名  眼前，面前"
-        ],
-        "notation": "目前(もくぜん)"
+        ]
     },
     {
         "name": "zokusuru",
         "trans": [
+            "属(ぞく)する",
             "③ 自动3  属于；隶属"
-        ],
-        "notation": "属(ぞく)する"
+        ]
     },
     {
         "name": "sa-bisusute-shon",
         "trans": [
+            "サービスステーション",
             "⑥ 名  服务站，修理站"
-        ],
-        "notation": "サービスステーション"
+        ]
     },
     {
         "name": "oou",
         "trans": [
+            "覆(おお)う",
             "⓪ 他动1  盖上，覆盖；掩饰，掩盖"
-        ],
-        "notation": "覆(おお)う"
+        ]
     },
     {
         "name": "ban'nen",
         "trans": [
+            "晩年(ばんねん)",
             "⓪ 名  晚年，老年"
-        ],
-        "notation": "晩年(ばんねん)"
+        ]
     },
     {
         "name": "herushi-",
         "trans": [
+            "ヘルシー",
             "① ナ形  健康的"
-        ],
-        "notation": "ヘルシー"
+        ]
     },
     {
         "name": "houkou",
         "trans": [
+            "咆哮(ほうこう)",
             "⓪ 名·自动3  咆哮，吼叫"
-        ],
-        "notation": "咆哮(ほうこう)"
+        ]
     },
     {
         "name": "houmushou",
         "trans": [
+            "法務省(ほうむしょう)",
             "③ 名  （日本政府机构）法务省"
-        ],
-        "notation": "法務省(ほうむしょう)"
+        ]
     },
     {
         "name": "benpi",
         "trans": [
+            "便秘(べんぴ)",
             "⓪ 名·自动3  便秘"
-        ],
-        "notation": "便秘(べんぴ)"
+        ]
     },
     {
         "name": "ho-musenta-",
         "trans": [
+            "ホームセンター",
             "④ 名  大型家居建材商店"
-        ],
-        "notation": "ホームセンター"
+        ]
     },
     {
         "name": "ouen",
         "trans": [
+            "応援(おうえん)",
             "⓪ 名·他动3  支援；声援，从旁助威"
-        ],
-        "notation": "応援(おうえん)"
+        ]
     },
     {
         "name": "makasu",
         "trans": [
+            "任(まか)す",
             "② 他动1  委托，托付；听任"
-        ],
-        "notation": "任(まか)す"
+        ]
     },
     {
         "name": "magirasu",
         "trans": [
+            "紛(まぎ)らす",
             "③ 他动1  蒙混过去，掩饰过去；排遣，解除，消除"
-        ],
-        "notation": "紛(まぎ)らす"
+        ]
     },
     {
         "name": "makuake",
         "trans": [
+            "幕開(まくあ)け",
             "⓪ 名  开幕，拉开序幕；开始"
-        ],
-        "notation": "幕開(まくあ)け"
+        ]
     },
     {
         "name": "machimachi",
         "trans": [
+            "まちまち",
             " ② 名·ナ形  各式各样，形形色色"
-        ],
-        "notation": "まちまち"
+        ]
     },
     {
         "name": "midasu",
         "trans": [
+            "見出(みだ)す",
             "⓪ 他动1  找到，发现；开始看"
-        ],
-        "notation": "見出(みだ)す"
+        ]
     },
     {
         "name": "hamideru",
         "trans": [
+            "食(は)み出(で)る",
             "③ 自动2  露出，超出（限度）"
-        ],
-        "notation": "食(は)み出(で)る"
+        ]
     },
     {
         "name": "baraethi-",
         "trans": [
+            "バラエティー",
             "② 名  多样性，变化"
-        ],
-        "notation": "バラエティー"
+        ]
     },
     {
         "name": "hantou",
         "trans": [
+            "半島(はんとう)",
             "⓪ 名  半岛"
-        ],
-        "notation": "半島(はんとう)"
+        ]
     },
     {
         "name": "boukou",
         "trans": [
+            "暴行(ぼうこう)",
             "⓪ 名·自动3  暴行，暴力行为"
-        ],
-        "notation": "暴行(ぼうこう)"
+        ]
     },
     {
         "name": "medo",
         "trans": [
+            "めど",
             " ① 名  目标；头绪，眉目"
-        ],
-        "notation": "めど"
+        ]
     },
     {
         "name": "popyura-",
         "trans": [
+            "ポピュラー",
             "① ナ形  流行的，受欢迎的"
-        ],
-        "notation": "ポピュラー"
+        ]
     },
     {
         "name": "houdou",
         "trans": [
+            "報道(ほうどう)",
             "⓪ 名·他动3  报道"
-        ],
-        "notation": "報道(ほうどう)"
+        ]
     },
     {
         "name": "minamihankyuu",
         "trans": [
+            "南半球(みなみはんきゅう)",
             "④ 名  南半球"
-        ],
-        "notation": "南半球(みなみはんきゅう)"
+        ]
     },
     {
         "name": "houyou",
         "trans": [
+            "包容(ほうよう)",
             "⓪ 名·他动3  包容，宽容"
-        ],
-        "notation": "包容(ほうよう)"
+        ]
     },
     {
         "name": "zentei",
         "trans": [
+            "前提(ぜんてい)",
             "⓪ 名  前提"
-        ],
-        "notation": "前提(ぜんてい)"
+        ]
     },
     {
         "name": "shintai",
         "trans": [
+            "身体(しんたい)",
             "① 名  身体"
-        ],
-        "notation": "身体(しんたい)"
+        ]
     },
     {
         "name": "po-zu",
         "trans": [
+            "ポーズ",
             "① 名  姿势，形态，样子"
-        ],
-        "notation": "ポーズ"
+        ]
     },
     {
         "name": "kouketsuatsu",
         "trans": [
+            "高血圧(こうけつあつ)",
             "④ 名  高血压"
-        ],
-        "notation": "高血圧(こうけつあつ)"
+        ]
     },
     {
         "name": "mushibamu",
         "trans": [
+            "蝕(むしば)む",
             "③ 他动1  虫咬，虫蛀；侵蚀，腐蚀"
-        ],
-        "notation": "蝕(むしば)む"
+        ]
     },
     {
         "name": "muzousa",
         "trans": [
+            "無造作(むぞうさ)",
             "② 名·ナ形  简单；随随便便，草率"
-        ],
-        "notation": "無造作(むぞうさ)"
+        ]
     },
     {
         "name": "mekanizumu",
         "trans": [
+            "メカニズム",
             "③ 名  结构，组织；（机械）装置"
-        ],
-        "notation": "メカニズム"
+        ]
     },
     {
         "name": "mekkiri",
         "trans": [
+            "めっきり",
             "(变化)  ③ 副  （变化）显著，明显，急剧"
-        ],
-        "notation": "めっきり"
+        ]
     },
     {
         "name": "porishi-",
         "trans": [
+            "ポリシー",
             "① 名  方针，政策；策略"
-        ],
-        "notation": "ポリシー"
+        ]
     },
     {
         "name": "maipe-su",
         "trans": [
+            "マイペース",
             " ③ 名  自己的速度，自己的做法，我行我素"
-        ],
-        "notation": "マイペース"
+        ]
     },
     {
         "name": "hajiku",
         "trans": [
+            "弾(はじ)く",
             "② 他动1  弹；抗，排斥"
-        ],
-        "notation": "弾(はじ)く"
+        ]
     },
     {
         "name": "youso",
         "trans": [
+            "要素(ようそ)",
             "① 名  要素；因素"
-        ],
-        "notation": "要素(ようそ)"
+        ]
     },
     {
         "name": "me-ta-",
         "trans": [
+            "メーター",
             "⓪ 名  计量仪表，计量器"
-        ],
-        "notation": "メーター"
+        ]
     },
     {
         "name": "surechigau",
         "trans": [
+            "擦(す)れ違(ちが)う",
             "④ 自动1  交错；擦肩而过；有分歧"
-        ],
-        "notation": "擦(す)れ違(ちが)う"
+        ]
     },
     {
         "name": "torikaesu",
         "trans": [
+            "取(と)り返(かえ)す",
             "③ 他动1  取回来，要回来；挽回，恢复"
-        ],
-        "notation": "取(と)り返(かえ)す"
+        ]
     },
     {
         "name": "torisageru",
         "trans": [
+            "取(と)り下(さ)げる",
             "④ 他动2  撤销，撤回"
-        ],
-        "notation": "取(と)り下(さ)げる"
+        ]
     },
     {
         "name": "aseru",
         "trans": [
+            "焦(あせ)る",
             "② 自他动1  焦躁，急躁，着急"
-        ],
-        "notation": "焦(あせ)る"
+        ]
     },
     {
         "name": "ouyou",
         "trans": [
+            "応用(おうよう)",
             "⓪ 名·他动3  应用，运用"
-        ],
-        "notation": "応用(おうよう)"
+        ]
     },
     {
         "name": "tsumeru",
         "trans": [
+            "詰(つ)める",
             "② 他动2  填，塞，塞进去；挤紧"
-        ],
-        "notation": "詰(つ)める"
+        ]
     },
     {
         "name": "misokonau",
         "trans": [
+            "見損(みそこ)なう",
             "⓪ 他动1  看错；错过看的机会；估计错误"
-        ],
-        "notation": "見損(みそこ)なう"
+        ]
     },
     {
         "name": "yaji",
         "trans": [
+            "野次(やじ)",
             "① 名  嘲笑的话，奚落声"
-        ],
-        "notation": "野次(やじ)"
+        ]
     },
     {
         "name": "yawaragu",
         "trans": [
+            "和(やわ)らぐ",
             "③ 自动1  变柔和，缓和下来；平静，放松"
-        ],
-        "notation": "和(やわ)らぐ"
+        ]
     },
     {
         "name": "yuukyuu",
         "trans": [
+            "有給(ゆうきゅう)",
             "⓪ 名  带薪，有报酬"
-        ],
-        "notation": "有給(ゆうきゅう)"
+        ]
     },
     {
         "name": "mikaesu",
         "trans": [
+            "見返(みかえ)す",
             "⓪ 他动1  回头看；重看，再看一遍；回看，对视；争气"
-        ],
-        "notation": "見返(みかえ)す"
+        ]
     },
     {
         "name": "misekakeru",
         "trans": [
+            "見(み)せかける",
             "⓪ 他动2  假装，伪装"
-        ],
-        "notation": "見(み)せかける"
+        ]
     },
     {
         "name": "yuusuu",
         "trans": [
+            "有数(ゆうすう)",
             "⓪ 名·ナ形  有数，屈指可数"
-        ],
-        "notation": "有数(ゆうすう)"
+        ]
     },
     {
         "name": "insotsu",
         "trans": [
+            "引率(いんそつ)",
             "⓪ 名·他动3  率领，带领"
-        ],
-        "notation": "引率(いんそつ)"
+        ]
     },
     {
         "name": "keihou",
         "trans": [
+            "刑法(けいほう)",
             "① 名  刑法"
-        ],
-        "notation": "刑法(けいほう)"
+        ]
     },
     {
         "name": "geragera",
         "trans": [
+            "げらげら",
             " ① 副  哈哈大笑，毫无顾忌地高声大笑"
-        ],
-        "notation": "げらげら"
+        ]
     },
     {
         "name": "nouritsu",
         "trans": [
+            "能率(のうりつ)",
             "⓪ 名  效率；劳动生产率"
-        ],
-        "notation": "能率(のうりつ)"
+        ]
     },
     {
         "name": "oudan",
         "trans": [
+            "横断(おうだん)",
             "⓪ 名·自他动3  横渡，横穿；切断"
-        ],
-        "notation": "横断(おうだん)"
+        ]
     },
     {
         "name": "zenji",
         "trans": [
+            "漸次(ぜんじ)",
             "① 副  逐渐，逐步，渐渐"
-        ],
-        "notation": "漸次(ぜんじ)"
+        ]
     },
     {
         "name": "honshin",
         "trans": [
+            "本心(ほんしん)",
             "① 名  真心，本心；本性"
-        ],
-        "notation": "本心(ほんしん)"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "解凍(かいとう)",
             "⓪ 名·他动3  解冻，化开"
-        ],
-        "notation": "解凍(かいとう)"
+        ]
     },
     {
         "name": "kaihei",
         "trans": [
+            "開閉(かいへい)",
             "⓪ 名·他动3  开和关，开合"
-        ],
-        "notation": "開閉(かいへい)"
+        ]
     },
     {
         "name": "kousaku",
         "trans": [
+            "耕作(こうさく)",
             "⓪ 名·他动3  耕作，耕种"
-        ],
-        "notation": "耕作(こうさく)"
+        ]
     },
     {
         "name": "gikou",
         "trans": [
+            "技巧(ぎこう)",
             "⓪ 名  技巧"
-        ],
-        "notation": "技巧(ぎこう)"
+        ]
     },
     {
         "name": "shouki",
         "trans": [
+            "正気(しょうき)",
             "⓪ 名  精神正常，神志清醒"
-        ],
-        "notation": "正気(しょうき)"
+        ]
     },
     {
         "name": "yattsukeru",
         "trans": [
+            "やっつける",
             " ④ 他动2  干完，草草完成；打败，击败"
-        ],
-        "notation": "やっつける"
+        ]
     },
     {
         "name": "yaritsukeru",
         "trans": [
+            "やりつける",
             " ④ 他动2  做惯，做熟"
-        ],
-        "notation": "やりつける"
+        ]
     },
     {
         "name": "oshaberi",
         "trans": [
+            "お喋(しゃべ)り",
             "② 名·ナ形·自他动3  喋喋不休（的人）；聊天"
-        ],
-        "notation": "お喋(しゃべ)り"
+        ]
     },
     {
         "name": "fukusha",
         "trans": [
+            "複写(ふくしゃ)",
             "⓪ 名·他动3  抄写，誊写；复印"
-        ],
-        "notation": "複写(ふくしゃ)"
+        ]
     },
     {
         "name": "ito",
         "trans": [
+            "意図(いと)",
             "① 名·他动3  意图，打算，企图"
-        ],
-        "notation": "意図(いと)"
+        ]
     },
     {
         "name": "gairyaku",
         "trans": [
+            "概略(がいりゃく)",
             "⓪ 名  概况，概要，概略"
-        ],
-        "notation": "概略(がいりゃく)"
+        ]
     },
     {
         "name": "karushiumu",
         "trans": [
+            "カルシウム",
             "③ 名  钙"
-        ],
-        "notation": "カルシウム"
+        ]
     },
     {
         "name": "fuuzoku",
         "trans": [
+            "風俗(ふうぞく)",
             "① 名  风俗"
-        ],
-        "notation": "風俗(ふうぞく)"
+        ]
     },
     {
         "name": "kyoushuu",
         "trans": [
+            "郷愁(きょうしゅう)",
             "⓪ 名  乡愁；思念，怀念"
-        ],
-        "notation": "郷愁(きょうしゅう)"
+        ]
     },
     {
         "name": "iryoku",
         "trans": [
+            "威力(いりょく)",
             "① 名  威力"
-        ],
-        "notation": "威力(いりょく)"
+        ]
     },
     {
         "name": "kouhai",
         "trans": [
+            "荒廃(こうはい)",
             "⓪ 名·自动3  荒废，荒芜；颓废，散漫"
-        ],
-        "notation": "荒廃(こうはい)"
+        ]
     },
     {
         "name": "nerinaosu",
         "trans": [
+            "練(ね)り直(なお)す",
             "④ 他动1  再搅拌；重新思考，推敲"
-        ],
-        "notation": "練(ね)り直(なお)す"
+        ]
     },
     {
         "name": "kashitsu",
         "trans": [
+            "加湿(かしつ)",
             "⓪ 名  加湿，湿润"
-        ],
-        "notation": "加湿(かしつ)"
+        ]
     },
     {
         "name": "shougen",
         "trans": [
+            "証言(しょうげん)",
             "③ 名·他动3  证言；作证"
-        ],
-        "notation": "証言(しょうげん)"
+        ]
     },
     {
         "name": "kanrei",
         "trans": [
+            "慣例(かんれい)",
             "⓪ 名  惯例，常规"
-        ],
-        "notation": "慣例(かんれい)"
+        ]
     },
     {
         "name": "kafuu",
         "trans": [
+            "家風(かふう)",
             "① 名  家风，门风"
-        ],
-        "notation": "家風(かふう)"
+        ]
     },
     {
         "name": "shichouson",
         "trans": [
+            "市町村(しちょうそん)",
             "② 名  市、镇、村（日本都道府县行政区划之下的地方自治体）"
-        ],
-        "notation": "市町村(しちょうそん)"
+        ]
     },
     {
         "name": "kigan",
         "trans": [
+            "祈願(きがん)",
             "① 名·他动3  祈祷"
-        ],
-        "notation": "祈願(きがん)"
+        ]
     },
     {
         "name": "ureyuki",
         "trans": [
+            "売(う)れ行(ゆ)き",
             "⓪ 名  销售（情况），销路，销量"
-        ],
-        "notation": "売(う)れ行(ゆ)き"
+        ]
     },
     {
         "name": "minoru",
         "trans": [
+            "実(みの)る",
             "② 自动1  （作物）结果实；有成果"
-        ],
-        "notation": "実(みの)る"
+        ]
     },
     {
         "name": "aomukeru",
         "trans": [
+            "仰向(あおむ)ける",
             "④ 他动2  仰，仰起，抬起"
-        ],
-        "notation": "仰向(あおむ)ける"
+        ]
     },
     {
         "name": "konketsu",
         "trans": [
+            "混血(こんけつ)",
             "⓪ 名·自动3  混血"
-        ],
-        "notation": "混血(こんけつ)"
+        ]
     },
     {
         "name": "konran",
         "trans": [
+            "混乱(こんらん)",
             "⓪ 名·自动3  混乱，乱七八糟"
-        ],
-        "notation": "混乱(こんらん)"
+        ]
     },
     {
         "name": "ichimokuryouzen",
         "trans": [
+            "一目瞭然(いちもくりょうぜん)",
             "② ナ形  一目了然的"
-        ],
-        "notation": "一目瞭然(いちもくりょうぜん)"
+        ]
     },
     {
         "name": "fuyuu",
         "trans": [
+            "富裕(ふゆう)",
             "⓪ 名·ナ形  富裕，富有"
-        ],
-        "notation": "富裕(ふゆう)"
+        ]
     },
     {
         "name": "uroko",
         "trans": [
+            "鱗(うろこ)",
             "⓪ 名  鳞"
-        ],
-        "notation": "鱗(うろこ)"
+        ]
     },
     {
         "name": "kangeki",
         "trans": [
+            "感激(かんげき)",
             "⓪ 名·自动3  感激，感动"
-        ],
-        "notation": "感激(かんげき)"
+        ]
     },
     {
         "name": "kogoe",
         "trans": [
+            "小声(こごえ)",
             "⓪ 名  小声，低声"
-        ],
-        "notation": "小声(こごえ)"
+        ]
     },
     {
         "name": "motareru",
         "trans": [
+            "凭(もた)れる",
             " ③ 自动2  倚靠，凭靠；积食，不消化"
-        ],
-        "notation": "凭(もた)れる"
+        ]
     },
     {
         "name": "momu",
         "trans": [
+            "揉(も)む",
             "⓪ 他动1  搓，揉；捏，按摩；争论"
-        ],
-        "notation": "揉(も)む"
+        ]
     },
     {
         "name": "yatou",
         "trans": [
+            "雇(やと)う",
             "② 他动1  雇，雇用"
-        ],
-        "notation": "雇(やと)う"
+        ]
     },
     {
         "name": "mijime",
         "trans": [
+            "惨(みじ)め",
             "① ナ形  凄惨的，悲惨的"
-        ],
-        "notation": "惨(みじ)め"
+        ]
     },
     {
         "name": "shinchou",
         "trans": [
+            "慎重(しんちょう)",
             "⓪ 名·ナ形  慎重，小心谨慎"
-        ],
-        "notation": "慎重(しんちょう)"
+        ]
     },
     {
         "name": "shouten",
         "trans": [
+            "焦点(しょうてん)",
             "① 名  焦点；热点"
-        ],
-        "notation": "焦点(しょうてん)"
+        ]
     },
     {
         "name": "kongou",
         "trans": [
+            "混合(こんごう)",
             "⓪ 名·自他动3  混，混合"
-        ],
-        "notation": "混合(こんごう)"
+        ]
     },
     {
         "name": "kasoku",
         "trans": [
+            "加速(かそく)",
             "⓪ 名·自他动3  加速"
-        ],
-        "notation": "加速(かそく)"
+        ]
     },
     {
         "name": "shuuen",
         "trans": [
+            "終焉(しゅうえん)",
             "⓪ 名  终老，临终"
-        ],
-        "notation": "終焉(しゅうえん)"
+        ]
     },
     {
         "name": "topikku",
         "trans": [
+            "トピック",
             "① 名  话题，主题，题目"
-        ],
-        "notation": "トピック"
+        ]
     },
     {
         "name": "okugai",
         "trans": [
+            "屋外(おくがい)",
             "② 名  室外，屋外，露天"
-        ],
-        "notation": "屋外(おくがい)"
+        ]
     },
     {
         "name": "okurasu",
         "trans": [
+            "遅(おく)らす",
             "⓪ 他动1  延缓，推迟"
-        ],
-        "notation": "遅(おく)らす"
+        ]
     },
     {
         "name": "taiwa",
         "trans": [
+            "対話(たいわ)",
             "⓪ 名·自动3  对话"
-        ],
-        "notation": "対話(たいわ)"
+        ]
     },
     {
         "name": "kenkin",
         "trans": [
+            "献金(けんきん)",
             "⓪ 名·自动3  捐款，捐献"
-        ],
-        "notation": "献金(けんきん)"
+        ]
     },
     {
         "name": "kanbu",
         "trans": [
+            "幹部(かんぶ)",
             "① 名  干部，领导"
-        ],
-        "notation": "幹部(かんぶ)"
+        ]
     },
     {
         "name": "hankei",
         "trans": [
+            "半径(はんけい)",
             "① 名  半径"
-        ],
-        "notation": "半径(はんけい)"
+        ]
     },
     {
         "name": "konmori",
         "trans": [
+            "こんもり",
             " ③ 副·自动3  树木繁茂，茂密；隆起，鼓起"
-        ],
-        "notation": "こんもり"
+        ]
     },
     {
         "name": "kaisetsu",
         "trans": [
+            "開設(かいせつ)",
             "⓪ 名·他动3  开设，开办"
-        ],
-        "notation": "開設(かいせつ)"
+        ]
     },
     {
         "name": "youbou",
         "trans": [
+            "要望(ようぼう)",
             "⓪ 名·他动3  希望，要求，强烈希望"
-        ],
-        "notation": "要望(ようぼう)"
+        ]
     },
     {
         "name": "shittori",
         "trans": [
+            "しっとり",
             " ③ 副·自动3  潮湿，湿润；恬静，安详"
-        ],
-        "notation": "しっとり"
+        ]
     },
     {
         "name": "medetai",
         "trans": [
+            "めでたい",
             " ③ イ形  可喜的，可贺的；幸运的"
-        ],
-        "notation": "めでたい"
+        ]
     },
     {
         "name": "ichiou",
         "trans": [
+            "一応(いちおう)",
             "⓪ 副  姑且，先；大体，大致"
-        ],
-        "notation": "一応(いちおう)"
+        ]
     },
     {
         "name": "bimyou",
         "trans": [
+            "微妙(びみょう)",
             "⓪ ナ形  微妙的"
-        ],
-        "notation": "微妙(びみょう)"
+        ]
     },
     {
         "name": "ranbou",
         "trans": [
+            "乱暴(らんぼう)",
             "⓪ 名·ナ形  粗野，粗鲁；蛮不讲理"
-        ],
-        "notation": "乱暴(らんぼう)"
+        ]
     },
     {
         "name": "detarame",
         "trans": [
+            "でたらめ",
             " ⓪ 名·ナ形  荒唐，胡闹，胡说八道"
-        ],
-        "notation": "でたらめ"
+        ]
     },
     {
         "name": "namaiki",
         "trans": [
+            "生意気(なまいき)",
             "⓪ 名·ナ形  自大，傲慢，狂妄"
-        ],
-        "notation": "生意気(なまいき)"
+        ]
     },
     {
         "name": "kenkyo",
         "trans": [
+            "謙虚(けんきょ)",
             "① ナ形  谦虚的，谦和的"
-        ],
-        "notation": "謙虚(けんきょ)"
+        ]
     },
     {
         "name": "taezu",
         "trans": [
+            "絶(た)えず",
             "① 副  不断，经常，无休止"
-        ],
-        "notation": "絶(た)えず"
+        ]
     },
     {
         "name": "gekkyuu",
         "trans": [
+            "月給(げっきゅう)",
             "⓪ 名  月薪，工资"
-        ],
-        "notation": "月給(げっきゅう)"
+        ]
     },
     {
         "name": "kougeki",
         "trans": [
+            "攻撃(こうげき)",
             "⓪ 名·他动3  攻击，进攻；抨击"
-        ],
-        "notation": "攻撃(こうげき)"
+        ]
     },
     {
         "name": "okonai",
         "trans": [
+            "行(おこな)い",
             "⓪ 名  行为，动作；品行，举止"
-        ],
-        "notation": "行(おこな)い"
+        ]
     },
     {
         "name": "osoban",
         "trans": [
+            "遅番(おそばん)",
             "⓪ 名  晚班"
-        ],
-        "notation": "遅番(おそばん)"
+        ]
     },
     {
         "name": "naien",
         "trans": [
+            "内縁(ないえん)",
             "⓪ 名  非正式的婚姻"
-        ],
-        "notation": "内縁(ないえん)"
+        ]
     },
     {
         "name": "kyuukon",
         "trans": [
+            "求婚(きゅうこん)",
             "⓪ 名·自动3  求婚"
-        ],
-        "notation": "求婚(きゅうこん)"
+        ]
     },
     {
         "name": "monosugoi",
         "trans": [
+            "ものすごい",
             " ④ イ形  令人害怕的；惊人的"
-        ],
-        "notation": "ものすごい"
+        ]
     },
     {
         "name": "shuurai",
         "trans": [
+            "襲来(しゅうらい)",
             "⓪ 名·自动3  袭来，来袭，攻来"
-        ],
-        "notation": "襲来(しゅうらい)"
+        ]
     },
     {
         "name": "kabushiki",
         "trans": [
+            "株式(かぶしき)",
             "② 名  股份；股票；股权"
-        ],
-        "notation": "株式(かぶしき)"
+        ]
     },
     {
         "name": "jihanki",
         "trans": [
+            "自販機(じはんき)",
             "② 名  自动售货机"
-        ],
-        "notation": "自販機(じはんき)"
+        ]
     },
     {
         "name": "shikkuri",
         "trans": [
+            "しっくり",
             " ③ 副·自动3  合适，吻合；融洽，对劲儿"
-        ],
-        "notation": "しっくり"
+        ]
     },
     {
         "name": "kattou",
         "trans": [
+            "葛藤(かっとう)",
             "⓪ 名·自动3  纠葛，纠纷；心里矛盾，内心冲突"
-        ],
-        "notation": "葛藤(かっとう)"
+        ]
     },
     {
         "name": "kudakudashii",
         "trans": [
+            "くだくだしい",
             " ⑤ イ形  麻烦的，烦琐的；啰唆的，冗长的"
-        ],
-        "notation": "くだくだしい"
+        ]
     },
     {
         "name": "moukaru",
         "trans": [
+            "儲(もう)かる",
             "③ 自动1  赚钱；捡到便宜"
-        ],
-        "notation": "儲(もう)かる"
+        ]
     },
     {
         "name": "somatsu",
         "trans": [
+            "粗末(そまつ)",
             "① 名·ナ形  粗糙，简陋；疏忽，简慢"
-        ],
-        "notation": "粗末(そまつ)"
+        ]
     },
     {
         "name": "nageku",
         "trans": [
+            "嘆(なげ)く",
             "② 自他动1  叹息，叹气；哀叹，悲叹"
-        ],
-        "notation": "嘆(なげ)く"
+        ]
     },
     {
         "name": "tsunagari",
         "trans": [
+            "繋(つな)がり",
             "⓪ 名  连接，相连；关联，关系"
-        ],
-        "notation": "繋(つな)がり"
+        ]
     },
     {
         "name": "kigu",
         "trans": [
+            "危惧(きぐ)",
             "① 名·他动3  畏惧，担心，害怕"
-        ],
-        "notation": "危惧(きぐ)"
+        ]
     },
     {
         "name": "hengen",
         "trans": [
+            "変幻(へんげん)",
             "⓪ 名·自动3  变幻，变化"
-        ],
-        "notation": "変幻(へんげん)"
+        ]
     },
     {
         "name": "fuusoku",
         "trans": [
+            "風速(ふうそく)",
             "⓪ 名  风速"
-        ],
-        "notation": "風速(ふうそく)"
+        ]
     },
     {
         "name": "oyakyoudai",
         "trans": [
+            "親兄弟(おやきょうだい)",
             "③ 名  家人，父母及兄弟姐妹"
-        ],
-        "notation": "親兄弟(おやきょうだい)"
+        ]
     },
     {
         "name": "hakkaku",
         "trans": [
+            "発覚(はっかく)",
             "⓪ 名·自动3  暴露，被发现"
-        ],
-        "notation": "発覚(はっかく)"
+        ]
     },
     {
         "name": "kyoten",
         "trans": [
+            "拠点(きょてん)",
             "⓪ 名  据点，基地"
-        ],
-        "notation": "拠点(きょてん)"
+        ]
     },
     {
         "name": "yoridokoro",
         "trans": [
+            "拠(よ)り所(どころ)",
             "⓪ 名  根据，依据"
-        ],
-        "notation": "拠(よ)り所(どころ)"
+        ]
     },
     {
         "name": "haishaku",
         "trans": [
+            "拝借(はいしゃく)",
             "⓪ 名·他动3  （自谦语）借"
-        ],
-        "notation": "拝借(はいしゃく)"
+        ]
     },
     {
         "name": "minji",
         "trans": [
+            "民事(みんじ)",
             "① 名  （法律）民事"
-        ],
-        "notation": "民事(みんじ)"
+        ]
     },
     {
         "name": "minpou",
         "trans": [
+            "民法(みんぽう)",
             "① 名  民法"
-        ],
-        "notation": "民法(みんぽう)"
+        ]
     },
     {
         "name": "mouderu",
         "trans": [
+            "詣(もう)でる",
             "③ 自动2  参拜（神社、寺院等）"
-        ],
-        "notation": "詣(もう)でる"
+        ]
     },
     {
         "name": "abura",
         "trans": [
+            "脂(あぶら)",
             "⓪ 名  脂肪，油脂"
-        ],
-        "notation": "脂(あぶら)"
+        ]
     },
     {
         "name": "juchuu",
         "trans": [
+            "受注(じゅちゅう)",
             "⓪ 名·他动3  接受订购，接受订货"
-        ],
-        "notation": "受注(じゅちゅう)"
+        ]
     },
     {
         "name": "henkin",
         "trans": [
+            "返金(へんきん)",
             "⓪ 名·自他动3  还债，还钱，还账"
-        ],
-        "notation": "返金(へんきん)"
+        ]
     },
     {
         "name": "torikakaru",
         "trans": [
+            "取(と)りかかる",
             "④ 自动1  着手，开始"
-        ],
-        "notation": "取(と)りかかる"
+        ]
     },
     {
         "name": "gaiken",
         "trans": [
+            "外見(がいけん)",
             "⓪ 名  外观，表面；外貌"
-        ],
-        "notation": "外見(がいけん)"
+        ]
     },
     {
         "name": "inasaku",
         "trans": [
+            "稲作(いなさく)",
             "⓪ 名  种稻；稻子的收成"
-        ],
-        "notation": "稲作(いなさく)"
+        ]
     },
     {
         "name": "shougyou",
         "trans": [
+            "商業(しょうぎょう)",
             "① 名  商业"
-        ],
-        "notation": "商業(しょうぎょう)"
+        ]
     },
     {
         "name": "satsugai",
         "trans": [
+            "殺害(さつがい)",
             "⓪ 名·他动3  杀害，杀人"
-        ],
-        "notation": "殺害(さつがい)"
+        ]
     },
     {
         "name": "eikaiwa",
         "trans": [
+            "英会話(えいかいわ)",
             "③ 名  英语会话"
-        ],
-        "notation": "英会話(えいかいわ)"
+        ]
     },
     {
         "name": "zaitaku",
         "trans": [
+            "在宅(ざいたく)",
             "⓪ 名·自动3  在家"
-        ],
-        "notation": "在宅(ざいたく)"
+        ]
     },
     {
         "name": "furyou",
         "trans": [
+            "不良(ふりょう)",
             "⓪ 名·ナ形  不好，不良；品行不端"
-        ],
-        "notation": "不良(ふりょう)"
+        ]
     },
     {
         "name": "teiden",
         "trans": [
+            "停電(ていでん)",
             "⓪ 名·自动3  停电"
-        ],
-        "notation": "停電(ていでん)"
+        ]
     },
     {
         "name": "torishimariyaku",
         "trans": [
+            "取締役(とりしまりやく)",
             "⓪ 名  董事"
-        ],
-        "notation": "取締役(とりしまりやく)"
+        ]
     },
     {
         "name": "senbei",
         "trans": [
+            "煎餅(せんべい)",
             "① 名  薄脆饼干"
-        ],
-        "notation": "煎餅(せんべい)"
+        ]
     },
     {
         "name": "kyuushoku",
         "trans": [
+            "求職(きゅうしょく)",
             "⓪ 名·自动3  求职，找工作"
-        ],
-        "notation": "求職(きゅうしょく)"
+        ]
     },
     {
         "name": "kentou",
         "trans": [
+            "健闘(けんとう)",
             "⓪ 名·自动3  奋斗，拼搏，勇敢战斗"
-        ],
-        "notation": "健闘(けんとう)"
+        ]
     },
     {
         "name": "shutoken",
         "trans": [
+            "首都圏(しゅとけん)",
             "② 名  首都圈，首都地区"
-        ],
-        "notation": "首都圏(しゅとけん)"
+        ]
     },
     {
         "name": "kashi",
         "trans": [
+            "瑕疵(かし)",
             "① 名  瑕疵，缺点"
-        ],
-        "notation": "瑕疵(かし)"
+        ]
     },
     {
         "name": "daburu",
         "trans": [
+            "ダブル",
             "① 名  成双；两倍，加倍"
-        ],
-        "notation": "ダブル"
+        ]
     },
     {
         "name": "zessan",
         "trans": [
+            "絶賛(ぜっさん)",
             "⓪ 名·他动3  盛赞，赞不绝口"
-        ],
-        "notation": "絶賛(ぜっさん)"
+        ]
     },
     {
         "name": "pikaichi",
         "trans": [
+            "ぴかいち",
             " ⓪ 名  出类拔萃，最好的，最优秀的"
-        ],
-        "notation": "ぴかいち"
+        ]
     },
     {
         "name": "onkou",
         "trans": [
+            "温厚(おんこう)",
             "⓪ ナ形  温厚的，敦厚的，温文尔雅的"
-        ],
-        "notation": "温厚(おんこう)"
+        ]
     },
     {
         "name": "onchi",
         "trans": [
+            "音痴(おんち)",
             "① 名  音痴；感觉迟钝的人"
-        ],
-        "notation": "音痴(おんち)"
+        ]
     },
     {
         "name": "zeiritsu",
         "trans": [
+            "税率(ぜいりつ)",
             "⓪ 名  税率"
-        ],
-        "notation": "税率(ぜいりつ)"
+        ]
     },
     {
         "name": "tsuuhou",
         "trans": [
+            "通報(つうほう)",
             "⓪ 名·他动3  通报，通知"
-        ],
-        "notation": "通報(つうほう)"
+        ]
     },
     {
         "name": "wa-rudokappu",
         "trans": [
+            "ワールドカップ",
             "⑤ 名  世界杯"
-        ],
-        "notation": "ワールドカップ"
+        ]
     },
     {
         "name": "chika",
         "trans": [
+            "地価(ちか)",
             "② 名  地价，土地价格"
-        ],
-        "notation": "地価(ちか)"
+        ]
     },
     {
         "name": "rifo-mu",
         "trans": [
+            "リフォーム",
             "② 名·他动3  改革，改良；翻新，改造"
-        ],
-        "notation": "リフォーム"
+        ]
     },
     {
         "name": "oyako",
         "trans": [
+            "親子(おやこ)",
             "① 名  父母和子女"
-        ],
-        "notation": "親子(おやこ)"
+        ]
     },
     {
         "name": "orijinarithi-",
         "trans": [
+            "オリジナリティー",
             "④ 名  独创性，创意，创造力"
-        ],
-        "notation": "オリジナリティー"
+        ]
     },
     {
         "name": "orugan",
         "trans": [
+            "オルガン",
             "⓪ 名  风琴"
-        ],
-        "notation": "オルガン"
+        ]
     },
     {
         "name": "kaizan",
         "trans": [
+            "改竄(かいざん)",
             "⓪ 名·他动3  篡改，涂改，删改"
-        ],
-        "notation": "改竄(かいざん)"
+        ]
     },
     {
         "name": "kaishin",
         "trans": [
+            "会心(かいしん)",
             "⓪ 名  满意，得意"
-        ],
-        "notation": "会心(かいしん)"
+        ]
     },
     {
         "name": "kaisuiyoku",
         "trans": [
+            "海水浴(かいすいよく)",
             "③ 名  海水浴"
-        ],
-        "notation": "海水浴(かいすいよく)"
+        ]
     },
     {
         "name": "kaunta-",
         "trans": [
+            "カウンター",
             "⓪ 名  柜台；服务台"
-        ],
-        "notation": "カウンター"
+        ]
     },
     {
         "name": "sango",
         "trans": [
+            "珊瑚(さんご)",
             "① 名  珊瑚"
-        ],
-        "notation": "珊瑚(さんご)"
+        ]
     },
     {
         "name": "kakujitsu",
         "trans": [
+            "隔日(かくじつ)",
             "⓪ 名  隔日，隔天"
-        ],
-        "notation": "隔日(かくじつ)"
+        ]
     },
     {
         "name": "kakuteru",
         "trans": [
+            "カクテル",
             "① 名  鸡尾酒"
-        ],
-        "notation": "カクテル"
+        ]
     },
     {
         "name": "kakeashi",
         "trans": [
+            "駆(か)け足(あし)",
             "② 名·自动3  快跑；走马观花地，急急忙忙地"
-        ],
-        "notation": "駆(か)け足(あし)"
+        ]
     },
     {
         "name": "kageki",
         "trans": [
+            "過激(かげき)",
             "⓪ 名·ナ形  过激，过度，过火"
-        ],
-        "notation": "過激(かげき)"
+        ]
     },
     {
         "name": "kakekko",
         "trans": [
+            "かけっこ",
             "(儿童用语)  ② 名·自动3  （儿童用语）赛跑"
-        ],
-        "notation": "かけっこ"
+        ]
     },
     {
         "name": "kairo",
         "trans": [
+            "回路(かいろ)",
             "① 名  电路，回路，线路"
-        ],
-        "notation": "回路(かいろ)"
+        ]
     },
     {
         "name": "kassai",
         "trans": [
+            "喝采(かっさい)",
             "⓪ 名·自动3  喝彩，欢呼"
-        ],
-        "notation": "喝采(かっさい)"
+        ]
     },
     {
         "name": "fuugawari",
         "trans": [
+            "風変(ふうが)わり",
             "③ 名·ナ形  奇特，古怪，与众不同"
-        ],
-        "notation": "風変(ふうが)わり"
+        ]
     },
     {
         "name": "haiguu",
         "trans": [
+            "配偶(はいぐう)",
             "⓪ 名  配偶，夫妇"
-        ],
-        "notation": "配偶(はいぐう)"
+        ]
     },
     {
         "name": "kourakuchi",
         "trans": [
+            "行楽地(こうらくち)",
             "④ 名  景点，游览地"
-        ],
-        "notation": "行楽地(こうらくち)"
+        ]
     },
     {
         "name": "ousetsu",
         "trans": [
+            "応接(おうせつ)",
             "⓪ 名·自他动3  接待，应接"
-        ],
-        "notation": "応接(おうせつ)"
+        ]
     },
     {
         "name": "uneune",
         "trans": [
+            "うねうね",
             " ① 副·自动3  蜿蜒起伏，弯弯曲曲"
-        ],
-        "notation": "うねうね"
+        ]
     },
     {
         "name": "shifuto",
         "trans": [
+            "シフト",
             "① 名  移动；改变；替换；换班"
-        ],
-        "notation": "シフト"
+        ]
     },
     {
         "name": "kasseika",
         "trans": [
+            "活性化(かっせいか)",
             "⓪ 名·自他动3  活化作用；激活，使活跃"
-        ],
-        "notation": "活性化(かっせいか)"
+        ]
     },
     {
         "name": "kaichuudentou",
         "trans": [
+            "懐中電灯(かいちゅうでんとう)",
             "⑤ 名  手电筒"
-        ],
-        "notation": "懐中電灯(かいちゅうでんとう)"
+        ]
     },
     {
         "name": "gaihaku",
         "trans": [
+            "外泊(がいはく)",
             "⓪ 名·自动3  在外过夜，夜不归宿"
-        ],
-        "notation": "外泊(がいはく)"
+        ]
     },
     {
         "name": "nobenobe",
         "trans": [
+            "延(のべ)々",
             "⓪ 副·ナ形  没完没了，接连不断"
-        ],
-        "notation": "延(のべ)々"
+        ]
     },
     {
         "name": "kandume",
         "trans": [
+            "缶詰(かんづめ)",
             "③ 名  罐头；（把人）关起来，隔离起来"
-        ],
-        "notation": "缶詰(かんづめ)"
+        ]
     },
     {
         "name": "soan",
         "trans": [
+            "素案(そあん)",
             "⓪ 名  草案"
-        ],
-        "notation": "素案(そあん)"
+        ]
     },
     {
         "name": "shimei",
         "trans": [
+            "使命(しめい)",
             "① 名  使命，任务"
-        ],
-        "notation": "使命(しめい)"
+        ]
     },
     {
         "name": "shichou",
         "trans": [
+            "思潮(しちょう)",
             "⓪ 名  思潮"
-        ],
-        "notation": "思潮(しちょう)"
+        ]
     },
     {
         "name": "gaiyou",
         "trans": [
+            "概要(がいよう)",
             "⓪ 名  概要，概略，大略"
-        ],
-        "notation": "概要(がいよう)"
+        ]
     },
     {
         "name": "tatsumaki",
         "trans": [
+            "竜巻(たつまき)",
             "⓪ 名  龙卷风"
-        ],
-        "notation": "竜巻(たつまき)"
+        ]
     },
     {
         "name": "korokke",
         "trans": [
+            "コロッケ",
             " ① 名  炸肉饼，油炸饼"
-        ],
-        "notation": "コロッケ"
+        ]
     },
     {
         "name": "kairo",
         "trans": [
+            "海路(かいろ)",
             "① 名  海路，漂洋过海"
-        ],
-        "notation": "海路(かいろ)"
+        ]
     },
     {
         "name": "jitou",
         "trans": [
+            "地頭(じとう)",
             "⓪ 名  该地，当地"
-        ],
-        "notation": "地頭(じとう)"
+        ]
     },
     {
         "name": "kaibou",
         "trans": [
+            "解剖(かいぼう)",
             "⓪ 名·他动3  解剖；剖析，分析"
-        ],
-        "notation": "解剖(かいぼう)"
+        ]
     },
     {
         "name": "nenbutsu",
         "trans": [
+            "念仏(ねんぶつ)",
             "⓪ 名·自动3  念佛，念经"
-        ],
-        "notation": "念仏(ねんぶつ)"
+        ]
     },
     {
         "name": "hachimitsu",
         "trans": [
+            "蜂蜜(はちみつ)",
             "⓪ 名  蜂蜜"
-        ],
-        "notation": "蜂蜜(はちみつ)"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "解答(かいとう)",
             "⓪ 名·自动3  答案，解答"
-        ],
-        "notation": "解答(かいとう)"
+        ]
     },
     {
         "name": "nodomoto",
         "trans": [
+            "喉元(のどもと)",
             "⓪ 名  咽喉，喉咙，嗓子"
-        ],
-        "notation": "喉元(のどもと)"
+        ]
     },
     {
         "name": "fukusui",
         "trans": [
+            "覆水(ふくすい)",
             "⓪ 名  覆水，泼出去的水"
-        ],
-        "notation": "覆水(ふくすい)"
+        ]
     },
     {
         "name": "hatsugen",
         "trans": [
+            "発言(はつげん)",
             "⓪ 名·自动3  发言"
-        ],
-        "notation": "発言(はつげん)"
+        ]
     },
     {
         "name": "kyaputen",
         "trans": [
+            "キャプテン",
             "① 名  首领；队长；船长"
-        ],
-        "notation": "キャプテン"
+        ]
     },
     {
         "name": "higan",
         "trans": [
+            "彼岸(ひがん)",
             "⓪ 名  春分、秋分时节；彼岸，对岸"
-        ],
-        "notation": "彼岸(ひがん)"
+        ]
     },
     {
         "name": "fushigi",
         "trans": [
+            "不思議(ふしぎ)",
             "⓪ 名·ナ形  不可思议，奇怪"
-        ],
-        "notation": "不思議(ふしぎ)"
+        ]
     },
     {
         "name": "kamo",
         "trans": [
+            "鴨(かも)",
             "① 名  鸭子；冤大头，容易上当受骗的人"
-        ],
-        "notation": "鴨(かも)"
+        ]
     },
     {
         "name": "amadare",
         "trans": [
+            "雨垂(あまだ)れ",
             "⓪ 名  （从房檐流下来的）雨滴，雨水"
-        ],
-        "notation": "雨垂(あまだ)れ"
+        ]
     },
     {
         "name": "morohiza",
         "trans": [
+            "両膝(もろひざ)",
             "⓪ 名  双膝"
-        ],
-        "notation": "両膝(もろひざ)"
+        ]
     },
     {
         "name": "tsurugi",
         "trans": [
+            "剣(つるぎ)",
             "③ 名  剑"
-        ],
-        "notation": "剣(つるぎ)"
+        ]
     },
     {
         "name": "toudai",
         "trans": [
+            "灯台(とうだい)",
             "⓪ 名  灯台，灯架；灯塔"
-        ],
-        "notation": "灯台(とうだい)"
+        ]
     },
     {
         "name": "ishibashi",
         "trans": [
+            "石橋(いしばし)",
             "⓪ 名  石桥"
-        ],
-        "notation": "石橋(いしばし)"
+        ]
     },
     {
         "name": "chuugen",
         "trans": [
+            "忠言(ちゅうげん)",
             "⓪ 名  忠言，忠告"
-        ],
-        "notation": "忠言(ちゅうげん)"
+        ]
     },
     {
         "name": "shimizu",
         "trans": [
+            "清水(しみず)",
             "⓪ 名  泉水，清泉水"
-        ],
-        "notation": "清水(しみず)"
+        ]
     },
     {
         "name": "taikutsu",
         "trans": [
+            "退屈(たいくつ)",
             "⓪ 名·ナ形·自动3  无聊，寂寞，厌倦"
-        ],
-        "notation": "退屈(たいくつ)"
+        ]
     },
     {
         "name": "shuukaku",
         "trans": [
+            "収穫(しゅうかく)",
             "⓪ 名·他动3  收获，收成；成果"
-        ],
-        "notation": "収穫(しゅうかく)"
+        ]
     },
     {
         "name": "akusen",
         "trans": [
+            "悪銭(あくせん)",
             "⓪ 名  不义之财"
-        ],
-        "notation": "悪銭(あくせん)"
+        ]
     },
     {
         "name": "chuugen",
         "trans": [
+            "中原(ちゅうげん)",
             "⓪ 名  中原"
-        ],
-        "notation": "中原(ちゅうげん)"
+        ]
     },
     {
         "name": "akusen",
         "trans": [
+            "悪戦(あくせん)",
             "⓪ 名·自动3  艰苦的战斗，恶战"
-        ],
-        "notation": "悪戦(あくせん)"
+        ]
     },
     {
         "name": "shouboushi",
         "trans": [
+            "消防士(しょうぼうし)",
             "③ 名  消防人员"
-        ],
-        "notation": "消防士(しょうぼうし)"
+        ]
     },
     {
         "name": "kunshi",
         "trans": [
+            "君子(くんし)",
             "① 名  君子"
-        ],
-        "notation": "君子(くんし)"
+        ]
     },
     {
         "name": "tsune",
         "trans": [
+            "常(つね)",
             "① 名  平常，普通；常事，常情"
-        ],
-        "notation": "常(つね)"
+        ]
     },
     {
         "name": "noren",
         "trans": [
+            "暖簾(のれん)",
             "⓪ 名  门帘，商店挂的布帘；商店的信誉"
-        ],
-        "notation": "暖簾(のれん)"
+        ]
     },
     {
         "name": "shuukai",
         "trans": [
+            "集会(しゅうかい)",
             "⓪ 名·自动3  集会"
-        ],
-        "notation": "集会(しゅうかい)"
+        ]
     },
     {
         "name": "imagoro",
         "trans": [
+            "今頃(いまごろ)",
             "⓪ 名·副  现在，此时；如今"
-        ],
-        "notation": "今頃(いまごろ)"
+        ]
     },
     {
         "name": "tetsu",
         "trans": [
+            "轍(てつ)",
             "① 名  车辙"
-        ],
-        "notation": "轍(てつ)"
+        ]
     },
     {
         "name": "kuu",
         "trans": [
+            "食(く)う",
             "① 他动1  吃，吃饭；生活；咬，叮；需要；遭受；受骗"
-        ],
-        "notation": "食(く)う"
+        ]
     },
     {
         "name": "chuugen",
         "trans": [
+            "中元(ちゅうげん)",
             "⓪ 名  中元节（阴历七月十五）；中元节礼品"
-        ],
-        "notation": "中元(ちゅうげん)"
+        ]
     },
     {
         "name": "kuwaeru",
         "trans": [
+            "加(くわ)える",
             "⓪ 他动2  加，添加；增大，加大；参加，加入；施加"
-        ],
-        "notation": "加(くわ)える"
+        ]
     },
     {
         "name": "arai",
         "trans": [
+            "荒(あら)い",
             "⓪ イ形  粗暴的；剧烈的；乱（花钱）的"
-        ],
-        "notation": "荒(あら)い"
+        ]
     },
     {
         "name": "seiten",
         "trans": [
+            "青天(せいてん)",
             "⓪ 名  青天，晴空"
-        ],
-        "notation": "青天(せいてん)"
+        ]
     },
     {
         "name": "tsumu",
         "trans": [
+            "摘(つ)む",
             "⓪ 他动1  摘，采，掐"
-        ],
-        "notation": "摘(つ)む"
+        ]
     },
     {
         "name": "shihai",
         "trans": [
+            "支配(しはい)",
             "① 名·他动3  支配；管理，统治"
-        ],
-        "notation": "支配(しはい)"
+        ]
     },
     {
         "name": "shibou",
         "trans": [
+            "志望(しぼう)",
             "⓪ 名·他动3  志愿，期望"
-        ],
-        "notation": "志望(しぼう)"
+        ]
     },
     {
         "name": "omoigakenai",
         "trans": [
+            "思(おも)いがけない",
             "⑤ イ形  意想不到的，意外的，偶然的"
-        ],
-        "notation": "思(おも)いがけない"
+        ]
     },
     {
         "name": "juuryoku",
         "trans": [
+            "重力(じゅうりょく)",
             "① 名  重力"
-        ],
-        "notation": "重力(じゅうりょく)"
+        ]
     },
     {
         "name": "shukan",
         "trans": [
+            "主観(しゅかん)",
             "⓪ 名  主观；自我"
-        ],
-        "notation": "主観(しゅかん)"
+        ]
     },
     {
         "name": "oshii",
         "trans": [
+            "惜(お)しい",
             "② イ形  可惜的；舍不得的；值得爱惜的，珍惜的"
-        ],
-        "notation": "惜(お)しい"
+        ]
     },
     {
         "name": "keibiin",
         "trans": [
+            "警備員(けいびいん)",
             "③ 名  警卫员"
-        ],
-        "notation": "警備員(けいびいん)"
+        ]
     },
     {
         "name": "kegawa",
         "trans": [
+            "毛皮(けがわ)",
             "⓪ 名  毛皮，皮货"
-        ],
-        "notation": "毛皮(けがわ)"
+        ]
     },
     {
         "name": "nejireru",
         "trans": [
+            "捻(ねじ)れる",
             "③ 自动2  弯曲；扭歪；性情乖僻"
-        ],
-        "notation": "捻(ねじ)れる"
+        ]
     },
     {
         "name": "awai",
         "trans": [
+            "淡(あわ)い",
             "② イ形  浅的，淡的；些微的"
-        ],
-        "notation": "淡(あわ)い"
+        ]
     },
     {
         "name": "juurai",
         "trans": [
+            "従来(じゅうらい)",
             "① 名·副  从来，直到现在"
-        ],
-        "notation": "従来(じゅうらい)"
+        ]
     },
     {
         "name": "shukanteki",
         "trans": [
+            "主観的(しゅかんてき)",
             "⓪ ナ形  主观的"
-        ],
-        "notation": "主観的(しゅかんてき)"
+        ]
     },
     {
         "name": "kawanagare",
         "trans": [
+            "川流(かわなが)れ",
             "③ 名  被河水冲走；溺死，淹死"
-        ],
-        "notation": "川流(かわなが)れ"
+        ]
     },
     {
         "name": "banji",
         "trans": [
+            "万事(ばんじ)",
             "① 名  万事，一切的事"
-        ],
-        "notation": "万事(ばんじ)"
+        ]
     },
     {
         "name": "hagishiri",
         "trans": [
+            "歯軋(はぎし)り",
             "② 名·自动3  磨牙；咬牙切齿"
-        ],
-        "notation": "歯軋(はぎし)り"
+        ]
     },
     {
         "name": "tsumazuku",
         "trans": [
+            "つまずく",
             " ⓪ 自动1  跌倒，摔倒；受挫，栽跟头"
-        ],
-        "notation": "つまずく"
+        ]
     },
     {
         "name": "kappa",
         "trans": [
+            "河童(かっぱ)",
             "⓪ 名  （日本民间传说中的动物）河童；擅长游泳的人"
-        ],
-        "notation": "河童(かっぱ)"
+        ]
     },
     {
         "name": "kuwawaru",
         "trans": [
+            "加(くわ)わる",
             "⓪ 自动1  添加，加上；增长；参加"
-        ],
-        "notation": "加(くわ)わる"
+        ]
     },
     {
         "name": "shamisen",
         "trans": [
+            "三味線(しゃみせん)",
             "⓪ 名  三味线，日本三弦琴"
-        ],
-        "notation": "三味線(しゃみせん)"
+        ]
     },
     {
         "name": "shareru",
         "trans": [
+            "洒落(しゃれ)る",
             "⓪ 自动2  打扮得漂亮；说俏皮话；别致"
-        ],
-        "notation": "洒落(しゃれ)る"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "銃(じゅう)",
             "① 名  枪"
-        ],
-        "notation": "銃(じゅう)"
+        ]
     },
     {
         "name": "atsuatsu",
         "trans": [
+            "あつあつ",
             " ⓪ ナ形  火热的，热气腾腾的；热恋的"
-        ],
-        "notation": "あつあつ"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "修士(しゅうし)",
             "① 名  硕士"
-        ],
-        "notation": "修士(しゅうし)"
+        ]
     },
     {
         "name": "tassei",
         "trans": [
+            "達成(たっせい)",
             "⓪ 名·他动3  达到，成就，完成"
-        ],
-        "notation": "達成(たっせい)"
+        ]
     },
     {
         "name": "tappuri",
         "trans": [
+            "たっぷり",
             " ③ 副  足够，充足；绰绰有余"
-        ],
-        "notation": "たっぷり"
+        ]
     },
     {
         "name": "datou",
         "trans": [
+            "妥当(だとう)",
             "⓪ 名·ナ形  妥当，妥善，稳妥"
-        ],
-        "notation": "妥当(だとう)"
+        ]
     },
     {
         "name": "tanomoshii",
         "trans": [
+            "頼(たの)もしい",
             "④ イ形  可靠的，有把握的；有出息的"
-        ],
-        "notation": "頼(たの)もしい"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "終始(しゅうし)",
             "① 副·自动3  自始至终；从头到尾"
-        ],
-        "notation": "終始(しゅうし)"
+        ]
     },
     {
         "name": "enogu",
         "trans": [
+            "絵(え)の具(ぐ)",
             "⓪ 名  颜料，水彩"
-        ],
-        "notation": "絵(え)の具(ぐ)"
+        ]
     },
     {
         "name": "shuushuu",
         "trans": [
+            "収集(しゅうしゅう)",
             "⓪ 名·他动3  收集，搜集"
-        ],
-        "notation": "収集(しゅうしゅう)"
+        ]
     },
     {
         "name": "shuukyou",
         "trans": [
+            "宗教(しゅうきょう)",
             "① 名  宗教"
-        ],
-        "notation": "宗教(しゅうきょう)"
+        ]
     },
     {
         "name": "natsukashii",
         "trans": [
+            "懐(なつ)かしい",
             "④ イ形  怀念的，眷恋的"
-        ],
-        "notation": "懐(なつ)かしい"
+        ]
     },
     {
         "name": "taichou",
         "trans": [
+            "体調(たいちょう)",
             "⓪ 名  身体状况，健康状态"
-        ],
-        "notation": "体調(たいちょう)"
+        ]
     },
     {
         "name": "taitoru",
         "trans": [
+            "タイトル",
             "① 名  标题；头衔；字幕"
-        ],
-        "notation": "タイトル"
+        ]
     },
     {
         "name": "taiho",
         "trans": [
+            "逮捕(たいほ)",
             "① 名·他动3  逮捕，拘捕"
-        ],
-        "notation": "逮捕(たいほ)"
+        ]
     },
     {
         "name": "dairi",
         "trans": [
+            "代理(だいり)",
             "⓪ 名·他动3  代理，代替；代办"
-        ],
-        "notation": "代理(だいり)"
+        ]
     },
     {
         "name": "taeru",
         "trans": [
+            "耐(た)える",
             "② 自动2  忍耐，忍受；担负，承担；耐，对抗；值得"
-        ],
-        "notation": "耐(た)える"
+        ]
     },
     {
         "name": "shuugou",
         "trans": [
+            "集合(しゅうごう)",
             "⓪ 名·自他动3  集合"
-        ],
-        "notation": "集合(しゅうごう)"
+        ]
     },
     {
         "name": "shuushi",
         "trans": [
+            "収支(しゅうし)",
             "① 名  收支"
-        ],
-        "notation": "収支(しゅうし)"
+        ]
     },
     {
         "name": "ketsueki",
         "trans": [
+            "血液(けつえき)",
             "② 名  血液"
-        ],
-        "notation": "血液(けつえき)"
+        ]
     },
     {
         "name": "kekkan",
         "trans": [
+            "欠陥(けっかん)",
             "⓪ 名  缺点，缺陷"
-        ],
-        "notation": "欠陥(けっかん)"
+        ]
     },
     {
         "name": "shuuzen",
         "trans": [
+            "修繕(しゅうぜん)",
             "⓪ 名·他动3  修缮，修理"
-        ],
-        "notation": "修繕(しゅうぜん)"
+        ]
     },
     {
         "name": "shuuchaku",
         "trans": [
+            "終着(しゅうちゃく)",
             "⓪ 名  终点"
-        ],
-        "notation": "終着(しゅうちゃく)"
+        ]
     },
     {
         "name": "tairitsu",
         "trans": [
+            "対立(たいりつ)",
             "⓪ 名·自动3  对立，冲突"
-        ],
-        "notation": "対立(たいりつ)"
+        ]
     },
     {
         "name": "koushin",
         "trans": [
+            "更新(こうしん)",
             "⓪ 名·他动3  更新；刷新；革新"
-        ],
-        "notation": "更新(こうしん)"
+        ]
     },
     {
         "name": "ken'i",
         "trans": [
+            "権威(けんい)",
             "① 名  权威，威信，权势"
-        ],
-        "notation": "権威(けんい)"
+        ]
     },
     {
         "name": "tairyoku",
         "trans": [
+            "体力(たいりょく)",
             "① 名  体力"
-        ],
-        "notation": "体力(たいりょく)"
+        ]
     },
     {
         "name": "taue",
         "trans": [
+            "田植(たう)え",
             "③ 名  插秧"
-        ],
-        "notation": "田植(たう)え"
+        ]
     },
     {
         "name": "taeru",
         "trans": [
+            "絶(た)える",
             "② 自动2  断绝，终了；停止，消失"
-        ],
-        "notation": "絶(た)える"
+        ]
     },
     {
         "name": "shuutoku",
         "trans": [
+            "習得(しゅうとく)",
             "⓪ 名·他动3  习得，学习，学会"
-        ],
-        "notation": "習得(しゅうとく)"
+        ]
     },
     {
         "name": "keishi",
         "trans": [
+            "軽視(けいし)",
             "① 名·他动3  轻视，蔑视"
-        ],
-        "notation": "軽視(けいし)"
+        ]
     },
     {
         "name": "shuushoku",
         "trans": [
+            "修飾(しゅうしょく)",
             "⓪ 名·他动3  修饰，装饰"
-        ],
-        "notation": "修飾(しゅうしょく)"
+        ]
     },
     {
         "name": "keii",
         "trans": [
+            "敬意(けいい)",
             "① 名  敬意"
-        ],
-        "notation": "敬意(けいい)"
+        ]
     },
     {
         "name": "fuuryoku",
         "trans": [
+            "風力(ふうりょく)",
             "① 名  风力，风速"
-        ],
-        "notation": "風力(ふうりょく)"
+        ]
     },
     {
         "name": "kei",
         "trans": [
+            "計(けい)",
             "① 名  合计，总计；计划，打算"
-        ],
-        "notation": "計(けい)"
+        ]
     },
     {
         "name": "keiki",
         "trans": [
+            "契機(けいき)",
             "① 名  契机"
-        ],
-        "notation": "契機(けいき)"
+        ]
     },
     {
         "name": "geri",
         "trans": [
+            "下痢(げり)",
             "⓪ 名·自动3  腹泻，拉肚子"
-        ],
-        "notation": "下痢(げり)"
+        ]
     },
     {
         "name": "taisei",
         "trans": [
+            "体制(たいせい)",
             "⓪ 名  体制，体系"
-        ],
-        "notation": "体制(たいせい)"
+        ]
     },
     {
         "name": "juugyouin",
         "trans": [
+            "従業員(じゅうぎょういん)",
             "③ 名  工作人员，职员"
-        ],
-        "notation": "従業員(じゅうぎょういん)"
+        ]
     },
     {
         "name": "shuukei",
         "trans": [
+            "集計(しゅうけい)",
             "⓪ 名·他动3  总计，合计"
-        ],
-        "notation": "集計(しゅうけい)"
+        ]
     },
     {
         "name": "koushuu",
         "trans": [
+            "講習(こうしゅう)",
             "⓪ 名·他动3  讲习，学习"
-        ],
-        "notation": "講習(こうしゅう)"
+        ]
     },
     {
         "name": "keikoku",
         "trans": [
+            "警告(けいこく)",
             "⓪ 名·自他动3  警告"
-        ],
-        "notation": "警告(けいこく)"
+        ]
     },
     {
         "name": "juufuku/choufuku",
         "trans": [
+            "重複(じゅうふく/ちょうふく)",
             "⓪ 名·自动3  重复"
-        ],
-        "notation": "重複(じゅうふく/ちょうふく)"
+        ]
     },
     {
         "name": "taisen",
         "trans": [
+            "対戦(たいせん)",
             "⓪ 名·自动3  对战，竞赛，交锋"
-        ],
-        "notation": "対戦(たいせん)"
+        ]
     },
     {
         "name": "shugi",
         "trans": [
+            "主義(しゅぎ)",
             "① 名  主义；主张"
-        ],
-        "notation": "主義(しゅぎ)"
+        ]
     },
     {
         "name": "taishou",
         "trans": [
+            "対照(たいしょう)",
             "⓪ 名·他动3  对照，对比"
-        ],
-        "notation": "対照(たいしょう)"
+        ]
     },
     {
         "name": "kunren",
         "trans": [
+            "訓練(くんれん)",
             "① 名·他动3  训练"
-        ],
-        "notation": "訓練(くんれん)"
+        ]
     },
     {
         "name": "ketsuatsu",
         "trans": [
+            "血圧(けつあつ)",
             "⓪ 名  血压"
-        ],
-        "notation": "血圧(けつあつ)"
+        ]
     },
     {
         "name": "daishou",
         "trans": [
+            "大小(だいしょう)",
             "① 名  大小"
-        ],
-        "notation": "大小(だいしょう)"
+        ]
     },
     {
         "name": "keiji",
         "trans": [
+            "刑事(けいじ)",
             "① 名  刑警；适用刑法的事项，刑事"
-        ],
-        "notation": "刑事(けいじ)"
+        ]
     },
     {
         "name": "dakishimeru",
         "trans": [
+            "抱(だ)き締(し)める",
             "④ 他动2  抱紧，拥抱，相拥"
-        ],
-        "notation": "抱(だ)き締(し)める"
+        ]
     },
     {
         "name": "tashutayou",
         "trans": [
+            "多種多様(たしゅたよう)",
             "① 名·ナ形  多种多样，各式各样，形形色色"
-        ],
-        "notation": "多種多様(たしゅたよう)"
+        ]
     },
     {
         "name": "tasuu",
         "trans": [
+            "多数(たすう)",
             "② 名  多数；多数人"
-        ],
-        "notation": "多数(たすう)"
+        ]
     },
     {
         "name": "tadasu",
         "trans": [
+            "正(ただ)す",
             "② 他动1  改正，订正；端正；矫正"
-        ],
-        "notation": "正(ただ)す"
+        ]
     },
     {
         "name": "keizoku",
         "trans": [
+            "継続(けいぞく)",
             "⓪ 名·自他动3  继续，连续"
-        ],
-        "notation": "継続(けいぞく)"
+        ]
     },
     {
         "name": "keido",
         "trans": [
+            "経度(けいど)",
             "① 名  经度"
-        ],
-        "notation": "経度(けいど)"
+        ]
     },
     {
         "name": "daijin",
         "trans": [
+            "大臣(だいじん)",
             "① 名  大臣，部长；国务大臣"
-        ],
-        "notation": "大臣(だいじん)"
+        ]
     },
     {
         "name": "gekidan",
         "trans": [
+            "劇団(げきだん)",
             "⓪ 名  剧团"
-        ],
-        "notation": "劇団(げきだん)"
+        ]
     },
     {
         "name": "keshikaran",
         "trans": [
+            "けしからん",
             " ④ 连语  不像话，岂有此理"
-        ],
-        "notation": "けしからん"
+        ]
     },
     {
         "name": "suppai",
         "trans": [
+            "酸(す)っぱい",
             "③ イ形  酸的"
-        ],
-        "notation": "酸(す)っぱい"
+        ]
     },
     {
         "name": "tachidomaru",
         "trans": [
+            "立(た)ち止(ど)まる",
             "④ 自动1  站住，停下，止步"
-        ],
-        "notation": "立(た)ち止(ど)まる"
+        ]
     },
     {
         "name": "kacchiri",
         "trans": [
+            "かっちり",
             " ③ 副·自动3  紧密，严实，严丝合缝"
-        ],
-        "notation": "かっちり"
+        ]
     },
     {
         "name": "gekigen",
         "trans": [
+            "激減(げきげん)",
             "⓪ 名·自动3  骤减，锐减"
-        ],
-        "notation": "激減(げきげん)"
+        ]
     },
     {
         "name": "teiki",
         "trans": [
+            "定期(ていき)",
             "① 名  定期；一定的期限"
-        ],
-        "notation": "定期(ていき)"
+        ]
     },
     {
         "name": "naderu",
         "trans": [
+            "撫(な)でる",
             "② 他动2  抚摸；安抚，抚慰"
-        ],
-        "notation": "撫(な)でる"
+        ]
     },
     {
         "name": "abareru",
         "trans": [
+            "暴(あば)れる",
             "⓪ 自动2  乱闹；闯荡，大胆行动"
-        ],
-        "notation": "暴(あば)れる"
+        ]
     },
     {
         "name": "sawagashii",
         "trans": [
+            "騒(さわ)がしい",
             "④ イ形  嘈杂的，吵闹的，喧闹的"
-        ],
-        "notation": "騒(さわ)がしい"
+        ]
     },
     {
         "name": "ketsugi",
         "trans": [
+            "決議(けつぎ)",
             "① 名·他动3  决议，决定"
-        ],
-        "notation": "決議(けつぎ)"
+        ]
     },
     {
         "name": "kekkou",
         "trans": [
+            "決行(けっこう)",
             "⓪ 名·他动3  照常进行，断然执行"
-        ],
-        "notation": "決行(けっこう)"
+        ]
     },
     {
         "name": "taiguu",
         "trans": [
+            "待遇(たいぐう)",
             "⓪ 名·他动3  待遇，报酬；接待，对待"
-        ],
-        "notation": "待遇(たいぐう)"
+        ]
     },
     {
         "name": "tagayasu",
         "trans": [
+            "耕(たがや)す",
             "③ 他动1  耕，耕作"
-        ],
-        "notation": "耕(たがや)す"
+        ]
     },
     {
         "name": "dakaratoitte",
         "trans": [
+            "だからと言(い)って",
             "① 接续  虽说……但是……"
-        ],
-        "notation": "だからと言(い)って"
+        ]
     },
     {
         "name": "tachinaoru",
         "trans": [
+            "立(た)ち直(なお)る",
             "④ 自动1  恢复，复原；（经济形势）好转，回升"
-        ],
-        "notation": "立(た)ち直(なお)る"
+        ]
     },
     {
         "name": "tachimachi",
         "trans": [
+            "たちまち",
             " ⓪ 副  立刻，马上；突然，忽然"
-        ],
-        "notation": "たちまち"
+        ]
     },
     {
         "name": "keitou",
         "trans": [
+            "系統(けいとう)",
             "⓪ 名  系统；体系"
-        ],
-        "notation": "系統(けいとう)"
+        ]
     },
     {
         "name": "geinou",
         "trans": [
+            "芸能(げいのう)",
             "⓪ 名  文艺，综艺；技艺，表演艺术"
-        ],
-        "notation": "芸能(げいのう)"
+        ]
     },
     {
         "name": "amayakasu",
         "trans": [
+            "甘(あま)やかす",
             "④ 他动1  姑息；娇惯，放任"
-        ],
-        "notation": "甘(あま)やかす"
+        ]
     },
     {
         "name": "gekizou",
         "trans": [
+            "激増(げきぞう)",
             "⓪ 名·自动3  激增，猛增"
-        ],
-        "notation": "激増(げきぞう)"
+        ]
     },
     {
         "name": "tatsujin",
         "trans": [
+            "達人(たつじん)",
             "⓪ 名  达人，高手，精通某方面的人"
-        ],
-        "notation": "達人(たつじん)"
+        ]
     },
     {
         "name": "tassuru",
         "trans": [
+            "達(たっ)する",
             "⓪ 自他动3  达到；完成；到达"
-        ],
-        "notation": "達(たっ)する"
+        ]
     },
     {
         "name": "taba",
         "trans": [
+            "束(たば)",
             "① 名  束，捆，把"
-        ],
-        "notation": "束(たば)"
+        ]
     },
     {
         "name": "kutsuu",
         "trans": [
+            "苦痛(くつう)",
             "⓪ 名  （肉体及精神上的）痛苦"
-        ],
-        "notation": "苦痛(くつう)"
+        ]
     },
     {
         "name": "kuttsukeru",
         "trans": [
+            "くっつける",
             " ④ 他动2  使靠近，使紧挨；拉拢；撮合"
-        ],
-        "notation": "くっつける"
+        ]
     },
     {
         "name": "kubun",
         "trans": [
+            "区分(くぶん)",
             "① 名·他动3  分开；分割，划分；分类"
-        ],
-        "notation": "区分(くぶん)"
+        ]
     },
     {
         "name": "kurushimeru",
         "trans": [
+            "苦(くる)しめる",
             "④ 他动2  使痛苦，折磨；使为难，使操心，使烦恼"
-        ],
-        "notation": "苦(くる)しめる"
+        ]
     },
     {
         "name": "tabidatsu",
         "trans": [
+            "旅立(たびだ)つ",
             "③ 自动1  启程，出发"
-        ],
-        "notation": "旅立(たびだ)つ"
+        ]
     },
     {
         "name": "tama",
         "trans": [
+            "玉(たま)",
             "② 名  球形物体；硬币；鸡蛋"
-        ],
-        "notation": "玉(たま)"
+        ]
     },
     {
         "name": "nikumu",
         "trans": [
+            "憎(にく)む",
             "② 他动1  憎恶，憎恨；厌恶"
-        ],
-        "notation": "憎(にく)む"
+        ]
     },
     {
         "name": "nigedasu",
         "trans": [
+            "逃(に)げ出(だ)す",
             "③ 自动1  逃走，逃跑，溜掉"
-        ],
-        "notation": "逃(に)げ出(だ)す"
+        ]
     },
     {
         "name": "kemui",
         "trans": [
+            "煙(けむ)い",
             "⓪ イ形  烟气呛人的；不易亲近的"
-        ],
-        "notation": "煙(けむ)い"
+        ]
     },
     {
         "name": "nisankatanso",
         "trans": [
+            "二酸化炭素(にさんかたんそ)",
             "⑤ 名  二氧化碳"
-        ],
-        "notation": "二酸化炭素(にさんかたんそ)"
+        ]
     },
     {
         "name": "nisemono",
         "trans": [
+            "偽物(にせもの)",
             "⓪ 名  假货，赝品"
-        ],
-        "notation": "偽物(にせもの)"
+        ]
     },
     {
         "name": "nikkune-mu",
         "trans": [
+            "ニックネーム",
             "④ 名  昵称；外号，绰号"
-        ],
-        "notation": "ニックネーム"
+        ]
     },
     {
         "name": "nikkou",
         "trans": [
+            "日光(にっこう)",
             "① 名  日光，阳光"
-        ],
-        "notation": "日光(にっこう)"
+        ]
     },
     {
         "name": "kotatsu",
         "trans": [
+            "こたつ",
             " ⓪ 名  被炉，暖炉"
-        ],
-        "notation": "こたつ"
+        ]
     },
     {
         "name": "kodawari",
         "trans": [
+            "拘(こだわ)り",
             "⓪ 名  拘泥；计较，在乎"
-        ],
-        "notation": "拘(こだわ)り"
+        ]
     },
     {
         "name": "gochagocha",
         "trans": [
+            "ごちゃごちゃ",
             " ① 副·ナ形·自动3  乱七八糟，凌乱，杂乱无章"
-        ],
-        "notation": "ごちゃごちゃ"
+        ]
     },
     {
         "name": "kotsu",
         "trans": [
+            "骨(こつ)",
             "② 名  骨头；要领，秘诀，窍门"
-        ],
-        "notation": "骨(こつ)"
+        ]
     },
     {
         "name": "kiyoi",
         "trans": [
+            "清(きよ)い",
             "② イ形  清澈的，干净的；纯洁的"
-        ],
-        "notation": "清(きよ)い"
+        ]
     },
     {
         "name": "kudoi",
         "trans": [
+            "くどい",
             " ② イ形  �唆的，喋喋不休的；味道浓的"
-        ],
-        "notation": "くどい"
+        ]
     },
     {
         "name": "kouun",
         "trans": [
+            "幸運(こううん)",
             "⓪ 名·ナ形  幸运，好运"
-        ],
-        "notation": "幸運(こううん)"
+        ]
     },
     {
         "name": "taru",
         "trans": [
+            "足(た)る",
             "⓪ 自动1  足够；值得；可以，够用"
-        ],
-        "notation": "足(た)る"
+        ]
     },
     {
         "name": "nanboku",
         "trans": [
+            "南北(なんぼく)",
             "① 名  南北"
-        ],
-        "notation": "南北(なんぼく)"
+        ]
     },
     {
         "name": "nanmon",
         "trans": [
+            "難問(なんもん)",
             "⓪ 名  难题，难以回答的问题"
-        ],
-        "notation": "難問(なんもん)"
+        ]
     },
     {
         "name": "teate",
         "trans": [
+            "手当(てあ)て",
             "① 名·他动3  津贴，补贴；医疗，治疗"
-        ],
-        "notation": "手当(てあ)て"
+        ]
     },
     {
         "name": "awatadashii",
         "trans": [
+            "慌(あわ)ただしい",
             "⑤ イ形  慌张的，匆忙的"
-        ],
-        "notation": "慌(あわ)ただしい"
+        ]
     },
     {
         "name": "nigasu",
         "trans": [
+            "逃(に)がす",
             "② 他动1  放跑；没有抓住；错过（机会）"
-        ],
-        "notation": "逃(に)がす"
+        ]
     },
     {
         "name": "tsukkomu",
         "trans": [
+            "突(つ)っ込(こ)む",
             "③ 自他动1  闯入；追究；投身于"
-        ],
-        "notation": "突(つ)っ込(こ)む"
+        ]
     },
     {
         "name": "tsutsumi",
         "trans": [
+            "包(つつ)み",
             "③ 名  包裹，包袱"
-        ],
-        "notation": "包(つつ)み"
+        ]
     },
     {
         "name": "chikaraduku",
         "trans": [
+            "力(ちから)づく",
             "④ 自动1  恢复体力；受到鼓舞"
-        ],
-        "notation": "力(ちから)づく"
+        ]
     },
     {
         "name": "tamatama",
         "trans": [
+            "たまたま",
             " ⓪ 副  偶然，无意中；偶尔，有时"
-        ],
-        "notation": "たまたま"
+        ]
     },
     {
         "name": "oogata",
         "trans": [
+            "大型(おおがた)",
             "⓪ 名·ナ形  大型"
-        ],
-        "notation": "大型(おおがた)"
+        ]
     },
     {
         "name": "kiyasui",
         "trans": [
+            "気安(きやす)い",
             "③ イ形  不客气的，不拘泥的，轻松的"
-        ],
-        "notation": "気安(きやす)い"
+        ]
     },
     {
         "name": "chanpion",
         "trans": [
+            "チャンピオン",
             "① 名  优胜者，冠军"
-        ],
-        "notation": "チャンピオン"
+        ]
     },
     {
         "name": "kousha",
         "trans": [
+            "後者(こうしゃ)",
             "① 名  后者"
-        ],
-        "notation": "後者(こうしゃ)"
+        ]
     },
     {
         "name": "chokusen",
         "trans": [
+            "直線(ちょくせん)",
             "⓪ 名  直线"
-        ],
-        "notation": "直線(ちょくせん)"
+        ]
     },
     {
         "name": "chiku",
         "trans": [
+            "地区(ちく)",
             "① 名  地区，地域"
-        ],
-        "notation": "地区(ちく)"
+        ]
     },
     {
         "name": "tsukiataru",
         "trans": [
+            "突(つ)き当(あ)たる",
             "④ 自动1  撞上，碰上；走到尽头；遇到（问题）"
-        ],
-        "notation": "突(つ)き当(あ)たる"
+        ]
     },
     {
         "name": "chikaraduyoi",
         "trans": [
+            "力強(ちからづよ)い",
             "⑤ イ形  强有力的，矫健的"
-        ],
-        "notation": "力強(ちからづよ)い"
+        ]
     },
     {
         "name": "channeru",
         "trans": [
+            "チャンネル",
             "⓪ 名  频道，波段；航道"
-        ],
-        "notation": "チャンネル"
+        ]
     },
     {
         "name": "tanjou",
         "trans": [
+            "誕生(たんじょう)",
             "⓪ 名·自动3  出生，诞生；成立，创办"
-        ],
-        "notation": "誕生(たんじょう)"
+        ]
     },
     {
         "name": "chika",
         "trans": [
+            "地下(ちか)",
             "① 名  地下；隐蔽的场所"
-        ],
-        "notation": "地下(ちか)"
+        ]
     },
     {
         "name": "chokuzen",
         "trans": [
+            "直前(ちょくぜん)",
             "⓪ 名  即将……之前；正前面"
-        ],
-        "notation": "直前(ちょくぜん)"
+        ]
     },
     {
         "name": "chokugo",
         "trans": [
+            "直後(ちょくご)",
             "① 名  刚……之后；正后面"
-        ],
-        "notation": "直後(ちょくご)"
+        ]
     },
     {
         "name": "chie",
         "trans": [
+            "知恵(ちえ)",
             "② 名  智慧；主意，办法"
-        ],
-        "notation": "知恵(ちえ)"
+        ]
     },
     {
         "name": "jitsurei",
         "trans": [
+            "実例(じつれい)",
             "⓪ 名  实例，实际的例子"
-        ],
-        "notation": "実例(じつれい)"
+        ]
     },
     {
         "name": "tansuu",
         "trans": [
+            "単数(たんすう)",
             "③ 名  单数"
-        ],
-        "notation": "単数(たんすう)"
+        ]
     },
     {
         "name": "chigaeru",
         "trans": [
+            "違(ちが)える",
             "⓪ 他动2  使不一样；弄错，搞错"
-        ],
-        "notation": "違(ちが)える"
+        ]
     },
     {
         "name": "tan'ni",
         "trans": [
+            "単(たん)に",
             "① 副  仅仅，只"
-        ],
-        "notation": "単(たん)に"
+        ]
     },
     {
         "name": "chuudoku",
         "trans": [
+            "中毒(ちゅうどく)",
             "① 名·自动3  中毒"
-        ],
-        "notation": "中毒(ちゅうどく)"
+        ]
     },
     {
         "name": "chirabaru",
         "trans": [
+            "散(ち)らばる",
             "⓪ 自动1  分散；散乱，零乱"
-        ],
-        "notation": "散(ち)らばる"
+        ]
     },
     {
         "name": "tansui",
         "trans": [
+            "淡水(たんすい)",
             "⓪ 名  淡水"
-        ],
-        "notation": "淡水(たんすい)"
+        ]
     },
     {
         "name": "tsuikyuu",
         "trans": [
+            "追求(ついきゅう)",
             "⓪ 名·他动3  追求，寻求"
-        ],
-        "notation": "追求(ついきゅう)"
+        ]
     },
     {
         "name": "tsuiyasu",
         "trans": [
+            "費(つい)やす",
             "③ 他动1  花费，耗费；浪费"
-        ],
-        "notation": "費(つい)やす"
+        ]
     },
     {
         "name": "tarento",
         "trans": [
+            "タレント",
             "⓪ 名  技能；艺人，演员"
-        ],
-        "notation": "タレント"
+        ]
     },
     {
         "name": "tan'itsu",
         "trans": [
+            "単一(たんいつ)",
             "⓪ 名·ナ形  单一；单独"
-        ],
-        "notation": "単一(たんいつ)"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "仮定(かてい)",
             "⓪ 名·自他动3  假定，假设"
-        ],
-        "notation": "仮定(かてい)"
+        ]
     },
     {
         "name": "tanshuku",
         "trans": [
+            "短縮(たんしゅく)",
             "⓪ 名·他动3  缩短，缩减"
-        ],
-        "notation": "短縮(たんしゅく)"
+        ]
     },
     {
         "name": "tsuujou",
         "trans": [
+            "通常(つうじょう)",
             "⓪ 名  通常，平常，普通，一般"
-        ],
-        "notation": "通常(つうじょう)"
+        ]
     },
     {
         "name": "tsue",
         "trans": [
+            "杖(つえ)",
             "① 名  拐杖；倚靠"
-        ],
-        "notation": "杖(つえ)"
+        ]
     },
     {
         "name": "tsukaiwake",
         "trans": [
+            "使(つか)い分(わ)け",
             "⓪ 名  区分使用；灵活运用"
-        ],
-        "notation": "使(つか)い分(わ)け"
+        ]
     },
     {
         "name": "teru",
         "trans": [
+            "照(て)る",
             "① 自动1  照耀，照射；放晴"
-        ],
-        "notation": "照(て)る"
+        ]
     },
     {
         "name": "tenkai",
         "trans": [
+            "展開(てんかい)",
             "⓪ 名·自他动3  开展，展开；展现"
-        ],
-        "notation": "展開(てんかい)"
+        ]
     },
     {
         "name": "tsukuduku",
         "trans": [
+            "つくづく",
             " ③ 副  仔细地；痛切，深切感到"
-        ],
-        "notation": "つくづく"
+        ]
     },
     {
         "name": "tsuduki",
         "trans": [
+            "続(つづ)き",
             "⓪ 名  后续，接续；连续，接连不断"
-        ],
-        "notation": "続(つづ)き"
+        ]
     },
     {
         "name": "oujiru",
         "trans": [
+            "応(おう)じる",
             "⓪ 自动2  响应，接受；答应；按照，根据"
-        ],
-        "notation": "応(おう)じる"
+        ]
     },
     {
         "name": "ourai",
         "trans": [
+            "往来(おうらい)",
             "⓪ 名·自动3  往来，通行；交际，来往"
-        ],
-        "notation": "往来(おうらい)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "努(つと)める",
             "③ 自动2  努力，尽力；效劳，效力"
-        ],
-        "notation": "努(つと)める"
+        ]
     },
     {
         "name": "tsuna",
         "trans": [
+            "綱(つな)",
             "② 名  绳索；命脉"
-        ],
-        "notation": "綱(つな)"
+        ]
     },
     {
         "name": "outou",
         "trans": [
+            "応答(おうとう)",
             "⓪ 名·自动3  应答，应对"
-        ],
-        "notation": "応答(おうとう)"
+        ]
     },
     {
         "name": "tetsugaku",
         "trans": [
+            "哲学(てつがく)",
             "② 名  哲学；人生观，世界观"
-        ],
-        "notation": "哲学(てつがく)"
+        ]
     },
     {
         "name": "shuui",
         "trans": [
+            "周囲(しゅうい)",
             "① 名  四周；外界，环境"
-        ],
-        "notation": "周囲(しゅうい)"
+        ]
     },
     {
         "name": "chuuou",
         "trans": [
+            "中央(ちゅうおう)",
             "③ 名  中央；中枢"
-        ],
-        "notation": "中央(ちゅうおう)"
+        ]
     },
     {
         "name": "kounin",
         "trans": [
+            "公認(こうにん)",
             "⓪ 名·他动3  公认，正式承认"
-        ],
-        "notation": "公認(こうにん)"
+        ]
     },
     {
         "name": "tsukiru",
         "trans": [
+            "尽(つ)きる",
             "② 自动2  用光，穷尽；完了，结束"
-        ],
-        "notation": "尽(つ)きる"
+        ]
     },
     {
         "name": "tsukusu",
         "trans": [
+            "尽(つ)くす",
             "② 他动1  尽力；效力；达到极点"
-        ],
-        "notation": "尽(つ)くす"
+        ]
     },
     {
         "name": "gaikai",
         "trans": [
+            "外界(がいかい)",
             "⓪ 名  外界，外部"
-        ],
-        "notation": "外界(がいかい)"
+        ]
     },
     {
         "name": "dorei",
         "trans": [
+            "奴隷(どれい)",
             "⓪ 名  奴隶，被某种东西束缚的人"
-        ],
-        "notation": "奴隷(どれい)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "務(つと)める",
             "③ 他动2  担任……职务；起……作用"
-        ],
-        "notation": "務(つと)める"
+        ]
     },
     {
         "name": "sentou",
         "trans": [
+            "戦闘(せんとう)",
             "⓪ 名·自动3  战斗"
-        ],
-        "notation": "戦闘(せんとう)"
+        ]
     },
     {
         "name": "terikaesu",
         "trans": [
+            "照(て)り返(かえ)す",
             "③ 他动1  反射，反照"
-        ],
-        "notation": "照(て)り返(かえ)す"
+        ]
     },
     {
         "name": "tenkan",
         "trans": [
+            "転換(てんかん)",
             "⓪ 名·自他动3  转换；转变"
-        ],
-        "notation": "転換(てんかん)"
+        ]
     },
     {
         "name": "denki",
         "trans": [
+            "伝記(でんき)",
             "⓪ 名  传，传记"
-        ],
-        "notation": "伝記(でんき)"
+        ]
     },
     {
         "name": "chuushouteki",
         "trans": [
+            "抽象的(ちゅうしょうてき)",
             "⓪ ナ形  抽象的"
-        ],
-        "notation": "抽象的(ちゅうしょうてき)"
+        ]
     },
     {
         "name": "chuusei",
         "trans": [
+            "中性(ちゅうせい)",
             "⓪ 名  中性"
-        ],
-        "notation": "中性(ちゅうせい)"
+        ]
     },
     {
         "name": "tsutomesaki",
         "trans": [
+            "勤(つと)め先(さき)",
             "⓪ 名  工作单位，工作地点"
-        ],
-        "notation": "勤(つと)め先(さき)"
+        ]
     },
     {
         "name": "chakuchaku",
         "trans": [
+            "着々(ちゃくちゃく)",
             "⓪ 副  进展顺利；稳扎稳打"
-        ],
-        "notation": "着々(ちゃくちゃく)"
+        ]
     },
     {
         "name": "ochitsuki",
         "trans": [
+            "落(お)ち着(つ)き",
             "⓪ 名  沉着，镇静；稳定"
-        ],
-        "notation": "落(お)ち着(つ)き"
+        ]
     },
     {
         "name": "juyou",
         "trans": [
+            "受容(じゅよう)",
             "⓪ 名·他动3  容纳，接受；鉴赏"
-        ],
-        "notation": "受容(じゅよう)"
+        ]
     },
     {
         "name": "kaikan",
         "trans": [
+            "快感(かいかん)",
             "⓪ 名  快感，感觉愉快"
-        ],
-        "notation": "快感(かいかん)"
+        ]
     },
     {
         "name": "sai",
         "trans": [
+            "差異(さい)",
             "① 名  差异，差别"
-        ],
-        "notation": "差異(さい)"
+        ]
     },
     {
         "name": "yuugi",
         "trans": [
+            "遊戯(ゆうぎ)",
             "① 名·自动3  玩耍，游戏"
-        ],
-        "notation": "遊戯(ゆうぎ)"
+        ]
     },
     {
         "name": "chosha",
         "trans": [
+            "著者(ちょしゃ)",
             "① 名  著者，作者"
-        ],
-        "notation": "著者(ちょしゃ)"
+        ]
     },
     {
         "name": "chokkaku",
         "trans": [
+            "直角(ちょっかく)",
             "⓪ 名  直角"
-        ],
-        "notation": "直角(ちょっかく)"
+        ]
     },
     {
         "name": "dan'yuu",
         "trans": [
+            "男優(だんゆう)",
             "⓪ 名  男演员"
-        ],
-        "notation": "男優(だんゆう)"
+        ]
     },
     {
         "name": "danryoku",
         "trans": [
+            "弾力(だんりょく)",
             "⓪ 名  弹力；弹性"
-        ],
-        "notation": "弾力(だんりょく)"
+        ]
     },
     {
         "name": "chuutai",
         "trans": [
+            "中退(ちゅうたい)",
             "⓪ 名·自动3  中途退学"
-        ],
-        "notation": "中退(ちゅうたい)"
+        ]
     },
     {
         "name": "chii",
         "trans": [
+            "地位(ちい)",
             "① 名  地位；身份，职位"
-        ],
-        "notation": "地位(ちい)"
+        ]
     },
     {
         "name": "charenji",
         "trans": [
+            "チャレンジ",
             "② 名·自动3  挑战"
-        ],
-        "notation": "チャレンジ"
+        ]
     },
     {
         "name": "kinshitsu",
         "trans": [
+            "均質(きんしつ)",
             "⓪ 名·ナ形  均质，等质，均匀"
-        ],
-        "notation": "均質(きんしつ)"
+        ]
     },
     {
         "name": "appu",
         "trans": [
+            "アップ",
             "① 名·自他动3  增高，提高"
-        ],
-        "notation": "アップ"
+        ]
     },
     {
         "name": "iten",
         "trans": [
+            "移転(いてん)",
             "⓪ 名·自他动3  迁移，搬家；转移"
-        ],
-        "notation": "移転(いてん)"
+        ]
     },
     {
         "name": "inori",
         "trans": [
+            "祈(いの)り",
             "③ 名  祈祷，祷告"
-        ],
-        "notation": "祈(いの)り"
+        ]
     },
     {
         "name": "ibaru",
         "trans": [
+            "威張(いば)る",
             "② 自动1  嚣张，自吹自擂，摆架子"
-        ],
-        "notation": "威張(いば)る"
+        ]
     },
     {
         "name": "imaichi",
         "trans": [
+            "いまいち",
             " ② 副  差一点儿，再加把劲儿"
-        ],
-        "notation": "いまいち"
+        ]
     },
     {
         "name": "oidasu",
         "trans": [
+            "追(お)い出(だ)す",
             "③ 他动1  赶出，驱赶；解雇"
-        ],
-        "notation": "追(お)い出(だ)す"
+        ]
     },
     {
         "name": "oinuku",
         "trans": [
+            "追(お)い抜(ぬ)く",
             "③ 他动1  赶过，超过；胜出，胜过"
-        ],
-        "notation": "追(お)い抜(ぬ)く"
+        ]
     },
     {
         "name": "ookutomo",
         "trans": [
+            "多(おお)くとも",
             "① 副  顶多，最多"
-        ],
-        "notation": "多(おお)くとも"
+        ]
     },
     {
         "name": "tsumikasaneru",
         "trans": [
+            "積(つ)み重(かさ)ねる",
             "⑤ 他动2  堆起来，垒起来；积累，继续"
-        ],
-        "notation": "積(つ)み重(かさ)ねる"
+        ]
     },
     {
         "name": "tsunageru",
         "trans": [
+            "繋(つな)げる",
             "⓪ 他动2  系，拴；接上，连上"
-        ],
-        "notation": "繋(つな)げる"
+        ]
     },
     {
         "name": "chidimaru",
         "trans": [
+            "縮(ちぢ)まる",
             "⓪ 自动1  收缩，缩小；畏缩，恐惧"
-        ],
-        "notation": "縮(ちぢ)まる"
+        ]
     },
     {
         "name": "osore",
         "trans": [
+            "恐(おそ)れ",
             "③ 名  畏惧，害怕；担心，忧虑"
-        ],
-        "notation": "恐(おそ)れ"
+        ]
     },
     {
         "name": "ochikomu",
         "trans": [
+            "落(お)ち込(こ)む",
             "⓪ 自动1  掉入，坠入；（情绪）低落；下陷，塌陷"
-        ],
-        "notation": "落(お)ち込(こ)む"
+        ]
     },
     {
         "name": "chuuzai",
         "trans": [
+            "駐在(ちゅうざい)",
             "⓪ 名·自动3  驻扎"
-        ],
-        "notation": "駐在(ちゅうざい)"
+        ]
     },
     {
         "name": "henzai",
         "trans": [
+            "遍在(へんざい)",
             "⓪ 名·自动3  普遍存在，遍及"
-        ],
-        "notation": "遍在(へんざい)"
+        ]
     },
     {
         "name": "shigeru",
         "trans": [
+            "茂(しげ)る",
             "② 自动1  （植物）繁茂，茂盛"
-        ],
-        "notation": "茂(しげ)る"
+        ]
     },
     {
         "name": "nitsumeru",
         "trans": [
+            "煮詰(につ)める",
             "③ 他动2  煮干；归纳，得出结论"
-        ],
-        "notation": "煮詰(につ)める"
+        ]
     },
     {
         "name": "nentou",
         "trans": [
+            "念頭(ねんとう)",
             "⓪ 名  心上，心头"
-        ],
-        "notation": "念頭(ねんとう)"
+        ]
     },
     {
         "name": "chouten",
         "trans": [
+            "頂点(ちょうてん)",
             "① 名  顶点；最高处；顶峰"
-        ],
-        "notation": "頂点(ちょうてん)"
+        ]
     },
     {
         "name": "ikkan",
         "trans": [
+            "一貫(いっかん)",
             "⓪ 名·自他动3  一贯，自始至终，始终如一"
-        ],
-        "notation": "一貫(いっかん)"
+        ]
     },
     {
         "name": "sengen",
         "trans": [
+            "宣言(せんげん)",
             "③ 名·他动3  宣布，宣言，宣告"
-        ],
-        "notation": "宣言(せんげん)"
+        ]
     },
     {
         "name": "tetteiteki",
         "trans": [
+            "徹底的(てっていてき)",
             "⓪ ナ形  彻底的"
-        ],
-        "notation": "徹底的(てっていてき)"
+        ]
     },
     {
         "name": "osameru",
         "trans": [
+            "納(おさ)める",
             "③ 他动2  缴纳；供应；结束"
-        ],
-        "notation": "納(おさ)める"
+        ]
     },
     {
         "name": "osamaru",
         "trans": [
+            "収(おさ)まる",
             "③ 自动1  收纳，容纳；恢复"
-        ],
-        "notation": "収(おさ)まる"
+        ]
     },
     {
         "name": "tenuki",
         "trans": [
+            "手抜(てぬ)き",
             "⓪ 名·自他动3  偷懒；偷工减料"
-        ],
-        "notation": "手抜(てぬ)き"
+        ]
     },
     {
         "name": "tenkei",
         "trans": [
+            "典型(てんけい)",
             "⓪ 名  典型；模范"
-        ],
-        "notation": "典型(てんけい)"
+        ]
     },
     {
         "name": "oozappa",
         "trans": [
+            "おおざっぱ",
             " ③ ナ形  粗枝大叶的；粗略的；粗心大意的"
-        ],
-        "notation": "おおざっぱ"
+        ]
     },
     {
         "name": "oomizu",
         "trans": [
+            "大水(おおみず)",
             "③ 名  大水，洪水"
-        ],
-        "notation": "大水(おおみず)"
+        ]
     },
     {
         "name": "okimari",
         "trans": [
+            "お決(き)まり",
             "⓪ 名  常规，惯例，老一套"
-        ],
-        "notation": "お決(き)まり"
+        ]
     },
     {
         "name": "sokosoko",
         "trans": [
+            "そこそこ",
             " ② 副·接尾  草草了事，匆匆忙忙；左右，大约"
-        ],
-        "notation": "そこそこ"
+        ]
     },
     {
         "name": "densetsu",
         "trans": [
+            "伝説(でんせつ)",
             "⓪ 名  传说"
-        ],
-        "notation": "伝説(でんせつ)"
+        ]
     },
     {
         "name": "oseji",
         "trans": [
+            "お世辞(せじ)",
             "⓪ 名  奉承话，恭维话"
-        ],
-        "notation": "お世辞(せじ)"
+        ]
     },
     {
         "name": "osou",
         "trans": [
+            "襲(おそ)う",
             "⓪ 他动1  袭击，侵袭；继承"
-        ],
-        "notation": "襲(おそ)う"
+        ]
     },
     {
         "name": "darashinai",
         "trans": [
+            "だらしない",
             " ④ イ形  放荡的，散漫的，吊儿郎当的；没出息的，不争气的"
-        ],
-        "notation": "だらしない"
+        ]
     },
     {
         "name": "chitsujo",
         "trans": [
+            "秩序(ちつじょ)",
             "① 名  秩序；条理"
-        ],
-        "notation": "秩序(ちつじょ)"
+        ]
     },
     {
         "name": "chiheisen",
         "trans": [
+            "地平線(ちへいせん)",
             "⓪ 名  地平线"
-        ],
-        "notation": "地平線(ちへいせん)"
+        ]
     },
     {
         "name": "tenten",
         "trans": [
+            "点々(てんてん)",
             "⓪ 副  星星点点；断断续续"
-        ],
-        "notation": "点々(てんてん)"
+        ]
     },
     {
         "name": "denryoku",
         "trans": [
+            "電力(でんりょく)",
             "① 名  电，电力"
-        ],
-        "notation": "電力(でんりょく)"
+        ]
     },
     {
         "name": "do",
         "trans": [
+            "度(ど)",
             "⓪ 名  尺度，程度；温度；次数"
-        ],
-        "notation": "度(ど)"
+        ]
     },
     {
         "name": "tou",
         "trans": [
+            "問(と)う",
             "① 他动1  问，打听；问候；征询；当作问题；追究 "
-        ],
-        "notation": "問(と)う"
+        ]
     },
     {
         "name": "amu",
         "trans": [
+            "編(あ)む",
             "① 他动1  编，编织；编纂"
-        ],
-        "notation": "編(あ)む"
+        ]
     },
     {
         "name": "ninja",
         "trans": [
+            "忍者(にんじゃ)",
             "① 名  忍者"
-        ],
-        "notation": "忍者(にんじゃ)"
+        ]
     },
     {
         "name": "doui",
         "trans": [
+            "同意(どうい)",
             "⓪ 名·自动3  同意，赞成"
-        ],
-        "notation": "同意(どうい)"
+        ]
     },
     {
         "name": "tsukekuwaeru",
         "trans": [
+            "付(つ)け加(くわ)える",
             "⑤ 他动2  补充，添加"
-        ],
-        "notation": "付(つ)け加(くわ)える"
+        ]
     },
     {
         "name": "shikataganai",
         "trans": [
+            "仕方(しかた)がない",
             "⑤ イ形  没有办法的；受不了的；不像话的"
-        ],
-        "notation": "仕方(しかた)がない"
+        ]
     },
     {
         "name": "denpa",
         "trans": [
+            "電波(でんぱ)",
             "① 名  电波"
-        ],
-        "notation": "電波(でんぱ)"
+        ]
     },
     {
         "name": "ten'nou",
         "trans": [
+            "天皇(てんのう)",
             "③ 名  天皇"
-        ],
-        "notation": "天皇(てんのう)"
+        ]
     },
     {
         "name": "tanchou",
         "trans": [
+            "単調(たんちょう)",
             "⓪ 名·ナ形  单调，平庸，无变化"
-        ],
-        "notation": "単調(たんちょう)"
+        ]
     },
     {
         "name": "tan'naru",
         "trans": [
+            "単(たん)なる",
             "① 连体  仅仅，只不过"
-        ],
-        "notation": "単(たん)なる"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "着(つ)ける",
             "② 他动2  穿，戴；（船）靠拢；入席"
-        ],
-        "notation": "着(つ)ける"
+        ]
     },
     {
         "name": "teburi",
         "trans": [
+            "手(て)ぶり",
             "① 名  手势，手的动作"
-        ],
-        "notation": "手(て)ぶり"
+        ]
     },
     {
         "name": "tenkin",
         "trans": [
+            "転勤(てんきん)",
             "⓪ 名·自动3  调动工作"
-        ],
-        "notation": "転勤(てんきん)"
+        ]
     },
     {
         "name": "touitsu",
         "trans": [
+            "統一(とういつ)",
             "⓪ 名·他动3  统一；集中；一致"
-        ],
-        "notation": "統一(とういつ)"
+        ]
     },
     {
         "name": "tanima",
         "trans": [
+            "谷間(たにま)",
             "⓪ 名  山涧，峡谷"
-        ],
-        "notation": "谷間(たにま)"
+        ]
     },
     {
         "name": "shoppai",
         "trans": [
+            "しょっぱい",
             " ③ イ形  咸的；小气的；为难的"
-        ],
-        "notation": "しょっぱい"
+        ]
     },
     {
         "name": "ichibetsu",
         "trans": [
+            "一瞥(いちべつ)",
             "⓪ 名·他动3  一瞥，看一眼"
-        ],
-        "notation": "一瞥(いちべつ)"
+        ]
     },
     {
         "name": "hounin",
         "trans": [
+            "放任(ほうにん)",
             "⓪ 名·他动3  放任，放任不管"
-        ],
-        "notation": "放任(ほうにん)"
+        ]
     },
     {
         "name": "senshoku",
         "trans": [
+            "染色(せんしょく)",
             "⓪ 名·自他动3  染色，上色"
-        ],
-        "notation": "染色(せんしょく)"
+        ]
     },
     {
         "name": "shibou",
         "trans": [
+            "脂肪(しぼう)",
             "⓪ 名  脂肪"
-        ],
-        "notation": "脂肪(しぼう)"
+        ]
     },
     {
         "name": "shijin",
         "trans": [
+            "詩人(しじん)",
             "⓪ 名  诗人；洞察力强的人，敏感的人"
-        ],
-        "notation": "詩人(しじん)"
+        ]
     },
     {
         "name": "shimijimi",
         "trans": [
+            "しみじみ",
             " ③ 副  深切地；恳切地；仔细地"
-        ],
-        "notation": "しみじみ"
+        ]
     },
     {
         "name": "kougei",
         "trans": [
+            "工芸(こうげい)",
             "⓪ 名  工艺，工艺制作"
-        ],
-        "notation": "工芸(こうげい)"
+        ]
     },
     {
         "name": "geinoujin",
         "trans": [
+            "芸能人(げいのうじん)",
             "③ 名  艺人，文艺工作者"
-        ],
-        "notation": "芸能人(げいのうじん)"
+        ]
     },
     {
         "name": "jimen",
         "trans": [
+            "地面(じめん)",
             "① 名  地面，地上；土地 "
-        ],
-        "notation": "地面(じめん)"
+        ]
     },
     {
         "name": "unazuku",
         "trans": [
+            "うなずく",
             " ③ 自动1  点头，首肯"
-        ],
-        "notation": "うなずく"
+        ]
     },
     {
         "name": "jakuten",
         "trans": [
+            "弱点(じゃくてん)",
             "③ 名  弱点；缺点，短处"
-        ],
-        "notation": "弱点(じゃくてん)"
+        ]
     },
     {
         "name": "shinan",
         "trans": [
+            "指南(しなん)",
             "① 名·他动3  教导，指示"
-        ],
-        "notation": "指南(しなん)"
+        ]
     },
     {
         "name": "abaraya",
         "trans": [
+            "あばら家(や)",
             "③ 名  破屋子；（自谦）寒舍"
-        ],
-        "notation": "あばら家(や)"
+        ]
     },
     {
         "name": "shirajirashii",
         "trans": [
+            "白々しい(しらじらしい)",
             "⑤ イ形  显而易见的，瞒不了人的；假装不解的"
-        ],
-        "notation": "白々しい(しらじらしい)"
+        ]
     },
     {
         "name": "senren",
         "trans": [
+            "洗練(せんれん)",
             "⓪ 名·他动3  洗练，精炼，千锤百炼；讲究，考究"
-        ],
-        "notation": "洗練(せんれん)"
+        ]
     },
     {
         "name": "jisetsu",
         "trans": [
+            "時節(じせつ)",
             "① 名  时节，时令；时机，机会"
-        ],
-        "notation": "時節(じせつ)"
+        ]
     },
     {
         "name": "gyakkyou",
         "trans": [
+            "逆境(ぎゃっきょう)",
             "⓪ 名  逆境"
-        ],
-        "notation": "逆境(ぎゃっきょう)"
+        ]
     },
     {
         "name": "shasei",
         "trans": [
+            "写生(しゃせい)",
             "⓪ 名·他动3  写生，速写"
-        ],
-        "notation": "写生(しゃせい)"
+        ]
     },
     {
         "name": "jittai",
         "trans": [
+            "実態(じったい)",
             "⓪ 名  实际状态，真实情况"
-        ],
-        "notation": "実態(じったい)"
+        ]
     },
     {
         "name": "orosu",
         "trans": [
+            "卸(おろ)す",
             "② 他动1  批发，批售"
-        ],
-        "notation": "卸(おろ)す"
+        ]
     },
     {
         "name": "yakkai",
         "trans": [
+            "やっかい",
             " ① 名·ナ形  麻烦，棘手；照顾，照料"
-        ],
-        "notation": "やっかい"
+        ]
     },
     {
         "name": "tourai",
         "trans": [
+            "到来(とうらい)",
             "⓪ 名·自动3  来到；（别人）送来"
-        ],
-        "notation": "到来(とうらい)"
+        ]
     },
     {
         "name": "saguru",
         "trans": [
+            "探(さぐ)る",
             "⓪ 他动1  摸，探；试探；探求"
-        ],
-        "notation": "探(さぐ)る"
+        ]
     },
     {
         "name": "jitsubutsu",
         "trans": [
+            "実物(じつぶつ)",
             "⓪ 名  实物，实在的东西；现货"
-        ],
-        "notation": "実物(じつぶつ)"
+        ]
     },
     {
         "name": "shakkuri",
         "trans": [
+            "しゃっくり",
             " ① 名·自动3  打嗝儿"
-        ],
-        "notation": "しゃっくり"
+        ]
     },
     {
         "name": "kika",
         "trans": [
+            "帰化(きか)",
             "① 名·自动3  入籍；（生物）适应水土"
-        ],
-        "notation": "帰化(きか)"
+        ]
     },
     {
         "name": "shadou",
         "trans": [
+            "車道(しゃどう)",
             "⓪ 名  车道，车行道"
-        ],
-        "notation": "車道(しゃどう)"
+        ]
     },
     {
         "name": "kakujitsu",
         "trans": [
+            "確実(かくじつ)",
             "⓪ 名·ナ形  准确，确凿；可靠"
-        ],
-        "notation": "確実(かくじつ)"
+        ]
     },
     {
         "name": "shutsugen",
         "trans": [
+            "出現(しゅつげん)",
             "⓪ 名·自动3  出现"
-        ],
-        "notation": "出現(しゅつげん)"
+        ]
     },
     {
         "name": "an'i",
         "trans": [
+            "安易(あんい)",
             "① 名·ナ形  容易，简单；安逸"
-        ],
-        "notation": "安易(あんい)"
+        ]
     },
     {
         "name": "jutsugo",
         "trans": [
+            "述語(じゅつご)",
             "⓪ 名  谓语"
-        ],
-        "notation": "述語(じゅつご)"
+        ]
     },
     {
         "name": "sonsuu",
         "trans": [
+            "尊崇(そんすう)",
             "⓪ 名·他动3  尊崇，尊敬"
-        ],
-        "notation": "尊崇(そんすう)"
+        ]
     },
     {
         "name": "kyouri",
         "trans": [
+            "郷里(きょうり)",
             "① 名  乡里，故乡"
-        ],
-        "notation": "郷里(きょうり)"
+        ]
     },
     {
         "name": "kuyamu",
         "trans": [
+            "悔(く)やむ",
             "② 他动1  懊悔，后悔；吊唁，哀悼"
-        ],
-        "notation": "悔(く)やむ"
+        ]
     },
     {
         "name": "kakuchou",
         "trans": [
+            "拡張(かくちょう)",
             "⓪ 名·他动3  扩充，扩张，扩展"
-        ],
-        "notation": "拡張(かくちょう)"
+        ]
     },
     {
         "name": "zansho",
         "trans": [
+            "残暑(ざんしょ)",
             "① 名  （秋后的）残暑，秋老虎"
-        ],
-        "notation": "残暑(ざんしょ)"
+        ]
     },
     {
         "name": "kiso",
         "trans": [
+            "基礎(きそ)",
             "① 名  基础；根基，基石"
-        ],
-        "notation": "基礎(きそ)"
+        ]
     },
     {
         "name": "junjun'ni",
         "trans": [
+            "順々(じゅんじゅん)に",
             "③ 副  按顺序，依次；逐渐"
-        ],
-        "notation": "順々(じゅんじゅん)に"
+        ]
     },
     {
         "name": "kyuuyou",
         "trans": [
+            "休養(きゅうよう)",
             "⓪ 名·自动3  休养"
-        ],
-        "notation": "休養(きゅうよう)"
+        ]
     },
     {
         "name": "kakutoku",
         "trans": [
+            "獲得(かくとく)",
             "⓪ 名·他动3  获得，获取"
-        ],
-        "notation": "獲得(かくとく)"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "協会(きょうかい)",
             "⓪ 名  协会，团体"
-        ],
-        "notation": "協会(きょうかい)"
+        ]
     },
     {
         "name": "kankaku",
         "trans": [
+            "感覚(かんかく)",
             "⓪ 名  感觉，知觉"
-        ],
-        "notation": "感覚(かんかく)"
+        ]
     },
     {
         "name": "kyoshou",
         "trans": [
+            "巨匠(きょしょう)",
             "⓪ 名  巨匠，泰斗，大家"
-        ],
-        "notation": "巨匠(きょしょう)"
+        ]
     },
     {
         "name": "sabetsu",
         "trans": [
+            "差別(さべつ)",
             "① 名·他动3  区别，差异；歧视，区别对待"
-        ],
-        "notation": "差別(さべつ)"
+        ]
     },
     {
         "name": "toro",
         "trans": [
+            "吐露(とろ)",
             "① 名·他动3  吐露"
-        ],
-        "notation": "吐露(とろ)"
+        ]
     },
     {
         "name": "setten",
         "trans": [
+            "接点(せってん)",
             "① 名  接点，接触点"
-        ],
-        "notation": "接点(せってん)"
+        ]
     },
     {
         "name": "gesutobausu",
         "trans": [
+            "ゲストハウス",
             "④ 名  宾馆，招待所"
-        ],
-        "notation": "ゲストハウス"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "境界(きょうかい)",
             "⓪ 名  边界，疆界"
-        ],
-        "notation": "境界(きょうかい)"
+        ]
     },
     {
         "name": "iiarawasu",
         "trans": [
+            "言(い)い表(あらわ)す",
             "⑤ 他动1  表达，陈述，说明"
-        ],
-        "notation": "言(い)い表(あらわ)す"
+        ]
     },
     {
         "name": "iitsukeru",
         "trans": [
+            "言(い)い付(つ)ける",
             "④ 他动2  命令，吩咐；告状；经常说"
-        ],
-        "notation": "言(い)い付(つ)ける"
+        ]
     },
     {
         "name": "iitsutaeru",
         "trans": [
+            "言(い)い伝(つた)える",
             "⑤ 他动2  传达，转告；流传"
-        ],
-        "notation": "言(い)い伝(つた)える"
+        ]
     },
     {
         "name": "shihon",
         "trans": [
+            "資本(しほん)",
             "⓪ 名  资本"
-        ],
-        "notation": "資本(しほん)"
+        ]
     },
     {
         "name": "kansatsu",
         "trans": [
+            "観察(かんさつ)",
             "⓪ 名·他动3  观察，仔细查看"
-        ],
-        "notation": "観察(かんさつ)"
+        ]
     },
     {
         "name": "shuugetsu",
         "trans": [
+            "秋月(しゅうげつ)",
             "⓪ 名  秋月"
-        ],
-        "notation": "秋月(しゅうげつ)"
+        ]
     },
     {
         "name": "daigomi",
         "trans": [
+            "醍醐味(だいごみ)",
             "③ 名  美味；妙趣，乐趣"
-        ],
-        "notation": "醍醐味(だいごみ)"
+        ]
     },
     {
         "name": "uchouten",
         "trans": [
+            "有頂天(うちょうてん)",
             "② 名·ナ形  得意扬扬，高兴得忘乎所以"
-        ],
-        "notation": "有頂天(うちょうてん)"
+        ]
     },
     {
         "name": "akuseku",
         "trans": [
+            "あくせく",
             "(为小事)  ① 副·自动3  辛辛苦苦，忙忙碌碌；（为小事）苦恼"
-        ],
-        "notation": "あくせく"
+        ]
     },
     {
         "name": "zatsugaku",
         "trans": [
+            "雑学(ざつがく)",
             "⓪ 名  杂学，成系统的学问；博学广闻"
-        ],
-        "notation": "雑学(ざつがく)"
+        ]
     },
     {
         "name": "shizumu",
         "trans": [
+            "沈(しず)む",
             "⓪ 自动1  沉没；下降；消沉；陷入"
-        ],
-        "notation": "沈(しず)む"
+        ]
     },
     {
         "name": "kabuseru",
         "trans": [
+            "被(かぶ)せる",
             "③ 他动2  盖上，蒙上；戴上（帽子）"
-        ],
-        "notation": "被(かぶ)せる"
+        ]
     },
     {
         "name": "karu",
         "trans": [
+            "刈(か)る",
             "⓪ 他动1  割；剪，修剪"
-        ],
-        "notation": "刈(か)る"
+        ]
     },
     {
         "name": "shiteki",
         "trans": [
+            "指摘(してき)",
             "⓪ 名·他动3  指出；指摘"
-        ],
-        "notation": "指摘(してき)"
+        ]
     },
     {
         "name": "jiten",
         "trans": [
+            "時点(じてん)",
             "① 名  时间点"
-        ],
-        "notation": "時点(じてん)"
+        ]
     },
     {
         "name": "heisoku",
         "trans": [
+            "閉塞(へいそく)",
             "⓪ 名·自他动3  阻塞，闭塞，堵塞"
-        ],
-        "notation": "閉塞(へいそく)"
+        ]
     },
     {
         "name": "mochimono",
         "trans": [
+            "持(も)ち物(もの)",
             "② 名  随身物品；所有物"
-        ],
-        "notation": "持(も)ち物(もの)"
+        ]
     },
     {
         "name": "shuttou",
         "trans": [
+            "出頭(しゅっとう)",
             "⓪ 名·自动3  出人头地；露面"
-        ],
-        "notation": "出頭(しゅっとう)"
+        ]
     },
     {
         "name": "kaisekiryouri",
         "trans": [
+            "懐石料理(かいせきりょうり)",
             "⑤ 名  怀石料理（一种高级日本料理）"
-        ],
-        "notation": "懐石料理(かいせきりょうり)"
+        ]
     },
     {
         "name": "sudachi",
         "trans": [
+            "巣立(すだ)ち",
             "⓪ 名·自动3  离巢；自立，独立"
-        ],
-        "notation": "巣立(すだ)ち"
+        ]
     },
     {
         "name": "sentensu",
         "trans": [
+            "センテンス",
             "① 名  句子"
-        ],
-        "notation": "センテンス"
+        ]
     },
     {
         "name": "shusai",
         "trans": [
+            "主催(しゅさい)",
             "⓪ 名·他动3  主办，举办"
-        ],
-        "notation": "主催(しゅさい)"
+        ]
     },
     {
         "name": "bakarashii",
         "trans": [
+            "ばからしい",
             " ④ イ形  愚蠢的；无聊的；不值得的"
-        ],
-        "notation": "ばからしい"
+        ]
     },
     {
         "name": "jushou",
         "trans": [
+            "受賞(じゅしょう)",
             "⓪ 名·自他动3  获奖，得奖"
-        ],
-        "notation": "受賞(じゅしょう)"
+        ]
     },
     {
         "name": "kyouguu",
         "trans": [
+            "境遇(きょうぐう)",
             "⓪ 名  境遇，处境"
-        ],
-        "notation": "境遇(きょうぐう)"
+        ]
     },
     {
         "name": "mousou",
         "trans": [
+            "妄想(もうそう)",
             "⓪ 名·他动3  妄想，胡思乱想"
-        ],
-        "notation": "妄想(もうそう)"
+        ]
     },
     {
         "name": "omonpakaru",
         "trans": [
+            "慮(おもんぱか)る",
             "⑤ 他动1  思虑，考虑"
-        ],
-        "notation": "慮(おもんぱか)る"
+        ]
     },
     {
         "name": "shushoku",
         "trans": [
+            "主食(しゅしょく)",
             "⓪ 名  主食"
-        ],
-        "notation": "主食(しゅしょく)"
+        ]
     },
     {
         "name": "eikou",
         "trans": [
+            "栄光(えいこう)",
             "⓪ 名  荣光，光荣"
-        ],
-        "notation": "栄光(えいこう)"
+        ]
     },
     {
         "name": "senryou",
         "trans": [
+            "占領(せんりょう)",
             "⓪ 名·他动3  占领；占据"
-        ],
-        "notation": "占領(せんりょう)"
+        ]
     },
     {
         "name": "benmei",
         "trans": [
+            "弁明(べんめい)",
             "⓪ 名·自他动3  解释，说明；辩解"
-        ],
-        "notation": "弁明(べんめい)"
+        ]
     },
     {
         "name": "junjou",
         "trans": [
+            "純情(じゅんじょう)",
             "⓪ 名·ナ形  纯真，天真，纯洁"
-        ],
-        "notation": "純情(じゅんじょう)"
+        ]
     },
     {
         "name": "shiyou",
         "trans": [
+            "仕様(しよう)",
             "⓪ 名  做法，办法"
-        ],
-        "notation": "仕様(しよう)"
+        ]
     },
     {
         "name": "shou",
         "trans": [
+            "～賞(しょう)",
             " 接尾  ……奖"
-        ],
-        "notation": "～賞(しょう)"
+        ]
     },
     {
         "name": "fukkiru",
         "trans": [
+            "吹(ふ)っ切(き)る",
             "③ 他动1  除去，消除（烦闷）"
-        ],
-        "notation": "吹(ふ)っ切(き)る"
+        ]
     },
     {
         "name": "busshitsu",
         "trans": [
+            "物資(ぶっしつ)",
             "⓪ 名  物质；物体"
-        ],
-        "notation": "物資(ぶっしつ)"
+        ]
     },
     {
         "name": "shuzai",
         "trans": [
+            "取材(しゅざい)",
             "⓪ 名·自他动3  采访；取材"
-        ],
-        "notation": "取材(しゅざい)"
+        ]
     },
     {
         "name": "oriau",
         "trans": [
+            "折(お)り合(あ)う",
             "③ 自动1  和睦相处；妥协"
-        ],
-        "notation": "折(お)り合(あ)う"
+        ]
     },
     {
         "name": "shouene",
         "trans": [
+            "省(しょう)エネ",
             "⓪ 名  节省能源"
-        ],
-        "notation": "省(しょう)エネ"
+        ]
     },
     {
         "name": "shouka",
         "trans": [
+            "消化(しょうか)",
             "⓪ 名·他动3  消化（食物）；理解（知识）"
-        ],
-        "notation": "消化(しょうか)"
+        ]
     },
     {
         "name": "arinomama",
         "trans": [
+            "ありのまま",
             " ⓪ 名·ナ形·副  如实，据实，实事求是"
-        ],
-        "notation": "ありのまま"
+        ]
     },
     {
         "name": "kakan",
         "trans": [
+            "果敢(かかん)",
             "⓪ ナ形  果断的，果敢的，勇敢的"
-        ],
-        "notation": "果敢(かかん)"
+        ]
     },
     {
         "name": "kodou",
         "trans": [
+            "鼓動(こどう)",
             "⓪ 名·自动3  跳动，搏动，悸动"
-        ],
-        "notation": "鼓動(こどう)"
+        ]
     },
     {
         "name": "ryuui",
         "trans": [
+            "留意(りゅうい)",
             "① 名·自动3  留意，留心，注意"
-        ],
-        "notation": "留意(りゅうい)"
+        ]
     },
     {
         "name": "entotsu",
         "trans": [
+            "煙突(えんとつ)",
             "⓪ 名  烟筒，烟囱"
-        ],
-        "notation": "煙突(えんとつ)"
+        ]
     },
     {
         "name": "jidoushi",
         "trans": [
+            "自動詞(じどうし)",
             "② 名  自动词"
-        ],
-        "notation": "自動詞(じどうし)"
+        ]
     },
     {
         "name": "shitoshito",
         "trans": [
+            "しとしと",
             "(雨)  ① 副  （雨）淅淅沥沥"
-        ],
-        "notation": "しとしと"
+        ]
     },
     {
         "name": "jinushi",
         "trans": [
+            "地主(じぬし)",
             "⓪ 名  地主，土地所有者"
-        ],
-        "notation": "地主(じぬし)"
+        ]
     },
     {
         "name": "kakuheiki",
         "trans": [
+            "核兵器(かくへいき)",
             "③ 名  核武器"
-        ],
-        "notation": "核兵器(かくへいき)"
+        ]
     },
     {
         "name": "kisei",
         "trans": [
+            "帰省(きせい)",
             "⓪ 名·自动3  回乡探亲，省亲"
-        ],
-        "notation": "帰省(きせい)"
+        ]
     },
     {
         "name": "shinpaigoto",
         "trans": [
+            "心配事(しんぱいごと)",
             "⓪ 名  担心的事，操心的事"
-        ],
-        "notation": "心配事(しんぱいごと)"
+        ]
     },
     {
         "name": "mittomonai",
         "trans": [
+            "みっともない",
             " ⑤ イ形  不像样的，不体面的；难看的"
-        ],
-        "notation": "みっともない"
+        ]
     },
     {
         "name": "shinkeishitsu",
         "trans": [
+            "神経質(しんけいしつ)",
             "③ 名·ナ形  神经质，敏感"
-        ],
-        "notation": "神経質(しんけいしつ)"
+        ]
     },
     {
         "name": "miayamaru",
         "trans": [
+            "見誤(みあやま)る",
             "④ 他动1  看错，看差；错认"
-        ],
-        "notation": "見誤(みあやま)る"
+        ]
     },
     {
         "name": "sayuu",
         "trans": [
+            "左右(さゆう)",
             "① 名·他动3  左边和右边；支配，操纵"
-        ],
-        "notation": "左右(さゆう)"
+        ]
     },
     {
         "name": "gararito",
         "trans": [
+            "がらりと",
             " ② 副  急剧变化，突然改变"
-        ],
-        "notation": "がらりと"
+        ]
     },
     {
         "name": "kyuukou",
         "trans": [
+            "休講(きゅうこう)",
             "⓪ 名·自动3  （老师）停课"
-        ],
-        "notation": "休講(きゅうこう)"
+        ]
     },
     {
         "name": "kotobadukai",
         "trans": [
+            "言葉遣(ことばづか)い",
             "④ 名  说法；（文章）措辞"
-        ],
-        "notation": "言葉遣(ことばづか)い"
+        ]
     },
     {
         "name": "koshitsu/koshuu",
         "trans": [
+            "固執(こしつ/こしゅう)",
             "⓪ 名·自他动3  坚持，固执"
-        ],
-        "notation": "固執(こしつ/こしゅう)"
+        ]
     },
     {
         "name": "akewatasu",
         "trans": [
+            "明(あ)け渡(わた)す",
             "④ 他动1  让出，腾出"
-        ],
-        "notation": "明(あ)け渡(わた)す"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "時機(じき)",
             "① 名  时机，机会"
-        ],
-        "notation": "時機(じき)"
+        ]
     },
     {
         "name": "gichou",
         "trans": [
+            "議長(ぎちょう)",
             "① 名  主持人，司仪；议长，主席"
-        ],
-        "notation": "議長(ぎちょう)"
+        ]
     },
     {
         "name": "kunji",
         "trans": [
+            "訓示(くんじ)",
             "⓪ 名·自他动3  训示，训话"
-        ],
-        "notation": "訓示(くんじ)"
+        ]
     },
     {
         "name": "oodokoro",
         "trans": [
+            "大所(おおどころ)",
             "③ 名  权威，泰斗；有钱人家"
-        ],
-        "notation": "大所(おおどころ)"
+        ]
     },
     {
         "name": "kousho",
         "trans": [
+            "高所(こうしょ)",
             "① 名  高处，高地；远见"
-        ],
-        "notation": "高所(こうしょ)"
+        ]
     },
     {
         "name": "kyoushuku",
         "trans": [
+            "恐縮(きょうしゅく)",
             "⓪ 名·自动3  对不起，过意不去；不好意思，惭愧"
-        ],
-        "notation": "恐縮(きょうしゅく)"
+        ]
     },
     {
         "name": "kenjitsu",
         "trans": [
+            "堅実(けんじつ)",
             "⓪ 名·ナ形  坚实，稳固；踏实，牢靠"
-        ],
-        "notation": "堅実(けんじつ)"
+        ]
     },
     {
         "name": "kakimidasu",
         "trans": [
+            "搔(か)き乱(みだ)す",
             "④ 他动1  搅乱，弄乱；扰乱，制造混乱"
-        ],
-        "notation": "搔(か)き乱(みだ)す"
+        ]
     },
     {
         "name": "sahai",
         "trans": [
+            "差配(さはい)",
             "⓪ 名·他动3  分派，负责管理"
-        ],
-        "notation": "差配(さはい)"
+        ]
     },
     {
         "name": "mukei",
         "trans": [
+            "無形(むけい)",
             "⓪ 名  无形"
-        ],
-        "notation": "無形(むけい)"
+        ]
     },
     {
         "name": "souryo",
         "trans": [
+            "僧侶(そうりょ)",
             "① 名  僧侣，和尚"
-        ],
-        "notation": "僧侶(そうりょ)"
+        ]
     },
     {
         "name": "utomashii",
         "trans": [
+            "疎(うと)ましい",
             "④ イ形  讨厌的，厌恶的，不愉快的"
-        ],
-        "notation": "疎(うと)ましい"
+        ]
     },
     {
         "name": "kyuumei",
         "trans": [
+            "究明(きゅうめい)",
             "⓪ 名·他动3  查明，研究明白"
-        ],
-        "notation": "究明(きゅうめい)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "地震(じしん)",
             "⓪ 名  地震"
-        ],
-        "notation": "地震(じしん)"
+        ]
     },
     {
         "name": "kashin",
         "trans": [
+            "過信(かしん)",
             "⓪ 名·他动3  过于相信"
-        ],
-        "notation": "過信(かしん)"
+        ]
     },
     {
         "name": "edo",
         "trans": [
+            "江戸(えど)",
             "⓪ 名  江户（东京旧称）"
-        ],
-        "notation": "江戸(えど)"
+        ]
     },
     {
         "name": "anshou",
         "trans": [
+            "暗唱(あんしょう)",
             "⓪ 名·他动3  记住，背诵"
-        ],
-        "notation": "暗唱(あんしょう)"
+        ]
     },
     {
         "name": "gimu",
         "trans": [
+            "義務(ぎむ)",
             "① 名  义务"
-        ],
-        "notation": "義務(ぎむ)"
+        ]
     },
     {
         "name": "shitsukeru",
         "trans": [
+            "しつける",
             "(动物)  ③ 他动2  教育，培养；训练（动物）"
-        ],
-        "notation": "しつける"
+        ]
     },
     {
         "name": "jisshi",
         "trans": [
+            "実施(じっし)",
             "⓪ 名·他动3  实施，实行"
-        ],
-        "notation": "実施(じっし)"
+        ]
     },
     {
         "name": "kakusei",
         "trans": [
+            "覚醒(かくせい)",
             "⓪ 名·自他动3  醒过来；觉醒，觉悟"
-        ],
-        "notation": "覚醒(かくせい)"
+        ]
     },
     {
         "name": "jissen",
         "trans": [
+            "実践(じっせん)",
             "⓪ 名·他动3  实践"
-        ],
-        "notation": "実践(じっせん)"
+        ]
     },
     {
         "name": "anmoku",
         "trans": [
+            "暗黙(あんもく)",
             "⓪ 名·自动3  沉默，默不作声"
-        ],
-        "notation": "暗黙(あんもく)"
+        ]
     },
     {
         "name": "tsuji",
         "trans": [
+            "辻(つじ)",
             "⓪ 名  十字路口；街头，路旁"
-        ],
-        "notation": "辻(つじ)"
+        ]
     },
     {
         "name": "saigen",
         "trans": [
+            "再現(さいげん)",
             "③ 名·自他动3  再现，重新出现"
-        ],
-        "notation": "再現(さいげん)"
+        ]
     },
     {
         "name": "kojin",
         "trans": [
+            "個人(こじん)",
             "① 名  个人"
-        ],
-        "notation": "個人(こじん)"
+        ]
     },
     {
         "name": "serifu",
         "trans": [
+            "台詞(せりふ)",
             "⓪ 名  台词；说法"
-        ],
-        "notation": "台詞(せりふ)"
+        ]
     },
     {
         "name": "jukugo",
         "trans": [
+            "熟語(じゅくご)",
             "⓪ 名  复合词；惯用句，成语"
-        ],
-        "notation": "熟語(じゅくご)"
+        ]
     },
     {
         "name": "yayoi",
         "trans": [
+            "弥生(やよい)",
             "⓪ 名  （阴历）三月"
-        ],
-        "notation": "弥生(やよい)"
+        ]
     },
     {
         "name": "ketsuryuu",
         "trans": [
+            "血流(けつりゅう)",
             "⓪ 名  血管内的血液流动"
-        ],
-        "notation": "血流(けつりゅう)"
+        ]
     },
     {
         "name": "junsui",
         "trans": [
+            "純粋(じゅんすい)",
             "⓪ 名·ナ形  纯粹，纯净；纯真"
-        ],
-        "notation": "純粋(じゅんすい)"
+        ]
     },
     {
         "name": "henbou",
         "trans": [
+            "変貌(へんぼう)",
             "⓪ 名·自动3  改观，变样，改变面貌"
-        ],
-        "notation": "変貌(へんぼう)"
+        ]
     },
     {
         "name": "tenki",
         "trans": [
+            "転機(てんき)",
             "① 名  转机，转折点"
-        ],
-        "notation": "転機(てんき)"
+        ]
     },
     {
         "name": "fushime",
         "trans": [
+            "節目(ふしめ)",
             "③ 名  阶段，段落；节点"
-        ],
-        "notation": "節目(ふしめ)"
+        ]
     },
     {
         "name": "yuumou",
         "trans": [
+            "勇猛(ゆうもう)",
             "⓪ 名·ナ形  勇猛"
-        ],
-        "notation": "勇猛(ゆうもう)"
+        ]
     },
     {
         "name": "shugo",
         "trans": [
+            "主語(しゅご)",
             "① 名  主语"
-        ],
-        "notation": "主語(しゅご)"
+        ]
     },
     {
         "name": "shudai",
         "trans": [
+            "主題(しゅだい)",
             "⓪ 名  主题，中心思想"
-        ],
-        "notation": "主題(しゅだい)"
+        ]
     },
     {
         "name": "fukekomu",
         "trans": [
+            "老(ふ)け込(こ)む",
             "⓪ 自动1  变老，老去，衰老"
-        ],
-        "notation": "老(ふ)け込(こ)む"
+        ]
     },
     {
         "name": "senshi",
         "trans": [
+            "戦士(せんし)",
             "① 名  战士"
-        ],
-        "notation": "戦士(せんし)"
+        ]
     },
     {
         "name": "daichi",
         "trans": [
+            "大地(だいち)",
             "① 名  大地；陆地"
-        ],
-        "notation": "大地(だいち)"
+        ]
     },
     {
         "name": "iinokosu",
         "trans": [
+            "言(い)い残(のこ)す",
             "④ 他动1  没有说完；留话，留言"
-        ],
-        "notation": "言(い)い残(のこ)す"
+        ]
     },
     {
         "name": "iihanatsu",
         "trans": [
+            "言(い)い放(はな)つ",
             "④ 他动1  断言；信口开河，乱说"
-        ],
-        "notation": "言(い)い放(はな)つ"
+        ]
     },
     {
         "name": "shukusha",
         "trans": [
+            "宿舎(しゅくしゃ)",
             "② 名  宿舍；投宿处，旅馆"
-        ],
-        "notation": "宿舎(しゅくしゃ)"
+        ]
     },
     {
         "name": "shukushou",
         "trans": [
+            "縮小(しゅくしょう)",
             "⓪ 名·自他动3  缩小，缩减"
-        ],
-        "notation": "縮小(しゅくしょう)"
+        ]
     },
     {
         "name": "ichizu",
         "trans": [
+            "一途(いちず)",
             "② ナ形  一心一意的；专心的；死心眼的"
-        ],
-        "notation": "一途(いちず)"
+        ]
     },
     {
         "name": "misueru",
         "trans": [
+            "見据(みす)える",
             "⓪ 他动2  目不转睛；看准，认清"
-        ],
-        "notation": "見据(みす)える"
+        ]
     },
     {
         "name": "shujinkou",
         "trans": [
+            "主人公(しゅじんこう)",
             "② 名  主人公，主角"
-        ],
-        "notation": "主人公(しゅじんこう)"
+        ]
     },
     {
         "name": "mikiru",
         "trans": [
+            "見切(みき)る",
             "② 他动1  看完；断念，放弃"
-        ],
-        "notation": "見切(みき)る"
+        ]
     },
     {
         "name": "kakusei",
         "trans": [
+            "隔世(かくせい)",
             "⓪ 名  隔世，隔代"
-        ],
-        "notation": "隔世(かくせい)"
+        ]
     },
     {
         "name": "shisou",
         "trans": [
+            "思想(しそう)",
             "⓪ 名  思想；想法"
-        ],
-        "notation": "思想(しそう)"
+        ]
     },
     {
         "name": "heion",
         "trans": [
+            "平穏(へいおん)",
             "⓪ 名·ナ形  平稳；平静；平安"
-        ],
-        "notation": "平穏(へいおん)"
+        ]
     },
     {
         "name": "meijiru",
         "trans": [
+            "命(めい)じる",
             "⓪ 他动2  命令，吩咐；任命"
-        ],
-        "notation": "命(めい)じる"
+        ]
     },
     {
         "name": "aragau",
         "trans": [
+            "抗(あらが)う",
             "③ 自动1  抵抗，抗争，反抗"
-        ],
-        "notation": "抗(あらが)う"
+        ]
     },
     {
         "name": "wakiagaru",
         "trans": [
+            "湧(わ)き上(あ)がる",
             "④ 自动1  （水）沸腾，开了；（观众）沸腾"
-        ],
-        "notation": "湧(わ)き上(あ)がる"
+        ]
     },
     {
         "name": "kui",
         "trans": [
+            "杭(くい)",
             "① 名  桩子"
-        ],
-        "notation": "杭(くい)"
+        ]
     },
     {
         "name": "yarou",
         "trans": [
+            "野郎(やろう)",
             "⓪ 名  小子，家伙"
-        ],
-        "notation": "野郎(やろう)"
+        ]
     },
     {
         "name": "amachua",
         "trans": [
+            "アマチュア",
             "⓪ 名  业余爱好者"
-        ],
-        "notation": "アマチュア"
+        ]
     },
     {
         "name": "ayashimu",
         "trans": [
+            "怪(あや)しむ",
             "③ 他动1  怀疑，觉得奇怪"
-        ],
-        "notation": "怪(あや)しむ"
+        ]
     },
     {
         "name": "aredake",
         "trans": [
+            "あれだけ",
             " ⓪ 副  那种程度，那样"
-        ],
-        "notation": "あれだけ"
+        ]
     },
     {
         "name": "kensatsukan",
         "trans": [
+            "検察官(けんさつかん)",
             "④ 名  检察官"
-        ],
-        "notation": "検察官(けんさつかん)"
+        ]
     },
     {
         "name": "awaremu",
         "trans": [
+            "哀(あわ)れむ",
             "③ 他动1  怜悯，怜惜，怜受"
-        ],
-        "notation": "哀(あわ)れむ"
+        ]
     },
     {
         "name": "an",
         "trans": [
+            "餡(あん)",
             "① 名  馅料，豆馅"
-        ],
-        "notation": "餡(あん)"
+        ]
     },
     {
         "name": "iiau",
         "trans": [
+            "言(い)い合(あ)う",
             "③ 自他动1  争论，争吵；各说各的"
-        ],
-        "notation": "言(い)い合(あ)う"
+        ]
     },
     {
         "name": "iatsu",
         "trans": [
+            "威圧(いあつ)",
             "⓪ 名  威逼，威慑"
-        ],
-        "notation": "威圧(いあつ)"
+        ]
     },
     {
         "name": "joshu",
         "trans": [
+            "助手(じょしゅ)",
             "⓪ 名  助手"
-        ],
-        "notation": "助手(じょしゅ)"
+        ]
     },
     {
         "name": "shokku",
         "trans": [
+            "ショック",
             "① 名  打击，震惊，冲击"
-        ],
-        "notation": "ショック"
+        ]
     },
     {
         "name": "shodou",
         "trans": [
+            "書道(しょどう)",
             "① 名  书法"
-        ],
-        "notation": "書道(しょどう)"
+        ]
     },
     {
         "name": "shotoku",
         "trans": [
+            "所得(しょとく)",
             "⓪ 名  所得，收入"
-        ],
-        "notation": "所得(しょとく)"
+        ]
     },
     {
         "name": "itsuzai",
         "trans": [
+            "逸材(いつざい)",
             "⓪ 名  卓越的人才，卓越的才能"
-        ],
-        "notation": "逸材(いつざい)"
+        ]
     },
     {
         "name": "kenmei",
         "trans": [
+            "懸命(けんめい)",
             "⓪ ナ形  拼命的，竭尽全力的"
-        ],
-        "notation": "懸命(けんめい)"
+        ]
     },
     {
         "name": "jojoni",
         "trans": [
+            "徐々に(じょじょに)",
             "① 副  慢慢地；逐步地"
-        ],
-        "notation": "徐々に(じょじょに)"
+        ]
     },
     {
         "name": "shoseki",
         "trans": [
+            "書籍(しょせき)",
             "① 名  书籍，图书"
-        ],
-        "notation": "書籍(しょせき)"
+        ]
     },
     {
         "name": "unga",
         "trans": [
+            "運河(うんが)",
             "① 名  运河"
-        ],
-        "notation": "運河(うんが)"
+        ]
     },
     {
         "name": "shochi",
         "trans": [
+            "処置(しょち)",
             "① 名·他动3  处理，处置；治疗"
-        ],
-        "notation": "処置(しょち)"
+        ]
     },
     {
         "name": "isshoku",
         "trans": [
+            "一色(いっしょく)",
             "④ 名  清一色；全都"
-        ],
-        "notation": "一色(いっしょく)"
+        ]
     },
     {
         "name": "inazuma",
         "trans": [
+            "稲妻(いなずま)",
             "⓪ 名  闪电；飞速，像闪电一般"
-        ],
-        "notation": "稲妻(いなずま)"
+        ]
     },
     {
         "name": "inta-nashonaru",
         "trans": [
+            "インターナショナル",
             "⑤ 名·ナ形  国际；国际的"
-        ],
-        "notation": "インターナショナル"
+        ]
     },
     {
         "name": "on'you",
         "trans": [
+            "陰陽(おんよう)",
             "⓪ 名  阴阳；正极和负极"
-        ],
-        "notation": "陰陽(おんよう)"
+        ]
     },
     {
         "name": "ui-kude-",
         "trans": [
+            "ウイークデー",
             "② 名  工作日，平日"
-        ],
-        "notation": "ウイークデー"
+        ]
     },
     {
         "name": "usugata",
         "trans": [
+            "薄型(うすがた)",
             "⓪ ナ形  超薄的，薄的"
-        ],
-        "notation": "薄型(うすがた)"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "討(う)つ",
             "① 他动1  讨伐，攻击"
-        ],
-        "notation": "討(う)つ"
+        ]
     },
     {
         "name": "usuppera",
         "trans": [
+            "薄(うす)っぺら",
             "⓪ ナ形  很薄的，单薄的；浅薄的，肤浅的"
-        ],
-        "notation": "薄(うす)っぺら"
+        ]
     },
     {
         "name": "shourei",
         "trans": [
+            "奨励(しょうれい)",
             "⓪ 名·他动3  奖励，鼓励"
-        ],
-        "notation": "奨励(しょうれい)"
+        ]
     },
     {
         "name": "enshuu",
         "trans": [
+            "円周(えんしゅう)",
             "⓪ 名  （数学）圆周"
-        ],
-        "notation": "円周(えんしゅう)"
+        ]
     },
     {
         "name": "entori-",
         "trans": [
+            "エントリー",
             "① 名·自动3  报名参加"
-        ],
-        "notation": "エントリー"
+        ]
     },
     {
         "name": "shouchou",
         "trans": [
+            "象徴(しょうちょう)",
             "⓪ 名·他动3  象征"
-        ],
-        "notation": "象徴(しょうちょう)"
+        ]
     },
     {
         "name": "unagi",
         "trans": [
+            "鰻(うなぎ)",
             "⓪ 名  鳗鱼"
-        ],
-        "notation": "鰻(うなぎ)"
+        ]
     },
     {
         "name": "joutou",
         "trans": [
+            "上等(じょうとう)",
             "⓪ 名·ナ形  上等，高级；优秀"
-        ],
-        "notation": "上等(じょうとう)"
+        ]
     },
     {
         "name": "shoudoku",
         "trans": [
+            "消毒(しょうどく)",
             "⓪ 名·他动3  消毒，杀菌"
-        ],
-        "notation": "消毒(しょうどく)"
+        ]
     },
     {
         "name": "shounika",
         "trans": [
+            "小児科(しょうにか)",
             "⓪ 名  儿科"
-        ],
-        "notation": "小児科(しょうにか)"
+        ]
     },
     {
         "name": "eame-ru",
         "trans": [
+            "エアメール",
             "③ 名  航空信件"
-        ],
-        "notation": "エアメール"
+        ]
     },
     {
         "name": "echiketto",
         "trans": [
+            "エチケット",
             " ① 名  礼节，礼仪"
-        ],
-        "notation": "エチケット"
+        ]
     },
     {
         "name": "yousei",
         "trans": [
+            "要請(ようせい)",
             "⓪ 名·他动3  请求，恳求，要求"
-        ],
-        "notation": "要請(ようせい)"
+        ]
     },
     {
         "name": "rounin",
         "trans": [
+            "浪人(ろうにん)",
             "⓪ 名·自动3  失学的学生，失业的人；流浪武士"
-        ],
-        "notation": "浪人(ろうにん)"
+        ]
     },
     {
         "name": "ifuku",
         "trans": [
+            "衣服(いふく)",
             "① 名  衣服，服装"
-        ],
-        "notation": "衣服(いふく)"
+        ]
     },
     {
         "name": "iyatoiuhodo",
         "trans": [
+            "いやというほど",
             " ② 副  厌烦，腻烦"
-        ],
-        "notation": "いやというほど"
+        ]
     },
     {
         "name": "iryuu",
         "trans": [
+            "遺留(いりゅう)",
             "⓪ 名·他动3  遗忘；（死后）遗留"
-        ],
-        "notation": "遺留(いりゅう)"
+        ]
     },
     {
         "name": "inkyo",
         "trans": [
+            "隠居(いんきょ)",
             "⓪ 名·自动3  隐居；退休"
-        ],
-        "notation": "隠居(いんきょ)"
+        ]
     },
     {
         "name": "essei",
         "trans": [
+            "エッセイ",
             "① 名  随笔，散文"
-        ],
-        "notation": "エッセイ"
+        ]
     },
     {
         "name": "tokushu",
         "trans": [
+            "特殊(とくしゅ)",
             "⓪ 名·ナ形  特殊，特别"
-        ],
-        "notation": "特殊(とくしゅ)"
+        ]
     },
     {
         "name": "koyou",
         "trans": [
+            "雇用(こよう)",
             "⓪ 名·他动3  雇佣，雇用"
-        ],
-        "notation": "雇用(こよう)"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "遺棄(いき)",
             "① 名·他动3  遗弃"
-        ],
-        "notation": "遺棄(いき)"
+        ]
     },
     {
         "name": "shokuen",
         "trans": [
+            "食塩(しょくえん)",
             "② 名  食用盐"
-        ],
-        "notation": "食塩(しょくえん)"
+        ]
     },
     {
         "name": "yaritoosu",
         "trans": [
+            "遣(や)り通(とお)す",
             "③ 他动1  做完，完成 "
-        ],
-        "notation": "遣(や)り通(とお)す"
+        ]
     },
     {
         "name": "shokuminchi",
         "trans": [
+            "植民地(しょくみんち)",
             "③ 名  殖民地"
-        ],
-        "notation": "植民地(しょくみんち)"
+        ]
     },
     {
         "name": "ikigomu",
         "trans": [
+            "意気込(いきご)む",
             "③ 自动1  振奋，鼓起干劲儿"
-        ],
-        "notation": "意気込(いきご)む"
+        ]
     },
     {
         "name": "roudoku",
         "trans": [
+            "朗読(ろうどく)",
             "⓪ 名·他动3  朗读，朗诵"
-        ],
-        "notation": "朗読(ろうどく)"
+        ]
     },
     {
         "name": "itameru",
         "trans": [
+            "炒(いた)める",
             "③ 他动2  炒，煎"
-        ],
-        "notation": "炒(いた)める"
+        ]
     },
     {
         "name": "furumau",
         "trans": [
+            "振(ふ)る舞(ま)う",
             "③ 自他动1  行动，动作；请客，招待"
-        ],
-        "notation": "振(ふ)る舞(ま)う"
+        ]
     },
     {
         "name": "shouhin",
         "trans": [
+            "賞品(しょうひん)",
             "⓪ 名  奖品"
-        ],
-        "notation": "賞品(しょうひん)"
+        ]
     },
     {
         "name": "eri",
         "trans": [
+            "襟(えり)",
             "② 名  领子，衣领"
-        ],
-        "notation": "襟(えり)"
+        ]
     },
     {
         "name": "engei",
         "trans": [
+            "園芸(えんげい)",
             "⓪ 名  园艺"
-        ],
-        "notation": "園芸(えんげい)"
+        ]
     },
     {
         "name": "shouri",
         "trans": [
+            "勝利(しょうり)",
             "① 名·自动3  胜利，成功"
-        ],
-        "notation": "勝利(しょうり)"
+        ]
     },
     {
         "name": "shouryaku",
         "trans": [
+            "省略(しょうりゃく)",
             "⓪ 名·他动3  省略"
-        ],
-        "notation": "省略(しょうりゃく)"
+        ]
     },
     {
         "name": "guigui",
         "trans": [
+            "ぐいぐい",
             "(喝)  ① 副  连续用力；使劲（喝），大口大口地（喝）"
-        ],
-        "notation": "ぐいぐい"
+        ]
     },
     {
         "name": "usureru",
         "trans": [
+            "薄(うす)れる",
             "⓪ 自动2  减弱，减退；变模糊"
-        ],
-        "notation": "薄(うす)れる"
+        ]
     },
     {
         "name": "insatsu",
         "trans": [
+            "印刷(いんさつ)",
             "⓪ 名·他动3  印刷"
-        ],
-        "notation": "印刷(いんさつ)"
+        ]
     },
     {
         "name": "shokunin",
         "trans": [
+            "職人(しょくにん)",
             "⓪ 名  工匠；行家"
-        ],
-        "notation": "職人(しょくにん)"
+        ]
     },
     {
         "name": "suzume",
         "trans": [
+            "雀(すずめ)",
             "⓪ 名  麻雀；多嘴的人"
-        ],
-        "notation": "雀(すずめ)"
+        ]
     },
     {
         "name": "sutto",
         "trans": [
+            "すっと",
             " ① 副  动作轻快；身心舒畅，痛快"
-        ],
-        "notation": "すっと"
+        ]
     },
     {
         "name": "shoho",
         "trans": [
+            "初歩(しょほ)",
             "① 名  初步，初学，入门阶段"
-        ],
-        "notation": "初歩(しょほ)"
+        ]
     },
     {
         "name": "goraku",
         "trans": [
+            "娯楽(ごらく)",
             "⓪ 名  娱乐"
-        ],
-        "notation": "娯楽(ごらく)"
+        ]
     },
     {
         "name": "shomei",
         "trans": [
+            "署名(しょめい)",
             "⓪ 名·自动3  署名，签名"
-        ],
-        "notation": "署名(しょめい)"
+        ]
     },
     {
         "name": "utagoe",
         "trans": [
+            "歌声(うたごえ)",
             "⓪ 名  歌声，合唱"
-        ],
-        "notation": "歌声(うたごえ)"
+        ]
     },
     {
         "name": "uchikeshi",
         "trans": [
+            "打(う)ち消(け)し",
             "⓪ 名  否定，否认"
-        ],
-        "notation": "打(う)ち消(け)し"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "撃(う)つ",
             "① 他动1  射击；攻击"
-        ],
-        "notation": "撃(う)つ"
+        ]
     },
     {
         "name": "ooguchi",
         "trans": [
+            "大口(おおぐち)",
             "⓪ 名  （张开）大口；大话"
-        ],
-        "notation": "大口(おおぐち)"
+        ]
     },
     {
         "name": "yasuraka",
         "trans": [
+            "安(やす)らか",
             "② ナ形  安稳的，安静的；无忧无虑的，安乐的"
-        ],
-        "notation": "安(やす)らか"
+        ]
     },
     {
         "name": "oozora",
         "trans": [
+            "大空(おおぞら)",
             "③ 名  天空"
-        ],
-        "notation": "大空(おおぞら)"
+        ]
     },
     {
         "name": "oomono",
         "trans": [
+            "大物(おおもの)",
             "⓪ 名  大人物；巨著；大生意"
-        ],
-        "notation": "大物(おおもの)"
+        ]
     },
     {
         "name": "okaeshi",
         "trans": [
+            "お返(かえ)し",
             "⓪ 名  回礼；找零"
-        ],
-        "notation": "お返(かえ)し"
+        ]
     },
     {
         "name": "shousoku",
         "trans": [
+            "消息(しょうそく)",
             "⓪ 名  消息，信息；情况"
-        ],
-        "notation": "消息(しょうそく)"
+        ]
     },
     {
         "name": "hikinobasu",
         "trans": [
+            "引(ひ)き伸(の)ばす",
             "④ 他动1  拉长；拖延"
-        ],
-        "notation": "引(ひ)き伸(の)ばす"
+        ]
     },
     {
         "name": "shounin",
         "trans": [
+            "商人(しょうにん)",
             "① 名  商人，生意人"
-        ],
-        "notation": "商人(しょうにん)"
+        ]
     },
     {
         "name": "shoumikigen",
         "trans": [
+            "賞味期限(しょうみきげん)",
             "④ 名  食品保质期，最佳食用期限"
-        ],
-        "notation": "賞味期限(しょうみきげん)"
+        ]
     },
     {
         "name": "oodai",
         "trans": [
+            "大台(おおだい)",
             "⓪ 名  （金额、数值的）大关"
-        ],
-        "notation": "大台(おおだい)"
+        ]
     },
     {
         "name": "giron",
         "trans": [
+            "議論(ぎろん)",
             "① 名·他动3  议论，讨论，争论"
-        ],
-        "notation": "議論(ぎろん)"
+        ]
     },
     {
         "name": "koukiatsu",
         "trans": [
+            "高気圧(こうきあつ)",
             "③ 名  高气压"
-        ],
-        "notation": "高気圧(こうきあつ)"
+        ]
     },
     {
         "name": "shobun",
         "trans": [
+            "処分(しょぶん)",
             "① 名·他动3  处理；扔掉；处分"
-        ],
-        "notation": "処分(しょぶん)"
+        ]
     },
     {
         "name": "sujimichi",
         "trans": [
+            "筋道(すじみち)",
             "② 名  理由，道理；手续，程序"
-        ],
-        "notation": "筋道(すじみち)"
+        ]
     },
     {
         "name": "suzu",
         "trans": [
+            "鈴(すず)",
             "⓪ 名  铃铛"
-        ],
-        "notation": "鈴(すず)"
+        ]
     },
     {
         "name": "awatemono",
         "trans": [
+            "慌(あわ)て者(もの)",
             "⓪ 名  冒失鬼；急性子"
-        ],
-        "notation": "慌(あわ)て者(もの)"
+        ]
     },
     {
         "name": "osokutomo",
         "trans": [
+            "遅(おそ)くとも",
             "② 副  最晚，最迟"
-        ],
-        "notation": "遅(おそ)くとも"
+        ]
     },
     {
         "name": "susumi",
         "trans": [
+            "進(すす)み",
             "⓪ 名  进步；进度"
-        ],
-        "notation": "進(すす)み"
+        ]
     },
     {
         "name": "joyuu",
         "trans": [
+            "女優(じょゆう)",
             "⓪ 名  女演员"
-        ],
-        "notation": "女優(じょゆう)"
+        ]
     },
     {
         "name": "shirazushirazu",
         "trans": [
+            "知(し)らず知(し)らず",
             "④ 副  不知不觉中，不由得，无形中"
-        ],
-        "notation": "知(し)らず知(し)らず"
+        ]
     },
     {
         "name": "shiritsu",
         "trans": [
+            "私立(しりつ)",
             "① 名  私立"
-        ],
-        "notation": "私立(しりつ)"
+        ]
     },
     {
         "name": "shinkuu",
         "trans": [
+            "真空(しんくう)",
             "⓪ 名  真空；空白（点）"
-        ],
-        "notation": "真空(しんくう)"
+        ]
     },
     {
         "name": "shinguru",
         "trans": [
+            "シングル",
             "① 名  单个，单人；单身"
-        ],
-        "notation": "シングル"
+        ]
     },
     {
         "name": "subayai",
         "trans": [
+            "素早(すばや)い",
             "③ イ形  迅速的，敏捷的，麻利的"
-        ],
-        "notation": "素早(すばや)い"
+        ]
     },
     {
         "name": "supi-ka-",
         "trans": [
+            "スピーカー",
             "② 名  发言的人；扬声器，喇叭"
-        ],
-        "notation": "スピーカー"
+        ]
     },
     {
         "name": "sumi",
         "trans": [
+            "墨(すみ)",
             "② 名  墨"
-        ],
-        "notation": "墨(すみ)"
+        ]
     },
     {
         "name": "zumi",
         "trans": [
+            "～済(ず)み",
             " 接尾  ……完了，……结束"
-        ],
-        "notation": "～済(ず)み"
+        ]
     },
     {
         "name": "tsukiageru",
         "trans": [
+            "突(つ)き上(あ)げる",
             "④ 他动2  从下往上顶；（下级对上级）施加压力"
-        ],
-        "notation": "突(つ)き上(あ)げる"
+        ]
     },
     {
         "name": "tsukiawaseru",
         "trans": [
+            "突(つ)き合(あ)わせる",
             "⑤ 他动2  把两个东西对上；对照，核对"
-        ],
-        "notation": "突(つ)き合(あ)わせる"
+        ]
     },
     {
         "name": "shinsa",
         "trans": [
+            "審査(しんさ)",
             "① 名·他动3  审查"
-        ],
-        "notation": "審査(しんさ)"
+        ]
     },
     {
         "name": "chimitsu",
         "trans": [
+            "緻密(ちみつ)",
             "⓪ 名·ナ形  细致，细腻；缜密，周密"
-        ],
-        "notation": "緻密(ちみつ)"
+        ]
     },
     {
         "name": "shinsai",
         "trans": [
+            "震災(しんさい)",
             "⓪ 名  地震灾害"
-        ],
-        "notation": "震災(しんさい)"
+        ]
     },
     {
         "name": "hassou",
         "trans": [
+            "発送(はっそう)",
             "⓪ 名·他动3  发送，寄出，发出"
-        ],
-        "notation": "発送(はっそう)"
+        ]
     },
     {
         "name": "suisen",
         "trans": [
+            "推薦(すいせん)",
             "⓪ 名·他动3  推荐"
-        ],
-        "notation": "推薦(すいせん)"
+        ]
     },
     {
         "name": "chimeiteki",
         "trans": [
+            "致命的(ちめいてき)",
             "⓪ ナ形  致命的，要命的"
-        ],
-        "notation": "致命的(ちめいてき)"
+        ]
     },
     {
         "name": "sukasu",
         "trans": [
+            "空(す)かす",
             "⓪ 他动1  空着（肚子）"
-        ],
-        "notation": "空(す)かす"
+        ]
     },
     {
         "name": "zukan",
         "trans": [
+            "図鑑(ずかん)",
             "⓪ 名  图鉴"
-        ],
-        "notation": "図鑑(ずかん)"
+        ]
     },
     {
         "name": "shinwa",
         "trans": [
+            "神話(しんわ)",
             "⓪ 名  神话"
-        ],
-        "notation": "神話(しんわ)"
+        ]
     },
     {
         "name": "suijun",
         "trans": [
+            "水準(すいじゅん)",
             "⓪ 名  水准；水平，标准"
-        ],
-        "notation": "水準(すいじゅん)"
+        ]
     },
     {
         "name": "koujoushin",
         "trans": [
+            "向上心(こうじょうしん)",
             "③ 名  上进心"
-        ],
-        "notation": "向上心(こうじょうしん)"
+        ]
     },
     {
         "name": "kousei",
         "trans": [
+            "公正(こうせい)",
             "⓪ 名·ナ形  公正，公平"
-        ],
-        "notation": "公正(こうせい)"
+        ]
     },
     {
         "name": "suki",
         "trans": [
+            "隙(すき)",
             "⓪ 名  空隙，间隙；闲暇"
-        ],
-        "notation": "隙(すき)"
+        ]
     },
     {
         "name": "kashiya",
         "trans": [
+            "貸家(かしや)",
             "⓪ 名  出租的房子"
-        ],
-        "notation": "貸家(かしや)"
+        ]
     },
     {
         "name": "suji",
         "trans": [
+            "筋(すじ)",
             "① 名  筋；逻辑，条理；情节"
-        ],
-        "notation": "筋(すじ)"
+        ]
     },
     {
         "name": "jiritsu",
         "trans": [
+            "自立(じりつ)",
             "⓪ 名·自动3  自立，独立"
-        ],
-        "notation": "自立(じりつ)"
+        ]
     },
     {
         "name": "shiru",
         "trans": [
+            "汁(しる)",
             "① 名  汁；汤；利益，好处"
-        ],
-        "notation": "汁(しる)"
+        ]
     },
     {
         "name": "shirouto",
         "trans": [
+            "素人(しろうと)",
             "① 名  外行；业余爱好者"
-        ],
-        "notation": "素人(しろうと)"
+        ]
     },
     {
         "name": "shinka",
         "trans": [
+            "進化(しんか)",
             "① 名·自动3  进化；进步"
-        ],
-        "notation": "進化(しんか)"
+        ]
     },
     {
         "name": "seinen",
         "trans": [
+            "成年(せいねん)",
             "⓪ 名  成年"
-        ],
-        "notation": "成年(せいねん)"
+        ]
     },
     {
         "name": "shingai",
         "trans": [
+            "侵害(しんがい)",
             "⓪ 名·他动3  侵害；侵犯"
-        ],
-        "notation": "侵害(しんがい)"
+        ]
     },
     {
         "name": "sute-ji",
         "trans": [
+            "ステージ",
             "② 名  舞台；讲坛；阶段，程度"
-        ],
-        "notation": "ステージ"
+        ]
     },
     {
         "name": "sunakku",
         "trans": [
+            "スナック",
             "② 名  零食，小点心；小吃店"
-        ],
-        "notation": "スナック"
+        ]
     },
     {
         "name": "zunou",
         "trans": [
+            "頭脳(ずのう)",
             "① 名  头脑，智力；首脑，领导人"
-        ],
-        "notation": "頭脳(ずのう)"
+        ]
     },
     {
         "name": "torikimeru",
         "trans": [
+            "取(と)り決(き)める",
             "⓪ 他动2  决定，商定，约定"
-        ],
-        "notation": "取(と)り決(き)める"
+        ]
     },
     {
         "name": "sumitsuku",
         "trans": [
+            "住(す)み着(つ)く",
             "③ 自动1  住惯，定居"
-        ],
-        "notation": "住(す)み着(つ)く"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "澄(す)む",
             "① 自动1  清澈；清晰悦耳；清静，宁静"
-        ],
-        "notation": "澄(す)む"
+        ]
     },
     {
         "name": "suraido",
         "trans": [
+            "スライド",
             "⓪ 名·自他动3  幻灯片；滑行，滑动"
-        ],
-        "notation": "スライド"
+        ]
     },
     {
         "name": "kantoku",
         "trans": [
+            "監督(かんとく)",
             "⓪ 名·他动3  导演；教练；监督"
-        ],
-        "notation": "監督(かんとく)"
+        ]
     },
     {
         "name": "seiketsu",
         "trans": [
+            "清潔(せいけつ)",
             "⓪ 名·ナ形  清洁，干净；纯洁"
-        ],
-        "notation": "清潔(せいけつ)"
+        ]
     },
     {
         "name": "koushou",
         "trans": [
+            "交渉(こうしょう)",
             "⓪ 名·自动3  交涉，商谈；联系"
-        ],
-        "notation": "交渉(こうしょう)"
+        ]
     },
     {
         "name": "seijouka",
         "trans": [
+            "正常化(せいじょうか)",
             "⓪ 名·他动3  正常化"
-        ],
-        "notation": "正常化(せいじょうか)"
+        ]
     },
     {
         "name": "seizei",
         "trans": [
+            "せいぜい",
             " ① 副  尽可能，尽量；最多，充其量"
-        ],
-        "notation": "せいぜい"
+        ]
     },
     {
         "name": "seinen",
         "trans": [
+            "青年(せいねん)",
             "⓪ 名  青年"
-        ],
-        "notation": "青年(せいねん)"
+        ]
     },
     {
         "name": "shinkei",
         "trans": [
+            "神経(しんけい)",
             "① 名  神经；感觉，感受"
-        ],
-        "notation": "神経(しんけい)"
+        ]
     },
     {
         "name": "koujou",
         "trans": [
+            "向上(こうじょう)",
             "⓪ 名·自动3  向上；提高；进步"
-        ],
-        "notation": "向上(こうじょう)"
+        ]
     },
     {
         "name": "jinkenhi",
         "trans": [
+            "人件費(じんけんひ)",
             "③ 名  人员开支，劳务费"
-        ],
-        "notation": "人件費(じんけんひ)"
+        ]
     },
     {
         "name": "zureru",
         "trans": [
+            "ずれる",
             " ② 自动2  移动，离开；偏离"
-        ],
-        "notation": "ずれる"
+        ]
     },
     {
         "name": "tekiyou",
         "trans": [
+            "適用(てきよう)",
             "⓪ 名·他动3  适用，应用"
-        ],
-        "notation": "適用(てきよう)"
+        ]
     },
     {
         "name": "dezaina-",
         "trans": [
+            "デザイナー",
             "② 名  设计师"
-        ],
-        "notation": "デザイナー"
+        ]
     },
     {
         "name": "umu",
         "trans": [
+            "有無(うむ)",
             "① 名  有无，有或没有"
-        ],
-        "notation": "有無(うむ)"
+        ]
     },
     {
         "name": "oome",
         "trans": [
+            "多(おお)め",
             "⓪ 名·ナ形  稍多些，略多些"
-        ],
-        "notation": "多(おお)め"
+        ]
     },
     {
         "name": "oshitoosu",
         "trans": [
+            "押(お)し通(とお)す",
             "③ 他动1  坚持到底，贯彻到底"
-        ],
-        "notation": "押(お)し通(とお)す"
+        ]
     },
     {
         "name": "ofisu",
         "trans": [
+            "オフィス",
             "① 名  办公室，事务所"
-        ],
-        "notation": "オフィス"
+        ]
     },
     {
         "name": "sekidou",
         "trans": [
+            "赤道(せきどう)",
             "⓪ 名  赤道"
-        ],
-        "notation": "赤道(せきどう)"
+        ]
     },
     {
         "name": "sedai",
         "trans": [
+            "世代(せだい)",
             "① 名  世代；辈"
-        ],
-        "notation": "世代(せだい)"
+        ]
     },
     {
         "name": "omoikiru",
         "trans": [
+            "思(おも)い切(き)る",
             "④ 自他动1  断念，死心，想开"
-        ],
-        "notation": "思(おも)い切(き)る"
+        ]
     },
     {
         "name": "setsu",
         "trans": [
+            "節(せつ)",
             "① 名  季节，节气；时候；贞节，节操"
-        ],
-        "notation": "節(せつ)"
+        ]
     },
     {
         "name": "karakau",
         "trans": [
+            "からかう",
             "③ 他动1  戏弄；嘲弄；调戏"
-        ],
-        "notation": "からかう"
+        ]
     },
     {
         "name": "sessuru",
         "trans": [
+            "接(せっ)する",
             "⓪ 自他动3  接触；相邻；接待，对待；连接；接上"
-        ],
-        "notation": "接(せっ)する"
+        ]
     },
     {
         "name": "shoujiru",
         "trans": [
+            "生(しょう)じる",
             "⓪ 自他动2  生，长；产生，发生；引起"
-        ],
-        "notation": "生(しょう)じる"
+        ]
     },
     {
         "name": "secchi",
         "trans": [
+            "設置(せっち)",
             "⓪ 名·他动3  设置，安装；设立（机构）"
-        ],
-        "notation": "設置(せっち)"
+        ]
     },
     {
         "name": "kousha",
         "trans": [
+            "校舎(こうしゃ)",
             "① 名  校舍"
-        ],
-        "notation": "校舎(こうしゃ)"
+        ]
     },
     {
         "name": "tamaranai",
         "trans": [
+            "堪(たま)らない",
             "⓪ イ形  忍受不了的"
-        ],
-        "notation": "堪(たま)らない"
+        ]
     },
     {
         "name": "heikai",
         "trans": [
+            "閉会(へいかい)",
             "⓪ 名·自他动3  闭幕；会议结束"
-        ],
-        "notation": "閉会(へいかい)"
+        ]
     },
     {
         "name": "shinshin",
         "trans": [
+            "心身(しんしん)",
             "① 名  身心，心与身"
-        ],
-        "notation": "心身(しんしん)"
+        ]
     },
     {
         "name": "seikei",
         "trans": [
+            "生計(せいけい)",
             "⓪ 名  生计，生活"
-        ],
-        "notation": "生計(せいけい)"
+        ]
     },
     {
         "name": "shokumu",
         "trans": [
+            "職務(しょくむ)",
             "① 名  职务；任务"
-        ],
-        "notation": "職務(しょくむ)"
+        ]
     },
     {
         "name": "shinboru",
         "trans": [
+            "シンボル",
             "① 名  象征；符号"
-        ],
-        "notation": "シンボル"
+        ]
     },
     {
         "name": "kokorogakari",
         "trans": [
+            "心掛(こころが)かり",
             "④ 名·ナ形  担心，不放心"
-        ],
-        "notation": "心掛(こころが)かり"
+        ]
     },
     {
         "name": "sabiru",
         "trans": [
+            "錆(さ)びる",
             "② 自动2  生锈，长锈"
-        ],
-        "notation": "錆(さ)びる"
+        ]
     },
     {
         "name": "zenhan",
         "trans": [
+            "前半(ぜんはん)",
             "⓪ 名  前半，前一半"
-        ],
-        "notation": "前半(ぜんはん)"
+        ]
     },
     {
         "name": "shoumei",
         "trans": [
+            "照明(しょうめい)",
             "⓪ 名  照明，灯光"
-        ],
-        "notation": "照明(しょうめい)"
+        ]
     },
     {
         "name": "sen'you",
         "trans": [
+            "専用(せんよう)",
             "⓪ 名·他动3  专用，专门用于"
-        ],
-        "notation": "専用(せんよう)"
+        ]
     },
     {
         "name": "kokorogake",
         "trans": [
+            "心掛(こころが)け",
             "⓪ 名  留心，注意；人品，为人；用心，努力"
-        ],
-        "notation": "心掛(こころが)け"
+        ]
     },
     {
         "name": "sukasazu",
         "trans": [
+            "すかさず",
             " ⓪ 副  立刻，马上"
-        ],
-        "notation": "すかさず"
+        ]
     },
     {
         "name": "zeikan",
         "trans": [
+            "税関(ぜいかん)",
             "⓪ 名  海关"
-        ],
-        "notation": "税関(ぜいかん)"
+        ]
     },
     {
         "name": "sonawaru",
         "trans": [
+            "備(そな)わる",
             "③ 自动1  设有；具有，具备（素质等）"
-        ],
-        "notation": "備(そな)わる"
+        ]
     },
     {
         "name": "koutei",
         "trans": [
+            "校庭(こうてい)",
             "⓪ 名  校园；操场"
-        ],
-        "notation": "校庭(こうてい)"
+        ]
     },
     {
         "name": "hikkakaru",
         "trans": [
+            "引(ひ)っ掛(か)かる",
             "④ 自动1  挂，挂住；牵连；受骗，上当"
-        ],
-        "notation": "引(ひ)っ掛(か)かる"
+        ]
     },
     {
         "name": "hikkurikaeru",
         "trans": [
+            "引(ひ)っ繰(く)り返(かえ)る",
             "⑤ 自动1  倒，翻倒，颠倒过来"
-        ],
-        "notation": "引(ひ)っ繰(く)り返(かえ)る"
+        ]
     },
     {
         "name": "souzoushii",
         "trans": [
+            "騒々しい(そうぞうしい)",
             "⑤ イ形  嘈杂的，吵闹的"
-        ],
-        "notation": "騒々しい(そうぞうしい)"
+        ]
     },
     {
         "name": "bunrui",
         "trans": [
+            "分類(ぶんるい)",
             "⓪ 名·他动3  分类"
-        ],
-        "notation": "分類(ぶんるい)"
+        ]
     },
     {
         "name": "machinami",
         "trans": [
+            "町並(まちな)み",
             "⓪ 名  街道，街景；街头建筑"
-        ],
-        "notation": "町並(まちな)み"
+        ]
     },
     {
         "name": "bonchi",
         "trans": [
+            "盆地(ぼんち)",
             "⓪ 名  盆地"
-        ],
-        "notation": "盆地(ぼんち)"
+        ]
     },
     {
         "name": "seibun",
         "trans": [
+            "成分(せいぶん)",
             "① 名  成分"
-        ],
-        "notation": "成分(せいぶん)"
+        ]
     },
     {
         "name": "kokonotokoro",
         "trans": [
+            "ここのところ",
             " ⑥ 副  暂时；目前，眼下"
-        ],
-        "notation": "ここのところ"
+        ]
     },
     {
         "name": "shindou",
         "trans": [
+            "振動(しんどう)",
             "⓪ 名·自动3  振动；摆动"
-        ],
-        "notation": "振動(しんどう)"
+        ]
     },
     {
         "name": "hanashikomu",
         "trans": [
+            "話(はな)し込(こ)む",
             "④ 自动1  谈得入迷，说得起劲"
-        ],
-        "notation": "話(はな)し込(こ)む"
+        ]
     },
     {
         "name": "harusaki",
         "trans": [
+            "春先(はるさき)",
             "⓪ 名  初春，早春"
-        ],
-        "notation": "春先(はるさき)"
+        ]
     },
     {
         "name": "kokoroe",
         "trans": [
+            "心得(こころえ)",
             "③ 名  心得，体会；规章制度，须知"
-        ],
-        "notation": "心得(こころえ)"
+        ]
     },
     {
         "name": "somosomo",
         "trans": [
+            "そもそも",
             " ① 副  原本，从一开始"
-        ],
-        "notation": "そもそも"
+        ]
     },
     {
         "name": "soramoyou",
         "trans": [
+            "空模様(そらもよう)",
             "③ 名  天气；形势"
-        ],
-        "notation": "空模様(そらもよう)"
+        ]
     },
     {
         "name": "sorekiri",
         "trans": [
+            "それきり",
             " ⓪ 副  只有那些；那以后再也"
-        ],
-        "notation": "それきり"
+        ]
     },
     {
         "name": "kokorogakeru",
         "trans": [
+            "心掛(こころが)ける",
             "⑤ 他动2  留心，注意，记在心里"
-        ],
-        "notation": "心掛(こころが)ける"
+        ]
     },
     {
         "name": "kokorodukai",
         "trans": [
+            "心遣(こころづか)い",
             "④ 名·自动3  担心，操心，关心"
-        ],
-        "notation": "心遣(こころづか)い"
+        ]
     },
     {
         "name": "koshiraeru",
         "trans": [
+            "拵(こしら)える",
             "⓪ 他动2  做，制造；筹（款）；捏造"
-        ],
-        "notation": "拵(こしら)える"
+        ]
     },
     {
         "name": "setsuritsu",
         "trans": [
+            "設立(せつりつ)",
             "⓪ 名·他动3  设立，创立"
-        ],
-        "notation": "設立(せつりつ)"
+        ]
     },
     {
         "name": "hagemasu",
         "trans": [
+            "励(はげ)ます",
             "③ 他动1  鼓励，激励"
-        ],
-        "notation": "励(はげ)ます"
+        ]
     },
     {
         "name": "hagemi",
         "trans": [
+            "励(はげ)み",
             "③ 名  努力，勤奋"
-        ],
-        "notation": "励(はげ)み"
+        ]
     },
     {
         "name": "semaru",
         "trans": [
+            "迫(せま)る",
             "② 自他动1  迫近；陷于困境；强迫，逼迫"
-        ],
-        "notation": "迫(せま)る"
+        ]
     },
     {
         "name": "semeru",
         "trans": [
+            "攻(せ)める",
             "② 他动2  攻击，进攻"
-        ],
-        "notation": "攻(せ)める"
+        ]
     },
     {
         "name": "seron/yoron",
         "trans": [
+            "世論(せろん/よろん)",
             "① 名  社会舆论"
-        ],
-        "notation": "世論(せろん/よろん)"
+        ]
     },
     {
         "name": "kishi",
         "trans": [
+            "岸(きし)",
             "② 名  岸"
-        ],
-        "notation": "岸(きし)"
+        ]
     },
     {
         "name": "zen",
         "trans": [
+            "善(ぜん)",
             "① 名  善，好事"
-        ],
-        "notation": "善(ぜん)"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "応(こた)える",
             "③ 自动2  响应；深感，痛感"
-        ],
-        "notation": "応(こた)える"
+        ]
     },
     {
         "name": "sen'i",
         "trans": [
+            "繊維(せんい)",
             "① 名  纤维"
-        ],
-        "notation": "繊維(せんい)"
+        ]
     },
     {
         "name": "fuujiru",
         "trans": [
+            "封(ふう)じる",
             "⓪ 他动2  封，封上；禁止；阻止"
-        ],
-        "notation": "封(ふう)じる"
+        ]
     },
     {
         "name": "hokkyoku",
         "trans": [
+            "北極(ほっきょく)",
             "⓪ 名  北极"
-        ],
-        "notation": "北極(ほっきょく)"
+        ]
     },
     {
         "name": "senkoku",
         "trans": [
+            "宣告(せんこく)",
             "⓪ 名·他动3  宣告，宣布"
-        ],
-        "notation": "宣告(せんこく)"
+        ]
     },
     {
         "name": "dokuritsu",
         "trans": [
+            "独立(どくりつ)",
             "⓪ 名·自动3  独立；自立门户"
-        ],
-        "notation": "独立(どくりつ)"
+        ]
     },
     {
         "name": "gekika",
         "trans": [
+            "激化(げきか)",
             "① 名·自动3  激化，加剧，愈演愈烈"
-        ],
-        "notation": "激化(げきか)"
+        ]
     },
     {
         "name": "senryaku",
         "trans": [
+            "戦略(せんりゃく)",
             "⓪ 名  战略，斗争策略"
-        ],
-        "notation": "戦略(せんりゃく)"
+        ]
     },
     {
         "name": "kouseki",
         "trans": [
+            "功績(こうせき)",
             "⓪ 名  功绩，功业"
-        ],
-        "notation": "功績(こうせき)"
+        ]
     },
     {
         "name": "nuu",
         "trans": [
+            "縫(ぬ)う",
             "① 他动1  缝；刺绣；缝合"
-        ],
-        "notation": "縫(ぬ)う"
+        ]
     },
     {
         "name": "kawaigaru",
         "trans": [
+            "かわいがる",
             " ④ 他动1  喜爱，疼爱"
-        ],
-        "notation": "かわいがる"
+        ]
     },
     {
         "name": "douitsu",
         "trans": [
+            "同一(どういつ)",
             "⓪ 名·ナ形  同样，相同"
-        ],
-        "notation": "同一(どういつ)"
+        ]
     },
     {
         "name": "kousen",
         "trans": [
+            "光線(こうせん)",
             "⓪ 名  光线"
-        ],
-        "notation": "光線(こうせん)"
+        ]
     },
     {
         "name": "shinshi",
         "trans": [
+            "紳士(しんし)",
             "① 名  绅士，君子 "
-        ],
-        "notation": "紳士(しんし)"
+        ]
     },
     {
         "name": "haken",
         "trans": [
+            "派遣(はけん)",
             "⓪ 名·他动3  派遣，派出"
-        ],
-        "notation": "派遣(はけん)"
+        ]
     },
     {
         "name": "hinshu",
         "trans": [
+            "品種(ひんしゅ)",
             "⓪ 名  种类，品种"
-        ],
-        "notation": "品種(ひんしゅ)"
+        ]
     },
     {
         "name": "binbou",
         "trans": [
+            "貧乏(びんぼう)",
             "① 名·ナ形  贫穷，贫困"
-        ],
-        "notation": "貧乏(びんぼう)"
+        ]
     },
     {
         "name": "jinshu",
         "trans": [
+            "人種(じんしゅ)",
             "⓪ 名  人种；种族"
-        ],
-        "notation": "人種(じんしゅ)"
+        ]
     },
     {
         "name": "hasamaru",
         "trans": [
+            "挟(はさ)まる",
             "③ 自动1  夹；处在（对立两方之间）"
-        ],
-        "notation": "挟(はさ)まる"
+        ]
     },
     {
         "name": "kanbyou",
         "trans": [
+            "看病(かんびょう)",
             "① 名·他动3  看护，护理"
-        ],
-        "notation": "看病(かんびょう)"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "更(ふ)ける",
             "② 自动2  夜深；秋意浓"
-        ],
-        "notation": "更(ふ)ける"
+        ]
     },
     {
         "name": "sontoku",
         "trans": [
+            "損得(そんとく)",
             "① 名  得失；盈亏"
-        ],
-        "notation": "損得(そんとく)"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "姓名(せいめい)",
             "① 名  姓名"
-        ],
-        "notation": "姓名(せいめい)"
+        ]
     },
     {
         "name": "seiyuu",
         "trans": [
+            "声優(せいゆう)",
             "⓪ 名  配音演员，声优"
-        ],
-        "notation": "声優(せいゆう)"
+        ]
     },
     {
         "name": "shinjin",
         "trans": [
+            "新人(しんじん)",
             "⓪ 名  新人，新手"
-        ],
-        "notation": "新人(しんじん)"
+        ]
     },
     {
         "name": "jinzou",
         "trans": [
+            "人造(じんぞう)",
             "⓪ 名  人造，人工制造"
-        ],
-        "notation": "人造(じんぞう)"
+        ]
     },
     {
         "name": "senryoku",
         "trans": [
+            "戦力(せんりょく)",
             "① 名  军事力量，作战能力"
-        ],
-        "notation": "戦力(せんりょく)"
+        ]
     },
     {
         "name": "senro",
         "trans": [
+            "線路(せんろ)",
             "① 名  （火车、电车的）线路，轨道"
-        ],
-        "notation": "線路(せんろ)"
+        ]
     },
     {
         "name": "soukin",
         "trans": [
+            "送金(そうきん)",
             "⓪ 名·自他动3  汇款，寄钱"
-        ],
-        "notation": "送金(そうきん)"
+        ]
     },
     {
         "name": "sougo",
         "trans": [
+            "相互(そうご)",
             "① 名  互相，相互；轮流，交替"
-        ],
-        "notation": "相互(そうご)"
+        ]
     },
     {
         "name": "kodai",
         "trans": [
+            "古代(こだい)",
             "① 名  古代"
-        ],
-        "notation": "古代(こだい)"
+        ]
     },
     {
         "name": "sonshitsu",
         "trans": [
+            "損失(そんしつ)",
             "⓪ 名·自他动3  损失；损耗"
-        ],
-        "notation": "損失(そんしつ)"
+        ]
     },
     {
         "name": "sukuu",
         "trans": [
+            "救(すく)う",
             "⓪ 他动1  救，救助；救济；挽救"
-        ],
-        "notation": "救(すく)う"
+        ]
     },
     {
         "name": "sougou",
         "trans": [
+            "総合(そうごう)",
             "⓪ 名·他动3  综合（考虑、开发等）"
-        ],
-        "notation": "総合(そうごう)"
+        ]
     },
     {
         "name": "soushoku",
         "trans": [
+            "装飾(そうしょく)",
             "⓪ 名·他动3  装饰，点缀"
-        ],
-        "notation": "装飾(そうしょく)"
+        ]
     },
     {
         "name": "sentei",
         "trans": [
+            "選定(せんてい)",
             "⓪ 名·他动3  选定"
-        ],
-        "notation": "選定(せんてい)"
+        ]
     },
     {
         "name": "sugureru",
         "trans": [
+            "優(すぐ)れる",
             "③ 自动2  优秀，出众，卓越"
-        ],
-        "notation": "優(すぐ)れる"
+        ]
     },
     {
         "name": "sentou",
         "trans": [
+            "先頭(せんとう)",
             "⓪ 名  前头，最前列；最先"
-        ],
-        "notation": "先頭(せんとう)"
+        ]
     },
     {
         "name": "sukasuka",
         "trans": [
+            "すかすか",
             " ⓪ 副·ナ形  顺利地；空荡荡，空隙很多"
-        ],
-        "notation": "すかすか"
+        ]
     },
     {
         "name": "soredokoroka",
         "trans": [
+            "それどころか",
             " ③ 接续  岂止如此，别说那个，甚至"
-        ],
-        "notation": "それどころか"
+        ]
     },
     {
         "name": "sorenishiteha",
         "trans": [
+            "それにしては",
             " ⑤ 接续  那么说"
-        ],
-        "notation": "それにしては"
+        ]
     },
     {
         "name": "sorenishitemo",
         "trans": [
+            "それにしても",
             " ⑤ 接续  尽管如此，即使那样"
-        ],
-        "notation": "それにしても"
+        ]
     },
     {
         "name": "soroi",
         "trans": [
+            "揃(そろ)い",
             "② 名  成套，成组；（多人）聚在一起"
-        ],
-        "notation": "揃(そろ)い"
+        ]
     },
     {
         "name": "koutei",
         "trans": [
+            "肯定(こうてい)",
             "⓪ 名·他动3  肯定，承认"
-        ],
-        "notation": "肯定(こうてい)"
+        ]
     },
     {
         "name": "souzou",
         "trans": [
+            "創造(そうぞう)",
             "⓪ 名·他动3  创造"
-        ],
-        "notation": "創造(そうぞう)"
+        ]
     },
     {
         "name": "semete",
         "trans": [
+            "せめて",
             " ① 副  至少，起码，哪怕是"
-        ],
-        "notation": "せめて"
+        ]
     },
     {
         "name": "zoudai",
         "trans": [
+            "増大(ぞうだい)",
             "⓪ 名·自他动3  增大；增多"
-        ],
-        "notation": "増大(ぞうだい)"
+        ]
     },
     {
         "name": "koushuu",
         "trans": [
+            "公衆(こうしゅう)",
             "⓪ 名  公共，公众"
-        ],
-        "notation": "公衆(こうしゅう)"
+        ]
     },
     {
         "name": "taion",
         "trans": [
+            "体温(たいおん)",
             "① 名  体温"
-        ],
-        "notation": "体温(たいおん)"
+        ]
     },
     {
         "name": "taikaku",
         "trans": [
+            "体格(たいかく)",
             "⓪ 名  体格，身体"
-        ],
-        "notation": "体格(たいかく)"
+        ]
     },
     {
         "name": "taigaku",
         "trans": [
+            "退学(たいがく)",
             "⓪ 名·自动3  退学"
-        ],
-        "notation": "退学(たいがく)"
+        ]
     },
     {
         "name": "gakkyuu",
         "trans": [
+            "学級(がっきゅう)",
             "⓪ 名  班级"
-        ],
-        "notation": "学級(がっきゅう)"
+        ]
     },
     {
         "name": "soubetsu",
         "trans": [
+            "送別(そうべつ)",
             "⓪ 名·他动3  送别，送行"
-        ],
-        "notation": "送別(そうべつ)"
+        ]
     },
     {
         "name": "so-su",
         "trans": [
+            "ソース",
             "① 名  酱料，调味汁"
-        ],
-        "notation": "ソース"
+        ]
     },
     {
         "name": "asa",
         "trans": [
+            "麻(あさ)",
             "② 名  麻，麻布"
-        ],
-        "notation": "麻(あさ)"
+        ]
     },
     {
         "name": "hitoshii",
         "trans": [
+            "等(ひと)しい",
             "③ イ形  相等的，相同的，一样的"
-        ],
-        "notation": "等(ひと)しい"
+        ]
     },
     {
         "name": "asagao",
         "trans": [
+            "朝顔(あさがお)",
             "② 名  牵牛花，喇叭花"
-        ],
-        "notation": "朝顔(あさがお)"
+        ]
     },
     {
         "name": "asanebou",
         "trans": [
+            "朝寝坊(あさねぼう)",
             "③ 名·自动3  睡懒觉，起床晚"
-        ],
-        "notation": "朝寝坊(あさねぼう)"
+        ]
     },
     {
         "name": "zokuzoku",
         "trans": [
+            "続々(ぞくぞく)",
             "① 副  接连不断地，陆续"
-        ],
-        "notation": "続々(ぞくぞく)"
+        ]
     },
     {
         "name": "taiki",
         "trans": [
+            "大気(たいき)",
             "① 名  大气，空气；度量大，宽宏大量"
-        ],
-        "notation": "大気(たいき)"
+        ]
     },
     {
         "name": "aisuru",
         "trans": [
+            "愛(あい)する",
             "③ 他动3  喜爱，热爱；爱；爱好"
-        ],
-        "notation": "愛(あい)する"
+        ]
     },
     {
         "name": "akanbou",
         "trans": [
+            "赤(あか)ん坊(ぼう)",
             "⓪ 名  婴儿；幼稚，不懂事"
-        ],
-        "notation": "赤(あか)ん坊(ぼう)"
+        ]
     },
     {
         "name": "sokutei",
         "trans": [
+            "測定(そくてい)",
             "⓪ 名·他动3  测定，测量"
-        ],
-        "notation": "測定(そくてい)"
+        ]
     },
     {
         "name": "soshiki",
         "trans": [
+            "組織(そしき)",
             "① 名·他动3  组织；结构；体系"
-        ],
-        "notation": "組織(そしき)"
+        ]
     },
     {
         "name": "azayaka",
         "trans": [
+            "鮮(あざ)やか",
             "② ナ形  鲜艳的，漂亮的；巧妙的，熟练的，优美的"
-        ],
-        "notation": "鮮(あざ)やか"
+        ]
     },
     {
         "name": "anime",
         "trans": [
+            "アニメ",
             " ① 名  动画片，动画制作"
-        ],
-        "notation": "アニメ"
+        ]
     },
     {
         "name": "aburae",
         "trans": [
+            "油絵(あぶらえ)",
             "③ 名  油画"
-        ],
-        "notation": "油絵(あぶらえ)"
+        ]
     },
     {
         "name": "sonaeru",
         "trans": [
+            "備(そな)える",
             "③ 他动2  具备，具有；准备；设置"
-        ],
-        "notation": "備(そな)える"
+        ]
     },
     {
         "name": "amagu",
         "trans": [
+            "雨具(あまぐ)",
             "② 名  雨具（雨伞、雨衣等）"
-        ],
-        "notation": "雨具(あまぐ)"
+        ]
     },
     {
         "name": "ga-ru",
         "trans": [
+            "ガール",
             "① 名  少女，女孩"
-        ],
-        "notation": "ガール"
+        ]
     },
     {
         "name": "kaikan",
         "trans": [
+            "会館(かいかん)",
             "⓪ 名  会馆（某团体住宿、开会、活动用的建筑）"
-        ],
-        "notation": "会館(かいかん)"
+        ]
     },
     {
         "name": "mutto",
         "trans": [
+            "むっと",
             " ⓪ 副·自动3  发火，怒上心头；闷得慌，憋得慌"
-        ],
-        "notation": "むっと"
+        ]
     },
     {
         "name": "meimei",
         "trans": [
+            "めいめい",
             " ③ 名·副  各个，各自"
-        ],
-        "notation": "めいめい"
+        ]
     },
     {
         "name": "kagai",
         "trans": [
+            "課外(かがい)",
             "① 名  课外，课堂以外"
-        ],
-        "notation": "課外(かがい)"
+        ]
     },
     {
         "name": "zensha",
         "trans": [
+            "前者(ぜんしゃ)",
             "① 名  前者"
-        ],
-        "notation": "前者(ぜんしゃ)"
+        ]
     },
     {
         "name": "senjutsu",
         "trans": [
+            "戦術(せんじゅつ)",
             "⓪ 名  战术，策略"
-        ],
-        "notation": "戦術(せんじゅつ)"
+        ]
     },
     {
         "name": "hikou",
         "trans": [
+            "非行(ひこう)",
             "⓪ 名  不正当的行为，不良行为"
-        ],
-        "notation": "非行(ひこう)"
+        ]
     },
     {
         "name": "zenshin",
         "trans": [
+            "前進(ぜんしん)",
             "⓪ 名·自动3  前进"
-        ],
-        "notation": "前進(ぜんしん)"
+        ]
     },
     {
         "name": "shin'ya",
         "trans": [
+            "深夜(しんや)",
             "① 名  深夜，三更半夜"
-        ],
-        "notation": "深夜(しんや)"
+        ]
     },
     {
         "name": "shinrigaku",
         "trans": [
+            "心理学(しんりがく)",
             "③ 名  心理学"
-        ],
-        "notation": "心理学(しんりがく)"
+        ]
     },
     {
         "name": "tsukkakaru",
         "trans": [
+            "突(つ)っかかる",
             "④ 自动1  顶撞，抬杠；猛扑；撞上，绊倒"
-        ],
-        "notation": "突(つ)っかかる"
+        ]
     },
     {
         "name": "kakiageru",
         "trans": [
+            "書(か)き上(あ)げる",
             "④ 他动2  写完，写成；列出"
-        ],
-        "notation": "書(か)き上(あ)げる"
+        ]
     },
     {
         "name": "kagiru",
         "trans": [
+            "限(かぎ)る",
             "② 自他动1  限定，限制；限于；最好"
-        ],
-        "notation": "限(かぎ)る"
+        ]
     },
     {
         "name": "kakuji",
         "trans": [
+            "各自(かくじ)",
             "① 名  各自，每个人"
-        ],
-        "notation": "各自(かくじ)"
+        ]
     },
     {
         "name": "kakusu",
         "trans": [
+            "隠(かく)す",
             "② 他动1  掩盖，掩饰；隐藏；隐瞒"
-        ],
-        "notation": "隠(かく)す"
+        ]
     },
     {
         "name": "ikuraka",
         "trans": [
+            "いくらか",
             " ① 名·副  稍微，一些，一点儿"
-        ],
-        "notation": "いくらか"
+        ]
     },
     {
         "name": "issekinichou",
         "trans": [
+            "一石二鳥(いっせきにちょう)",
             "⓪ 名  一石二鸟，一箭双雕"
-        ],
-        "notation": "一石二鳥(いっせきにちょう)"
+        ]
     },
     {
         "name": "umizoi",
         "trans": [
+            "海沿(うみぞ)い",
             "⓪ 名  沿海"
-        ],
-        "notation": "海沿(うみぞ)い"
+        ]
     },
     {
         "name": "kakimazeru",
         "trans": [
+            "かき混(ま)ぜる",
             "④ 他动2  搅拌，混合"
-        ],
-        "notation": "かき混(ま)ぜる"
+        ]
     },
     {
         "name": "kakujin",
         "trans": [
+            "各人(かくじん)",
             "① 名  各人，各自"
-        ],
-        "notation": "各人(かくじん)"
+        ]
     },
     {
         "name": "gobusata",
         "trans": [
+            "ご無沙汰(ぶさた)",
             "⓪ 名·自动3  久未问候，久未拜访"
-        ],
-        "notation": "ご無沙汰(ぶさた)"
+        ]
     },
     {
         "name": "jisan",
         "trans": [
+            "持参(じさん)",
             "⓪ 名·他动3  携带，带来，自备"
-        ],
-        "notation": "持参(じさん)"
+        ]
     },
     {
         "name": "shinagire",
         "trans": [
+            "品切(しなぎ)れ",
             "⓪ 名  卖完，售罄"
-        ],
-        "notation": "品切(しなぎ)れ"
+        ]
     },
     {
         "name": "shatta-",
         "trans": [
+            "シャッター",
             "① 名  快门；百叶窗"
-        ],
-        "notation": "シャッター"
+        ]
     },
     {
         "name": "seisuu",
         "trans": [
+            "整数(せいすう)",
             "③ 名  整数"
-        ],
-        "notation": "整数(せいすう)"
+        ]
     },
     {
         "name": "soutei",
         "trans": [
+            "想定(そうてい)",
             "⓪ 名·他动3  估计，设想，假想"
-        ],
-        "notation": "想定(そうてい)"
+        ]
     },
     {
         "name": "tsuuyou",
         "trans": [
+            "通用(つうよう)",
             "⓪ 名·自动3  通用，流通"
-        ],
-        "notation": "通用(つうよう)"
+        ]
     },
     {
         "name": "tegaki",
         "trans": [
+            "手書(てが)き",
             "⓪ 名·他动3  手写，手抄"
-        ],
-        "notation": "手書(てが)き"
+        ]
     },
     {
         "name": "choujikan",
         "trans": [
+            "長時間(ちょうじかん)",
             "③ 名  长时间"
-        ],
-        "notation": "長時間(ちょうじかん)"
+        ]
     },
     {
         "name": "baketsu",
         "trans": [
+            "バケツ",
             "⓪ 名  水桶"
-        ],
-        "notation": "バケツ"
+        ]
     },
     {
         "name": "shinken",
         "trans": [
+            "真剣(しんけん)",
             "⓪ ナ形  认真的，一丝不苟的"
-        ],
-        "notation": "真剣(しんけん)"
+        ]
     },
     {
         "name": "hoeru",
         "trans": [
+            "吠(ほ)える",
             "② 自动2  （动物）吼叫"
-        ],
-        "notation": "吠(ほ)える"
+        ]
     },
     {
         "name": "jinken",
         "trans": [
+            "人権(じんけん)",
             "⓪ 名  人权"
-        ],
-        "notation": "人権(じんけん)"
+        ]
     },
     {
         "name": "hitonemuri",
         "trans": [
+            "一眠(ひとねむ)り",
             "② 名·自动3  打盹儿，睡一会儿"
-        ],
-        "notation": "一眠(ひとねむ)り"
+        ]
     },
     {
         "name": "hanbai",
         "trans": [
+            "販売(はんばい)",
             "⓪ 名·他动3  贩卖，销售"
-        ],
-        "notation": "販売(はんばい)"
+        ]
     },
     {
         "name": "kamoku",
         "trans": [
+            "科目(かもく)",
             "⓪ 名  科目；学科；项目"
-        ],
-        "notation": "科目(かもく)"
+        ]
     },
     {
         "name": "hanmen",
         "trans": [
+            "反面(はんめん)",
             "③ 名·副  反面；另一面"
-        ],
-        "notation": "反面(はんめん)"
+        ]
     },
     {
         "name": "madogiwa",
         "trans": [
+            "窓際(まどぎわ)",
             "⓪ 名  窗边，靠窗"
-        ],
-        "notation": "窓際(まどぎわ)"
+        ]
     },
     {
         "name": "tsuru",
         "trans": [
+            "吊(つ)る",
             "⓪ 自他动1  吊，悬，挂"
-        ],
-        "notation": "吊(つ)る"
+        ]
     },
     {
         "name": "autoretto",
         "trans": [
+            "アウトレット",
             "④ 名  工厂直销，（奥特莱斯 ）直销店"
-        ],
-        "notation": "アウトレット"
+        ]
     },
     {
         "name": "iawaseru",
         "trans": [
+            "居合(いあ)わせる",
             "④ 自动2  正好在场"
-        ],
-        "notation": "居合(いあ)わせる"
+        ]
     },
     {
         "name": "ukabiagaru",
         "trans": [
+            "浮(う)かび上(あ)がる",
             "⑤ 自动1  浮起来；显露；翻身，发迹"
-        ],
-        "notation": "浮(う)かび上(あ)がる"
+        ]
     },
     {
         "name": "tsuya",
         "trans": [
+            "艶(つや)",
             "⓪ 名  光泽，光亮，润泽"
-        ],
-        "notation": "艶(つや)"
+        ]
     },
     {
         "name": "tokutei",
         "trans": [
+            "特定(とくてい)",
             "⓪ 名·他动3  特别指定；查明，断定"
-        ],
-        "notation": "特定(とくてい)"
+        ]
     },
     {
         "name": "ushiroashi",
         "trans": [
+            "後(うし)ろ足(あし)",
             "③ 名  后腿，后肢；转过身去要跑"
-        ],
-        "notation": "後(うし)ろ足(あし)"
+        ]
     },
     {
         "name": "umibiraki",
         "trans": [
+            "海開(うみびら)き",
             "③ 名  开放海水浴场"
-        ],
-        "notation": "海開(うみびら)き"
+        ]
     },
     {
         "name": "oshiekomu",
         "trans": [
+            "教(おし)え込(こ)む",
             "④ 他动1  灌输，谆谆教诲"
-        ],
-        "notation": "教(おし)え込(こ)む"
+        ]
     },
     {
         "name": "korekushon",
         "trans": [
+            "コレクション",
             "② 名  收集，收藏"
-        ],
-        "notation": "コレクション"
+        ]
     },
     {
         "name": "oshitsukeru",
         "trans": [
+            "押(お)し付(つ)ける",
             "④ 他动2  压，按住；强加于人"
-        ],
-        "notation": "押(お)し付(つ)ける"
+        ]
     },
     {
         "name": "ronten",
         "trans": [
+            "論点(ろんてん)",
             "③ 名  论点，争论的中心点"
-        ],
-        "notation": "論点(ろんてん)"
+        ]
     },
     {
         "name": "orihime",
         "trans": [
+            "織姫(おりひめ)",
             "② 名  织女；织女星"
-        ],
-        "notation": "織姫(おりひめ)"
+        ]
     },
     {
         "name": "ohinasama",
         "trans": [
+            "お雛様(ひなさま)",
             "② 名  古装人偶；女儿节"
-        ],
-        "notation": "お雛様(ひなさま)"
+        ]
     },
     {
         "name": "gaiheki",
         "trans": [
+            "外壁(がいへき)",
             "⓪ 名  外壁，外墙"
-        ],
-        "notation": "外壁(がいへき)"
+        ]
     },
     {
         "name": "kaunseringu",
         "trans": [
+            "カウンセリング",
             "② 名  心理咨询，咨询指导"
-        ],
-        "notation": "カウンセリング"
+        ]
     },
     {
         "name": "kaeshin",
         "trans": [
+            "替(か)え芯(しん)",
             "⓪ 名  替芯，备用芯"
-        ],
-        "notation": "替(か)え芯(しん)"
+        ]
     },
     {
         "name": "sounan",
         "trans": [
+            "遭難(そうなん)",
             "⓪ 名·自动3  遇难，遇险"
-        ],
-        "notation": "遭難(そうなん)"
+        ]
     },
     {
         "name": "kotogara",
         "trans": [
+            "事柄(ことがら)",
             "⓪ 名  事情，事态"
-        ],
-        "notation": "事柄(ことがら)"
+        ]
     },
     {
         "name": "kokki",
         "trans": [
+            "国旗(こっき)",
             "⓪ 名  国旗"
-        ],
-        "notation": "国旗(こっき)"
+        ]
     },
     {
         "name": "kawagutsu",
         "trans": [
+            "革靴(かわぐつ)",
             "⓪ 名  皮鞋"
-        ],
-        "notation": "革靴(かわぐつ)"
+        ]
     },
     {
         "name": "koten",
         "trans": [
+            "古典(こてん)",
             "⓪ 名  古书，古籍；古典作品"
-        ],
-        "notation": "古典(こてん)"
+        ]
     },
     {
         "name": "tomo",
         "trans": [
+            "友(とも)",
             "① 名  朋友，友人"
-        ],
-        "notation": "友(とも)"
+        ]
     },
     {
         "name": "hatsuden",
         "trans": [
+            "発電(はつでん)",
             "⓪ 名·自动3  发电"
-        ],
-        "notation": "発電(はつでん)"
+        ]
     },
     {
         "name": "koto",
         "trans": [
+            "琴(こと)",
             "① 名  古琴，筝"
-        ],
-        "notation": "琴(こと)"
+        ]
     },
     {
         "name": "kadai",
         "trans": [
+            "過大(かだい)",
             "⓪ ナ形  过大的"
-        ],
-        "notation": "過大(かだい)"
+        ]
     },
     {
         "name": "kotodukeru",
         "trans": [
+            "言付(ことづ)ける",
             "④ 他动2  托人带口信"
-        ],
-        "notation": "言付(ことづ)ける"
+        ]
     },
     {
         "name": "kotoni",
         "trans": [
+            "殊(こと)に",
             "① 副  特别，尤其"
-        ],
-        "notation": "殊(こと)に"
+        ]
     },
     {
         "name": "dokusha",
         "trans": [
+            "読者(どくしゃ)",
             "① 名  读者"
-        ],
-        "notation": "読者(どくしゃ)"
+        ]
     },
     {
         "name": "konasu",
         "trans": [
+            "こなす",
             " ⓪ 他动1  运用自如，掌握；做完；弄碎；销售"
-        ],
-        "notation": "こなす"
+        ]
     },
     {
         "name": "konomu",
         "trans": [
+            "好(この)む",
             "② 他动1  喜爱，爱好，喜欢"
-        ],
-        "notation": "好(この)む"
+        ]
     },
     {
         "name": "kanki",
         "trans": [
+            "換気(かんき)",
             "① 名·自动3  换气，通风"
-        ],
-        "notation": "換気(かんき)"
+        ]
     },
     {
         "name": "kisokutadashii",
         "trans": [
+            "規則正(きそくただ)しい",
             "⑥ イ形  有规律的"
-        ],
-        "notation": "規則正(きそくただ)しい"
+        ]
     },
     {
         "name": "guusuu",
         "trans": [
+            "偶数(ぐうすう)",
             "③ 名  偶数"
-        ],
-        "notation": "偶数(ぐうすう)"
+        ]
     },
     {
         "name": "kenson",
         "trans": [
+            "謙遜(けんそん)",
             "⓪ 名·ナ形·自动3  谦逊，谦虚"
-        ],
-        "notation": "謙遜(けんそん)"
+        ]
     },
     {
         "name": "sukusuku",
         "trans": [
+            "すくすく",
             " ② 副  茁壮成长，长得很快"
-        ],
-        "notation": "すくすく"
+        ]
     },
     {
         "name": "kousei",
         "trans": [
+            "厚生(こうせい)",
             "⓪ 名  福利，保健，卫生"
-        ],
-        "notation": "厚生(こうせい)"
+        ]
     },
     {
         "name": "tareru",
         "trans": [
+            "垂(た)れる",
             "② 自他动2  下垂，耷拉；使下垂"
-        ],
-        "notation": "垂(た)れる"
+        ]
     },
     {
         "name": "katamukeru",
         "trans": [
+            "傾(かたむ)ける",
             "④ 他动2  使倾斜；倾注；败（家）"
-        ],
-        "notation": "傾(かたむ)ける"
+        ]
     },
     {
         "name": "korogasu",
         "trans": [
+            "転(ころ)がす",
             "⓪ 他动1  滚动，转动；弄倒；推进（事物）"
-        ],
-        "notation": "転(ころ)がす"
+        ]
     },
     {
         "name": "gorogoro",
         "trans": [
+            "ごろごろ",
             " ① 副·自动3  闲着没事；咕噜咕噜滚动；到处都是；轰隆声"
-        ],
-        "notation": "ごろごろ"
+        ]
     },
     {
         "name": "shinmiri",
         "trans": [
+            "しんみり",
             " ③ 副·自动3  心平气和；沉静，寂静"
-        ],
-        "notation": "しんみり"
+        ]
     },
     {
         "name": "konkyo",
         "trans": [
+            "根拠(こんきょ)",
             "① 名  根据，依据"
-        ],
-        "notation": "根拠(こんきょ)"
+        ]
     },
     {
         "name": "katameru",
         "trans": [
+            "固(かた)める",
             "⓪ 他动2  使凝固；坚定，巩固"
-        ],
-        "notation": "固(かた)める"
+        ]
     },
     {
         "name": "kachimake",
         "trans": [
+            "勝(か)ち負(ま)け",
             "① 名  胜负，输赢"
-        ],
-        "notation": "勝(か)ち負(ま)け"
+        ]
     },
     {
         "name": "henkaku",
         "trans": [
+            "変革(へんかく)",
             "⓪ 名·自他动3  变革，改革"
-        ],
-        "notation": "変革(へんかく)"
+        ]
     },
     {
         "name": "saezuru",
         "trans": [
+            "囀(さえず)る",
             "③ 自动1  （小鸟）叽叽喳喳；喋喋不休"
-        ],
-        "notation": "囀(さえず)る"
+        ]
     },
     {
         "name": "sosokkashii",
         "trans": [
+            "そそっかしい",
             " ⑤ イ形  毛手毛脚的，粗心大意的"
-        ],
-        "notation": "そそっかしい"
+        ]
     },
     {
         "name": "kappatsu",
         "trans": [
+            "活発(かっぱつ)",
             "⓪ ナ形  活泼的，活跃的"
-        ],
-        "notation": "活発(かっぱつ)"
+        ]
     },
     {
         "name": "fukanzen",
         "trans": [
+            "不完全(ふかんぜん)",
             "② 名·ナ形  不完全，不完备，不足"
-        ],
-        "notation": "不完全(ふかんぜん)"
+        ]
     },
     {
         "name": "katsuyou",
         "trans": [
+            "活用(かつよう)",
             "⓪ 名·自他动3  灵活运用；词尾变化"
-        ],
-        "notation": "活用(かつよう)"
+        ]
     },
     {
         "name": "bouhan",
         "trans": [
+            "防犯(ぼうはん)",
             "⓪ 名  防止犯罪"
-        ],
-        "notation": "防犯(ぼうはん)"
+        ]
     },
     {
         "name": "hansuru",
         "trans": [
+            "反(はん)する",
             "③ 自动3  违反；相反，相悖"
-        ],
-        "notation": "反(はん)する"
+        ]
     },
     {
         "name": "kan'nen",
         "trans": [
+            "観念(かんねん)",
             "① 名  观念，想法"
-        ],
-        "notation": "観念(かんねん)"
+        ]
     },
     {
         "name": "hansei",
         "trans": [
+            "反省(はんせい)",
             "⓪ 名·他动3  反省，自我检查"
-        ],
-        "notation": "反省(はんせい)"
+        ]
     },
     {
         "name": "kondou",
         "trans": [
+            "混同(こんどう)",
             "⓪ 名·自动3  混为一谈，混淆"
-        ],
-        "notation": "混同(こんどう)"
+        ]
     },
     {
         "name": "saikai",
         "trans": [
+            "再開(さいかい)",
             "⓪ 名·自动3  重新开始，重新进行"
-        ],
-        "notation": "再開(さいかい)"
+        ]
     },
     {
         "name": "katsu",
         "trans": [
+            "且(か)つ",
             "① 副·接续  一边……一边……；而且，并且"
-        ],
-        "notation": "且(か)つ"
+        ]
     },
     {
         "name": "kakki",
         "trans": [
+            "活気(かっき)",
             "⓪ 名  活力，生机，朝气"
-        ],
-        "notation": "活気(かっき)"
+        ]
     },
     {
         "name": "saisoku",
         "trans": [
+            "催促(さいそく)",
             "① 名·他动3  催促，催；催讨"
-        ],
-        "notation": "催促(さいそく)"
+        ]
     },
     {
         "name": "hitei",
         "trans": [
+            "否定(ひてい)",
             "⓪ 名·他动3  否定，否认"
-        ],
-        "notation": "否定(ひてい)"
+        ]
     },
     {
         "name": "boranthia",
         "trans": [
+            "ボランティア",
             "② 名  志愿者"
-        ],
-        "notation": "ボランティア"
+        ]
     },
     {
         "name": "komugi",
         "trans": [
+            "小麦(こむぎ)",
             "⓪ 名  小麦"
-        ],
-        "notation": "小麦(こむぎ)"
+        ]
     },
     {
         "name": "hitoiki",
         "trans": [
+            "一息(ひといき)",
             "② 名  喘口气；一口气；加把劲儿"
-        ],
-        "notation": "一息(ひといき)"
+        ]
     },
     {
         "name": "maiku",
         "trans": [
+            "マイク",
             " ① 名  麦克风，话筒，扩音器"
-        ],
-        "notation": "マイク"
+        ]
     },
     {
         "name": "hitome",
         "trans": [
+            "一目(ひとめ)",
             "② 名  看一眼，一看；一眼看穿"
-        ],
-        "notation": "一目(ひとめ)"
+        ]
     },
     {
         "name": "hitome",
         "trans": [
+            "人目(ひとめ)",
             "⓪ 名  他人的眼光，世人的目光"
-        ],
-        "notation": "人目(ひとめ)"
+        ]
     },
     {
         "name": "saichuu",
         "trans": [
+            "最中(さいちゅう)",
             "① 名  正在……之中；最盛时期"
-        ],
-        "notation": "最中(さいちゅう)"
+        ]
     },
     {
         "name": "kiatsu",
         "trans": [
+            "気圧(きあつ)",
             "⓪ 名  气压"
-        ],
-        "notation": "気圧(きあつ)"
+        ]
     },
     {
         "name": "kahansuu",
         "trans": [
+            "過半数(かはんすう)",
             "② 名  过半数，半数以上"
-        ],
-        "notation": "過半数(かはんすう)"
+        ]
     },
     {
         "name": "togeru",
         "trans": [
+            "遂(と)げる",
             "② 他动2  完成（任务），实现（愿望）"
-        ],
-        "notation": "遂(と)げる"
+        ]
     },
     {
         "name": "saiban",
         "trans": [
+            "裁判(さいばん)",
             "① 名·他动3  评判；审判，裁判"
-        ],
-        "notation": "裁判(さいばん)"
+        ]
     },
     {
         "name": "hisan",
         "trans": [
+            "悲惨(ひさん)",
             "⓪ 名·ナ形  悲惨，凄惨"
-        ],
-        "notation": "悲惨(ひさん)"
+        ]
     },
     {
         "name": "komen",
         "trans": [
+            "湖面(こめん)",
             "⓪ 名  湖面"
-        ],
-        "notation": "湖面(こめん)"
+        ]
     },
     {
         "name": "kabu",
         "trans": [
+            "株(かぶ)",
             "⓪ 名  股份，股票"
-        ],
-        "notation": "株(かぶ)"
+        ]
     },
     {
         "name": "honshitsu",
         "trans": [
+            "本質(ほんしつ)",
             "⓪ 名  本质，骨子里"
-        ],
-        "notation": "本質(ほんしつ)"
+        ]
     },
     {
         "name": "dokuji",
         "trans": [
+            "独自(どくじ)",
             "① 名·ナ形  独自，个人；独特的"
-        ],
-        "notation": "独自(どくじ)"
+        ]
     },
     {
         "name": "hitogomi",
         "trans": [
+            "人込(ひとご)み",
             "⓪ 名  人群，人山人海"
-        ],
-        "notation": "人込(ひとご)み"
+        ]
     },
     {
         "name": "kapuseru",
         "trans": [
+            "カプセル",
             " ① 名  胶囊；密封舱"
-        ],
-        "notation": "カプセル"
+        ]
     },
     {
         "name": "kamau",
         "trans": [
+            "構(かま)う",
             "② 自他动1  管，干预；照顾，照料"
-        ],
-        "notation": "構(かま)う"
+        ]
     },
     {
         "name": "kamikiru",
         "trans": [
+            "噛(か)み切(き)る",
             "③ 他动1  咬断，咬破"
-        ],
-        "notation": "噛(か)み切(き)る"
+        ]
     },
     {
         "name": "kamishimeru",
         "trans": [
+            "噛(か)み締(し)める",
             "④ 他动2  用力咬紧；仔细品味"
-        ],
-        "notation": "噛(か)み締(し)める"
+        ]
     },
     {
         "name": "sutasuta",
         "trans": [
+            "すたすた",
             " ① 副  急忙，匆忙，飞快"
-        ],
-        "notation": "すたすた"
+        ]
     },
     {
         "name": "suppari",
         "trans": [
+            "すっぱり",
             "(断绝)  ③ 副  干脆利落地切断；彻底（断绝），干脆"
-        ],
-        "notation": "すっぱり"
+        ]
     },
     {
         "name": "kikime",
         "trans": [
+            "効(き)き目(め)",
             "⓪ 名  （药物的）效力，（建议等的）效果，作用"
-        ],
-        "notation": "効(き)き目(め)"
+        ]
     },
     {
         "name": "madika",
         "trans": [
+            "間近(まぢか)",
             "① 名·ナ形  眼前，跟前，眼看就要"
-        ],
-        "notation": "間近(まぢか)"
+        ]
     },
     {
         "name": "hanketsu",
         "trans": [
+            "判決(はんけつ)",
             "⓪ 名·他动3  判决"
-        ],
-        "notation": "判決(はんけつ)"
+        ]
     },
     {
         "name": "machikado",
         "trans": [
+            "街角(まちかど)",
             "⓪ 名  街角，街头"
-        ],
-        "notation": "街角(まちかど)"
+        ]
     },
     {
         "name": "kigou",
         "trans": [
+            "記号(きごう)",
             "⓪ 名  记号，符号"
-        ],
-        "notation": "記号(きごう)"
+        ]
     },
     {
         "name": "kamotsu",
         "trans": [
+            "貨物(かもつ)",
             "① 名  货物；货车"
-        ],
-        "notation": "貨物(かもつ)"
+        ]
     },
     {
         "name": "kara",
         "trans": [
+            "空(から)",
             "② 名  空，空虚，空洞"
-        ],
-        "notation": "空(から)"
+        ]
     },
     {
         "name": "kijun",
         "trans": [
+            "基準(きじゅん)",
             "⓪ 名  基准，标准，依据，准则"
-        ],
-        "notation": "基準(きじゅん)"
+        ]
     },
     {
         "name": "kanchigai",
         "trans": [
+            "勘違(かんちが)い",
             "③ 名·自动3  判断错误，错觉；误会，误解"
-        ],
-        "notation": "勘違(かんちが)い"
+        ]
     },
     {
         "name": "kizutsukeru",
         "trans": [
+            "傷付(きずつ)ける",
             "④ 他动2  伤，弄伤；伤害；败坏"
-        ],
-        "notation": "傷付(きずつ)ける"
+        ]
     },
     {
         "name": "hitorigoto",
         "trans": [
+            "独(ひと)り言(ごと)",
             "⓪ 名  自言自语（的话）"
-        ],
-        "notation": "独(ひと)り言(ごと)"
+        ]
     },
     {
         "name": "hayakutomo",
         "trans": [
+            "早(はや)くとも",
             "① 副  最快也要"
-        ],
-        "notation": "早(はや)くとも"
+        ]
     },
     {
         "name": "tokorodokoro",
         "trans": [
+            "所々(ところどころ)",
             "④ 名  到处，处处"
-        ],
-        "notation": "所々(ところどころ)"
+        ]
     },
     {
         "name": "yohou",
         "trans": [
+            "予報(よほう)",
             "⓪ 名·他动3  预报"
-        ],
-        "notation": "予報(よほう)"
+        ]
     },
     {
         "name": "kiseki",
         "trans": [
+            "奇跡(きせき)",
             "② 名  奇迹，不可思议的事"
-        ],
-        "notation": "奇跡(きせき)"
+        ]
     },
     {
         "name": "fuka",
         "trans": [
+            "不可(ふか)",
             "① 名  不可，不行；不合格"
-        ],
-        "notation": "不可(ふか)"
+        ]
     },
     {
         "name": "hyoushi",
         "trans": [
+            "表紙(ひょうし)",
             "③ 名  封面，书皮，封皮"
-        ],
-        "notation": "表紙(ひょうし)"
+        ]
     },
     {
         "name": "akuma",
         "trans": [
+            "悪魔(あくま)",
             "① 名  恶魔"
-        ],
-        "notation": "悪魔(あくま)"
+        ]
     },
     {
         "name": "kichi",
         "trans": [
+            "基地(きち)",
             "① 名  基地，根据地"
-        ],
-        "notation": "基地(きち)"
+        ]
     },
     {
         "name": "kanren",
         "trans": [
+            "関連(かんれん)",
             "⓪ 名·自动3  关联，联系；有关系"
-        ],
-        "notation": "関連(かんれん)"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "昇(のぼ)る",
             "⓪ 自动1  升；上升；升级，高升"
-        ],
-        "notation": "昇(のぼ)る"
+        ]
     },
     {
         "name": "norikiru",
         "trans": [
+            "乗(の)り切(き)る",
             "③ 自动1  排除（困难），渡过（难关）"
-        ],
-        "notation": "乗(の)り切(き)る"
+        ]
     },
     {
         "name": "norikoeru",
         "trans": [
+            "乗(の)り越(こ)える",
             "④ 自动2  跨过，越过；渡过（危机）；超越（前人）"
-        ],
-        "notation": "乗(の)り越(こ)える"
+        ]
     },
     {
         "name": "katsugu",
         "trans": [
+            "担(かつ)ぐ",
             "② 他动1  扛，挑，背；以……为领袖"
-        ],
-        "notation": "担(かつ)ぐ"
+        ]
     },
     {
         "name": "katsuji",
         "trans": [
+            "活字(かつじ)",
             "⓪ 名  活字；活字印刷品"
-        ],
-        "notation": "活字(かつじ)"
+        ]
     },
     {
         "name": "zaimoku",
         "trans": [
+            "材木(ざいもく)",
             "⓪ 名  木材，木料"
-        ],
-        "notation": "材木(ざいもく)"
+        ]
     },
     {
         "name": "douwa",
         "trans": [
+            "童話(どうわ)",
             "⓪ 名  童话"
-        ],
-        "notation": "童話(どうわ)"
+        ]
     },
     {
         "name": "akumade",
         "trans": [
+            "あくまで",
             " ② 副  到底，彻底；始终"
-        ],
-        "notation": "あくまで"
+        ]
     },
     {
         "name": "fukusuu",
         "trans": [
+            "複数(ふくすう)",
             "③ 名  复数（两个以上的数）；（语法中的）复数"
-        ],
-        "notation": "複数(ふくすう)"
+        ]
     },
     {
         "name": "kishou",
         "trans": [
+            "気象(きしょう)",
             "⓪ 名  气象；天性，脾气，秉性"
-        ],
-        "notation": "気象(きしょう)"
+        ]
     },
     {
         "name": "houan",
         "trans": [
+            "法案(ほうあん)",
             "⓪ 名  法案，法律草案"
-        ],
-        "notation": "法案(ほうあん)"
+        ]
     },
     {
         "name": "hijoushiki",
         "trans": [
+            "非常識(ひじょうしき)",
             "② 名·ナ形  不合常理，脱离常识"
-        ],
-        "notation": "非常識(ひじょうしき)"
+        ]
     },
     {
         "name": "kizuguchi",
         "trans": [
+            "傷口(きずぐち)",
             "⓪ 名  伤口"
-        ],
-        "notation": "傷口(きずぐち)"
+        ]
     },
     {
         "name": "surasura",
         "trans": [
+            "すらすら",
             " ① 副  流畅，流利，顺利"
-        ],
-        "notation": "すらすら"
+        ]
     },
     {
         "name": "doukan",
         "trans": [
+            "同感(どうかん)",
             "⓪ 名·自动3  同感；同意，赞同"
-        ],
-        "notation": "同感(どうかん)"
+        ]
     },
     {
         "name": "ueki",
         "trans": [
+            "植木(うえき)",
             "⓪ 名  栽种的树，盆栽的花木"
-        ],
-        "notation": "植木(うえき)"
+        ]
     },
     {
         "name": "douki",
         "trans": [
+            "動機(どうき)",
             "⓪ 名  动机，意图"
-        ],
-        "notation": "動機(どうき)"
+        ]
     },
     {
         "name": "mendou",
         "trans": [
+            "面倒(めんどう)",
             "③ 名·ナ形  麻烦，费事；照顾，照料"
-        ],
-        "notation": "面倒(めんどう)"
+        ]
     },
     {
         "name": "kichitto",
         "trans": [
+            "きちっと",
             " ② 副  整整齐齐；准时，如期；牢牢地"
-        ],
-        "notation": "きちっと"
+        ]
     },
     {
         "name": "kissa",
         "trans": [
+            "喫茶(きっさ)",
             "⓪ 名  喝茶，饮茶"
-        ],
-        "notation": "喫茶(きっさ)"
+        ]
     },
     {
         "name": "doukyo",
         "trans": [
+            "同居(どうきょ)",
             "⓪ 名·自动3  共同居住"
-        ],
-        "notation": "同居(どうきょ)"
+        ]
     },
     {
         "name": "touge",
         "trans": [
+            "峠(とうげ)",
             "③ 名  山顶，岭；顶点，紧要时期"
-        ],
-        "notation": "峠(とうげ)"
+        ]
     },
     {
         "name": "kinyuu",
         "trans": [
+            "記入(きにゅう)",
             "⓪ 名·他动3  记上，填写，写上"
-        ],
-        "notation": "記入(きにゅう)"
+        ]
     },
     {
         "name": "suitei",
         "trans": [
+            "推定(すいてい)",
             "⓪ 名·他动3  推断，推算；设想"
-        ],
-        "notation": "推定(すいてい)"
+        ]
     },
     {
         "name": "doujou",
         "trans": [
+            "同情(どうじょう)",
             "⓪ 名·自动3  同情"
-        ],
-        "notation": "同情(どうじょう)"
+        ]
     },
     {
         "name": "soyosoyo",
         "trans": [
+            "そよそよ",
             " ① 副  风轻轻吹拂"
-        ],
-        "notation": "そよそよ"
+        ]
     },
     {
         "name": "aozora",
         "trans": [
+            "青空(あおぞら)",
             "③ 名  蓝天，晴空"
-        ],
-        "notation": "青空(あおぞら)"
+        ]
     },
     {
         "name": "toraeru",
         "trans": [
+            "捉(とら)える",
             "③ 他动2  捉住；紧紧抓住；捕获"
-        ],
-        "notation": "捉(とら)える"
+        ]
     },
     {
         "name": "toraberu",
         "trans": [
+            "トラブル",
             "② 名  纠纷，纷争；故障"
-        ],
-        "notation": "トラブル"
+        ]
     },
     {
         "name": "douyou",
         "trans": [
+            "同様(どうよう)",
             "⓪ 名·ナ形  同样，同等"
-        ],
-        "notation": "同様(どうよう)"
+        ]
     },
     {
         "name": "nukasu",
         "trans": [
+            "抜(ぬ)かす",
             "⓪ 他动1  遗漏，漏掉；跳过"
-        ],
-        "notation": "抜(ぬ)かす"
+        ]
     },
     {
         "name": "hatashite",
         "trans": [
+            "果(は)たして",
             "② 副  果然；果真；到底，究竟"
-        ],
-        "notation": "果(は)たして"
+        ]
     },
     {
         "name": "hatasu",
         "trans": [
+            "果(は)たす",
             "② 他动1  完成，实现"
-        ],
-        "notation": "果(は)たす"
+        ]
     },
     {
         "name": "touyou",
         "trans": [
+            "東洋(とうよう)",
             "① 名  东洋，东方"
-        ],
-        "notation": "東洋(とうよう)"
+        ]
     },
     {
         "name": "nochihodo",
         "trans": [
+            "のちほど",
             " ⓪ 副  过一会儿，随后"
-        ],
-        "notation": "のちほど"
+        ]
     },
     {
         "name": "nobe",
         "trans": [
+            "延(の)べ",
             "① 名  总计，共计，合计"
-        ],
-        "notation": "延(の)べ"
+        ]
     },
     {
         "name": "hatarakimono",
         "trans": [
+            "働(はたら)き者(もの)",
             "⓪ 名  干活能手，勤劳的人"
-        ],
-        "notation": "働(はたら)き者(もの)"
+        ]
     },
     {
         "name": "hachi",
         "trans": [
+            "鉢(はち)",
             "② 名  钵，盆"
-        ],
-        "notation": "鉢(はち)"
+        ]
     },
     {
         "name": "hakki",
         "trans": [
+            "発揮(はっき)",
             "⓪ 名·他动3  发挥，施展"
-        ],
-        "notation": "発揮(はっき)"
+        ]
     },
     {
         "name": "hanashikotoba",
         "trans": [
+            "話(はな)し言葉(ことば)",
             "④ 名  口语"
-        ],
-        "notation": "話(はな)し言葉(ことば)"
+        ]
     },
     {
         "name": "neage",
         "trans": [
+            "値上(ねあ)げ",
             "⓪ 名·他动3  涨价，提价"
-        ],
-        "notation": "値上(ねあ)げ"
+        ]
     },
     {
         "name": "nekasu",
         "trans": [
+            "寝(ね)かす",
             "⓪ 他动1  使睡觉，使躺下；放平，放倒"
-        ],
-        "notation": "寝(ね)かす"
+        ]
     },
     {
         "name": "neji",
         "trans": [
+            "ねじ",
             " ① 名  螺丝；发条"
-        ],
-        "notation": "ねじ"
+        ]
     },
     {
         "name": "tokuyuu",
         "trans": [
+            "特有(とくゆう)",
             "⓪ 名·ナ形  特有，独有"
-        ],
-        "notation": "特有(とくゆう)"
+        ]
     },
     {
         "name": "hassha",
         "trans": [
+            "発射(はっしゃ)",
             "⓪ 名·他动3  发射"
-        ],
-        "notation": "発射(はっしゃ)"
+        ]
     },
     {
         "name": "hanareru",
         "trans": [
+            "離(はな)れる",
             "③ 自动2  分离；离去；距离，相隔"
-        ],
-        "notation": "離(はな)れる"
+        ]
     },
     {
         "name": "nettai",
         "trans": [
+            "熱帯(ねったい)",
             "⓪ 名  热带"
-        ],
-        "notation": "熱帯(ねったい)"
+        ]
     },
     {
         "name": "hanahadashii",
         "trans": [
+            "甚(はなは)だしい",
             "⑤ イ形  很，甚，非常"
-        ],
-        "notation": "甚(はなは)だしい"
+        ]
     },
     {
         "name": "tokkuni",
         "trans": [
+            "とっくに",
             " ⓪ 副  很早以前，早就"
-        ],
-        "notation": "とっくに"
+        ]
     },
     {
         "name": "hatsukoi",
         "trans": [
+            "初恋(はつこい)",
             "⓪ 名  初恋"
-        ],
-        "notation": "初恋(はつこい)"
+        ]
     },
     {
         "name": "hakkou",
         "trans": [
+            "発行(はっこう)",
             "⓪ 名·他动3  发行（出版物、纸币）"
-        ],
-        "notation": "発行(はっこう)"
+        ]
     },
     {
         "name": "nukidasu",
         "trans": [
+            "抜(ぬ)き出(だ)す",
             "③ 他动1  拔出，抽出；选拔，挑选"
-        ],
-        "notation": "抜(ぬ)き出(だ)す"
+        ]
     },
     {
         "name": "nusumi",
         "trans": [
+            "盗(ぬす)み",
             "③ 名  偷盗，偷窃"
-        ],
-        "notation": "盗(ぬす)み"
+        ]
     },
     {
         "name": "ne",
         "trans": [
+            "根(ね)",
             "① 名  根；根源；天生，本性"
-        ],
-        "notation": "根(ね)"
+        ]
     },
     {
         "name": "neagari",
         "trans": [
+            "値上(ねあ)がり",
             "⓪ 名·自动3  价格上涨"
-        ],
-        "notation": "値上(ねあ)がり"
+        ]
     },
     {
         "name": "gatagata",
         "trans": [
+            "がたがた",
             " ① 副·自动3  咔嗒咔嗒；摇摇晃晃；哆哆嗦嗦"
-        ],
-        "notation": "がたがた"
+        ]
     },
     {
         "name": "tokekomu",
         "trans": [
+            "溶(と)け込(こ)む",
             "⓪ 自动1  溶化；融入，融洽"
-        ],
-        "notation": "溶(と)け込(こ)む"
+        ]
     },
     {
         "name": "hato",
         "trans": [
+            "鳩(はと)",
             "① 名  鸽子"
-        ],
-        "notation": "鳩(はと)"
+        ]
     },
     {
         "name": "noroi",
         "trans": [
+            "鈍(のろ)い",
             "② イ形  缓慢的；迟钝的；磨蹭的"
-        ],
-        "notation": "鈍(のろ)い"
+        ]
     },
     {
         "name": "tousen",
         "trans": [
+            "当選(とうせん)",
             "⓪ 名·自动3  当选，中选"
-        ],
-        "notation": "当選(とうせん)"
+        ]
     },
     {
         "name": "dounimo",
         "trans": [
+            "どうにも",
             "(后接否定)  ① 副  （后接否定）无论如何也；实在，的确"
-        ],
-        "notation": "どうにも"
+        ]
     },
     {
         "name": "nenpai",
         "trans": [
+            "年配(ねんぱい)",
             "⓪ 名  大致年龄；上了年纪"
-        ],
-        "notation": "年配(ねんぱい)"
+        ]
     },
     {
         "name": "nenryou",
         "trans": [
+            "燃料(ねんりょう)",
             "③ 名  燃料"
-        ],
-        "notation": "燃料(ねんりょう)"
+        ]
     },
     {
         "name": "buntan",
         "trans": [
+            "分担(ぶんたん)",
             "⓪ 名·他动3  分担"
-        ],
-        "notation": "分担(ぶんたん)"
+        ]
     },
     {
         "name": "nou",
         "trans": [
+            "能(のう)",
             "① 名  能力，才能"
-        ],
-        "notation": "能(のう)"
+        ]
     },
     {
         "name": "dounyuu",
         "trans": [
+            "導入(どうにゅう)",
             "⓪ 名·他动3  引入，导入，引进（外资）"
-        ],
-        "notation": "導入(どうにゅう)"
+        ]
     },
     {
         "name": "kyuuen",
         "trans": [
+            "救援(きゅうえん)",
             "⓪ 名·他动3  救援，支援"
-        ],
-        "notation": "救援(きゅうえん)"
+        ]
     },
     {
         "name": "touhyou",
         "trans": [
+            "投票(とうひょう)",
             "⓪ 名·自动3  投票"
-        ],
-        "notation": "投票(とうひょう)"
+        ]
     },
     {
         "name": "necchuu",
         "trans": [
+            "熱中(ねっちゅう)",
             "⓪ 名·自动3  热衷，入迷，专心致志"
-        ],
-        "notation": "熱中(ねっちゅう)"
+        ]
     },
     {
         "name": "nebiki",
         "trans": [
+            "値引(ねび)き",
             "⓪ 名·他动3  减价，降价"
-        ],
-        "notation": "値引(ねび)き"
+        ]
     },
     {
         "name": "noudo",
         "trans": [
+            "濃度(のうど)",
             "① 名  浓度"
-        ],
-        "notation": "濃度(のうど)"
+        ]
     },
     {
         "name": "nerau",
         "trans": [
+            "狙(ねら)う",
             "⓪ 他动1  瞄准；以……为目标"
-        ],
-        "notation": "狙(ねら)う"
+        ]
     },
     {
         "name": "norikomu",
         "trans": [
+            "乗(の)り込(こ)む",
             "③ 自动1  乘上，坐上（车、船等）；（一起）乘坐；进入，闯入"
-        ],
-        "notation": "乗(の)り込(こ)む"
+        ]
     },
     {
         "name": "ba",
         "trans": [
+            "場(ば)",
             "⓪ 名  场所；场面，场合"
-        ],
-        "notation": "場(ば)"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "灰(はい)",
             "⓪ 名  灰，灰烬"
-        ],
-        "notation": "灰(はい)"
+        ]
     },
     {
         "name": "haikingu",
         "trans": [
+            "ハイキング",
             "① 名·自动3  郊游，远足，徒步旅游"
-        ],
-        "notation": "ハイキング"
+        ]
     },
     {
         "name": "nengetsu",
         "trans": [
+            "年月(ねんげつ)",
             "① 名  岁月，光阴"
-        ],
-        "notation": "年月(ねんげつ)"
+        ]
     },
     {
         "name": "haiku",
         "trans": [
+            "俳句(はいく)",
             "⓪ 名  俳句（由五、七、五共十七个音组成的短诗）"
-        ],
-        "notation": "俳句(はいく)"
+        ]
     },
     {
         "name": "nen'notame",
         "trans": [
+            "念(ねん)のため",
             "⓪ 连语  保险起见，慎重起见"
-        ],
-        "notation": "念(ねん)のため"
+        ]
     },
     {
         "name": "haishi",
         "trans": [
+            "廃止(はいし)",
             "⓪ 名·他动3  废止，废除，作废"
-        ],
-        "notation": "廃止(はいし)"
+        ]
     },
     {
         "name": "katsukatsu",
         "trans": [
+            "かつかつ",
             " ⓪ 副  好不容易，勉勉强强"
-        ],
-        "notation": "かつかつ"
+        ]
     },
     {
         "name": "hashigo",
         "trans": [
+            "梯子(はしご)",
             "⓪ 名  梯子"
-        ],
-        "notation": "梯子(はしご)"
+        ]
     },
     {
         "name": "pata-n",
         "trans": [
+            "パターン",
             "② 名  类型，模式；图案"
-        ],
-        "notation": "パターン"
+        ]
     },
     {
         "name": "aogu",
         "trans": [
+            "扇(あお)ぐ",
             "② 他动1  扇（风、火等）；煽动"
-        ],
-        "notation": "扇(あお)ぐ"
+        ]
     },
     {
         "name": "akippoi",
         "trans": [
+            "飽(あ)きっぽい",
             "④ イ形  没常性的，动不动就厌烦的"
-        ],
-        "notation": "飽(あ)きっぽい"
+        ]
     },
     {
         "name": "ban'nou",
         "trans": [
+            "万能(ばんのう)",
             "⓪ 名  万能，全能；效果，效验"
-        ],
-        "notation": "万能(ばんのう)"
+        ]
     },
     {
         "name": "bi",
         "trans": [
+            "美(び)",
             "① 名  美，美丽；出色"
-        ],
-        "notation": "美(び)"
+        ]
     },
     {
         "name": "hikiageru",
         "trans": [
+            "引(ひ)き上(あ)げる",
             "④ 他动2  提升；抬高"
-        ],
-        "notation": "引(ひ)き上(あ)げる"
+        ]
     },
     {
         "name": "hikitsuduki",
         "trans": [
+            "引(ひ)き続(つづ)き",
             "⓪ 名·副  紧接着，继续；连续"
-        ],
-        "notation": "引(ひ)き続(つづ)き"
+        ]
     },
     {
         "name": "hikitomeru",
         "trans": [
+            "引(ひ)き止(と)める",
             "④ 他动2  阻止，制止，勒住，拉住；留，挽留"
-        ],
-        "notation": "引(ひ)き止(と)める"
+        ]
     },
     {
         "name": "aki",
         "trans": [
+            "空(あ)き",
             "⓪ 名  空；空闲；空缺"
-        ],
-        "notation": "空(あ)き"
+        ]
     },
     {
         "name": "hairyo",
         "trans": [
+            "配慮(はいりょ)",
             "① 名·他动3  关怀，照顾，照料"
-        ],
-        "notation": "配慮(はいりょ)"
+        ]
     },
     {
         "name": "souchi",
         "trans": [
+            "装置(そうち)",
             "① 名  装置，设备，装备"
-        ],
-        "notation": "装置(そうち)"
+        ]
     },
     {
         "name": "bakudan",
         "trans": [
+            "爆弾(ばくだん)",
             "⓪ 名  炸弹"
-        ],
-        "notation": "爆弾(ばくだん)"
+        ]
     },
     {
         "name": "mushinkei",
         "trans": [
+            "無神経(むしんけい)",
             "② 名·ナ形  反应迟钝，反应慢"
-        ],
-        "notation": "無神経(むしんけい)"
+        ]
     },
     {
         "name": "hakobi",
         "trans": [
+            "運(はこ)び",
             "⓪ 名  搬运；进度；阶段"
-        ],
-        "notation": "運(はこ)び"
+        ]
     },
     {
         "name": "hasan",
         "trans": [
+            "破産(はさん)",
             "⓪ 名·自动3  破产"
-        ],
-        "notation": "破産(はさん)"
+        ]
     },
     {
         "name": "bishobisho",
         "trans": [
+            "びしょびしょ",
             "(雨)  ① ナ形·副  湿透的；（雨）连绵不断"
-        ],
-        "notation": "びしょびしょ"
+        ]
     },
     {
         "name": "manjuu",
         "trans": [
+            "饅頭(まんじゅう)",
             "③ 名  包子，豆沙包"
-        ],
-        "notation": "饅頭(まんじゅう)"
+        ]
     },
     {
         "name": "nendo",
         "trans": [
+            "年度(ねんど)",
             "① 名  年度"
-        ],
-        "notation": "年度(ねんど)"
+        ]
     },
     {
         "name": "mikata",
         "trans": [
+            "味方(みかた)",
             "⓪ 名·自动3  我方；同伴，伙伴"
-        ],
-        "notation": "味方(みかた)"
+        ]
     },
     {
         "name": "toubun",
         "trans": [
+            "等分(とうぶん)",
             "⓪ 名·他动3  等分；平均分配"
-        ],
-        "notation": "等分(とうぶん)"
+        ]
     },
     {
         "name": "nenkin",
         "trans": [
+            "年金(ねんきん)",
             "⓪ 名  养老金"
-        ],
-        "notation": "年金(ねんきん)"
+        ]
     },
     {
         "name": "haikei",
         "trans": [
+            "背景(はいけい)",
             "⓪ 名  背景；舞台布景；后盾"
-        ],
-        "notation": "背景(はいけい)"
+        ]
     },
     {
         "name": "noki",
         "trans": [
+            "軒(のき)",
             "⓪ 名  房檐"
-        ],
-        "notation": "軒(のき)"
+        ]
     },
     {
         "name": "mizukara",
         "trans": [
+            "自(みずか)ら",
             "① 名·副  自己；亲自"
-        ],
-        "notation": "自(みずか)ら"
+        ]
     },
     {
         "name": "baishou",
         "trans": [
+            "賠償(ばいしょう)",
             "⓪ 名·他动3  赔偿，补偿"
-        ],
-        "notation": "賠償(ばいしょう)"
+        ]
     },
     {
         "name": "hisoka",
         "trans": [
+            "密(ひそ)か",
             "② ナ形  秘密的，暗中的，偷偷的"
-        ],
-        "notation": "密(ひそ)か"
+        ]
     },
     {
         "name": "bitamin",
         "trans": [
+            "ビタミン",
             "② 名  维生素"
-        ],
-        "notation": "ビタミン"
+        ]
     },
     {
         "name": "pitari",
         "trans": [
+            "ぴたり",
             " ② 副  紧贴着；正合适；突然停止"
-        ],
-        "notation": "ぴたり"
+        ]
     },
     {
         "name": "akuru",
         "trans": [
+            "明(あ)くる",
             "⓪ 连体  下一个；次，翌，第二"
-        ],
-        "notation": "明(あ)くる"
+        ]
     },
     {
         "name": "bishou",
         "trans": [
+            "微笑(びしょう)",
             "⓪ 名·自动3  微笑"
-        ],
-        "notation": "微笑(びしょう)"
+        ]
     },
     {
         "name": "hayaoki",
         "trans": [
+            "早起(はやお)き",
             "② 名·自动3  早起，早早起来"
-        ],
-        "notation": "早起(はやお)き"
+        ]
     },
     {
         "name": "akegata",
         "trans": [
+            "明(あ)け方(がた)",
             "⓪ 名  黎明，拂晓"
-        ],
-        "notation": "明(あ)け方(がた)"
+        ]
     },
     {
         "name": "akeru",
         "trans": [
+            "空(あ)ける",
             "⓪ 他动2  空开；空出；抽空"
-        ],
-        "notation": "空(あ)ける"
+        ]
     },
     {
         "name": "hane",
         "trans": [
+            "羽(はね)",
             "⓪ 名  羽毛；翅膀"
-        ],
-        "notation": "羽(はね)"
+        ]
     },
     {
         "name": "ozuozu",
         "trans": [
+            "おずおず",
             " ① 副·自动3  战战兢兢，惴惴不安"
-        ],
-        "notation": "おずおず"
+        ]
     },
     {
         "name": "hikyou",
         "trans": [
+            "卑怯(ひきょう)",
             "② 名·ナ形  胆怯，懦弱；卑鄙，无耻"
-        ],
-        "notation": "卑怯(ひきょう)"
+        ]
     },
     {
         "name": "haijo",
         "trans": [
+            "排除(はいじょ)",
             "① 名·他动3  排除，消除"
-        ],
-        "notation": "排除(はいじょ)"
+        ]
     },
     {
         "name": "higeki",
         "trans": [
+            "悲劇(ひげき)",
             "① 名  悲剧"
-        ],
-        "notation": "悲劇(ひげき)"
+        ]
     },
     {
         "name": "hama",
         "trans": [
+            "浜(はま)",
             "② 名  海滨"
-        ],
-        "notation": "浜(はま)"
+        ]
     },
     {
         "name": "hayane",
         "trans": [
+            "早寝(はやね)",
             "② 名·自动3  早睡，提前睡觉"
-        ],
-        "notation": "早寝(はやね)"
+        ]
     },
     {
         "name": "hikou",
         "trans": [
+            "飛行(ひこう)",
             "⓪ 名·自动3  飞行，航空"
-        ],
-        "notation": "飛行(ひこう)"
+        ]
     },
     {
         "name": "haraikomu",
         "trans": [
+            "払(はら)い込(こ)む",
             "④ 他动1  缴纳，交纳"
-        ],
-        "notation": "払(はら)い込(こ)む"
+        ]
     },
     {
         "name": "fukuramu",
         "trans": [
+            "膨(ふく)らむ",
             "⓪ 自动1  膨胀，鼓起"
-        ],
-        "notation": "膨(ふく)らむ"
+        ]
     },
     {
         "name": "higoro",
         "trans": [
+            "日頃(ひごろ)",
             "⓪ 名·副  平常，平时"
-        ],
-        "notation": "日頃(ひごろ)"
+        ]
     },
     {
         "name": "sakihodo",
         "trans": [
+            "先程(さきほど)",
             "⓪ 副  刚才，方寸"
-        ],
-        "notation": "先程(さきほど)"
+        ]
     },
     {
         "name": "harikiru",
         "trans": [
+            "張(は)り切(き)る",
             "③ 自动1  拉紧，绷紧；干劲十足，精神百倍；紧张"
-        ],
-        "notation": "張(は)り切(き)る"
+        ]
     },
     {
         "name": "haruka",
         "trans": [
+            "はるか",
             " ① ナ形·副  遥远，远远；程度相差很大"
-        ],
-        "notation": "はるか"
+        ]
     },
     {
         "name": "han'ei",
         "trans": [
+            "反映(はんえい)",
             "⓪ 名·自他动3  （光）反射；反映"
-        ],
-        "notation": "反映(はんえい)"
+        ]
     },
     {
         "name": "hikkomu",
         "trans": [
+            "引(ひ)っ込(こ)む",
             "③ 自动1  隐退，退居；畏缩，退缩；塌，凹进去"
-        ],
-        "notation": "引(ひ)っ込(こ)む"
+        ]
     },
     {
         "name": "han'ei",
         "trans": [
+            "繁栄(はんえい)",
             "⓪ 名·自动3  繁荣，昌盛"
-        ],
-        "notation": "繁栄(はんえい)"
+        ]
     },
     {
         "name": "hitsujuhin",
         "trans": [
+            "必需品(ひつじゅひん)",
             "⓪ 名  必需品"
-        ],
-        "notation": "必需品(ひつじゅひん)"
+        ]
     },
     {
         "name": "hitomazu",
         "trans": [
+            "ひとまず",
             " ② 副  暂且，姑且，总之"
-        ],
-        "notation": "ひとまず"
+        ]
     },
     {
         "name": "hitorideni",
         "trans": [
+            "ひとりでに",
             " ⓪ 副  自然而然地；自动地"
-        ],
-        "notation": "ひとりでに"
+        ]
     },
     {
         "name": "hinan",
         "trans": [
+            "避難(ひなん)",
             "① 名·自动3  避难，逃难"
-        ],
-        "notation": "避難(ひなん)"
+        ]
     },
     {
         "name": "mizuiro",
         "trans": [
+            "水色(みずいろ)",
             "⓪ 名  淡蓝色"
-        ],
-        "notation": "水色(みずいろ)"
+        ]
     },
     {
         "name": "hantei",
         "trans": [
+            "判定(はんてい)",
             "⓪ 名·他动3  判定，判断"
-        ],
-        "notation": "判定(はんてい)"
+        ]
     },
     {
         "name": "funsui",
         "trans": [
+            "噴水(ふんすい)",
             "⓪ 名  喷泉"
-        ],
-        "notation": "噴水(ふんすい)"
+        ]
     },
     {
         "name": "hogo",
         "trans": [
+            "保護(ほご)",
             "① 名·他动3  保护，庇护"
-        ],
-        "notation": "保護(ほご)"
+        ]
     },
     {
         "name": "bunseki",
         "trans": [
+            "分析(ぶんせき)",
             "⓪ 名·他动3  （化学用语）分析，化验；分析，剖析（事物）"
-        ],
-        "notation": "分析(ぶんせき)"
+        ]
     },
     {
         "name": "mikaduki",
         "trans": [
+            "三日月(みかづき)",
             "⓪ 名  新月，月牙"
-        ],
-        "notation": "三日月(みかづき)"
+        ]
     },
     {
         "name": "fukushi",
         "trans": [
+            "福祉(ふくし)",
             "② 名  福祉，福利"
-        ],
-        "notation": "福祉(ふくし)"
+        ]
     },
     {
         "name": "hayasu",
         "trans": [
+            "生(は)やす",
             "② 他动1  使（植物等）生长；留（胡子）"
-        ],
-        "notation": "生(は)やす"
+        ]
     },
     {
         "name": "fukyou",
         "trans": [
+            "不況(ふきょう)",
             "⓪ 名  经济萧条"
-        ],
-        "notation": "不況(ふきょう)"
+        ]
     },
     {
         "name": "hiniku",
         "trans": [
+            "皮肉(ひにく)",
             "⓪ 名·ナ形  讽刺，挖苦"
-        ],
-        "notation": "皮肉(ひにく)"
+        ]
     },
     {
         "name": "bakudai",
         "trans": [
+            "莫大(ばくだい)",
             "⓪ 名·ナ形  莫大，巨大"
-        ],
-        "notation": "莫大(ばくだい)"
+        ]
     },
     {
         "name": "bouenkyou",
         "trans": [
+            "望遠鏡(ぼうえんきょう)",
             "⓪ 名  望远镜"
-        ],
-        "notation": "望遠鏡(ぼうえんきょう)"
+        ]
     },
     {
         "name": "haka",
         "trans": [
+            "墓(はか)",
             "② 名  坟墓"
-        ],
-        "notation": "墓(はか)"
+        ]
     },
     {
         "name": "hinode",
         "trans": [
+            "日(ひ)の出(で)",
             "⓪ 名  日出（时分）"
-        ],
-        "notation": "日(ひ)の出(で)"
+        ]
     },
     {
         "name": "hibiku",
         "trans": [
+            "響(ひび)く",
             "② 自动1  响；回响；影响"
-        ],
-        "notation": "響(ひび)く"
+        ]
     },
     {
         "name": "hakase",
         "trans": [
+            "博士(はかせ)",
             "① 名  博士"
-        ],
-        "notation": "博士(はかせ)"
+        ]
     },
     {
         "name": "seishun",
         "trans": [
+            "青春(せいしゅん)",
             "⓪ 名  青春"
-        ],
-        "notation": "青春(せいしゅん)"
+        ]
     },
     {
         "name": "hougen",
         "trans": [
+            "方言(ほうげん)",
             "③ 名  方言"
-        ],
-        "notation": "方言(ほうげん)"
+        ]
     },
     {
         "name": "bakuhatsuteki",
         "trans": [
+            "爆発的(ばくはつてき)",
             "⓪ ナ形  爆炸性的；急剧的，惊人的"
-        ],
-        "notation": "爆発的(ばくはつてき)"
+        ]
     },
     {
         "name": "bunryou",
         "trans": [
+            "分量(ぶんりょう)",
             "③ 名  分量；数量；重量"
-        ],
-        "notation": "分量(ぶんりょう)"
+        ]
     },
     {
         "name": "seishin",
         "trans": [
+            "精神(せいしん)",
             "① 名  精神；思想"
-        ],
-        "notation": "精神(せいしん)"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "平行(へいこう)",
             "⓪ 名·自动3  平行，并行"
-        ],
-        "notation": "平行(へいこう)"
+        ]
     },
     {
         "name": "min'you",
         "trans": [
+            "民謡(みんよう)",
             "⓪ 名  民谣"
-        ],
-        "notation": "民謡(みんよう)"
+        ]
     },
     {
         "name": "shinkou",
         "trans": [
+            "信仰(しんこう)",
             "⓪ 名·他动3  信仰"
-        ],
-        "notation": "信仰(しんこう)"
+        ]
     },
     {
         "name": "fukakujitsu",
         "trans": [
+            "不確実(ふかくじつ)",
             "② 名·ナ形  不准确，不可靠"
-        ],
-        "notation": "不確実(ふかくじつ)"
+        ]
     },
     {
         "name": "minshu",
         "trans": [
+            "民主(みんしゅ)",
             "① 名  民主"
-        ],
-        "notation": "民主(みんしゅ)"
+        ]
     },
     {
         "name": "kozeni",
         "trans": [
+            "小銭(こぜに)",
             "⓪ 名  零钱，零用钱；少量资金"
-        ],
-        "notation": "小銭(こぜに)"
+        ]
     },
     {
         "name": "songai",
         "trans": [
+            "損害(そんがい)",
             "⓪ 名·自他动3  损害，损失，损伤"
-        ],
-        "notation": "損害(そんがい)"
+        ]
     },
     {
         "name": "sukitooru",
         "trans": [
+            "透(す)き通(とお)る",
             "③ 自动1  透明，透过去；清澈"
-        ],
-        "notation": "透(す)き通(とお)る"
+        ]
     },
     {
         "name": "seijuku",
         "trans": [
+            "成熟(せいじゅく)",
             "⓪ 名·自动3  成熟"
-        ],
-        "notation": "成熟(せいじゅく)"
+        ]
     },
     {
         "name": "besuto",
         "trans": [
+            "ベスト",
             "① 名  最好，最上等，最优秀；全力"
-        ],
-        "notation": "ベスト"
+        ]
     },
     {
         "name": "hiyake",
         "trans": [
+            "日焼(ひや)け",
             "⓪ 名·自动3  （皮肤）晒黑；（土地）晒干"
-        ],
-        "notation": "日焼(ひや)け"
+        ]
     },
     {
         "name": "zukei",
         "trans": [
+            "図形(ずけい)",
             "⓪ 名  图形"
-        ],
-        "notation": "図形(ずけい)"
+        ]
     },
     {
         "name": "seireki",
         "trans": [
+            "西暦(せいれき)",
             "⓪ 名  公历"
-        ],
-        "notation": "西暦(せいれき)"
+        ]
     },
     {
         "name": "heikousen",
         "trans": [
+            "平行線(へいこうせん)",
             "⓪ 名  平行线"
-        ],
-        "notation": "平行線(へいこうせん)"
+        ]
     },
     {
         "name": "hyouhon",
         "trans": [
+            "標本(ひょうほん)",
             "⓪ 名  标本，样品"
-        ],
-        "notation": "標本(ひょうほん)"
+        ]
     },
     {
         "name": "heiki",
         "trans": [
+            "兵器(へいき)",
             "① 名  兵器，武器"
-        ],
-        "notation": "兵器(へいき)"
+        ]
     },
     {
         "name": "seifuku",
         "trans": [
+            "制服(せいふく)",
             "⓪ 名  制服"
-        ],
-        "notation": "制服(せいふく)"
+        ]
     },
     {
         "name": "makasu",
         "trans": [
+            "負(ま)かす",
             "⓪ 他动1  打败，战胜；讲价"
-        ],
-        "notation": "負(ま)かす"
+        ]
     },
     {
         "name": "hongoku",
         "trans": [
+            "本国(ほんごく)",
             "① 名  本国，祖国；故乡"
-        ],
-        "notation": "本国(ほんごく)"
+        ]
     },
     {
         "name": "heikou",
         "trans": [
+            "並行(へいこう)",
             "⓪ 名·自动3  并行；同时进行"
-        ],
-        "notation": "並行(へいこう)"
+        ]
     },
     {
         "name": "fuusen",
         "trans": [
+            "風船(ふうせん)",
             "⓪ 名  气球"
-        ],
-        "notation": "風船(ふうせん)"
+        ]
     },
     {
         "name": "hanshoku",
         "trans": [
+            "繁殖(はんしょく)",
             "⓪ 名·自动3  繁殖，滋生"
-        ],
-        "notation": "繁殖(はんしょく)"
+        ]
     },
     {
         "name": "ma-ketto",
         "trans": [
+            "マーケット",
             "① 名  市场，商场；销售市场"
-        ],
-        "notation": "マーケット"
+        ]
     },
     {
         "name": "houteishiki",
         "trans": [
+            "方程式(ほうていしき)",
             "③ 名  （数学）方程式"
-        ],
-        "notation": "方程式(ほうていしき)"
+        ]
     },
     {
         "name": "sha-pu",
         "trans": [
+            "シャープ",
             "① ナ形  尖锐的；敏锐的；清晰的"
-        ],
-        "notation": "シャープ"
+        ]
     },
     {
         "name": "seibi",
         "trans": [
+            "整備(せいび)",
             "① 名·他动3  整备；配备；整顿"
-        ],
-        "notation": "整備(せいび)"
+        ]
     },
     {
         "name": "hyouron",
         "trans": [
+            "評論(ひょうろん)",
             "⓪ 名·他动3  评论"
-        ],
-        "notation": "評論(ひょうろん)"
+        ]
     },
     {
         "name": "hiritsu",
         "trans": [
+            "比率(ひりつ)",
             "⓪ 名  比率"
-        ],
-        "notation": "比率(ひりつ)"
+        ]
     },
     {
         "name": "fuudo",
         "trans": [
+            "風土(ふうど)",
             "① 名  风土，水土"
-        ],
-        "notation": "風土(ふうど)"
+        ]
     },
     {
         "name": "byousha",
         "trans": [
+            "描写(びょうしゃ)",
             "⓪ 名·他动3  描写，描绘"
-        ],
-        "notation": "描写(びょうしゃ)"
+        ]
     },
     {
         "name": "hirou",
         "trans": [
+            "披露(ひろう)",
             "① 名·他动3  宣布；公布，发表"
-        ],
-        "notation": "披露(ひろう)"
+        ]
     },
     {
         "name": "besutosera-",
         "trans": [
+            "ベストセラー",
             "④ 名  畅销书"
-        ],
-        "notation": "ベストセラー"
+        ]
     },
     {
         "name": "kieyuku",
         "trans": [
+            "消(き)え行(ゆ)く",
             "⓪ 自动1  消失，行将灭绝"
-        ],
-        "notation": "消(き)え行(ゆ)く"
+        ]
     },
     {
         "name": "seiu",
         "trans": [
+            "晴雨(せいう)",
             "① 名  晴天或雨天"
-        ],
-        "notation": "晴雨(せいう)"
+        ]
     },
     {
         "name": "katsuryoku",
         "trans": [
+            "活力(かつりょく)",
             "② 名  活力，生命力"
-        ],
-        "notation": "活力(かつりょく)"
+        ]
     },
     {
         "name": "saikin",
         "trans": [
+            "細菌(さいきん)",
             "⓪ 名  细菌"
-        ],
-        "notation": "細菌(さいきん)"
+        ]
     },
     {
         "name": "kigaru",
         "trans": [
+            "気軽(きがる)",
             "⓪ ナ形  爽快的，轻松愉快的"
-        ],
-        "notation": "気軽(きがる)"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "過程(かてい)",
             "⓪ 名  过程"
-        ],
-        "notation": "過程(かてい)"
+        ]
     },
     {
         "name": "houshin",
         "trans": [
+            "方針(ほうしん)",
             "⓪ 名  方针"
-        ],
-        "notation": "方針(ほうしん)"
+        ]
     },
     {
         "name": "katoitte",
         "trans": [
+            "かといって",
             " ① 接续  虽然⋯⋯但是⋯⋯"
-        ],
-        "notation": "かといって"
+        ]
     },
     {
         "name": "kiki",
         "trans": [
+            "危機(きき)",
             "① 名  危机，险关"
-        ],
-        "notation": "危機(きき)"
+        ]
     },
     {
         "name": "kikitori",
         "trans": [
+            "聞(き)き取(と)り",
             "⓪ 名  听取；听懂"
-        ],
-        "notation": "聞(き)き取(と)り"
+        ]
     },
     {
         "name": "kaneru",
         "trans": [
+            "兼(か)ねる",
             "② 他动2·接尾  兼，兼任，兼职；难以……，不能……"
-        ],
-        "notation": "兼(か)ねる"
+        ]
     },
     {
         "name": "hirouen",
         "trans": [
+            "披露宴(ひろうえん)",
             "② 名  宴会，婚宴"
-        ],
-        "notation": "披露宴(ひろうえん)"
+        ]
     },
     {
         "name": "seitou",
         "trans": [
+            "政党(せいとう)",
             "⓪ 名  政党"
-        ],
-        "notation": "政党(せいとう)"
+        ]
     },
     {
         "name": "bunmei",
         "trans": [
+            "文明(ぶんめい)",
             "⓪ 名  文明，物质文化"
-        ],
-        "notation": "文明(ぶんめい)"
+        ]
     },
     {
         "name": "heisa",
         "trans": [
+            "閉鎖(へいさ)",
             "⓪ 名·自他动3  关闭，封锁"
-        ],
-        "notation": "閉鎖(へいさ)"
+        ]
     },
     {
         "name": "pin",
         "trans": [
+            "ピン",
             "① 名  别针；大头针"
-        ],
-        "notation": "ピン"
+        ]
     },
     {
         "name": "bu-mu",
         "trans": [
+            "ブーム",
             "① 名  热潮，潮流"
-        ],
-        "notation": "ブーム"
+        ]
     },
     {
         "name": "fuun",
         "trans": [
+            "不運(ふうん)",
             "① 名·ナ形  运气不好"
-        ],
-        "notation": "不運(ふうん)"
+        ]
     },
     {
         "name": "fue",
         "trans": [
+            "笛(ふえ)",
             "⓪ 名  笛子；哨子"
-        ],
-        "notation": "笛(ふえ)"
+        ]
     },
     {
         "name": "henshuu",
         "trans": [
+            "編集(へんしゅう)",
             "⓪ 名·他动3  编辑"
-        ],
-        "notation": "編集(へんしゅう)"
+        ]
     },
     {
         "name": "fukai",
         "trans": [
+            "不快(ふかい)",
             "② 名·ナ形  不愉快；身体不适"
-        ],
-        "notation": "不快(ふかい)"
+        ]
     },
     {
         "name": "seiten",
         "trans": [
+            "晴天(せいてん)",
             "⓪ 名  晴天"
-        ],
-        "notation": "晴天(せいてん)"
+        ]
     },
     {
         "name": "hendou",
         "trans": [
+            "変動(へんどう)",
             "⓪ 名·自动3  变动，变化"
-        ],
-        "notation": "変動(へんどう)"
+        ]
     },
     {
         "name": "tsuriau",
         "trans": [
+            "釣(つ)り合(あ)う",
             "③ 自动1  保持平衡；相称"
-        ],
-        "notation": "釣(つ)り合(あ)う"
+        ]
     },
     {
         "name": "hitotoori",
         "trans": [
+            "一通(ひととお)り",
             "⓪ 名·副  大概，粗略；普通"
-        ],
-        "notation": "一通(ひととお)り"
+        ]
     },
     {
         "name": "hitodoori",
         "trans": [
+            "人通(ひとどお)り",
             "⓪ 名  人来人往，来往行人"
-        ],
-        "notation": "人通(ひとどお)り"
+        ]
     },
     {
         "name": "bunmyaku",
         "trans": [
+            "文脈(ぶんみゃく)",
             "⓪ 名  文章脉络，前后文逻辑"
-        ],
-        "notation": "文脈(ぶんみゃく)"
+        ]
     },
     {
         "name": "seijitsu",
         "trans": [
+            "誠実(せいじつ)",
             "⓪ 名·ナ形  诚实，真诚"
-        ],
-        "notation": "誠実(せいじつ)"
+        ]
     },
     {
         "name": "heitai",
         "trans": [
+            "兵隊(へいたい)",
             "⓪ 名  军队；军人"
-        ],
-        "notation": "兵隊(へいたい)"
+        ]
     },
     {
         "name": "bukiyou",
         "trans": [
+            "不器用(ぶきよう)",
             "② 名·ナ形  笨手笨脚，不灵活"
-        ],
-        "notation": "不器用(ぶきよう)"
+        ]
     },
     {
         "name": "heiwa",
         "trans": [
+            "平和(へいわ)",
             "⓪ 名·ナ形  和平，和睦"
-        ],
-        "notation": "平和(へいわ)"
+        ]
     },
     {
         "name": "heso",
         "trans": [
+            "臍(へそ)",
             "⓪ 名  肚脐"
-        ],
-        "notation": "臍(へそ)"
+        ]
     },
     {
         "name": "seiiku",
         "trans": [
+            "生育(せいいく)",
             "⓪ 名·自他动3  生长；生育；繁殖"
-        ],
-        "notation": "生育(せいいく)"
+        ]
     },
     {
         "name": "betsujin",
         "trans": [
+            "別人(べつじん)",
             "⓪ 名  别人,其他人"
-        ],
-        "notation": "別人(べつじん)"
+        ]
     },
     {
         "name": "beteran",
         "trans": [
+            "ベテラン",
             "⓪ 名  老手，经验丰富的人"
-        ],
-        "notation": "ベテラン"
+        ]
     },
     {
         "name": "bou",
         "trans": [
+            "棒(ぼう)",
             "⓪ 名  棒，棍子"
-        ],
-        "notation": "棒(ぼう)"
+        ]
     },
     {
         "name": "gungun",
         "trans": [
+            "ぐんぐん",
             " ① 副  用力，使劲儿；很快地，突飞猛进；稳步地"
-        ],
-        "notation": "ぐんぐん"
+        ]
     },
     {
         "name": "houshiki",
         "trans": [
+            "方式(ほうしき)",
             "⓪ 名  方式，形式"
-        ],
-        "notation": "方式(ほうしき)"
+        ]
     },
     {
         "name": "fukidasu",
         "trans": [
+            "噴(ふ)き出(だ)す",
             "③ 自动1  喷出，冒出；忍不住笑出来"
-        ],
-        "notation": "噴(ふ)き出(だ)す"
+        ]
     },
     {
         "name": "houtai",
         "trans": [
+            "包帯(ほうたい)",
             "⓪ 名  绷带"
-        ],
-        "notation": "包帯(ほうたい)"
+        ]
     },
     {
         "name": "boudai",
         "trans": [
+            "膨大(ぼうだい)",
             "⓪ 名·ナ形·自动3  庞大，巨大；膨胀"
-        ],
-        "notation": "膨大(ぼうだい)"
+        ]
     },
     {
         "name": "hotteoku",
         "trans": [
+            "放(ほ)って置(お)く",
             "⓪ 连语  放置不管，放一边"
-        ],
-        "notation": "放(ほ)って置(お)く"
+        ]
     },
     {
         "name": "horu",
         "trans": [
+            "彫(ほ)る",
             "① 他动1  刻，雕刻"
-        ],
-        "notation": "彫(ほ)る"
+        ]
     },
     {
         "name": "boroboro",
         "trans": [
+            "ぼろぼろ",
             " ① 副·ナ形  破破烂烂；扑簌扑簌地掉落，哩哩啦啦；身心俱疲"
-        ],
-        "notation": "ぼろぼろ"
+        ]
     },
     {
         "name": "honkakuteki",
         "trans": [
+            "本格的(ほんかくてき)",
             "⓪ ナ形  真正的；正式的"
-        ],
-        "notation": "本格的(ほんかくてき)"
+        ]
     },
     {
         "name": "honki",
         "trans": [
+            "本気(ほんき)",
             "⓪ 名·ナ形  认真，当真"
-        ],
-        "notation": "本気(ほんき)"
+        ]
     },
     {
         "name": "honrai",
         "trans": [
+            "本来(ほんらい)",
             "① 名·副  本来，原来"
-        ],
-        "notation": "本来(ほんらい)"
+        ]
     },
     {
         "name": "masatsu",
         "trans": [
+            "摩擦(まさつ)",
             "⓪ 名·自他动3  摩擦；闹矛盾，有分歧"
-        ],
-        "notation": "摩擦(まさつ)"
+        ]
     },
     {
         "name": "masani",
         "trans": [
+            "まさに",
             " ① 副  真正，的确；将要，快要 "
-        ],
-        "notation": "まさに"
+        ]
     },
     {
         "name": "mazaru",
         "trans": [
+            "混(ま)ざる",
             "② 自动1  混杂，夹杂，掺杂"
-        ],
-        "notation": "混(ま)ざる"
+        ]
     },
     {
         "name": "mashite",
         "trans": [
+            "まして",
             " ① 副  何况，况且；更，更加 "
-        ],
-        "notation": "まして"
+        ]
     },
     {
         "name": "houmen",
         "trans": [
+            "方面(ほうめん)",
             "③ 名  方面；领域"
-        ],
-        "notation": "方面(ほうめん)"
+        ]
     },
     {
         "name": "houridasu",
         "trans": [
+            "放(ほう)り出(だ)す",
             "④ 他动1  扔出去，抛出去；中途放弃；开除"
-        ],
-        "notation": "放(ほう)り出(だ)す"
+        ]
     },
     {
         "name": "bouryoku",
         "trans": [
+            "暴力(ぼうりょく)",
             "① 名  暴力，武力"
-        ],
-        "notation": "暴力(ぼうりょく)"
+        ]
     },
     {
         "name": "hobo",
         "trans": [
+            "ほぼ",
             " ① 副  大体上，几乎，大概"
-        ],
-        "notation": "ほぼ"
+        ]
     },
     {
         "name": "masu",
         "trans": [
+            "増(ま)す",
             "⓪ 自他动1  （数量）增加，增多；（程度）增长；胜过"
-        ],
-        "notation": "増(ま)す"
+        ]
     },
     {
         "name": "houseki",
         "trans": [
+            "宝石(ほうせき)",
             "⓪ 名  宝石"
-        ],
-        "notation": "宝石(ほうせき)"
+        ]
     },
     {
         "name": "mare",
         "trans": [
+            "稀(まれ)",
             "⓪ ナ形  稀罕的，稀奇的，稀少的"
-        ],
-        "notation": "稀(まれ)"
+        ]
     },
     {
         "name": "mawarimichi",
         "trans": [
+            "回(まわ)り道(みち)",
             "⓪ 名·自动3  绕道，绕远"
-        ],
-        "notation": "回(まわ)り道(みち)"
+        ]
     },
     {
         "name": "man'ichi",
         "trans": [
+            "万一(まんいち)",
             "① 副  万一，倘若，假如"
-        ],
-        "notation": "万一(まんいち)"
+        ]
     },
     {
         "name": "housoku",
         "trans": [
+            "法則(ほうそく)",
             "⓪ 名  法则；定律"
-        ],
-        "notation": "法則(ほうそく)"
+        ]
     },
     {
         "name": "heihoume-toru",
         "trans": [
+            "平方(へいほう)メートル",
             "⑤ 名  平方米"
-        ],
-        "notation": "平方(へいほう)メートル"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "幕(まく)",
             "② 名  帷幕；（戏剧）幕；场面"
-        ],
-        "notation": "幕(まく)"
+        ]
     },
     {
         "name": "makoto",
         "trans": [
+            "まこと",
             " ⓪ 名·副  真的，事实；真，实在"
-        ],
-        "notation": "まこと"
+        ]
     },
     {
         "name": "heibon",
         "trans": [
+            "平凡(へいぼん)",
             "⓪ 名·ナ形  平凡，普通"
-        ],
-        "notation": "平凡(へいぼん)"
+        ]
     },
     {
         "name": "hokan",
         "trans": [
+            "保管(ほかん)",
             "⓪ 名·他动3  保管"
-        ],
-        "notation": "保管(ほかん)"
+        ]
     },
     {
         "name": "heiretsu",
         "trans": [
+            "並列(へいれつ)",
             "⓪ 名·自他动3  并列，并排；并联"
-        ],
-        "notation": "並列(へいれつ)"
+        ]
     },
     {
         "name": "fukaketsu",
         "trans": [
+            "不可欠(ふかけつ)",
             "② 名·ナ形  不可或缺的，必不可少的"
-        ],
-        "notation": "不可欠(ふかけつ)"
+        ]
     },
     {
         "name": "masukomi",
         "trans": [
+            "マスコミ",
             " ⓪ 名  大众传媒，大众传播"
-        ],
-        "notation": "マスコミ"
+        ]
     },
     {
         "name": "bokuchiku",
         "trans": [
+            "牧畜(ぼくちく)",
             "⓪ 名  畜牧，畜牧业"
-        ],
-        "notation": "牧畜(ぼくちく)"
+        ]
     },
     {
         "name": "machiawase",
         "trans": [
+            "待(ま)ち合(あ)わせ",
             "⓪ 名  碰头，会面，见面"
-        ],
-        "notation": "待(ま)ち合(あ)わせ"
+        ]
     },
     {
         "name": "hoken",
         "trans": [
+            "保険(ほけん)",
             "⓪ 名  保险"
-        ],
-        "notation": "保険(ほけん)"
+        ]
     },
     {
         "name": "machinozomu",
         "trans": [
+            "待(ま)ち望(のぞ)む",
             "④ 他动1  盼望，殷切希望"
-        ],
-        "notation": "待(ま)ち望(のぞ)む"
+        ]
     },
     {
         "name": "massa-ji",
         "trans": [
+            "マッサージ",
             "③ 名·他动3  按摩，推拿"
-        ],
-        "notation": "マッサージ"
+        ]
     },
     {
         "name": "maneki",
         "trans": [
+            "招(まね)き",
             "③ 名  邀请，招待"
-        ],
-        "notation": "招(まね)き"
+        ]
     },
     {
         "name": "mayu",
         "trans": [
+            "眉(まゆ)",
             "① 名  眉毛"
-        ],
-        "notation": "眉(まゆ)"
+        ]
     },
     {
         "name": "hokoru",
         "trans": [
+            "誇(ほこ)る",
             "② 自动1  夸耀；自豪，骄傲"
-        ],
-        "notation": "誇(ほこ)る"
+        ]
     },
     {
         "name": "mame",
         "trans": [
+            "まめ",
             " ⓪ 名·ナ形  勤快，勤奋；认真；健康"
-        ],
-        "notation": "まめ"
+        ]
     },
     {
         "name": "marugoto",
         "trans": [
+            "丸(まる)ごと",
             "⓪ 副  整个儿，完整，全部"
-        ],
-        "notation": "丸(まる)ごと"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "身(み)",
             "⓪ 名  身体；身份"
-        ],
-        "notation": "身(み)"
+        ]
     },
     {
         "name": "mi-thingu",
         "trans": [
+            "ミーティング",
             "⓪ 名  会，会议"
-        ],
-        "notation": "ミーティング"
+        ]
     },
     {
         "name": "hoshu",
         "trans": [
+            "保守(ほしゅ)",
             "① 名·他动3  （思想）保守；保养（机器）"
-        ],
-        "notation": "保守(ほしゅ)"
+        ]
     },
     {
         "name": "kizutsuku",
         "trans": [
+            "傷付(きずつ)く",
             "③ 自动1  受伤；遭受损坏"
-        ],
-        "notation": "傷付(きずつ)く"
+        ]
     },
     {
         "name": "mioboe",
         "trans": [
+            "見覚(みおぼ)え",
             "⓪ 名  眼熟，熟悉，认识"
-        ],
-        "notation": "見覚(みおぼ)え"
+        ]
     },
     {
         "name": "gishiki",
         "trans": [
+            "儀式(ぎしき)",
             "① 名  仪式，典礼"
-        ],
-        "notation": "儀式(ぎしき)"
+        ]
     },
     {
         "name": "buki",
         "trans": [
+            "武器(ぶき)",
             "① 名  武器"
-        ],
-        "notation": "武器(ぶき)"
+        ]
     },
     {
         "name": "boufuuu",
         "trans": [
+            "暴風雨(ぼうふうう)",
             "③ 名  暴风雨"
-        ],
-        "notation": "暴風雨(ぼうふうう)"
+        ]
     },
     {
         "name": "boufuusetsu",
         "trans": [
+            "暴風雪(ぼうふうせつ)",
             "③ 名  暴风雪"
-        ],
-        "notation": "暴風雪(ぼうふうせつ)"
+        ]
     },
     {
         "name": "kansoku",
         "trans": [
+            "観測(かんそく)",
             "⓪ 名·他动3  观测；观察"
-        ],
-        "notation": "観測(かんそく)"
+        ]
     },
     {
         "name": "tobu",
         "trans": [
+            "跳(と)ぶ",
             "⓪ 自动1  跳；飞跑；越过，跳过"
-        ],
-        "notation": "跳(と)ぶ"
+        ]
     },
     {
         "name": "komayaka",
         "trans": [
+            "細(こま)やか",
             "② ナ形  细致的，详细的；细腻的"
-        ],
-        "notation": "細(こま)やか"
+        ]
     },
     {
         "name": "ho-mupe-ji",
         "trans": [
+            "ホームページ",
             "④ 名  （网站）主页，首页"
-        ],
-        "notation": "ホームページ"
+        ]
     },
     {
         "name": "mairu",
         "trans": [
+            "参(まい)る",
             "① 自动1  去；来；参拜；服输，受不了"
-        ],
-        "notation": "参(まい)る"
+        ]
     },
     {
         "name": "tomoni",
         "trans": [
+            "共(とも)に",
             "⓪ 副  一起，共同"
-        ],
-        "notation": "共(とも)に"
+        ]
     },
     {
         "name": "ninshin",
         "trans": [
+            "妊娠(にんしん)",
             "⓪ 名·自动3  妊娠，怀孕"
-        ],
-        "notation": "妊娠(にんしん)"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "器械(きかい)",
             "② 名  机器，器械；仪器"
-        ],
-        "notation": "器械(きかい)"
+        ]
     },
     {
         "name": "katsuyaku",
         "trans": [
+            "活躍(かつやく)",
             "⓪ 名·自动3  活跃，活动"
-        ],
-        "notation": "活躍(かつやく)"
+        ]
     },
     {
         "name": "maemotte",
         "trans": [
+            "前(まえ)もって",
             "③ 副  事先，预先"
-        ],
-        "notation": "前(まえ)もって"
+        ]
     },
     {
         "name": "hisai",
         "trans": [
+            "被災(ひさい)",
             "⓪ 名·自动3  受灾，遭灾"
-        ],
-        "notation": "被災(ひさい)"
+        ]
     },
     {
         "name": "hojo",
         "trans": [
+            "補助(ほじょ)",
             "① 名·他动3  补助，辅助"
-        ],
-        "notation": "補助(ほじょ)"
+        ]
     },
     {
         "name": "misuteru",
         "trans": [
+            "見捨(みす)てる",
             "⓪ 他动2  抛弃，弃之不顾"
-        ],
-        "notation": "見捨(みす)てる"
+        ]
     },
     {
         "name": "hentou",
         "trans": [
+            "返答(へんとう)",
             "③ 名·自动3  回答，回复"
-        ],
-        "notation": "返答(へんとう)"
+        ]
     },
     {
         "name": "hinan",
         "trans": [
+            "非難(ひなん)",
             "① 名·他动3  非难，谴责"
-        ],
-        "notation": "非難(ひなん)"
+        ]
     },
     {
         "name": "doukyuusei",
         "trans": [
+            "同級生(どうきゅうせい)",
             "③ 名  同年级的学生"
-        ],
-        "notation": "同級生(どうきゅうせい)"
+        ]
     },
     {
         "name": "ninshiki",
         "trans": [
+            "認識(にんしき)",
             "⓪ 名·他动3  认识，了解，理解"
-        ],
-        "notation": "認識(にんしき)"
+        ]
     },
     {
         "name": "hyoujun",
         "trans": [
+            "標準(ひょうじゅん)",
             "⓪ 名  标准"
-        ],
-        "notation": "標準(ひょうじゅん)"
+        ]
     },
     {
         "name": "benron",
         "trans": [
+            "弁論(べんろん)",
             "⓪ 名·自动3  辩论，争辩"
-        ],
-        "notation": "弁論(べんろん)"
+        ]
     },
     {
         "name": "hakamairi",
         "trans": [
+            "墓参(はかまい)り",
             "③ 名·自动3  扫墓"
-        ],
-        "notation": "墓参(はかまい)り"
+        ]
     },
     {
         "name": "kidou",
         "trans": [
+            "起動(きどう)",
             "⓪ 名·自动3  启动，开始运转"
-        ],
-        "notation": "起動(きどう)"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "保障(ほしょう)",
             "⓪ 名·他动3  保障"
-        ],
-        "notation": "保障(ほしょう)"
+        ]
     },
     {
         "name": "tomokaku",
         "trans": [
+            "ともかく",
             " ① 副  暂且不论；无论如何，总之"
-        ],
-        "notation": "ともかく"
+        ]
     },
     {
         "name": "masshiroi",
         "trans": [
+            "真(ま)っ白(しろ)い",
             "④ イ形  雪白的，洁白的"
-        ],
-        "notation": "真(ま)っ白(しろ)い"
+        ]
     },
     {
         "name": "touji",
         "trans": [
+            "当時(とうじ)",
             "① 名  当时，那个时候"
-        ],
-        "notation": "当時(とうじ)"
+        ]
     },
     {
         "name": "suichoku",
         "trans": [
+            "垂直(すいちょく)",
             "⓪ 名·ナ形  垂直"
-        ],
-        "notation": "垂直(すいちょく)"
+        ]
     },
     {
         "name": "hagareru",
         "trans": [
+            "剥(は)がれる",
             "③ 自动2  剥落，剥下"
-        ],
-        "notation": "剥(は)がれる"
+        ]
     },
     {
         "name": "doumyaku",
         "trans": [
+            "動脈(どうみゃく)",
             "⓪ 名  动脉"
-        ],
-        "notation": "動脈(どうみゃく)"
+        ]
     },
     {
         "name": "hitomi",
         "trans": [
+            "瞳(ひとみ)",
             "⓪ 名  瞳孔；眼睛"
-        ],
-        "notation": "瞳(ひとみ)"
+        ]
     },
     {
         "name": "mizuppoi",
         "trans": [
+            "水(みず)っぽい",
             "④ イ形  水分多的，淡而无味的"
-        ],
-        "notation": "水(みず)っぽい"
+        ]
     },
     {
         "name": "funsou",
         "trans": [
+            "紛争(ふんそう)",
             "⓪ 名·自动3  纷争，纠纷"
-        ],
-        "notation": "紛争(ふんそう)"
+        ]
     },
     {
         "name": "tobasu",
         "trans": [
+            "飛(と)ばす",
             "⓪ 他动1  使……飞起；吹跑；（驱车）疾驰；跳过，越过"
-        ],
-        "notation": "飛(と)ばす"
+        ]
     },
     {
         "name": "sagasu",
         "trans": [
+            "探(さが)す",
             "⓪ 他动1  寻找；追求；搜寻"
-        ],
-        "notation": "探(さが)す"
+        ]
     },
     {
         "name": "mitasu",
         "trans": [
+            "満(み)たす",
             "② 他动1  充满，填满；满足"
-        ],
-        "notation": "満(み)たす"
+        ]
     },
     {
         "name": "muishiki",
         "trans": [
+            "無意識(むいしき)",
             "② 名·ナ形  无意识，不自觉；不省人事，失去知觉"
-        ],
-        "notation": "無意識(むいしき)"
+        ]
     },
     {
         "name": "midareru",
         "trans": [
+            "乱(みだ)れる",
             "③ 自动2  乱，不太平；杂乱；混乱"
-        ],
-        "notation": "乱(みだ)れる"
+        ]
     },
     {
         "name": "mukeikaku",
         "trans": [
+            "無計画(むけいかく)",
             "② 名·ナ形  无计划"
-        ],
-        "notation": "無計画(むけいかく)"
+        ]
     },
     {
         "name": "kaiten",
         "trans": [
+            "回転(かいてん)",
             "⓪ 名·自动3  旋转，回转；周转（资金）"
-        ],
-        "notation": "回転(かいてん)"
+        ]
     },
     {
         "name": "myouji",
         "trans": [
+            "名字(みょうじ)",
             "① 名  姓，姓氏"
-        ],
-        "notation": "名字(みょうじ)"
+        ]
     },
     {
         "name": "mugen",
         "trans": [
+            "無限(むげん)",
             "⓪ 名·ナ形  无限，无止境"
-        ],
-        "notation": "無限(むげん)"
+        ]
     },
     {
         "name": "mirai",
         "trans": [
+            "未来(みらい)",
             "① 名  未来"
-        ],
-        "notation": "未来(みらい)"
+        ]
     },
     {
         "name": "miwakeru",
         "trans": [
+            "見分(みわ)ける",
             "⓪ 他动2  识别；鉴别，辨别"
-        ],
-        "notation": "見分(みわ)ける"
+        ]
     },
     {
         "name": "mujun",
         "trans": [
+            "矛盾(むじゅん)",
             "⓪ 名·自动3  矛盾"
-        ],
-        "notation": "矛盾(むじゅん)"
+        ]
     },
     {
         "name": "musuu",
         "trans": [
+            "無数(むすう)",
             "② 名·ナ形  无数"
-        ],
-        "notation": "無数(むすう)"
+        ]
     },
     {
         "name": "metsuki",
         "trans": [
+            "目(め)つき",
             "① 名  眼神，目光"
-        ],
-        "notation": "目(め)つき"
+        ]
     },
     {
         "name": "mettani",
         "trans": [
+            "めったに",
             "(后接否定)  ① 副  （后接否定）极少，几乎"
-        ],
-        "notation": "めったに"
+        ]
     },
     {
         "name": "muriyari",
         "trans": [
+            "無理(むり)やり",
             "⓪ 副  硬，强迫，强逼"
-        ],
-        "notation": "無理(むり)やり"
+        ]
     },
     {
         "name": "mure",
         "trans": [
+            "群(む)れ",
             "② 名  群；伙伴"
-        ],
-        "notation": "群(む)れ"
+        ]
     },
     {
         "name": "meisan",
         "trans": [
+            "名産(めいさん)",
             "⓪ 名  著名产品，特产"
-        ],
-        "notation": "名産(めいさん)"
+        ]
     },
     {
         "name": "me-ka-",
         "trans": [
+            "メーカー",
             "① 名  制造商，制造者"
-        ],
-        "notation": "メーカー"
+        ]
     },
     {
         "name": "shihei",
         "trans": [
+            "紙幣(しへい)",
             "① 名  纸币"
-        ],
-        "notation": "紙幣(しへい)"
+        ]
     },
     {
         "name": "hikikomoru",
         "trans": [
+            "引(ひ)きこもる",
             "④ 自动1  闷在家里；隐居，退隐"
-        ],
-        "notation": "引(ひ)きこもる"
+        ]
     },
     {
         "name": "hikisagaru",
         "trans": [
+            "引(ひ)き下(さ)がる",
             "④ 自动1  退下；撒手不干 "
-        ],
-        "notation": "引(ひ)き下(さ)がる"
+        ]
     },
     {
         "name": "megumareru",
         "trans": [
+            "恵(めぐ)まれる",
             "⓪ 自动2  受到恩惠，富有"
-        ],
-        "notation": "恵(めぐ)まれる"
+        ]
     },
     {
         "name": "yamai",
         "trans": [
+            "病(やまい)",
             "① 名  疾病；毛病"
-        ],
-        "notation": "病(やまい)"
+        ]
     },
     {
         "name": "yamuwoezu",
         "trans": [
+            "やむをえず",
             " ④ 副  不得已，无可奈何"
-        ],
-        "notation": "やむをえず"
+        ]
     },
     {
         "name": "mushiro",
         "trans": [
+            "むしろ",
             " ① 副  宁可，与其⋯⋯倒不如⋯⋯"
-        ],
-        "notation": "むしろ"
+        ]
     },
     {
         "name": "yaya",
         "trans": [
+            "やや",
             " ① 副  稍微，稍稍；一会儿"
-        ],
-        "notation": "やや"
+        ]
     },
     {
         "name": "megumi",
         "trans": [
+            "恵(めぐ)み",
             "⓪ 名  恩赐，恩惠"
-        ],
-        "notation": "恵(めぐ)み"
+        ]
     },
     {
         "name": "biseibutsu",
         "trans": [
+            "微生物(びせいぶつ)",
             "② 名  微生物"
-        ],
-        "notation": "微生物(びせいぶつ)"
+        ]
     },
     {
         "name": "meguriau",
         "trans": [
+            "巡(めぐ)り合(あ)う",
             "④ 自动1  邂逅，巧遇"
-        ],
-        "notation": "巡(めぐ)り合(あ)う"
+        ]
     },
     {
         "name": "meguru",
         "trans": [
+            "巡(めぐ)る",
             "⓪ 自动1  围绕，绕着；循环；巡游"
-        ],
-        "notation": "巡(めぐ)る"
+        ]
     },
     {
         "name": "hitogenomu",
         "trans": [
+            "ヒトゲノム",
             " ③ 名  人类基因组"
-        ],
-        "notation": "ヒトゲノム"
+        ]
     },
     {
         "name": "hiyaku",
         "trans": [
+            "飛躍(ひやく)",
             "⓪ 名·自动3  活跃；（成绩）飞跃；跳跃 "
-        ],
-        "notation": "飛躍(ひやく)"
+        ]
     },
     {
         "name": "mesaki",
         "trans": [
+            "目先(めさき)",
             "③ 名  眼前；当前；不远的将来"
-        ],
-        "notation": "目先(めさき)"
+        ]
     },
     {
         "name": "hyon'na",
         "trans": [
+            "ひょんな",
             " ① 连体  奇怪的，意想不到的"
-        ],
-        "notation": "ひょんな"
+        ]
     },
     {
         "name": "mezasu",
         "trans": [
+            "目指(めざ)す",
             "② 他动1  以……为目标"
-        ],
-        "notation": "目指(めざ)す"
+        ]
     },
     {
         "name": "hiyayaka",
         "trans": [
+            "冷(ひ)ややか",
             "② ナ形  冷的，凉的；冷淡的，冷冰冰的；冷静的"
-        ],
-        "notation": "冷(ひ)ややか"
+        ]
     },
     {
         "name": "hirihiri",
         "trans": [
+            "ひりひり",
             " ① 副·自动3  刺痛，火辣辣；辣得慌"
-        ],
-        "notation": "ひりひり"
+        ]
     },
     {
         "name": "hirugaesu",
         "trans": [
+            "翻(ひるがえ)す",
             "③ 他动1  翻转，突然改变；使……飘扬"
-        ],
-        "notation": "翻(ひるがえ)す"
+        ]
     },
     {
         "name": "bunretsu",
         "trans": [
+            "分裂(ぶんれつ)",
             "⓪ 名·自动3  分裂，裂开"
-        ],
-        "notation": "分裂(ぶんれつ)"
+        ]
     },
     {
         "name": "seiki",
         "trans": [
+            "世紀(せいき)",
             "① 名  世纪"
-        ],
-        "notation": "世紀(せいき)"
+        ]
     },
     {
         "name": "hei",
         "trans": [
+            "兵(へい)",
             "① 名  兵，士兵；军队"
-        ],
-        "notation": "兵(へい)"
+        ]
     },
     {
         "name": "heiya",
         "trans": [
+            "平野(へいや)",
             "⓪ 名  平原"
-        ],
-        "notation": "平野(へいや)"
+        ]
     },
     {
         "name": "ba-kari-",
         "trans": [
+            "ベーカリー",
             "① 名  面包店，面包房"
-        ],
-        "notation": "ベーカリー"
+        ]
     },
     {
         "name": "binshou",
         "trans": [
+            "敏捷(びんしょう)",
             "⓪ 名·ナ形  敏捷，灵活"
-        ],
-        "notation": "敏捷(びんしょう)"
+        ]
     },
     {
         "name": "fi-dobakku",
         "trans": [
+            "フィードバック",
             "④ 名·他动3  反馈"
-        ],
-        "notation": "フィードバック"
+        ]
     },
     {
         "name": "motenasu",
         "trans": [
+            "持(も)て成(な)す",
             "③ 他动1  接待；招待，请客"
-        ],
-        "notation": "持(も)て成(な)す"
+        ]
     },
     {
         "name": "ronjiru",
         "trans": [
+            "論(ろん)じる",
             "⓪ 他动2  论述，阐明；争论，辩论"
-        ],
-        "notation": "論(ろん)じる"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "掻(か)く",
             "① 他动1  搔，挠；搅和"
-        ],
-        "notation": "掻(か)く"
+        ]
     },
     {
         "name": "mukeru",
         "trans": [
+            "向(む)ける",
             "⓪ 自他动2  向着，朝向；用作；派遣"
-        ],
-        "notation": "向(む)ける"
+        ]
     },
     {
         "name": "ronsou",
         "trans": [
+            "論争(ろんそう)",
             "⓪ 名·自动3  争论，争辩"
-        ],
-        "notation": "論争(ろんそう)"
+        ]
     },
     {
         "name": "fuuchou",
         "trans": [
+            "風潮(ふうちょう)",
             "⓪ 名  潮流，倾向"
-        ],
-        "notation": "風潮(ふうちょう)"
+        ]
     },
     {
         "name": "keigu",
         "trans": [
+            "敬具(けいぐ)",
             "① 名  （书信用语）谨启，敬上"
-        ],
-        "notation": "敬具(けいぐ)"
+        ]
     },
     {
         "name": "fesuthibaru",
         "trans": [
+            "フェスティバル",
             "① 名  节日，庆典"
-        ],
-        "notation": "フェスティバル"
+        ]
     },
     {
         "name": "men",
         "trans": [
+            "面(めん)",
             "① 名  脸；表面；方面"
-        ],
-        "notation": "面(めん)"
+        ]
     },
     {
         "name": "yasei",
         "trans": [
+            "野生(やせい)",
             "⓪ 名·自动3  野生"
-        ],
-        "notation": "野生(やせい)"
+        ]
     },
     {
         "name": "menseki",
         "trans": [
+            "面積(めんせき)",
             "① 名  面积"
-        ],
-        "notation": "面積(めんせき)"
+        ]
     },
     {
         "name": "fukafuka",
         "trans": [
+            "ふかふか",
             " ① 副·自动3  松软的样子，暄腾"
-        ],
-        "notation": "ふかふか"
+        ]
     },
     {
         "name": "mezamashi",
         "trans": [
+            "目覚(めざ)まし",
             "② 名  叫醒；闹钟"
-        ],
-        "notation": "目覚(めざ)まし"
+        ]
     },
     {
         "name": "mezameru",
         "trans": [
+            "目覚(めざ)める",
             "③ 自动2  睡醒，醒来；醒悟"
-        ],
-        "notation": "目覚(めざ)める"
+        ]
     },
     {
         "name": "yobou",
         "trans": [
+            "予防(よぼう)",
             "⓪ 名·他动3  预防"
-        ],
-        "notation": "予防(よぼう)"
+        ]
     },
     {
         "name": "hisomeru",
         "trans": [
+            "潜(ひそ)める",
             "③ 他动2  隐藏，潜藏；不作声"
-        ],
-        "notation": "潜(ひそ)める"
+        ]
     },
     {
         "name": "yakusha",
         "trans": [
+            "役者(やくしゃ)",
             "⓪ 名  演员；有才华的人"
-        ],
-        "notation": "役者(やくしゃ)"
+        ]
     },
     {
         "name": "meikaku",
         "trans": [
+            "明確(めいかく)",
             "⓪ 名·ナ形  明确，清晰明了"
-        ],
-        "notation": "明確(めいかく)"
+        ]
     },
     {
         "name": "mokunin",
         "trans": [
+            "黙認(もくにん)",
             "⓪ 名·他动3  默认，默许"
-        ],
-        "notation": "黙認(もくにん)"
+        ]
     },
     {
         "name": "myou",
         "trans": [
+            "妙(みょう)",
             "① 名·ナ形  美妙；奇妙"
-        ],
-        "notation": "妙(みょう)"
+        ]
     },
     {
         "name": "moguru",
         "trans": [
+            "潜(もぐ)る",
             "② 自动1  潜入（水中）；潜藏，藏入"
-        ],
-        "notation": "潜(もぐ)る"
+        ]
     },
     {
         "name": "fushou",
         "trans": [
+            "負傷(ふしょう)",
             "⓪ 名·自动3  受伤，负伤"
-        ],
-        "notation": "負傷(ふしょう)"
+        ]
     },
     {
         "name": "menzei",
         "trans": [
+            "免税(めんぜい)",
             "⓪ 名·他动3  免税"
-        ],
-        "notation": "免税(めんぜい)"
+        ]
     },
     {
         "name": "moushiwake",
         "trans": [
+            "申(もう)し訳(わけ)",
             "⓪ 名·自动3  辩解，申辩"
-        ],
-        "notation": "申(もう)し訳(わけ)"
+        ]
     },
     {
         "name": "gotagota",
         "trans": [
+            "ごたごた",
             " ⓪ 名·自动3·副  纠纷，争执；乱七八糟"
-        ],
-        "notation": "ごたごた"
+        ]
     },
     {
         "name": "mokugeki",
         "trans": [
+            "目撃(もくげき)",
             "⓪ 名·他动3  目击，亲眼看到"
-        ],
-        "notation": "目撃(もくげき)"
+        ]
     },
     {
         "name": "budou",
         "trans": [
+            "武道(ぶどう)",
             "① 名  武艺，武术；武士道"
-        ],
-        "notation": "武道(ぶどう)"
+        ]
     },
     {
         "name": "akka",
         "trans": [
+            "悪化(あっか)",
             "⓪ 名·自动3  恶化"
-        ],
-        "notation": "悪化(あっか)"
+        ]
     },
     {
         "name": "mokuji",
         "trans": [
+            "目次(もくじ)",
             "⓪ 名  目录"
-        ],
-        "notation": "目次(もくじ)"
+        ]
     },
     {
         "name": "yajirushi",
         "trans": [
+            "矢印(やじるし)",
             "② 名  箭头，箭形符号"
-        ],
-        "notation": "矢印(やじるし)"
+        ]
     },
     {
         "name": "yosen",
         "trans": [
+            "予選(よせん)",
             "⓪ 名·他动3  预选；预赛"
-        ],
-        "notation": "予選(よせん)"
+        ]
     },
     {
         "name": "myougonichi",
         "trans": [
+            "明後日(みょうごにち)",
             "③ 名  后天"
-        ],
-        "notation": "明後日(みょうごにち)"
+        ]
     },
     {
         "name": "atsukamashii",
         "trans": [
+            "厚(あつ)かましい",
             "⑤ イ形  厚脸皮的，无耻的"
-        ],
-        "notation": "厚(あつ)かましい"
+        ]
     },
     {
         "name": "fuminshou",
         "trans": [
+            "不眠症(ふみんしょう)",
             "⓪ 名  失眠症"
-        ],
-        "notation": "不眠症(ふみんしょう)"
+        ]
     },
     {
         "name": "furi-ma-ketto",
         "trans": [
+            "フリーマーケット",
             "④ 名  跳蚤市场，自由市场"
-        ],
-        "notation": "フリーマーケット"
+        ]
     },
     {
         "name": "furikomu",
         "trans": [
+            "振(ふ)り込(こ)む",
             "③ 他动1  汇款，转账"
-        ],
-        "notation": "振(ふ)り込(こ)む"
+        ]
     },
     {
         "name": "mokei",
         "trans": [
+            "模型(もけい)",
             "⓪ 名  模型"
-        ],
-        "notation": "模型(もけい)"
+        ]
     },
     {
         "name": "moshikashitara",
         "trans": [
+            "もしかしたら",
             " ① 副  或许，说不定"
-        ],
-        "notation": "もしかしたら"
+        ]
     },
     {
         "name": "yobi",
         "trans": [
+            "予備(よび)",
             "① 名  预备，提前准备"
-        ],
-        "notation": "予備(よび)"
+        ]
     },
     {
         "name": "jounetsu",
         "trans": [
+            "情熱(じょうねつ)",
             "⓪ 名  热情，激情"
-        ],
-        "notation": "情熱(じょうねつ)"
+        ]
     },
     {
         "name": "muimi",
         "trans": [
+            "無意味(むいみ)",
             "② 名·ナ形  无意义，无价值"
-        ],
-        "notation": "無意味(むいみ)"
+        ]
     },
     {
         "name": "kyuusoku",
         "trans": [
+            "休息(きゅうそく)",
             "⓪ 名·自动3  休息，放松"
-        ],
-        "notation": "休息(きゅうそく)"
+        ]
     },
     {
         "name": "purofi-ru",
         "trans": [
+            "プロフィール",
             "③ 名  侧面，侧面像；人物简介"
-        ],
-        "notation": "プロフィール"
+        ]
     },
     {
         "name": "meisaku",
         "trans": [
+            "名作(めいさく)",
             "⓪ 名  名作，优秀作品"
-        ],
-        "notation": "名作(めいさく)"
+        ]
     },
     {
         "name": "mokuzai",
         "trans": [
+            "木材(もくざい)",
             "② 名  木材，木料"
-        ],
-        "notation": "木材(もくざい)"
+        ]
     },
     {
         "name": "fumikiru",
         "trans": [
+            "踏(ふ)み切(き)る",
             "③ 他动1  下定决心；起跳"
-        ],
-        "notation": "踏(ふ)み切(き)る"
+        ]
     },
     {
         "name": "yakusho",
         "trans": [
+            "役所(やくしょ)",
             "③ 名  官署，政府机关"
-        ],
-        "notation": "役所(やくしょ)"
+        ]
     },
     {
         "name": "shouhai",
         "trans": [
+            "勝敗(しょうはい)",
             "⓪ 名  胜败，胜负"
-        ],
-        "notation": "勝敗(しょうはい)"
+        ]
     },
     {
         "name": "yobidasu",
         "trans": [
+            "呼(よ)び出(だ)す",
             "③ 他动1  叫来；邀请"
-        ],
-        "notation": "呼(よ)び出(だ)す"
+        ]
     },
     {
         "name": "yobitomeru",
         "trans": [
+            "呼(よ)び止(と)める",
             "④ 他动2  叫住，叫停"
-        ],
-        "notation": "呼(よ)び止(と)める"
+        ]
     },
     {
         "name": "punpun",
         "trans": [
+            "ぷんぷん",
             " ① 副·自动3  气味冲；怒气冲冲"
-        ],
-        "notation": "ぷんぷん"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "元(もと)",
             "② 名  根源，起源；根基；原因"
-        ],
-        "notation": "元(もと)"
+        ]
     },
     {
         "name": "yagate",
         "trans": [
+            "やがて",
             " ⓪ 副  不久，马上；大约，将近，差不多；归根结底，毕竟"
-        ],
-        "notation": "やがて"
+        ]
     },
     {
         "name": "fuda",
         "trans": [
+            "札(ふだ)",
             "⓪ 名  牌子；告示牌；号牌"
-        ],
-        "notation": "札(ふだ)"
+        ]
     },
     {
         "name": "mejirushi",
         "trans": [
+            "目印(めじるし)",
             "② 名  标记，记号"
-        ],
-        "notation": "目印(めじるし)"
+        ]
     },
     {
         "name": "mochinushi",
         "trans": [
+            "持(も)ち主(ぬし)",
             "② 名  持有者，所有者"
-        ],
-        "notation": "持(も)ち主(ぬし)"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "役(やく)",
             "② 名  职务；角色"
-        ],
-        "notation": "役(やく)"
+        ]
     },
     {
         "name": "arasuji",
         "trans": [
+            "粗筋(あらすじ)",
             "⓪ 名  概要，梗概"
-        ],
-        "notation": "粗筋(あらすじ)"
+        ]
     },
     {
         "name": "monogataru",
         "trans": [
+            "物語(ものがた)る",
             "④ 他动1  讲，讲述；表现出"
-        ],
-        "notation": "物語(ものがた)る"
+        ]
     },
     {
         "name": "shouganai",
         "trans": [
+            "しょうがない",
             " ④ イ形  没有办法的"
-        ],
-        "notation": "しょうがない"
+        ]
     },
     {
         "name": "furimawasu",
         "trans": [
+            "振(ふ)り回(まわ)す",
             "④ 他动1  抡起，挥舞；滥用；炫耀；折腾"
-        ],
-        "notation": "振(ふ)り回(まわ)す"
+        ]
     },
     {
         "name": "musekinin",
         "trans": [
+            "無責任(むせきにん)",
             "② 名·ナ形  不负责任"
-        ],
-        "notation": "無責任(むせきにん)"
+        ]
     },
     {
         "name": "mudan",
         "trans": [
+            "無断(むだん)",
             "⓪ 名  无故，擅自，私自"
-        ],
-        "notation": "無断(むだん)"
+        ]
     },
     {
         "name": "jouhatsu",
         "trans": [
+            "蒸発(じょうはつ)",
             "⓪ 名·自动3  蒸发；失踪"
-        ],
-        "notation": "蒸発(じょうはつ)"
+        ]
     },
     {
         "name": "motoduku",
         "trans": [
+            "基(もと)づく",
             "③ 自动1  根据，按照；起因于"
-        ],
-        "notation": "基(もと)づく"
+        ]
     },
     {
         "name": "muyou",
         "trans": [
+            "無用(むよう)",
             "⓪ 名·ナ形  无用，没有用处；不用，不需要；没事，无事"
-        ],
-        "notation": "無用(むよう)"
+        ]
     },
     {
         "name": "shibafu",
         "trans": [
+            "芝生(しばふ)",
             "⓪ 名  草坪"
-        ],
-        "notation": "芝生(しばふ)"
+        ]
     },
     {
         "name": "bunken",
         "trans": [
+            "文献(ぶんけん)",
             "⓪ 名  文献，参考资料"
-        ],
-        "notation": "文献(ぶんけん)"
+        ]
     },
     {
         "name": "shousuu",
         "trans": [
+            "少数(しょうすう)",
             "③ 名  少数"
-        ],
-        "notation": "少数(しょうすう)"
+        ]
     },
     {
         "name": "miwatasu",
         "trans": [
+            "見渡(みわた)す",
             "⓪ 他动1  放眼望去，远望"
-        ],
-        "notation": "見渡(みわた)す"
+        ]
     },
     {
         "name": "kyuukyuusha",
         "trans": [
+            "救急車(きゅうきゅうしゃ)",
             "③ 名  救护车"
-        ],
-        "notation": "救急車(きゅうきゅうしゃ)"
+        ]
     },
     {
         "name": "rousoku",
         "trans": [
+            "蝋燭(ろうそく)",
             "③ 名  蜡烛"
-        ],
-        "notation": "蝋燭(ろうそく)"
+        ]
     },
     {
         "name": "shousuuten",
         "trans": [
+            "小数点(しょうすうてん)",
             "③ 名  小数点"
-        ],
-        "notation": "小数点(しょうすうてん)"
+        ]
     },
     {
         "name": "motarasu",
         "trans": [
+            "もたらす",
             "(去)  ③ 他动1  带来（去）；招致，造成（某种结果）"
-        ],
-        "notation": "もたらす"
+        ]
     },
     {
         "name": "kyuugyou",
         "trans": [
+            "休業(きゅうぎょう)",
             "⓪ 名·自动3  休业，停工"
-        ],
-        "notation": "休業(きゅうぎょう)"
+        ]
     },
     {
         "name": "yakuhin",
         "trans": [
+            "薬品(やくひん)",
             "⓪ 名  药品"
-        ],
-        "notation": "薬品(やくひん)"
+        ]
     },
     {
         "name": "yuuyuu",
         "trans": [
+            "悠々(ゆうゆう)",
             "③ 副·ナ形  悠然自得；绰绰有余"
-        ],
-        "notation": "悠々(ゆうゆう)"
+        ]
     },
     {
         "name": "shousuru",
         "trans": [
+            "称(しょう)する",
             "③ 他动3  名字叫……；假称，冒充；称赞"
-        ],
-        "notation": "称(しょう)する"
+        ]
     },
     {
         "name": "mohou",
         "trans": [
+            "模倣(もほう)",
             "⓪ 名·他动3  模仿，效仿"
-        ],
-        "notation": "模倣(もほう)"
+        ]
     },
     {
         "name": "nibui",
         "trans": [
+            "鈍(にぶ)い",
             "② イ形  钝的；迟钝的"
-        ],
-        "notation": "鈍(にぶ)い"
+        ]
     },
     {
         "name": "yakusuru",
         "trans": [
+            "訳(やく)する",
             "③ 他动3  翻译；解释"
-        ],
-        "notation": "訳(やく)する"
+        ]
     },
     {
         "name": "yaritogeru",
         "trans": [
+            "やり遂(と)げる",
             "④ 他动2  做完，完成，实现"
-        ],
-        "notation": "やり遂(と)げる"
+        ]
     },
     {
         "name": "yuiitsu",
         "trans": [
+            "唯一(ゆいいつ)",
             "① 名  唯一，独一无二"
-        ],
-        "notation": "唯一(ゆいいつ)"
+        ]
     },
     {
         "name": "yuuigi",
         "trans": [
+            "有意義(ゆういぎ)",
             "③ 名·ナ形  有意义，有价值"
-        ],
-        "notation": "有意義(ゆういぎ)"
+        ]
     },
     {
         "name": "youi",
         "trans": [
+            "容易(ようい)",
             "⓪ ナ形  容易的，简单的"
-        ],
-        "notation": "容易(ようい)"
+        ]
     },
     {
         "name": "yuukan",
         "trans": [
+            "夕刊(ゆうかん)",
             "⓪ 名  晚报"
-        ],
-        "notation": "夕刊(ゆうかん)"
+        ]
     },
     {
         "name": "yuujou",
         "trans": [
+            "友情(ゆうじょう)",
             "⓪ 名  友情"
-        ],
-        "notation": "友情(ゆうじょう)"
+        ]
     },
     {
         "name": "yougan",
         "trans": [
+            "溶岩(ようがん)",
             "① 名  熔岩，岩浆"
-        ],
-        "notation": "溶岩(ようがん)"
+        ]
     },
     {
         "name": "moshikashite",
         "trans": [
+            "もしかして",
             " ① 副  如果；也许，说不定，或者"
-        ],
-        "notation": "もしかして"
+        ]
     },
     {
         "name": "moshikasuruto",
         "trans": [
+            "もしかすると",
             " ① 副  也许，或许，可能"
-        ],
-        "notation": "もしかすると"
+        ]
     },
     {
         "name": "yuusen",
         "trans": [
+            "優先(ゆうせん)",
             "⓪ 名·自动3  优先"
-        ],
-        "notation": "優先(ゆうせん)"
+        ]
     },
     {
         "name": "yuusenteki",
         "trans": [
+            "優先的(ゆうせんてき)",
             "⓪ ナ形  优先的"
-        ],
-        "notation": "優先的(ゆうせんてき)"
+        ]
     },
     {
         "name": "kichikichi",
         "trans": [
+            "きちきち",
             "(塞得)  ⓪ 副·ナ形  （塞得）满满的；（时间）恰好，刚好；准确无误"
-        ],
-        "notation": "きちきち"
+        ]
     },
     {
         "name": "yuunou",
         "trans": [
+            "有能(ゆうのう)",
             "⓪ 名·ナ形  有才能（的人），能干"
-        ],
-        "notation": "有能(ゆうのう)"
+        ]
     },
     {
         "name": "youki",
         "trans": [
+            "陽気(ようき)",
             "⓪ ナ形  快乐的，愉快的；开朗的，爽朗的；热闹的，活跃的"
-        ],
-        "notation": "陽気(ようき)"
+        ]
     },
     {
         "name": "youken",
         "trans": [
+            "用件(ようけん)",
             "③ 名  事，事情"
-        ],
-        "notation": "用件(ようけん)"
+        ]
     },
     {
         "name": "yuuryou",
         "trans": [
+            "優良(ゆうりょう)",
             "⓪ 名·ナ形  优良"
-        ],
-        "notation": "優良(ゆうりょう)"
+        ]
     },
     {
         "name": "yukue",
         "trans": [
+            "行方(ゆくえ)",
             "⓪ 名  去向，下落"
-        ],
-        "notation": "行方(ゆくえ)"
+        ]
     },
     {
         "name": "rain",
         "trans": [
+            "ライン",
             "① 名  线；路线；航线"
-        ],
-        "notation": "ライン"
+        ]
     },
     {
         "name": "medaru",
         "trans": [
+            "メダル",
             "⓪ 名  奖牌，奖章"
-        ],
-        "notation": "メダル"
+        ]
     },
     {
         "name": "yobisute",
         "trans": [
+            "呼(よ)び捨(す)て",
             "⓪ 名  （不加敬称）直呼其名"
-        ],
-        "notation": "呼(よ)び捨(す)て"
+        ]
     },
     {
         "name": "meyasu",
         "trans": [
+            "目安(めやす)",
             "⓪ 名  目标，基准；大体的推测"
-        ],
-        "notation": "目安(めやす)"
+        ]
     },
     {
         "name": "hikishimeru",
         "trans": [
+            "引(ひ)き締(し)める",
             "④ 他动2  勒紧；紧缩，缩减"
-        ],
-        "notation": "引(ひ)き締(し)める"
+        ]
     },
     {
         "name": "musubi",
         "trans": [
+            "結(むす)び",
             "⓪ 名  结，打结；结束，终结"
-        ],
-        "notation": "結(むす)び"
+        ]
     },
     {
         "name": "raibaru",
         "trans": [
+            "ライバル",
             "① 名  竞争对手，竞争者"
-        ],
-        "notation": "ライバル"
+        ]
     },
     {
         "name": "yukiki",
         "trans": [
+            "行(ゆき)き来()",
             "② 名·自动3  往来，往返；来往，交往"
-        ],
-        "notation": "行(ゆき)き来()"
+        ]
     },
     {
         "name": "yukisugiru",
         "trans": [
+            "行(ゆ)き過(す)ぎる",
             "④ 自动2  经过；走过站；过度"
-        ],
-        "notation": "行(ゆ)き過(す)ぎる"
+        ]
     },
     {
         "name": "yuketsu",
         "trans": [
+            "輸血(ゆけつ)",
             "⓪ 名·自动3  输血"
-        ],
-        "notation": "輸血(ゆけつ)"
+        ]
     },
     {
         "name": "yutori",
         "trans": [
+            "ゆとり",
             " ⓪ 名  宽裕，富余，绰绰有余"
-        ],
-        "notation": "ゆとり"
+        ]
     },
     {
         "name": "youshi",
         "trans": [
+            "要旨(ようし)",
             "① 名  要点，主要内容"
-        ],
-        "notation": "要旨(ようし)"
+        ]
     },
     {
         "name": "rakudai",
         "trans": [
+            "落第(らくだい)",
             "⓪ 名·自动3  不及格，留级"
-        ],
-        "notation": "落第(らくだい)"
+        ]
     },
     {
         "name": "raberu",
         "trans": [
+            "ラベル",
             "① 名  商品标签；商标"
-        ],
-        "notation": "ラベル"
+        ]
     },
     {
         "name": "rigai",
         "trans": [
+            "利害(りがい)",
             "① 名  利害，得失"
-        ],
-        "notation": "利害(りがい)"
+        ]
     },
     {
         "name": "youjinbukai",
         "trans": [
+            "用心深(ようじんぶか)い",
             "⑥ イ形  十分细心的，十分谨慎的"
-        ],
-        "notation": "用心深(ようじんぶか)い"
+        ]
     },
     {
         "name": "yousuruni",
         "trans": [
+            "要(よう)するに",
             "③ 副  综上所述；简言之"
-        ],
-        "notation": "要(よう)するに"
+        ]
     },
     {
         "name": "rireki",
         "trans": [
+            "履歴(りれき)",
             "⓪ 名  履历，经历"
-        ],
-        "notation": "履歴(りれき)"
+        ]
     },
     {
         "name": "youseki",
         "trans": [
+            "容積(ようせき)",
             "① 名  容积，体积；容量"
-        ],
-        "notation": "容積(ようせき)"
+        ]
     },
     {
         "name": "reja-",
         "trans": [
+            "レジャー",
             "① 名  空闲，业余时间；休闲娱乐"
-        ],
-        "notation": "レジャー"
+        ]
     },
     {
         "name": "retasu",
         "trans": [
+            "レタス",
             "① 名  生菜，叶用莴苣"
-        ],
-        "notation": "レタス"
+        ]
     },
     {
         "name": "renkyuu",
         "trans": [
+            "連休(れんきゅう)",
             "⓪ 名  连续放假，连休"
-        ],
-        "notation": "連休(れんきゅう)"
+        ]
     },
     {
         "name": "kosokoso",
         "trans": [
+            "こそこそ",
             " ① 副·自动3  偷偷摸摸，鬼鬼祟祟"
-        ],
-        "notation": "こそこそ"
+        ]
     },
     {
         "name": "youten",
         "trans": [
+            "要点(ようてん)",
             "③ 名  要点，要领"
-        ],
-        "notation": "要点(ようてん)"
+        ]
     },
     {
         "name": "tobichiru",
         "trans": [
+            "飛(と)び散(ち)る",
             "③ 自动1  飞散；飘落；人群跑散"
-        ],
-        "notation": "飛(と)び散(ち)る"
+        ]
     },
     {
         "name": "tobitsuku",
         "trans": [
+            "飛(と)びつく",
             "③ 自动1  扑过来；（被吸引得）扑过去"
-        ],
-        "notation": "飛(と)びつく"
+        ]
     },
     {
         "name": "tobihaneru",
         "trans": [
+            "飛(と)び跳(は)ねる",
             "④ 自动2  跳跃，蹦跳"
-        ],
-        "notation": "飛(と)び跳(は)ねる"
+        ]
     },
     {
         "name": "yoka",
         "trans": [
+            "余暇(よか)",
             "① 名  闲暇时间，业余时间"
-        ],
-        "notation": "余暇(よか)"
+        ]
     },
     {
         "name": "rouhi",
         "trans": [
+            "浪費(ろうひ)",
             "⓪ 名·他动3  浪费；糟蹋"
-        ],
-        "notation": "浪費(ろうひ)"
+        ]
     },
     {
         "name": "ro-n",
         "trans": [
+            "ローン",
             "① 名  贷款"
-        ],
-        "notation": "ローン"
+        ]
     },
     {
         "name": "rokuga",
         "trans": [
+            "録画(ろくが)",
             "⓪ 名·他动3  录像"
-        ],
-        "notation": "録画(ろくが)"
+        ]
     },
     {
         "name": "yoki",
         "trans": [
+            "予期(よき)",
             "① 名·他动3  预期，预料，预想"
-        ],
-        "notation": "予期(よき)"
+        ]
     },
     {
         "name": "yokin",
         "trans": [
+            "預金(よきん)",
             "⓪ 名·自他动3  存款"
-        ],
-        "notation": "預金(よきん)"
+        ]
     },
     {
         "name": "romanchikku",
         "trans": [
+            "ロマンチック",
             "④ ナ形  浪漫的，幻想的"
-        ],
-        "notation": "ロマンチック"
+        ]
     },
     {
         "name": "ronri",
         "trans": [
+            "論理(ろんり)",
             "① 名  逻辑；道理"
-        ],
-        "notation": "論理(ろんり)"
+        ]
     },
     {
         "name": "yoku",
         "trans": [
+            "欲(よく)",
             "② 名  欲望"
-        ],
-        "notation": "欲(よく)"
+        ]
     },
     {
         "name": "wakawakashii",
         "trans": [
+            "若々しい(わかわかしい)",
             "⑤ イ形  年轻的，朝气蓬勃的"
-        ],
-        "notation": "若々しい(わかわかしい)"
+        ]
     },
     {
         "name": "waki",
         "trans": [
+            "脇(わき)",
             "② 名  腋下；侧面，旁边"
-        ],
-        "notation": "脇(わき)"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "湧(わ)く",
             "⓪ 自动1  涌出，涌现；产生"
-        ],
-        "notation": "湧(わ)く"
+        ]
     },
     {
         "name": "yokushitsu",
         "trans": [
+            "浴室(よくしつ)",
             "⓪ 名  浴室"
-        ],
-        "notation": "浴室(よくしつ)"
+        ]
     },
     {
         "name": "yokujitsu",
         "trans": [
+            "翌日(よくじつ)",
             "⓪ 名  第二天"
-        ],
-        "notation": "翌日(よくじつ)"
+        ]
     },
     {
         "name": "waza",
         "trans": [
+            "技(わざ)",
             "② 名  技术，本领；招数"
-        ],
-        "notation": "技(わざ)"
+        ]
     },
     {
         "name": "wazato",
         "trans": [
+            "わざと",
             " ① 副  故意，有意"
-        ],
-        "notation": "わざと"
+        ]
     },
     {
         "name": "yokei",
         "trans": [
+            "余計(よけい)",
             "⓪ ナ形·副  多余，无用；格外，更加"
-        ],
-        "notation": "余計(よけい)"
+        ]
     },
     {
         "name": "wata",
         "trans": [
+            "綿(わた)",
             "② 名  棉花"
-        ],
-        "notation": "綿(わた)"
+        ]
     },
     {
         "name": "warumono",
         "trans": [
+            "悪者(わるもの)",
             "⓪ 名  坏人"
-        ],
-        "notation": "悪者(わるもの)"
+        ]
     },
     {
         "name": "gansho",
         "trans": [
+            "願書(がんしょ)",
             "① 名  申请书，志愿书"
-        ],
-        "notation": "願書(がんしょ)"
+        ]
     },
     {
         "name": "guuzen",
         "trans": [
+            "偶然(ぐうぜん)",
             "⓪ 名·ナ形·副  偶然，碰巧"
-        ],
-        "notation": "偶然(ぐうぜん)"
+        ]
     },
     {
         "name": "kakarichou",
         "trans": [
+            "係長(かかりちょう)",
             "③ 名  （公司里的职务）股长，系长"
-        ],
-        "notation": "係長(かかりちょう)"
+        ]
     },
     {
         "name": "kakigoori",
         "trans": [
+            "かき氷(ごおり)",
             "③ 名  刨冰"
-        ],
-        "notation": "かき氷(ごおり)"
+        ]
     },
     {
         "name": "sumoggu",
         "trans": [
+            "スモッグ",
             "② 名  烟雾，烟尘"
-        ],
-        "notation": "スモッグ"
+        ]
     },
     {
         "name": "sumikomu",
         "trans": [
+            "住(す)み込(こ)む",
             "③ 自动1  住在雇主家里"
-        ],
-        "notation": "住(す)み込(こ)む"
+        ]
     },
     {
         "name": "wareware",
         "trans": [
+            "我々(われわれ)",
             "⓪ 名  我们"
-        ],
-        "notation": "我々(われわれ)"
+        ]
     },
     {
         "name": "nimokakawarazu",
         "trans": [
+            "にもかかわらず",
             " ① 连语·接续  虽然⋯⋯但是⋯⋯；尽管⋯⋯可是⋯⋯"
-        ],
-        "notation": "にもかかわらず"
+        ]
     },
     {
         "name": "nyuukai",
         "trans": [
+            "入会(にゅうかい)",
             "⓪ 名·自动3  入会；参加某个团体"
-        ],
-        "notation": "入会(にゅうかい)"
+        ]
     },
     {
         "name": "asayuu",
         "trans": [
+            "朝夕(あさゆう)",
             "① 名  早晨和晚上；经常"
-        ],
-        "notation": "朝夕(あさゆう)"
+        ]
     },
     {
         "name": "asshuku",
         "trans": [
+            "圧縮(あっしゅく)",
             "⓪ 名·他动3  压缩（体积）；缩短（长度）"
-        ],
-        "notation": "圧縮(あっしゅく)"
+        ]
     },
     {
         "name": "kinomi",
         "trans": [
+            "木(き)の実(み)",
             "① 名  树上的果实"
-        ],
-        "notation": "木(き)の実(み)"
+        ]
     },
     {
         "name": "noufu",
         "trans": [
+            "納付(のうふ)",
             "⓪ 名·他动3  （向政府）缴纳"
-        ],
-        "notation": "納付(のうふ)"
+        ]
     },
     {
         "name": "aijou",
         "trans": [
+            "愛情(あいじょう)",
             "⓪ 名  爱，爱情；热爱"
-        ],
-        "notation": "愛情(あいじょう)"
+        ]
     },
     {
         "name": "kiban",
         "trans": [
+            "基盤(きばん)",
             "⓪ 名  基础；底座"
-        ],
-        "notation": "基盤(きばん)"
+        ]
     },
     {
         "name": "suigara",
         "trans": [
+            "吸殻(すいがら)",
             "⓪ 名  烟蒂，烟头儿"
-        ],
-        "notation": "吸殻(すいがら)"
+        ]
     },
     {
         "name": "kimama",
         "trans": [
+            "気(き)まま",
             "⓪ 名·ナ形  任性，随意，随便"
-        ],
-        "notation": "気(き)まま"
+        ]
     },
     {
         "name": "yoshiashi",
         "trans": [
+            "良(よ)し悪(あ)し",
             "① 名  善恶，好坏；有利有弊"
-        ],
-        "notation": "良(よ)し悪(あ)し"
+        ]
     },
     {
         "name": "aiduchi",
         "trans": [
+            "相槌(あいづち)",
             "⓪ 名  随声附和，帮腔"
-        ],
-        "notation": "相槌(あいづち)"
+        ]
     },
     {
         "name": "kimekomaka",
         "trans": [
+            "きめこまか",
             "(皮肤)  ③ ナ形  （皮肤）细腻的；（做法）细致的"
-        ],
-        "notation": "きめこまか"
+        ]
     },
     {
         "name": "uyouyo",
         "trans": [
+            "うようよ",
             " ① 副·自动3  聚在一起蠕动"
-        ],
-        "notation": "うようよ"
+        ]
     },
     {
         "name": "gyakuten",
         "trans": [
+            "逆転(ぎゃくてん)",
             "⓪ 名·自他动3  逆转，反转；倒退，倒过来"
-        ],
-        "notation": "逆転(ぎゃくてん)"
+        ]
     },
     {
         "name": "yobikakeru",
         "trans": [
+            "呼(よ)び掛(か)ける",
             "④ 他动2  打招呼；呼吁"
-        ],
-        "notation": "呼(よ)び掛(か)ける"
+        ]
     },
     {
         "name": "kyakkanteki",
         "trans": [
+            "客観的(きゃっかんてき)",
             "⓪ ナ形  客观的"
-        ],
-        "notation": "客観的(きゃっかんてき)"
+        ]
     },
     {
         "name": "kyanpu",
         "trans": [
+            "キャンプ",
             "① 名·自动3  帐篷；露营，野营"
-        ],
-        "notation": "キャンプ"
+        ]
     },
     {
         "name": "musubitsukeru",
         "trans": [
+            "結(むす)び付(つ)ける",
             "⑤ 他动2  系上，拴上；结合起来"
-        ],
-        "notation": "結(むす)び付(つ)ける"
+        ]
     },
     {
         "name": "iiai",
         "trans": [
+            "言(い)い合(あ)い",
             "⓪ 名·自动3  争吵，吵架"
-        ],
-        "notation": "言(い)い合(あ)い"
+        ]
     },
     {
         "name": "niyaniya",
         "trans": [
+            "にやにや",
             " ① 副·自动3  偷偷地笑；冷笑"
-        ],
-        "notation": "にやにや"
+        ]
     },
     {
         "name": "bunkazai",
         "trans": [
+            "文化財(ぶんかざい)",
             "③ 名  文化遗产"
-        ],
-        "notation": "文化財(ぶんかざい)"
+        ]
     },
     {
         "name": "futashika",
         "trans": [
+            "不確(ふたし)か",
             "② ナ形  不确定的，含糊的"
-        ],
-        "notation": "不確(ふたし)か"
+        ]
     },
     {
         "name": "fuzoku",
         "trans": [
+            "付属(ふぞく)",
             "⓪ 名·自动3  附属"
-        ],
-        "notation": "付属(ふぞく)"
+        ]
     },
     {
         "name": "karou",
         "trans": [
+            "過労(かろう)",
             "⓪ 名·自动3  过劳，疲劳过度"
-        ],
-        "notation": "過労(かろう)"
+        ]
     },
     {
         "name": "yokusei",
         "trans": [
+            "抑制(よくせい)",
             "⓪ 名·他动3  抑制，制止"
-        ],
-        "notation": "抑制(よくせい)"
+        ]
     },
     {
         "name": "kihon",
         "trans": [
+            "基本(きほん)",
             "⓪ 名  基本，基础"
-        ],
-        "notation": "基本(きほん)"
+        ]
     },
     {
         "name": "kimi",
         "trans": [
+            "気味(きみ)",
             "② 名  心情，情绪"
-        ],
-        "notation": "気味(きみ)"
+        ]
     },
     {
         "name": "ryoushuu",
         "trans": [
+            "領収(りょうしゅう)",
             "⓪ 名·他动3  收款"
-        ],
-        "notation": "領収(りょうしゅう)"
+        ]
     },
     {
         "name": "yuttari",
         "trans": [
+            "ゆったり",
             " ③ 副·自动3  宽敞舒适；舒畅"
-        ],
-        "notation": "ゆったり"
+        ]
     },
     {
         "name": "yokan",
         "trans": [
+            "予感(よかん)",
             "⓪ 名·他动3  预感；预兆"
-        ],
-        "notation": "予感(よかん)"
+        ]
     },
     {
         "name": "fureau",
         "trans": [
+            "触(ふ)れ合(あ)う",
             "③ 自动1  互相接触，互相挨着"
-        ],
-        "notation": "触(ふ)れ合(あ)う"
+        ]
     },
     {
         "name": "roudousha",
         "trans": [
+            "労働者(ろうどうしゃ)",
             "③ 名  劳动者"
-        ],
-        "notation": "労働者(ろうどうしゃ)"
+        ]
     },
     {
         "name": "yofukashi",
         "trans": [
+            "夜更(よふ)かし",
             "② 名·自动3  熬夜"
-        ],
-        "notation": "夜更(よふ)かし"
+        ]
     },
     {
         "name": "kimyou",
         "trans": [
+            "奇妙(きみょう)",
             "① ナ形  奇妙的，不可思议的"
-        ],
-        "notation": "奇妙(きみょう)"
+        ]
     },
     {
         "name": "yobun",
         "trans": [
+            "余分(よぶん)",
             "⓪ 名·ナ形  多余，剩余；超额，额外"
-        ],
-        "notation": "余分(よぶん)"
+        ]
     },
     {
         "name": "bikubiku",
         "trans": [
+            "びくびく",
             " ① 副·自动3  战战兢兢，害怕得发抖；颤抖"
-        ],
-        "notation": "びくびく"
+        ]
     },
     {
         "name": "kyuushuu",
         "trans": [
+            "吸収(きゅうしゅう)",
             "⓪ 名·他动3  吸收，吸取"
-        ],
-        "notation": "吸収(きゅうしゅう)"
+        ]
     },
     {
         "name": "yokuasa",
         "trans": [
+            "翌朝(よくあさ)",
             "⓪ 名  第二天早晨，次日早晨"
-        ],
-        "notation": "翌朝(よくあさ)"
+        ]
     },
     {
         "name": "kin'yuu",
         "trans": [
+            "金融(きんゆう)",
             "⓪ 名  金融"
-        ],
-        "notation": "金融(きんゆう)"
+        ]
     },
     {
         "name": "yomitoru",
         "trans": [
+            "読(よ)み取(と)る",
             "③ 他动1  读懂，领会，看明白"
-        ],
-        "notation": "読(よ)み取(と)る"
+        ]
     },
     {
         "name": "kuiki",
         "trans": [
+            "区域(くいき)",
             "① 名  区域，地区"
-        ],
-        "notation": "区域(くいき)"
+        ]
     },
     {
         "name": "kuizu",
         "trans": [
+            "クイズ",
             "① 名  猜谜，智力问答"
-        ],
-        "notation": "クイズ"
+        ]
     },
     {
         "name": "yowamaru",
         "trans": [
+            "弱(よわ)まる",
             "③ 自动1  变弱，减弱，衰弱"
-        ],
-        "notation": "弱(よわ)まる"
+        ]
     },
     {
         "name": "yowameru",
         "trans": [
+            "弱(よわ)める",
             "③ 他动2  使减弱，使削弱，使降低"
-        ],
-        "notation": "弱(よわ)める"
+        ]
     },
     {
         "name": "yowayowashii",
         "trans": [
+            "弱々しい(よわよわしい)",
             "⑤ イ形  弱不禁风的，软弱无力的"
-        ],
-        "notation": "弱々しい(よわよわしい)"
+        ]
     },
     {
         "name": "reisei",
         "trans": [
+            "冷静(れいせい)",
             "⓪ 名·ナ形  冷静，镇静"
-        ],
-        "notation": "冷静(れいせい)"
+        ]
     },
     {
         "name": "mochikomu",
         "trans": [
+            "持(も)ち込(こ)む",
             "⓪ 他动1  带入，拿进来；提出（意见、问题等）"
-        ],
-        "notation": "持(も)ち込(こ)む"
+        ]
     },
     {
         "name": "youryou",
         "trans": [
+            "要領(ようりょう)",
             "③ 名  要领，要点；窍门"
-        ],
-        "notation": "要領(ようりょう)"
+        ]
     },
     {
         "name": "rinji",
         "trans": [
+            "臨時(りんじ)",
             "⓪ 名  临时，暂时"
-        ],
-        "notation": "臨時(りんじ)"
+        ]
     },
     {
         "name": "kyuugeki",
         "trans": [
+            "急激(きゅうげき)",
             "⓪ ナ形  急剧的，骤然的"
-        ],
-        "notation": "急激(きゅうげき)"
+        ]
     },
     {
         "name": "bunbougu",
         "trans": [
+            "文房具(ぶんぼうぐ)",
             "③ 名  文具"
-        ],
-        "notation": "文房具(ぶんぼうぐ)"
+        ]
     },
     {
         "name": "mochiiru",
         "trans": [
+            "用(もち)いる",
             "③ 他动2  用，使用；采用；录用"
-        ],
-        "notation": "用(もち)いる"
+        ]
     },
     {
         "name": "yakan",
         "trans": [
+            "夜間(やかん)",
             "① 名  夜间，夜晚"
-        ],
-        "notation": "夜間(やかん)"
+        ]
     },
     {
         "name": "miwatasukagiri",
         "trans": [
+            "見渡(みわた)す限(かぎ)り",
             "⑤ 接续  一望无际"
-        ],
-        "notation": "見渡(みわた)す限(かぎ)り"
+        ]
     },
     {
         "name": "youhin",
         "trans": [
+            "用品(ようひん)",
             "⓪ 名  用品；必备的物品"
-        ],
-        "notation": "用品(ようひん)"
+        ]
     },
     {
         "name": "ryuuiki",
         "trans": [
+            "流域(りゅういき)",
             "⓪ 名  流域"
-        ],
-        "notation": "流域(りゅういき)"
+        ]
     },
     {
         "name": "youto",
         "trans": [
+            "用途(ようと)",
             "① 名  用途，用处"
-        ],
-        "notation": "用途(ようと)"
+        ]
     },
     {
         "name": "monowasure",
         "trans": [
+            "物忘(ものわす)れ",
             "③ 名·自动3  健忘，忘性大"
-        ],
-        "notation": "物忘(ものわす)れ"
+        ]
     },
     {
         "name": "yusou",
         "trans": [
+            "輸送(ゆそう)",
             "⓪ 名·他动3  输送，运输"
-        ],
-        "notation": "輸送(ゆそう)"
+        ]
     },
     {
         "name": "rikuchi",
         "trans": [
+            "陸地(りくち)",
             "⓪ 名  陆地"
-        ],
-        "notation": "陸地(りくち)"
+        ]
     },
     {
         "name": "youshiki",
         "trans": [
+            "様式(ようしき)",
             "⓪ 名  样式，方式；（艺术作品等的）风格"
-        ],
-        "notation": "様式(ようしき)"
+        ]
     },
     {
         "name": "surikizu",
         "trans": [
+            "擦(す)り傷(きず)",
             "② 名  擦伤，擦破"
-        ],
-        "notation": "擦(す)り傷(きず)"
+        ]
     },
     {
         "name": "bunkai",
         "trans": [
+            "分解(ぶんかい)",
             "⓪ 名·自他动3  拆开，拆卸；（化学用语）分解"
-        ],
-        "notation": "分解(ぶんかい)"
+        ]
     },
     {
         "name": "suwarikomu",
         "trans": [
+            "座(すわ)り込(こ)む",
             "④ 自动1  坐下不动；坐着不走 "
-        ],
-        "notation": "座(すわ)り込(こ)む"
+        ]
     },
     {
         "name": "atehamaru",
         "trans": [
+            "当(あ)て嵌(は)まる",
             "④ 自动1  适用，适合，恰当，符合条件"
-        ],
-        "notation": "当(あ)て嵌(は)まる"
+        ]
     },
     {
         "name": "atokataduke",
         "trans": [
+            "後片付(あとかたづ)け",
             "③ 名·自动3  善后，整理，收拾"
-        ],
-        "notation": "後片付(あとかたづ)け"
+        ]
     },
     {
         "name": "aburu",
         "trans": [
+            "炙(あぶ)る",
             "② 他动1  烤，晒；烘干"
-        ],
-        "notation": "炙(あぶ)る"
+        ]
     },
     {
         "name": "gasagasa",
         "trans": [
+            "がさがさ",
             " ① 副·ナ形·自动3  粗糙，干燥；发出沙沙声"
-        ],
-        "notation": "がさがさ"
+        ]
     },
     {
         "name": "amarini",
         "trans": [
+            "あまりに",
             " ⓪ 副  太，过于"
-        ],
-        "notation": "あまりに"
+        ]
     },
     {
         "name": "kakizome",
         "trans": [
+            "書初(かきぞ)め",
             "⓪ 名·自动3  新春开笔（新年第一次提笔写字）"
-        ],
-        "notation": "書初(かきぞ)め"
+        ]
     },
     {
         "name": "katariau",
         "trans": [
+            "語(かた)り合(あ)う",
             "④ 他动1  交谈，商谈"
-        ],
-        "notation": "語(かた)り合(あ)う"
+        ]
     },
     {
         "name": "iromegane",
         "trans": [
+            "色眼鏡(いろめがね)",
             "③ 名  有色眼镜，墨镜；偏见"
-        ],
-        "notation": "色眼鏡(いろめがね)"
+        ]
     },
     {
         "name": "kadan",
         "trans": [
+            "花壇(かだん)",
             "① 名  花坛"
-        ],
-        "notation": "花壇(かだん)"
+        ]
     },
     {
         "name": "ami",
         "trans": [
+            "網(あみ)",
             "② 名  网；罗网，法网"
-        ],
-        "notation": "網(あみ)"
+        ]
     },
     {
         "name": "ayaui",
         "trans": [
+            "危(あや)うい",
             "⓪ イ形  危险的"
-        ],
-        "notation": "危(あや)うい"
+        ]
     },
     {
         "name": "kasaneawaseru",
         "trans": [
+            "重(かさ)ね合(あ)わせる",
             "⑥ 他动2  重叠在一起，叠加"
-        ],
-        "notation": "重(かさ)ね合(あ)わせる"
+        ]
     },
     {
         "name": "ayamari",
         "trans": [
+            "誤(あやま)り",
             "④ 名  错，错误"
-        ],
-        "notation": "誤(あやま)り"
+        ]
     },
     {
         "name": "kadomatsu",
         "trans": [
+            "門松(かどまつ)",
             "② 名  门松（新年在门前装饰的松枝）"
-        ],
-        "notation": "門松(かどまつ)"
+        ]
     },
     {
         "name": "gakekuzure",
         "trans": [
+            "崖崩(がけくず)れ",
             "③ 名  塌方，滑坡"
-        ],
-        "notation": "崖崩(がけくず)れ"
+        ]
     },
     {
         "name": "futatabi",
         "trans": [
+            "再(ふたた)び",
             "⓪ 副  再次，又，重"
-        ],
-        "notation": "再(ふたた)び"
+        ]
     },
     {
         "name": "arasotte",
         "trans": [
+            "争(あらそ)って",
             "③ 副  争先恐后地"
-        ],
-        "notation": "争(あらそ)って"
+        ]
     },
     {
         "name": "yakushoku",
         "trans": [
+            "役職(やくしょく)",
             "⓪ 名  官职，职务；要职"
-        ],
-        "notation": "役職(やくしょく)"
+        ]
     },
     {
         "name": "yokoku",
         "trans": [
+            "予告(よこく)",
             "⓪ 名·他动3  预告，预先通知"
-        ],
-        "notation": "予告(よこく)"
+        ]
     },
     {
         "name": "muigi",
         "trans": [
+            "無意義(むいぎ)",
             "② 名·ナ形  无意义，没有价值"
-        ],
-        "notation": "無意義(むいぎ)"
+        ]
     },
     {
         "name": "kakekomu",
         "trans": [
+            "駆(か)け込(こ)む",
             "⓪ 自动1  跑进去，跑到里面"
-        ],
-        "notation": "駆(か)け込(こ)む"
+        ]
     },
     {
         "name": "aratamaru",
         "trans": [
+            "改(あらた)まる",
             "④ 自动1  改，变，更新；改善；郑重其事"
-        ],
-        "notation": "改(あらた)まる"
+        ]
     },
     {
         "name": "fukeiki",
         "trans": [
+            "不景気(ふけいき)",
             "② 名·ナ形  不景气，经济萧条"
-        ],
-        "notation": "不景気(ふけいき)"
+        ]
     },
     {
         "name": "fusawashii",
         "trans": [
+            "ふさわしい",
             " ④ イ形  合适的，相称的"
-        ],
-        "notation": "ふさわしい"
+        ]
     },
     {
         "name": "bushi",
         "trans": [
+            "武士(ぶし)",
             "① 名  武士"
-        ],
-        "notation": "武士(ぶし)"
+        ]
     },
     {
         "name": "karasu",
         "trans": [
+            "枯(か)らす",
             "⓪ 他动1  使……枯萎"
-        ],
-        "notation": "枯(か)らす"
+        ]
     },
     {
         "name": "karadatsuki",
         "trans": [
+            "体付(からだつ)き",
             "⓪ 名  体格，体形"
-        ],
-        "notation": "体付(からだつ)き"
+        ]
     },
     {
         "name": "karate",
         "trans": [
+            "空手(からて)",
             "⓪ 名  空手道；空手，赤手空拳"
-        ],
-        "notation": "空手(からて)"
+        ]
     },
     {
         "name": "busshitsu",
         "trans": [
+            "物質(ぶっしつ)",
             "⓪ 名  物质"
-        ],
-        "notation": "物質(ぶっしつ)"
+        ]
     },
     {
         "name": "kariireru",
         "trans": [
+            "借(か)り入(い)れる",
             "④ 他动2  借入，租来"
-        ],
-        "notation": "借(か)り入(い)れる"
+        ]
     },
     {
         "name": "kanpa",
         "trans": [
+            "寒波(かんぱ)",
             "① 名  寒潮，寒流"
-        ],
-        "notation": "寒波(かんぱ)"
+        ]
     },
     {
         "name": "kanbatsu",
         "trans": [
+            "干(かん)ばつ",
             "⓪ 名  旱，干旱"
-        ],
-        "notation": "干(かん)ばつ"
+        ]
     },
     {
         "name": "arashi",
         "trans": [
+            "嵐(あらし)",
             "① 名  暴风雨"
-        ],
-        "notation": "嵐(あらし)"
+        ]
     },
     {
         "name": "yohodo",
         "trans": [
+            "よほど",
             " ⓪ 副·ナ形  很，相当，非常"
-        ],
-        "notation": "よほど"
+        ]
     },
     {
         "name": "bungei",
         "trans": [
+            "文芸(ぶんげい)",
             "⓪ 名  文艺；文学与艺术"
-        ],
-        "notation": "文芸(ぶんげい)"
+        ]
     },
     {
         "name": "arasoi",
         "trans": [
+            "争(あらそ)い",
             "⓪ 名  争论，纠纷；竞争"
-        ],
-        "notation": "争(あらそ)い"
+        ]
     },
     {
         "name": "fusei",
         "trans": [
+            "不正(ふせい)",
             "⓪ 名·ナ形  不正当，非法"
-        ],
-        "notation": "不正(ふせい)"
+        ]
     },
     {
         "name": "karugaruto",
         "trans": [
+            "軽々と(かるがると)",
             "③ 副  轻轻地，轻而易举地"
-        ],
-        "notation": "軽々と(かるがると)"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "勘(かん)",
             "⓪ 名  直觉，第六感"
-        ],
-        "notation": "勘(かん)"
+        ]
     },
     {
         "name": "burei",
         "trans": [
+            "無礼(ぶれい)",
             "① 名·ナ形  无礼，没礼貌"
-        ],
-        "notation": "無礼(ぶれい)"
+        ]
     },
     {
         "name": "puro",
         "trans": [
+            "プロ",
             " ① 名  专业，职业"
-        ],
-        "notation": "プロ"
+        ]
     },
     {
         "name": "funka",
         "trans": [
+            "噴火(ふんか)",
             "⓪ 名·自动3  火山喷发"
-        ],
-        "notation": "噴火(ふんか)"
+        ]
     },
     {
         "name": "kansou",
         "trans": [
+            "乾燥(かんそう)",
             "⓪ 名·自他动3  干燥，干巴；枯燥无味"
-        ],
-        "notation": "乾燥(かんそう)"
+        ]
     },
     {
         "name": "shougai",
         "trans": [
+            "障害(しょうがい)",
             "⓪ 名  障碍，妨碍；故障，毛病"
-        ],
-        "notation": "障害(しょうがい)"
+        ]
     },
     {
         "name": "sashihiku",
         "trans": [
+            "差(さ)し引(ひ)く",
             "③ 他动1  扣除，减去；相抵"
-        ],
-        "notation": "差(さ)し引(ひ)く"
+        ]
     },
     {
         "name": "kazoeageru",
         "trans": [
+            "数(かぞ)え上(あ)げる",
             "⑤ 他动2  一一列举；数完"
-        ],
-        "notation": "数(かぞ)え上(あ)げる"
+        ]
     },
     {
         "name": "sasetsu",
         "trans": [
+            "左折(させつ)",
             "⓪ 名·自动3  左转，左拐"
-        ],
-        "notation": "左折(させつ)"
+        ]
     },
     {
         "name": "bussou",
         "trans": [
+            "物騒(ぶっそう)",
             "③ 名·ナ形  不太平，不安定；危险"
-        ],
-        "notation": "物騒(ぶっそう)"
+        ]
     },
     {
         "name": "sazo",
         "trans": [
+            "さぞ",
             " ① 副  想必；一定是"
-        ],
-        "notation": "さぞ"
+        ]
     },
     {
         "name": "kanshi",
         "trans": [
+            "監視(かんし)",
             "⓪ 名·他动3  监视"
-        ],
-        "notation": "監視(かんし)"
+        ]
     },
     {
         "name": "shouka",
         "trans": [
+            "消火(しょうか)",
             "⓪ 名·自他动3  消防，灭火"
-        ],
-        "notation": "消火(しょうか)"
+        ]
     },
     {
         "name": "kanshou",
         "trans": [
+            "鑑賞(かんしょう)",
             "⓪ 名·他动3  鉴赏，欣赏"
-        ],
-        "notation": "鑑賞(かんしょう)"
+        ]
     },
     {
         "name": "futtou",
         "trans": [
+            "沸騰(ふっとう)",
             "⓪ 名·自动3  沸腾；情绪高涨，欢呼雀跃"
-        ],
-        "notation": "沸騰(ふっとう)"
+        ]
     },
     {
         "name": "zatsuon",
         "trans": [
+            "雑音(ざつおん)",
             "⓪ 名  杂音，噪音"
-        ],
-        "notation": "雑音(ざつおん)"
+        ]
     },
     {
         "name": "futou",
         "trans": [
+            "不当(ふとう)",
             "⓪ 名·ナ形  不正当，不合理"
-        ],
-        "notation": "不当(ふとう)"
+        ]
     },
     {
         "name": "iin",
         "trans": [
+            "委員(いいん)",
             "① 名  委员"
-        ],
-        "notation": "委員(いいん)"
+        ]
     },
     {
         "name": "kansei",
         "trans": [
+            "歓声(かんせい)",
             "⓪ 名  欢呼声"
-        ],
-        "notation": "歓声(かんせい)"
+        ]
     },
     {
         "name": "fumanzoku",
         "trans": [
+            "不満足(ふまんぞく)",
             "② 名·ナ形  不满足，不满意"
-        ],
-        "notation": "不満足(ふまんぞく)"
+        ]
     },
     {
         "name": "kansen",
         "trans": [
+            "感染(かんせん)",
             "⓪ 名·自动3  感染，传染；沾染"
-        ],
-        "notation": "感染(かんせん)"
+        ]
     },
     {
         "name": "fuhen",
         "trans": [
+            "普遍(ふへん)",
             "⓪ 名  普遍"
-        ],
-        "notation": "普遍(ふへん)"
+        ]
     },
     {
         "name": "zatsudan",
         "trans": [
+            "雑談(ざつだん)",
             "⓪ 名·自动3  闲谈，闲聊"
-        ],
-        "notation": "雑談(ざつだん)"
+        ]
     },
     {
         "name": "fubuki",
         "trans": [
+            "吹雪(ふぶき)",
             "① 名  暴风雪"
-        ],
-        "notation": "吹雪(ふぶき)"
+        ]
     },
     {
         "name": "sakkyoku",
         "trans": [
+            "作曲(さっきょく)",
             "⓪ 名·自他动3  作曲，谱曲"
-        ],
-        "notation": "作曲(さっきょく)"
+        ]
     },
     {
         "name": "satto",
         "trans": [
+            "さっと",
             " ① 副  突然，忽然，一下子"
-        ],
-        "notation": "さっと"
+        ]
     },
     {
         "name": "sadou",
         "trans": [
+            "茶道(さどう)",
             "① 名  （日本）茶道"
-        ],
-        "notation": "茶道(さどう)"
+        ]
     },
     {
         "name": "fuhei",
         "trans": [
+            "不平(ふへい)",
             "⓪ 名·ナ形  不平，不满，牢骚"
-        ],
-        "notation": "不平(ふへい)"
+        ]
     },
     {
         "name": "saru",
         "trans": [
+            "去(さ)る",
             "① 自他动1  离开，离去；过去，消失；去掉，消除；断绝关系"
-        ],
-        "notation": "去(さ)る"
+        ]
     },
     {
         "name": "zankoku",
         "trans": [
+            "残酷(ざんこく)",
             "⓪ 名·ナ形  残忍，残酷"
-        ],
-        "notation": "残酷(ざんこく)"
+        ]
     },
     {
         "name": "sanzan",
         "trans": [
+            "さんざん",
             " ③ 副·ナ形  狠狠地；深深地；凄惨，狼狈"
-        ],
-        "notation": "さんざん"
+        ]
     },
     {
         "name": "shouko",
         "trans": [
+            "証拠(しょうこ)",
             "⓪ 名  证据，事实根据"
-        ],
-        "notation": "証拠(しょうこ)"
+        ]
     },
     {
         "name": "fuhenteki",
         "trans": [
+            "普遍的(ふへんてき)",
             "⓪ ナ形  普遍性的"
-        ],
-        "notation": "普遍的(ふへんてき)"
+        ]
     },
     {
         "name": "shoukin",
         "trans": [
+            "賞金(しょうきん)",
             "⓪ 名  赏金；奖金，奖赏"
-        ],
-        "notation": "賞金(しょうきん)"
+        ]
     },
     {
         "name": "kasanete",
         "trans": [
+            "重(かさ)ねて",
             "⓪ 副  重复，再一次"
-        ],
-        "notation": "重(かさ)ねて"
+        ]
     },
     {
         "name": "kashidasu",
         "trans": [
+            "貸(か)し出(だ)す",
             "③ 他动1  出借，出租"
-        ],
-        "notation": "貸(か)し出(だ)す"
+        ]
     },
     {
         "name": "iiwake",
         "trans": [
+            "言(い)い訳(わけ)",
             "⓪ 名·自动3  解释，分辩，辩解"
-        ],
-        "notation": "言(い)い訳(わけ)"
+        ]
     },
     {
         "name": "torimatomeru",
         "trans": [
+            "取(と)りまとめる",
             "⑤ 他动2  归纳，汇总，整理；调解"
-        ],
-        "notation": "取(と)りまとめる"
+        ]
     },
     {
         "name": "jiban",
         "trans": [
+            "地盤(じばん)",
             "⓪ 名  地基；地盘，势力范围"
-        ],
-        "notation": "地盤(じばん)"
+        ]
     },
     {
         "name": "ikigai",
         "trans": [
+            "生(い)きがい",
             "⓪ 名  生存的意义"
-        ],
-        "notation": "生(い)きがい"
+        ]
     },
     {
         "name": "bumon",
         "trans": [
+            "部門(ぶもん)",
             "① 名  部门"
-        ],
-        "notation": "部門(ぶもん)"
+        ]
     },
     {
         "name": "sanshutsu",
         "trans": [
+            "産出(さんしゅつ)",
             "⓪ 名·他动3  出产，生产"
-        ],
-        "notation": "産出(さんしゅつ)"
+        ]
     },
     {
         "name": "gakujutsu",
         "trans": [
+            "学術(がくじゅつ)",
             "② 名  学术"
-        ],
-        "notation": "学術(がくじゅつ)"
+        ]
     },
     {
         "name": "burasagaru",
         "trans": [
+            "ぶら下(さ)がる",
             "⓪ 自动1  下垂，耷拉；眼看到手 "
-        ],
-        "notation": "ぶら下(さ)がる"
+        ]
     },
     {
         "name": "kakushin",
         "trans": [
+            "確信(かくしん)",
             "⓪ 名·他动3  确信，坚信"
-        ],
-        "notation": "確信(かくしん)"
+        ]
     },
     {
         "name": "joukyou",
         "trans": [
+            "上京(じょうきょう)",
             "⓪ 名·自动3  进京；到东京去"
-        ],
-        "notation": "上京(じょうきょう)"
+        ]
     },
     {
         "name": "gakusetsu",
         "trans": [
+            "学説(がくせつ)",
             "⓪ 名  学说"
-        ],
-        "notation": "学説(がくせつ)"
+        ]
     },
     {
         "name": "puran",
         "trans": [
+            "プラン",
             "① 名  计划，方案"
-        ],
-        "notation": "プラン"
+        ]
     },
     {
         "name": "furi",
         "trans": [
+            "不利(ふり)",
             "① 名·ナ形  不利"
-        ],
-        "notation": "不利(ふり)"
+        ]
     },
     {
         "name": "sabaku",
         "trans": [
+            "砂漠(さばく)",
             "⓪ 名  沙漠"
-        ],
-        "notation": "砂漠(さばく)"
+        ]
     },
     {
         "name": "zarazara",
         "trans": [
+            "ざらざら",
             " ① 副·自动3  粗糙，不光滑；哗啦哗啦声"
-        ],
-        "notation": "ざらざら"
+        ]
     },
     {
         "name": "kakuritsu",
         "trans": [
+            "確立(かくりつ)",
             "⓪ 名·自他动3  确立，确定"
-        ],
-        "notation": "確立(かくりつ)"
+        ]
     },
     {
         "name": "fukureru",
         "trans": [
+            "膨(ふく)れる",
             "⓪ 自动2  膨胀，鼓出；噘嘴"
-        ],
-        "notation": "膨(ふく)れる"
+        ]
     },
     {
         "name": "bubunteki",
         "trans": [
+            "部分的(ぶぶんてき)",
             "⓪ ナ形  部分的"
-        ],
-        "notation": "部分的(ぶぶんてき)"
+        ]
     },
     {
         "name": "shussei",
         "trans": [
+            "出生(しゅっせい)",
             "⓪ 名·自动3  出生，诞生"
-        ],
-        "notation": "出生(しゅっせい)"
+        ]
     },
     {
         "name": "gake",
         "trans": [
+            "崖(がけ)",
             "⓪ 名  山崖，悬崖"
-        ],
-        "notation": "崖(がけ)"
+        ]
     },
     {
         "name": "shunkan",
         "trans": [
+            "瞬間(しゅんかん)",
             "⓪ 名  瞬间，刹那，转眼"
-        ],
-        "notation": "瞬間(しゅんかん)"
+        ]
     },
     {
         "name": "toriyameru",
         "trans": [
+            "取(と)りやめる",
             "⓪ 他动2  中止，停止，作罢"
-        ],
-        "notation": "取(と)りやめる"
+        ]
     },
     {
         "name": "uwaki",
         "trans": [
+            "浮気(うわき)",
             "⓪ 名·自动3·ナ形  见异思迁；出轨"
-        ],
-        "notation": "浮気(うわき)"
+        ]
     },
     {
         "name": "kazegusuri",
         "trans": [
+            "風邪薬(かぜぐすり)",
             "③ 名  感冒药"
-        ],
-        "notation": "風邪薬(かぜぐすり)"
+        ]
     },
     {
         "name": "bunsho",
         "trans": [
+            "文書(ぶんしょ)",
             "① 名  文书，文件，公文"
-        ],
-        "notation": "文書(ぶんしょ)"
+        ]
     },
     {
         "name": "kakei",
         "trans": [
+            "家計(かけい)",
             "⓪ 名  家庭经济情况，家庭收支情况"
-        ],
-        "notation": "家計(かけい)"
+        ]
     },
     {
         "name": "deshi",
         "trans": [
+            "弟子(でし)",
             "② 名  弟子，徒弟"
-        ],
-        "notation": "弟子(でし)"
+        ]
     },
     {
         "name": "fumei",
         "trans": [
+            "不明(ふめい)",
             "⓪ 名·ナ形  不明，不清楚；无才，无能"
-        ],
-        "notation": "不明(ふめい)"
+        ]
     },
     {
         "name": "kaketsu",
         "trans": [
+            "可決(かけつ)",
             "⓪ 名·他动3  通过"
-        ],
-        "notation": "可決(かけつ)"
+        ]
     },
     {
         "name": "angai",
         "trans": [
+            "案外(あんがい)",
             "① 副·ナ形  意想不到，出乎意料"
-        ],
-        "notation": "案外(あんがい)"
+        ]
     },
     {
         "name": "kaketsukeru",
         "trans": [
+            "駆(か)け付(つ)ける",
             "⓪ 自动2  急忙赶到，奔赴"
-        ],
-        "notation": "駆(か)け付(つ)ける"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "駆(か)ける",
             "② 自动2  奔跑；策马奔腾"
-        ],
-        "notation": "駆(か)ける"
+        ]
     },
     {
         "name": "kinko",
         "trans": [
+            "金庫(きんこ)",
             "① 名  保险柜，金库"
-        ],
-        "notation": "金庫(きんこ)"
+        ]
     },
     {
         "name": "tsuukai",
         "trans": [
+            "痛快(つうかい)",
             "⓪ 名·ナ形  痛快，愉快，快活"
-        ],
-        "notation": "痛快(つうかい)"
+        ]
     },
     {
         "name": "teikiatsu",
         "trans": [
+            "低気圧(ていきあつ)",
             "③ 名  低气压；透不过气，不高兴"
-        ],
-        "notation": "低気圧(ていきあつ)"
+        ]
     },
     {
         "name": "ikkou",
         "trans": [
+            "一向(いっこう)",
             "⓪ 副  完全，全然，一点儿也"
-        ],
-        "notation": "一向(いっこう)"
+        ]
     },
     {
         "name": "akutenkou",
         "trans": [
+            "悪天候(あくてんこう)",
             "③ 名  坏天气，恶劣的天气"
-        ],
-        "notation": "悪天候(あくてんこう)"
+        ]
     },
     {
         "name": "tatoeru",
         "trans": [
+            "例(たと)える",
             "③ 他动2  比喻，比方"
-        ],
-        "notation": "例(たと)える"
+        ]
     },
     {
         "name": "nigoru",
         "trans": [
+            "濁(にご)る",
             "② 自动1  混浊，不清；起邪念"
-        ],
-        "notation": "濁(にご)る"
+        ]
     },
     {
         "name": "surarito",
         "trans": [
+            "すらりと",
             " ② 副  身材苗条；快速地，嗖地一下；顺利地"
-        ],
-        "notation": "すらりと"
+        ]
     },
     {
         "name": "kagen",
         "trans": [
+            "加減(かげん)",
             "⓪ 名·他动3  程度，状况；调整，调节"
-        ],
-        "notation": "加減(かげん)"
+        ]
     },
     {
         "name": "ikinokoru",
         "trans": [
+            "生(い)き残(のこ)る",
             "④ 自动1  幸存，活下来"
-        ],
-        "notation": "生(い)き残(のこ)る"
+        ]
     },
     {
         "name": "kyuujo",
         "trans": [
+            "救助(きゅうじょ)",
             "① 名·他动3  救助，拯救，抢救"
-        ],
-        "notation": "救助(きゅうじょ)"
+        ]
     },
     {
         "name": "oioi",
         "trans": [
+            "おいおい",
             " ① 叹·副  喂喂；哇哇大哭"
-        ],
-        "notation": "おいおい"
+        ]
     },
     {
         "name": "izatoiutoki",
         "trans": [
+            "いざという時(とき)",
             "① 连语  紧要关头，危急时刻"
-        ],
-        "notation": "いざという時(とき)"
+        ]
     },
     {
         "name": "kyoukun",
         "trans": [
+            "教訓(きょうくん)",
             "⓪ 名  教训"
-        ],
-        "notation": "教訓(きょうくん)"
+        ]
     },
     {
         "name": "izumi",
         "trans": [
+            "泉(いずみ)",
             "⓪ 名  泉水；源泉"
-        ],
-        "notation": "泉(いずみ)"
+        ]
     },
     {
         "name": "gyoumu",
         "trans": [
+            "業務(ぎょうむ)",
             "① 名  业务，工作"
-        ],
-        "notation": "業務(ぎょうむ)"
+        ]
     },
     {
         "name": "junkan",
         "trans": [
+            "循環(じゅんかん)",
             "⓪ 名·自动3  循环"
-        ],
-        "notation": "循環(じゅんかん)"
+        ]
     },
     {
         "name": "ikebana",
         "trans": [
+            "生(い)け花(ばな)",
             "② 名  插花"
-        ],
-        "notation": "生(い)け花(ばな)"
+        ]
     },
     {
         "name": "kyouyou",
         "trans": [
+            "教養(きょうよう)",
             "⓪ 名  教养，修养；素养；学识"
-        ],
-        "notation": "教養(きょうよう)"
+        ]
     },
     {
         "name": "ita",
         "trans": [
+            "板(いた)",
             "① 名  木板；菜板"
-        ],
-        "notation": "板(いた)"
+        ]
     },
     {
         "name": "itarutokoro",
         "trans": [
+            "至(いた)る所(ところ)",
             "② 副  处处，到处"
-        ],
-        "notation": "至(いた)る所(ところ)"
+        ]
     },
     {
         "name": "kingyo",
         "trans": [
+            "金魚(きんぎょ)",
             "① 名  金鱼"
-        ],
-        "notation": "金魚(きんぎょ)"
+        ]
     },
     {
         "name": "tsumekomu",
         "trans": [
+            "詰(つ)め込(こ)む",
             "⓪ 他动1  塞入，装满；灌输"
-        ],
-        "notation": "詰(つ)め込(こ)む"
+        ]
     },
     {
         "name": "kyuuyo",
         "trans": [
+            "給与(きゅうよ)",
             "① 名·他动3  工资，薪酬；供应，供给"
-        ],
-        "notation": "給与(きゅうよ)"
+        ]
     },
     {
         "name": "denaosu",
         "trans": [
+            "出直(でなお)す",
             "③ 自动1  重来，重新开始"
-        ],
-        "notation": "出直(でなお)す"
+        ]
     },
     {
         "name": "terashiawaseru",
         "trans": [
+            "照(て)らし合(あ)わせる",
             "⑥ 他动2  核对，对照"
-        ],
-        "notation": "照(て)らし合(あ)わせる"
+        ]
     },
     {
         "name": "kasakasa",
         "trans": [
+            "かさかさ",
             " ⓪ 副·ナ形·自动3  干燥，干巴巴；沙沙响"
-        ],
-        "notation": "かさかさ"
+        ]
     },
     {
         "name": "tobimawaru",
         "trans": [
+            "飛(と)び回(まわ)る",
             "④ 自动1  飞来飞去；到处奔走，东奔西走"
-        ],
-        "notation": "飛(と)び回(まわ)る"
+        ]
     },
     {
         "name": "ken'eki",
         "trans": [
+            "権益(けんえき)",
             "① 名  权益"
-        ],
-        "notation": "権益(けんえき)"
+        ]
     },
     {
         "name": "kyoukan",
         "trans": [
+            "教官(きょうかん)",
             "⓪ 名  教官，教员"
-        ],
-        "notation": "教官(きょうかん)"
+        ]
     },
     {
         "name": "an",
         "trans": [
+            "案(あん)",
             "① 名  主意，办法；计划，方案；设想"
-        ],
-        "notation": "案(あん)"
+        ]
     },
     {
         "name": "oke",
         "trans": [
+            "桶(おけ)",
             "① 名  桶，木桶"
-        ],
-        "notation": "桶(おけ)"
+        ]
     },
     {
         "name": "kyokusen",
         "trans": [
+            "曲線(きょくせん)",
             "⓪ 名  曲线"
-        ],
-        "notation": "曲線(きょくせん)"
+        ]
     },
     {
         "name": "sararito",
         "trans": [
+            "さらりと",
             " ② 副  光滑；干爽；痛快直接地说；爽快"
-        ],
-        "notation": "さらりと"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "執(と)る",
             "① 他动1  处理，办理；执笔，提笔"
-        ],
-        "notation": "執(と)る"
+        ]
     },
     {
         "name": "nagaame",
         "trans": [
+            "長雨(ながあめ)",
             "⓪ 名  连日降雨，长时间降雨"
-        ],
-        "notation": "長雨(ながあめ)"
+        ]
     },
     {
         "name": "hasen",
         "trans": [
+            "波線(はせん)",
             "⓪ 名  波浪线，波纹线"
-        ],
-        "notation": "波線(はせん)"
+        ]
     },
     {
         "name": "nigosu",
         "trans": [
+            "濁(にご)す",
             "② 他动1  弄脏，弄混浊；含糊，支吾"
-        ],
-        "notation": "濁(にご)す"
+        ]
     },
     {
         "name": "nurigusuri",
         "trans": [
+            "塗(ぬりぐす)り薬()",
             "③ 名  外敷药"
-        ],
-        "notation": "塗(ぬりぐす)り薬()"
+        ]
     },
     {
         "name": "neppa",
         "trans": [
+            "熱波(ねっぱ)",
             "① 名  热气流，热浪"
-        ],
-        "notation": "熱波(ねっぱ)"
+        ]
     },
     {
         "name": "kin'niku",
         "trans": [
+            "筋肉(きんにく)",
             "① 名  肌肉"
-        ],
-        "notation": "筋肉(きんにく)"
+        ]
     },
     {
         "name": "atsuryoku",
         "trans": [
+            "圧力(あつりょく)",
             "② 名  压力"
-        ],
-        "notation": "圧力(あつりょく)"
+        ]
     },
     {
         "name": "aratameru",
         "trans": [
+            "改(あらた)める",
             "④ 他动2  改，改变；修改；改正"
-        ],
-        "notation": "改(あらた)める"
+        ]
     },
     {
         "name": "kyokutan",
         "trans": [
+            "極端(きょくたん)",
             "③ 名·ナ形  极端"
-        ],
-        "notation": "極端(きょくたん)"
+        ]
     },
     {
         "name": "issai",
         "trans": [
+            "一切(いっさい)",
             "① 名·副  一切，全部，都"
-        ],
-        "notation": "一切(いっさい)"
+        ]
     },
     {
         "name": "kirikizu",
         "trans": [
+            "切(き)り傷(きず)",
             "② 名  刀伤，划伤，割伤"
-        ],
-        "notation": "切(き)り傷(きず)"
+        ]
     },
     {
         "name": "sukuu",
         "trans": [
+            "掬(すく)う",
             "⓪ 他动1  捞出，舀，捧起"
-        ],
-        "notation": "掬(すく)う"
+        ]
     },
     {
         "name": "araware",
         "trans": [
+            "現(あらわ)れ",
             "④ 名  体现，表现"
-        ],
-        "notation": "現(あらわ)れ"
+        ]
     },
     {
         "name": "ari",
         "trans": [
+            "蟻(あり)",
             "⓪ 名  蚂蚁"
-        ],
-        "notation": "蟻(あり)"
+        ]
     },
     {
         "name": "kouso",
         "trans": [
+            "酵素(こうそ)",
             "① 名  酵素，酶"
-        ],
-        "notation": "酵素(こうそ)"
+        ]
     },
     {
         "name": "bakushou",
         "trans": [
+            "爆笑(ばくしょう)",
             "⓪ 名·自动3  哄堂大笑，放声大笑"
-        ],
-        "notation": "爆笑(ばくしょう)"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "著(あらわ)す",
             "③ 他动1  著书，写作"
-        ],
-        "notation": "著(あらわ)す"
+        ]
     },
     {
         "name": "shishagonyuu",
         "trans": [
+            "四捨五入(ししゃごにゅう)",
             "① 名·他动3  四舍五入"
-        ],
-        "notation": "四捨五入(ししゃごにゅう)"
+        ]
     },
     {
         "name": "tsuru",
         "trans": [
+            "鶴(つる)",
             "① 名  鹤"
-        ],
-        "notation": "鶴(つる)"
+        ]
     },
     {
         "name": "de-ta",
         "trans": [
+            "データ",
             "① 名  数据，资料，材料"
-        ],
-        "notation": "データ"
+        ]
     },
     {
         "name": "awa",
         "trans": [
+            "泡(あわ)",
             "② 名  泡，泡沫"
-        ],
-        "notation": "泡(あわ)"
+        ]
     },
     {
         "name": "itsutonaku",
         "trans": [
+            "いつとなく",
             " ① 副  不知不觉，说不上什么时候"
-        ],
-        "notation": "いつとなく"
+        ]
     },
     {
         "name": "onaidoshi",
         "trans": [
+            "同(おな)い年(どし)",
             "② 名  同年，同岁"
-        ],
-        "notation": "同(おな)い年(どし)"
+        ]
     },
     {
         "name": "joshou",
         "trans": [
+            "女将(じょしょう)",
             "⓪ 名  （餐厅、旅馆等的）女老板，女掌柜"
-        ],
-        "notation": "女将(じょしょう)"
+        ]
     },
     {
         "name": "inobe-shon",
         "trans": [
+            "イノベーション",
             "③ 名  改革，革新，变革"
-        ],
-        "notation": "イノベーション"
+        ]
     },
     {
         "name": "opera",
         "trans": [
+            "オペラ",
             "① 名  歌剧"
-        ],
-        "notation": "オペラ"
+        ]
     },
     {
         "name": "sesshu",
         "trans": [
+            "接種(せっしゅ)",
             "① 名·他动3  接种，注射"
-        ],
-        "notation": "接種(せっしゅ)"
+        ]
     },
     {
         "name": "ensuto",
         "trans": [
+            "エンスト",
             "⓪ 名  引擎故障，熄火"
-        ],
-        "notation": "エンスト"
+        ]
     },
     {
         "name": "ittan",
         "trans": [
+            "一旦(いったん)",
             "⓪ 副  一旦，既然；暂且，姑且"
-        ],
-        "notation": "一旦(いったん)"
+        ]
     },
     {
         "name": "kikidasu",
         "trans": [
+            "聞(き)き出(だ)す",
             "③ 他动1  刺探出，打听出；开始听"
-        ],
-        "notation": "聞(き)き出(だ)す"
+        ]
     },
     {
         "name": "migoto",
         "trans": [
+            "見事(みごと)",
             "① ナ形·副  完美的，漂亮的；完全，彻底"
-        ],
-        "notation": "見事(みごと)"
+        ]
     },
     {
         "name": "kyasshu",
         "trans": [
+            "キャッシュ",
             "① 名  现金"
-        ],
-        "notation": "キャッシュ"
+        ]
     },
     {
         "name": "icchi",
         "trans": [
+            "一致(いっち)",
             "⓪ 名·自动3  一致"
-        ],
-        "notation": "一致(いっち)"
+        ]
     },
     {
         "name": "kurippu",
         "trans": [
+            "クリップ",
             "② 名  夹子；回形针"
-        ],
-        "notation": "クリップ"
+        ]
     },
     {
         "name": "keishou",
         "trans": [
+            "軽傷(けいしょう)",
             "⓪ 名  轻伤"
-        ],
-        "notation": "軽傷(けいしょう)"
+        ]
     },
     {
         "name": "otsu",
         "trans": [
+            "乙(おつ)",
             "① 名·ナ形  乙；第二；别致的；奇怪的"
-        ],
-        "notation": "乙(おつ)"
+        ]
     },
     {
         "name": "joushou",
         "trans": [
+            "上昇(じょうしょう)",
             "⓪ 名·自动3  上升；升高"
-        ],
-        "notation": "上昇(じょうしょう)"
+        ]
     },
     {
         "name": "jiritsu",
         "trans": [
+            "自律(じりつ)",
             "⓪ 名  自律"
-        ],
-        "notation": "自律(じりつ)"
+        ]
     },
     {
         "name": "isshu",
         "trans": [
+            "一種(いっしゅ)",
             "① 名·副  一种；某种，稍许，一点儿"
-        ],
-        "notation": "一種(いっしゅ)"
+        ]
     },
     {
         "name": "tanjun",
         "trans": [
+            "単純(たんじゅん)",
             "⓪ 名·ナ形  单纯，简单"
-        ],
-        "notation": "単純(たんじゅん)"
+        ]
     },
     {
         "name": "gentai",
         "trans": [
+            "減退(げんたい)",
             "⓪ 名·自动3  减退，衰退"
-        ],
-        "notation": "減退(げんたい)"
+        ]
     },
     {
         "name": "miuchi",
         "trans": [
+            "身内(みうち)",
             "⓪ 名  全身，浑身；亲属；自家人"
-        ],
-        "notation": "身内(みうち)"
+        ]
     },
     {
         "name": "kakusan",
         "trans": [
+            "拡散(かくさん)",
             "⓪ 名·自动3  扩散"
-        ],
-        "notation": "拡散(かくさん)"
+        ]
     },
     {
         "name": "shinkinkan",
         "trans": [
+            "親近感(しんきんかん)",
             "③ 名  亲切，亲近感"
-        ],
-        "notation": "親近感(しんきんかん)"
+        ]
     },
     {
         "name": "narikin",
         "trans": [
+            "成金(なりきん)",
             "⓪ 名  暴发户，暴富的人"
-        ],
-        "notation": "成金(なりきん)"
+        ]
     },
     {
         "name": "antena",
         "trans": [
+            "アンテナ",
             "⓪ 名  天线"
-        ],
-        "notation": "アンテナ"
+        ]
     },
     {
         "name": "kiritsu",
         "trans": [
+            "規律(きりつ)",
             "⓪ 名  规律；纪律，规章"
-        ],
-        "notation": "規律(きりつ)"
+        ]
     },
     {
         "name": "dejitaru",
         "trans": [
+            "デジタル",
             "① 名  数字（的），数字化（的）"
-        ],
-        "notation": "デジタル"
+        ]
     },
     {
         "name": "shoumou",
         "trans": [
+            "消耗(しょうもう)",
             "⓪ 名·自他动3  消耗，耗尽"
-        ],
-        "notation": "消耗(しょうもう)"
+        ]
     },
     {
         "name": "kogarashi",
         "trans": [
+            "木枯(こが)らし",
             "② 名  寒风，秋风"
-        ],
-        "notation": "木枯(こが)らし"
+        ]
     },
     {
         "name": "genryou",
         "trans": [
+            "減量(げんりょう)",
             "⓪ 名·自他动3  分量减少；减轻体重"
-        ],
-        "notation": "減量(げんりょう)"
+        ]
     },
     {
         "name": "shikyuu",
         "trans": [
+            "至急(しきゅう)",
             "⓪ 名·副  火速，赶快；急，加急"
-        ],
-        "notation": "至急(しきゅう)"
+        ]
     },
     {
         "name": "sasoiawaseru",
         "trans": [
+            "誘(さそ)い合(あ)わせる",
             "⑥ 他动2  相约，相邀"
-        ],
-        "notation": "誘(さそ)い合(あ)わせる"
+        ]
     },
     {
         "name": "butsubutsu",
         "trans": [
+            "ぶつぶつ",
             " ① 副·名  发牢骚，抱怨；一颗颗"
-        ],
-        "notation": "ぶつぶつ"
+        ]
     },
     {
         "name": "shishou",
         "trans": [
+            "死傷(ししょう)",
             "⓪ 名·自动3  死伤，伤亡"
-        ],
-        "notation": "死傷(ししょう)"
+        ]
     },
     {
         "name": "kousa",
         "trans": [
+            "考査(こうさ)",
             "① 名·他动3  审查，审核；测验，考试"
-        ],
-        "notation": "考査(こうさ)"
+        ]
     },
     {
         "name": "kuchibashi",
         "trans": [
+            "嘴(くちばし)",
             "⓪ 名  （鸟类的）嘴，喙"
-        ],
-        "notation": "嘴(くちばし)"
+        ]
     },
     {
         "name": "kosodate",
         "trans": [
+            "子育(こそだ)て",
             "② 名·自动3  育儿，抚养孩子"
-        ],
-        "notation": "子育(こそだ)て"
+        ]
     },
     {
         "name": "sagashidasu",
         "trans": [
+            "探(さが)し出(だ)す",
             "④ 他动1  找出，找到，发现"
-        ],
-        "notation": "探(さが)し出(だ)す"
+        ]
     },
     {
         "name": "sasa",
         "trans": [
+            "笹(ささ)",
             "⓪ 名  小竹子，细竹"
-        ],
-        "notation": "笹(ささ)"
+        ]
     },
     {
         "name": "kuttsuku",
         "trans": [
+            "くっつく",
             " ③ 自动1  紧粘在一起；附着；紧挨着，紧跟着"
-        ],
-        "notation": "くっつく"
+        ]
     },
     {
         "name": "fukyou",
         "trans": [
+            "不興(ふきょう)",
             "⓪ 名  扫兴，不高兴"
-        ],
-        "notation": "不興(ふきょう)"
+        ]
     },
     {
         "name": "toutetsu",
         "trans": [
+            "透徹(とうてつ)",
             "⓪ 名·自动3  透彻，清晰；清澈，清新"
-        ],
-        "notation": "透徹(とうてつ)"
+        ]
     },
     {
         "name": "koumyou",
         "trans": [
+            "高名(こうみょう)",
             "⓪ 名  著名，有名"
-        ],
-        "notation": "高名(こうみょう)"
+        ]
     },
     {
         "name": "ittei",
         "trans": [
+            "一定(いってい)",
             "⓪ 名·自他动3  某种程度，一定；规定，统一；固定"
-        ],
-        "notation": "一定(いってい)"
+        ]
     },
     {
         "name": "usuakarui",
         "trans": [
+            "薄明(うすあか)るい",
             "⑤ イ形  不明亮的，微暗的"
-        ],
-        "notation": "薄明(うすあか)るい"
+        ]
     },
     {
         "name": "kakutei",
         "trans": [
+            "確定(かくてい)",
             "⓪ 名·自他动3  确定，决定"
-        ],
-        "notation": "確定(かくてい)"
+        ]
     },
     {
         "name": "gyousei",
         "trans": [
+            "行政(ぎょうせい)",
             "⓪ 名  行政；政务"
-        ],
-        "notation": "行政(ぎょうせい)"
+        ]
     },
     {
         "name": "katakoto",
         "trans": [
+            "片言(かたこと)",
             "⓪ 名  只言片语，不完整的话"
-        ],
-        "notation": "片言(かたこと)"
+        ]
     },
     {
         "name": "ichidanto",
         "trans": [
+            "一段(いちだん)と",
             "⓪ 副  更加，愈发，格外"
-        ],
-        "notation": "一段(いちだん)と"
+        ]
     },
     {
         "name": "shizumaru",
         "trans": [
+            "鎮(しず)まる",
             "③ 自动1  平息，平复；疼痛止住"
-        ],
-        "notation": "鎮(しず)まる"
+        ]
     },
     {
         "name": "kouin",
         "trans": [
+            "光陰(こういん)",
             "⓪ 名  光阴，时光，岁月"
-        ],
-        "notation": "光陰(こういん)"
+        ]
     },
     {
         "name": "kuten",
         "trans": [
+            "句点(くてん)",
             "⓪ 名  句号"
-        ],
-        "notation": "句点(くてん)"
+        ]
     },
     {
         "name": "sageru",
         "trans": [
+            "提(さ)げる",
             "② 他动2  提，挎"
-        ],
-        "notation": "提(さ)げる"
+        ]
     },
     {
         "name": "idai",
         "trans": [
+            "偉大(いだい)",
             "⓪ ナ形  伟大的"
-        ],
-        "notation": "偉大(いだい)"
+        ]
     },
     {
         "name": "isseini",
         "trans": [
+            "一斉(いっせい)に",
             "⓪ 副  一齐，同时"
-        ],
-        "notation": "一斉(いっせい)に"
+        ]
     },
     {
         "name": "hogaraka",
         "trans": [
+            "朗(ほが)らか",
             "② ナ形  开朗的，爽快的；快活的"
-        ],
-        "notation": "朗(ほが)らか"
+        ]
     },
     {
         "name": "tsuyuake",
         "trans": [
+            "梅雨明(つゆあ)け",
             "⓪ 名  出梅，梅雨期结束"
-        ],
-        "notation": "梅雨明(つゆあ)け"
+        ]
     },
     {
         "name": "osaekomu",
         "trans": [
+            "押(お)さえ込(こ)む",
             "④ 他动1  压住，按住；控制住，压制"
-        ],
-        "notation": "押(お)さえ込(こ)む"
+        ]
     },
     {
         "name": "ichiryuu",
         "trans": [
+            "一流(いちりゅう)",
             "⓪ 名  一流，头等；一个流派"
-        ],
-        "notation": "一流(いちりゅう)"
+        ]
     },
     {
         "name": "furuwaseru",
         "trans": [
+            "震(ふる)わせる",
             "⓪ 他动2  使发抖；使震动"
-        ],
-        "notation": "震(ふる)わせる"
+        ]
     },
     {
         "name": "kyodai",
         "trans": [
+            "巨大(きょだい)",
             "⓪ ナ形  巨大的"
-        ],
-        "notation": "巨大(きょだい)"
+        ]
     },
     {
         "name": "tsuredasu",
         "trans": [
+            "連(つ)れ出(だ)す",
             "③ 他动1  带出去，领出去"
-        ],
-        "notation": "連(つ)れ出(だ)す"
+        ]
     },
     {
         "name": "kire",
         "trans": [
+            "切(き)れ",
             "② 名  切割；碎片"
-        ],
-        "notation": "切(き)れ"
+        ]
     },
     {
         "name": "ippou",
         "trans": [
+            "一方(いっぽう)",
             "③ 名·接续  一个方向；一方面；从另一方面说"
-        ],
-        "notation": "一方(いっぽう)"
+        ]
     },
     {
         "name": "kyousou",
         "trans": [
+            "競走(きょうそう)",
             "⓪ 名·自动3  赛跑"
-        ],
-        "notation": "競走(きょうそう)"
+        ]
     },
     {
         "name": "itami",
         "trans": [
+            "傷(いた)み",
             "③ 名  损伤；腐坏"
-        ],
-        "notation": "傷(いた)み"
+        ]
     },
     {
         "name": "jukusei",
         "trans": [
+            "熟成(じゅくせい)",
             "⓪ 名·自动3  熟练，成熟"
-        ],
-        "notation": "熟成(じゅくせい)"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "意思(いし)",
             "① 名  意思，想法；打算"
-        ],
-        "notation": "意思(いし)"
+        ]
     },
     {
         "name": "kinjiru",
         "trans": [
+            "禁(きん)じる",
             "⓪ 他动2  禁止，不允许"
-        ],
-        "notation": "禁(きん)じる"
+        ]
     },
     {
         "name": "iji",
         "trans": [
+            "維持(いじ)",
             "① 名·他动3  维持，保持"
-        ],
-        "notation": "維持(いじ)"
+        ]
     },
     {
         "name": "gyogyou",
         "trans": [
+            "漁業(ぎょぎょう)",
             "① 名  渔业，水产业"
-        ],
-        "notation": "漁業(ぎょぎょう)"
+        ]
     },
     {
         "name": "futan",
         "trans": [
+            "負担(ふたん)",
             "⓪ 名·他动3  承担，负担"
-        ],
-        "notation": "負担(ふたん)"
+        ]
     },
     {
         "name": "tsumiageru",
         "trans": [
+            "積(つ)み上(あ)げる",
             "④ 他动2  堆积起来；积累起来；装完"
-        ],
-        "notation": "積(つ)み上(あ)げる"
+        ]
     },
     {
         "name": "funshitsu",
         "trans": [
+            "紛失(ふんしつ)",
             "⓪ 名·自他动3  遗失，丢失"
-        ],
-        "notation": "紛失(ふんしつ)"
+        ]
     },
     {
         "name": "nikomu",
         "trans": [
+            "煮込(にこ)む",
             "② 他动1  炖，熬；煮透，煮熟"
-        ],
-        "notation": "煮込(にこ)む"
+        ]
     },
     {
         "name": "youbun",
         "trans": [
+            "養分(ようぶん)",
             "① 名  养分"
-        ],
-        "notation": "養分(ようぶん)"
+        ]
     },
     {
         "name": "kitaeageru",
         "trans": [
+            "鍛(きた)え上(あ)げる",
             "⑤ 他动2  锻造好；充分锻炼"
-        ],
-        "notation": "鍛(きた)え上(あ)げる"
+        ]
     },
     {
         "name": "tsumeawaseru",
         "trans": [
+            "詰(つ)め合(あ)わせる",
             "⑤ 他动2  混装，混着装（水果、食品等）"
-        ],
-        "notation": "詰(つ)め合(あ)わせる"
+        ]
     },
     {
         "name": "ueru",
         "trans": [
+            "飢(う)える",
             "② 自动2  饿，饥饿；渴望，渴求"
-        ],
-        "notation": "飢(う)える"
+        ]
     },
     {
         "name": "kaisan",
         "trans": [
+            "解散(かいさん)",
             "⓪ 名·自他动3  解散；散会；解体"
-        ],
-        "notation": "解散(かいさん)"
+        ]
     },
     {
         "name": "koufun",
         "trans": [
+            "興奮(こうふん)",
             "⓪ 名·自动3  兴奋，激动"
-        ],
-        "notation": "興奮(こうふん)"
+        ]
     },
     {
         "name": "uo",
         "trans": [
+            "魚(うお)",
             "⓪ 名  鱼类的总称"
-        ],
-        "notation": "魚(うお)"
+        ]
     },
     {
         "name": "kouhan",
         "trans": [
+            "後半(こうはん)",
             "⓪ 名  后半，后一半"
-        ],
-        "notation": "後半(こうはん)"
+        ]
     },
     {
         "name": "ichigaini",
         "trans": [
+            "一概(いちがい)に",
             "⓪ 副  一概，一律"
-        ],
-        "notation": "一概(いちがい)に"
+        ]
     },
     {
         "name": "matsuru",
         "trans": [
+            "祭(まつ)る",
             "⓪ 他动1  祭祀；供奉"
-        ],
-        "notation": "祭(まつ)る"
+        ]
     },
     {
         "name": "enshuu",
         "trans": [
+            "演習(えんしゅう)",
             "⓪ 名·自动3  （军事）演习；专题研讨会；练习"
-        ],
-        "notation": "演習(えんしゅう)"
+        ]
     },
     {
         "name": "go-rudenwi-ku",
         "trans": [
+            "ゴールデンウィーク",
             "⑥ 名  黄金周，连休假期"
-        ],
-        "notation": "ゴールデンウィーク"
+        ]
     },
     {
         "name": "enchou",
         "trans": [
+            "延長(えんちょう)",
             "⓪ 名·他动3  延长；延续，扩展"
-        ],
-        "notation": "延長(えんちょう)"
+        ]
     },
     {
         "name": "omoikomu",
         "trans": [
+            "思(おも)い込(こ)む",
             "④ 自动1  深信；下定决心"
-        ],
-        "notation": "思(おも)い込(こ)む"
+        ]
     },
     {
         "name": "iyoku",
         "trans": [
+            "意欲(いよく)",
             "① 名  意愿；积极性"
-        ],
-        "notation": "意欲(いよく)"
+        ]
     },
     {
         "name": "kakugo",
         "trans": [
+            "覚悟(かくご)",
             "① 名·自他动3  思想准备，决心；觉悟"
-        ],
-        "notation": "覚悟(かくご)"
+        ]
     },
     {
         "name": "kashitsu",
         "trans": [
+            "過失(かしつ)",
             "⓪ 名  过失，过错"
-        ],
-        "notation": "過失(かしつ)"
+        ]
     },
     {
         "name": "irui",
         "trans": [
+            "衣類(いるい)",
             "① 名  衣服，衣物"
-        ],
-        "notation": "衣類(いるい)"
+        ]
     },
     {
         "name": "kokusan",
         "trans": [
+            "国産(こくさん)",
             "⓪ 名  国产"
-        ],
-        "notation": "国産(こくさん)"
+        ]
     },
     {
         "name": "intai",
         "trans": [
+            "引退(いんたい)",
             "⓪ 名·自动3  隐退，退役"
-        ],
-        "notation": "引退(いんたい)"
+        ]
     },
     {
         "name": "uridasu",
         "trans": [
+            "売(う)り出(だ)す",
             "③ 他动1  开始出售；大甩卖；出名"
-        ],
-        "notation": "売(う)り出(だ)す"
+        ]
     },
     {
         "name": "infure",
         "trans": [
+            "インフレ",
             "⓪ 名  通货膨胀"
-        ],
-        "notation": "インフレ"
+        ]
     },
     {
         "name": "unmei",
         "trans": [
+            "運命(うんめい)",
             "① 名  命，命运"
-        ],
-        "notation": "運命(うんめい)"
+        ]
     },
     {
         "name": "kajitsu",
         "trans": [
+            "果実(かじつ)",
             "① 名  果实；收益"
-        ],
-        "notation": "果実(かじつ)"
+        ]
     },
     {
         "name": "kashima",
         "trans": [
+            "貸間(かしま)",
             "⓪ 名  出租的房间"
-        ],
-        "notation": "貸間(かしま)"
+        ]
     },
     {
         "name": "eien",
         "trans": [
+            "永遠(えいえん)",
             "⓪ 名·ナ形  永远，永恒"
-        ],
-        "notation": "永遠(えいえん)"
+        ]
     },
     {
         "name": "kogu",
         "trans": [
+            "漕(こ)ぐ",
             "① 他动1  划（船）；蹬（自行车）；荡（秋千）"
-        ],
-        "notation": "漕(こ)ぐ"
+        ]
     },
     {
         "name": "eikyuu",
         "trans": [
+            "永久(えいきゅう)",
             "⓪ 名·ナ形  永久，永远"
-        ],
-        "notation": "永久(えいきゅう)"
+        ]
     },
     {
         "name": "kouhyou",
         "trans": [
+            "公表(こうひょう)",
             "⓪ 名·他动3  公布，宣布"
-        ],
-        "notation": "公表(こうひょう)"
+        ]
     },
     {
         "name": "kaimotomeru",
         "trans": [
+            "買(か)い求(もと)める",
             "⑤ 他动2  买，购买"
-        ],
-        "notation": "買(か)い求(もと)める"
+        ]
     },
     {
         "name": "shimikomu",
         "trans": [
+            "染(し)み込(こ)む",
             "③ 自动1  渗；渗入；铭刻（于心）"
-        ],
-        "notation": "染(し)み込(こ)む"
+        ]
     },
     {
         "name": "jouzai",
         "trans": [
+            "錠剤(じょうざい)",
             "⓪ 名  药丸，药片"
-        ],
-        "notation": "錠剤(じょうざい)"
+        ]
     },
     {
         "name": "haeru",
         "trans": [
+            "生(は)える",
             "② 自动2  长（草、胡须等），生（根），发（霉）"
-        ],
-        "notation": "生(は)える"
+        ]
     },
     {
         "name": "bassuru",
         "trans": [
+            "罰(ばっ)する",
             "⓪ 他动3  处罚，惩罚"
-        ],
-        "notation": "罰(ばっ)する"
+        ]
     },
     {
         "name": "shoyuu",
         "trans": [
+            "所有(しょゆう)",
             "⓪ 名·他动3  所有，拥有"
-        ],
-        "notation": "所有(しょゆう)"
+        ]
     },
     {
         "name": "kakuu",
         "trans": [
+            "架空(かくう)",
             "⓪ 名·ナ形  架空，空想，虚构"
-        ],
-        "notation": "架空(かくう)"
+        ]
     },
     {
         "name": "soreru",
         "trans": [
+            "逸(そ)れる",
             "② 自动2  脱离正轨；（音乐）走调"
-        ],
-        "notation": "逸(そ)れる"
+        ]
     },
     {
         "name": "gakugyou",
         "trans": [
+            "学業(がくぎょう)",
             "② 名  学业"
-        ],
-        "notation": "学業(がくぎょう)"
+        ]
     },
     {
         "name": "utagai",
         "trans": [
+            "疑(うたが)い",
             "⓪ 名  怀疑，疑问；嫌疑"
-        ],
-        "notation": "疑(うたが)い"
+        ]
     },
     {
         "name": "kouhyou",
         "trans": [
+            "好評(こうひょう)",
             "⓪ 名·ナ形  好评"
-        ],
-        "notation": "好評(こうひょう)"
+        ]
     },
     {
         "name": "uchikesu",
         "trans": [
+            "打(う)ち消(け)す",
             "⓪ 他动1  否定，否认；消除"
-        ],
-        "notation": "打(う)ち消(け)す"
+        ]
     },
     {
         "name": "kaisei",
         "trans": [
+            "快晴(かいせい)",
             "⓪ 名  晴朗，万里无云"
-        ],
-        "notation": "快晴(かいせい)"
+        ]
     },
     {
         "name": "umaru",
         "trans": [
+            "埋(う)まる",
             "⓪ 自动1  埋着；填满；填补"
-        ],
-        "notation": "埋(う)まる"
+        ]
     },
     {
         "name": "jiware",
         "trans": [
+            "地割(じわ)れ",
             "⓪ 名·自动3  地裂，地面开裂"
-        ],
-        "notation": "地割(じわ)れ"
+        ]
     },
     {
         "name": "koufu",
         "trans": [
+            "交付(こうふ)",
             "① 名·他动3  交付，交给，发给"
-        ],
-        "notation": "交付(こうふ)"
+        ]
     },
     {
         "name": "shingen",
         "trans": [
+            "震源(しんげん)",
             "⓪ 名  震源"
-        ],
-        "notation": "震源(しんげん)"
+        ]
     },
     {
         "name": "kaibatsu",
         "trans": [
+            "海抜(かいばつ)",
             "⓪ 名  海拔"
-        ],
-        "notation": "海抜(かいばつ)"
+        ]
     },
     {
         "name": "shinsui",
         "trans": [
+            "浸水(しんすい)",
             "⓪ 名·自动3  浸水"
-        ],
-        "notation": "浸水(しんすい)"
+        ]
     },
     {
         "name": "kajou",
         "trans": [
+            "過剰(かじょう)",
             "⓪ 名·ナ形  过剩，过多"
-        ],
-        "notation": "過剰(かじょう)"
+        ]
     },
     {
         "name": "shindo",
         "trans": [
+            "震度(しんど)",
             "① 名  地震烈度"
-        ],
-        "notation": "震度(しんど)"
+        ]
     },
     {
         "name": "koudo",
         "trans": [
+            "高度(こうど)",
             "① 名·ナ形  高度，海拔；（程度）高"
-        ],
-        "notation": "高度(こうど)"
+        ]
     },
     {
         "name": "suibotsu",
         "trans": [
+            "水没(すいぼつ)",
             "⓪ 名·自动3  淹没，没于水中"
-        ],
-        "notation": "水没(すいぼつ)"
+        ]
     },
     {
         "name": "imasara",
         "trans": [
+            "今更(いまさら)",
             "⓪ 副  事到如今，事已至此"
-        ],
-        "notation": "今更(いまさら)"
+        ]
     },
     {
         "name": "imadoki",
         "trans": [
+            "今時(いまどき)",
             "⓪ 名  如今，当代；这时候"
-        ],
-        "notation": "今時(いまどき)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "欠(か)く",
             "① 他动1  缺乏，缺少；弄坏；缺欠，怠慢"
-        ],
-        "notation": "欠(か)く"
+        ]
     },
     {
         "name": "gaku",
         "trans": [
+            "額(がく)",
             "⓪ 名  金额"
-        ],
-        "notation": "額(がく)"
+        ]
     },
     {
         "name": "in'you",
         "trans": [
+            "引用(いんよう)",
             "⓪ 名·他动3  引用（文章、事例等）"
-        ],
-        "notation": "引用(いんよう)"
+        ]
     },
     {
         "name": "gaibu",
         "trans": [
+            "外部(がいぶ)",
             "① 名  外部"
-        ],
-        "notation": "外部(がいぶ)"
+        ]
     },
     {
         "name": "inryoku",
         "trans": [
+            "引力(いんりょく)",
             "① 名  引力，万有引力"
-        ],
-        "notation": "引力(いんりょく)"
+        ]
     },
     {
         "name": "uirusu",
         "trans": [
+            "ウイルス",
             "② 名  病毒；计算机病毒"
-        ],
-        "notation": "ウイルス"
+        ]
     },
     {
         "name": "kaiyou",
         "trans": [
+            "海洋(かいよう)",
             "⓪ 名  海洋"
-        ],
-        "notation": "海洋(かいよう)"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "返(かえ)る",
             "① 自动1  归还；恢复，还原"
-        ],
-        "notation": "返(かえ)る"
+        ]
     },
     {
         "name": "kaotsuki",
         "trans": [
+            "顔(かお)つき",
             "⓪ 名  相貌；表情"
-        ],
-        "notation": "顔(かお)つき"
+        ]
     },
     {
         "name": "imanotokoro",
         "trans": [
+            "今(いま)の所(ところ)",
             "⓪ 名  现在，目前，眼下"
-        ],
-        "notation": "今(いま)の所(ところ)"
+        ]
     },
     {
         "name": "kakaeru",
         "trans": [
+            "抱(かか)える",
             "⓪ 他动2  抱着；承担，担负"
-        ],
-        "notation": "抱(かか)える"
+        ]
     },
     {
         "name": "jimejime",
         "trans": [
+            "じめじめ",
             " ① 副·自动3  潮湿，湿润；阴郁，忧郁"
-        ],
-        "notation": "じめじめ"
+        ]
     },
     {
         "name": "kakikomu",
         "trans": [
+            "書(か)き込(こ)む",
             "③ 他动1  写上，填写"
-        ],
-        "notation": "書(か)き込(こ)む"
+        ]
     },
     {
         "name": "kakitomeru",
         "trans": [
+            "書(か)き留(と)める",
             "④ 他动2  记下来，写下来"
-        ],
-        "notation": "書(か)き留(と)める"
+        ]
     },
     {
         "name": "kagirinai",
         "trans": [
+            "限(かぎ)りない",
             "④ イ形  无限的，无止境的；无比的，极大的"
-        ],
-        "notation": "限(かぎ)りない"
+        ]
     },
     {
         "name": "omoitsuku",
         "trans": [
+            "思(おも)いつく",
             "④ 他动1  （忽然）想出，想起，想到"
-        ],
-        "notation": "思(おも)いつく"
+        ]
     },
     {
         "name": "usumeru",
         "trans": [
+            "薄(うす)める",
             "⓪ 他动2  稀释，冲淡"
-        ],
-        "notation": "薄(うす)める"
+        ]
     },
     {
         "name": "kazei",
         "trans": [
+            "課税(かぜい)",
             "⓪ 名·自动3  课税，征税"
-        ],
-        "notation": "課税(かぜい)"
+        ]
     },
     {
         "name": "umidasu",
         "trans": [
+            "生(う)み出(だ)す",
             "③ 他动1  产出，生出；创作出"
-        ],
-        "notation": "生(う)み出(だ)す"
+        ]
     },
     {
         "name": "enkai",
         "trans": [
+            "沿海(えんかい)",
             "⓪ 名  沿海"
-        ],
-        "notation": "沿海(えんかい)"
+        ]
     },
     {
         "name": "kaidan",
         "trans": [
+            "会談(かいだん)",
             "⓪ 名·自动3  会谈，面谈"
-        ],
-        "notation": "会談(かいだん)"
+        ]
     },
     {
         "name": "betabeta",
         "trans": [
+            "べたべた",
             " ① 副·自动3  黏糊糊；厚厚地涂抹；缠人"
-        ],
-        "notation": "べたべた"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "回答(かいとう)",
             "⓪ 名·自动3  回答，回复，答复"
-        ],
-        "notation": "回答(かいとう)"
+        ]
     },
     {
         "name": "omoimoyoranai",
         "trans": [
+            "思(おも)いもよらない",
             "② 连语  出乎意料，万万没想到"
-        ],
-        "notation": "思(おも)いもよらない"
+        ]
     },
     {
         "name": "kataippou",
         "trans": [
+            "片一方(かたいっぽう)",
             "③ 名  （两个中的）一个；（一对中的）一只；（两方当中的）一方"
-        ],
-        "notation": "片一方(かたいっぽう)"
+        ]
     },
     {
         "name": "koubutsu",
         "trans": [
+            "鉱物(こうぶつ)",
             "① 名  矿物"
-        ],
-        "notation": "鉱物(こうぶつ)"
+        ]
     },
     {
         "name": "omonjiru",
         "trans": [
+            "重(おも)んじる",
             "④ 他动2  重视；尊重，器重"
-        ],
-        "notation": "重(おも)んじる"
+        ]
     },
     {
         "name": "gai",
         "trans": [
+            "害(がい)",
             "① 名  损害；害，害处"
-        ],
-        "notation": "害(がい)"
+        ]
     },
     {
         "name": "gogaku",
         "trans": [
+            "語学(ごがく)",
             "① 名  外语学习；语言学"
-        ],
-        "notation": "語学(ごがく)"
+        ]
     },
     {
         "name": "kaiireru",
         "trans": [
+            "買(かい)い入()れる",
             "④ 他动2  买进，收购，采购"
-        ],
-        "notation": "買(かい)い入()れる"
+        ]
     },
     {
         "name": "kokuou",
         "trans": [
+            "国王(こくおう)",
             "③ 名  国王"
-        ],
-        "notation": "国王(こくおう)"
+        ]
     },
     {
         "name": "kaikaku",
         "trans": [
+            "改革(かいかく)",
             "⓪ 名·他动3  改革，革新"
-        ],
-        "notation": "改革(かいかく)"
+        ]
     },
     {
         "name": "eisei",
         "trans": [
+            "衛生(えいせい)",
             "⓪ 名  卫生"
-        ],
-        "notation": "衛生(えいせい)"
+        ]
     },
     {
         "name": "kaikan",
         "trans": [
+            "開館(かいかん)",
             "⓪ 名·自动3  开馆，开门；建馆"
-        ],
-        "notation": "開館(かいかん)"
+        ]
     },
     {
         "name": "oyobosu",
         "trans": [
+            "及(およ)ぼす",
             "③ 他动1  波及，牵涉，影响到"
-        ],
-        "notation": "及(およ)ぼす"
+        ]
     },
     {
         "name": "ondan",
         "trans": [
+            "温暖(おんだん)",
             "⓪ 名·ナ形  温暖"
-        ],
-        "notation": "温暖(おんだん)"
+        ]
     },
     {
         "name": "kaishuu",
         "trans": [
+            "回収(かいしゅう)",
             "⓪ 名·他动3  回收，收回"
-        ],
-        "notation": "回収(かいしゅう)"
+        ]
     },
     {
         "name": "koumu",
         "trans": [
+            "公務(こうむ)",
             "① 名  公务，公事"
-        ],
-        "notation": "公務(こうむ)"
+        ]
     },
     {
         "name": "kaisei",
         "trans": [
+            "改正(かいせい)",
             "⓪ 名·他动3  改正；修改"
-        ],
-        "notation": "改正(かいせい)"
+        ]
     },
     {
         "name": "nanimokamo",
         "trans": [
+            "なにもかも",
             " ① 连语  全部，一切"
-        ],
-        "notation": "なにもかも"
+        ]
     },
     {
         "name": "namagusai",
         "trans": [
+            "生臭(なまぐさ)い",
             "④ イ形  腥的；血腥的"
-        ],
-        "notation": "生臭(なまぐさ)い"
+        ]
     },
     {
         "name": "kaizou",
         "trans": [
+            "改造(かいぞう)",
             "⓪ 名·他动3  改造，改建"
-        ],
-        "notation": "改造(かいぞう)"
+        ]
     },
     {
         "name": "on'yomi",
         "trans": [
+            "音読(おんよ)み",
             "⓪ 名·他动3  音读"
-        ],
-        "notation": "音読(おんよ)み"
+        ]
     },
     {
         "name": "onryou",
         "trans": [
+            "音量(おんりょう)",
             "⓪ 名  音量"
-        ],
-        "notation": "音量(おんりょう)"
+        ]
     },
     {
         "name": "kaiko",
         "trans": [
+            "解雇(かいこ)",
             "① 名·他动3  解雇"
-        ],
-        "notation": "解雇(かいこ)"
+        ]
     },
     {
         "name": "eizou",
         "trans": [
+            "映像(えいぞう)",
             "⓪ 名  影像；形象，印象"
-        ],
-        "notation": "映像(えいぞう)"
+        ]
     },
     {
         "name": "omouzonbun",
         "trans": [
+            "思(おも)う存分(ぞんぶん)",
             "② 副  尽情地，痛快地"
-        ],
-        "notation": "思(おも)う存分(ぞんぶん)"
+        ]
     },
     {
         "name": "gaikou",
         "trans": [
+            "外交(がいこう)",
             "⓪ 名  外交"
-        ],
-        "notation": "外交(がいこう)"
+        ]
     },
     {
         "name": "ehon",
         "trans": [
+            "絵本(えほん)",
             "② 名  绘本，图画书"
-        ],
-        "notation": "絵本(えほん)"
+        ]
     },
     {
         "name": "katana",
         "trans": [
+            "刀(かたな)",
             "③ 名  刀，大刀"
-        ],
-        "notation": "刀(かたな)"
+        ]
     },
     {
         "name": "torikumu",
         "trans": [
+            "取(と)り組(く)む",
             "③ 自动1  埋头苦干；和……比赛"
-        ],
-        "notation": "取(と)り組(く)む"
+        ]
     },
     {
         "name": "nadukeru",
         "trans": [
+            "名付(なづ)ける",
             "③ 他动2  命名，起名"
-        ],
-        "notation": "名付(なづ)ける"
+        ]
     },
     {
         "name": "okan",
         "trans": [
+            "悪寒(おかん)",
             "⓪ 名  发冷，恶寒"
-        ],
-        "notation": "悪寒(おかん)"
+        ]
     },
     {
         "name": "torishimaru",
         "trans": [
+            "取(と)り締(し)まる",
             "④ 他动1  监督，管理，取缔"
-        ],
-        "notation": "取(と)り締(し)まる"
+        ]
     },
     {
         "name": "kadai",
         "trans": [
+            "課題(かだい)",
             "⓪ 名  （提出的）题目，课题，任务"
-        ],
-        "notation": "課題(かだい)"
+        ]
     },
     {
         "name": "torimodosu",
         "trans": [
+            "取(と)り戻(もど)す",
             "④ 他动1  取回，拿回，收回；挽回，恢复"
-        ],
-        "notation": "取(と)り戻(もど)す"
+        ]
     },
     {
         "name": "nashitogeru",
         "trans": [
+            "成(な)し遂(と)げる",
             "④ 他动2  完成，做完"
-        ],
-        "notation": "成(な)し遂(と)げる"
+        ]
     },
     {
         "name": "nasu",
         "trans": [
+            "成(な)す",
             "① 他动1  形成，构成；完成，达到目的"
-        ],
-        "notation": "成(な)す"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "採(と)る",
             "① 他动1  采用，录用，招收，招生"
-        ],
-        "notation": "採(と)る"
+        ]
     },
     {
         "name": "tondemonai",
         "trans": [
+            "とんでもない",
             " ⑤ イ形  令人意外的；岂有此理的；不客气，不用谢 "
-        ],
-        "notation": "とんでもない"
+        ]
     },
     {
         "name": "suisoku",
         "trans": [
+            "推測(すいそく)",
             "⓪ 名·他动3  推测，猜测"
-        ],
-        "notation": "推測(すいそく)"
+        ]
     },
     {
         "name": "nakusu",
         "trans": [
+            "亡(な)くす",
             "⓪ 他动1  丧失，死去"
-        ],
-        "notation": "亡(な)くす"
+        ]
     },
     {
         "name": "kasen",
         "trans": [
+            "下線(かせん)",
             "⓪ 名  下画线"
-        ],
-        "notation": "下線(かせん)"
+        ]
     },
     {
         "name": "kata",
         "trans": [
+            "型(かた)",
             "② 名  模型；类型，样式；惯例"
-        ],
-        "notation": "型(かた)"
+        ]
     },
     {
         "name": "kudokudo",
         "trans": [
+            "くどくど",
             " ① 副  没完没了，絮叨，啰唆"
-        ],
-        "notation": "くどくど"
+        ]
     },
     {
         "name": "suiteki",
         "trans": [
+            "水滴(すいてき)",
             "⓪ 名  水滴"
-        ],
-        "notation": "水滴(すいてき)"
+        ]
     },
     {
         "name": "nasakenai",
         "trans": [
+            "情(なさ)けない",
             "④ イ形  无情的；可怜的；可耻的"
-        ],
-        "notation": "情(なさ)けない"
+        ]
     },
     {
         "name": "suiso",
         "trans": [
+            "水素(すいそ)",
             "① 名  氢"
-        ],
-        "notation": "水素(すいそ)"
+        ]
     },
     {
         "name": "tashinamu",
         "trans": [
+            "嗜(たしな)む",
             "③ 他动1  爱好，嗜好；谨慎；熟悉"
-        ],
-        "notation": "嗜(たしな)む"
+        ]
     },
     {
         "name": "suihei",
         "trans": [
+            "水平(すいへい)",
             "⓪ 名  水平方向；平稳"
-        ],
-        "notation": "水平(すいへい)"
+        ]
     },
     {
         "name": "haibi",
         "trans": [
+            "拝眉(はいび)",
             "① 名·自动3  拜谒，拜见"
-        ],
-        "notation": "拝眉(はいび)"
+        ]
     },
     {
         "name": "sangiin",
         "trans": [
+            "参議院(さんぎいん)",
             "③ 名  参议院 "
-        ],
-        "notation": "参議院(さんぎいん)"
+        ]
     },
     {
         "name": "koushi",
         "trans": [
+            "講師(こうし)",
             "① 名  讲师；演讲者"
-        ],
-        "notation": "講師(こうし)"
+        ]
     },
     {
         "name": "kajiru",
         "trans": [
+            "かじる",
             " ② 他动1  咬；一知半解，稍微懂得一点"
-        ],
-        "notation": "かじる"
+        ]
     },
     {
         "name": "namahenji",
         "trans": [
+            "生返事(なまへんじ)",
             "③ 名·自动3  含糊的回答，支支吾吾"
-        ],
-        "notation": "生返事(なまへんじ)"
+        ]
     },
     {
         "name": "nami",
         "trans": [
+            "並(なみ)",
             "⓪ 名·接尾  普通，一般，中等程度；与……同样的程度"
-        ],
-        "notation": "並(なみ)"
+        ]
     },
     {
         "name": "naritatsu",
         "trans": [
+            "成(な)り立(た)つ",
             "③ 自动1  成立，谈妥；构成；划得来"
-        ],
-        "notation": "成(な)り立(た)つ"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "成(な)る",
             "① 自动1  做完，完成；成，成功；构成"
-        ],
-        "notation": "成(な)る"
+        ]
     },
     {
         "name": "nareru",
         "trans": [
+            "馴(な)れる",
             "② 自动2  （动物）驯熟；（人）亲近，混熟"
-        ],
-        "notation": "馴(な)れる"
+        ]
     },
     {
         "name": "kyorokyoro",
         "trans": [
+            "きょろきょろ",
             " ① 副·自动3  东张西望"
-        ],
-        "notation": "きょろきょろ"
+        ]
     },
     {
         "name": "kouri",
         "trans": [
+            "小売(こうり)",
             "⓪ 名·他动3  零售"
-        ],
-        "notation": "小売(こうり)"
+        ]
     },
     {
         "name": "gouri",
         "trans": [
+            "合理(ごうり)",
             "① 名  合理"
-        ],
-        "notation": "合理(ごうり)"
+        ]
     },
     {
         "name": "toriageru",
         "trans": [
+            "取(と)り上(あ)げる",
             "⓪ 他动2  拿起；没收，吊销；采纳；提出，提起"
-        ],
-        "notation": "取(と)り上(あ)げる"
+        ]
     },
     {
         "name": "nayamasu",
         "trans": [
+            "悩(なや)ます",
             "③ 他动1  使苦恼，使为难"
-        ],
-        "notation": "悩(なや)ます"
+        ]
     },
     {
         "name": "narau",
         "trans": [
+            "倣(なら)う",
             "② 他动1  模仿，仿效"
-        ],
-        "notation": "倣(なら)う"
+        ]
     },
     {
         "name": "narasu",
         "trans": [
+            "鳴(な)らす",
             "⓪ 他动1  使发出声响；出名"
-        ],
-        "notation": "鳴(な)らす"
+        ]
     },
     {
         "name": "nawa",
         "trans": [
+            "縄(なわ)",
             "② 名  绳子"
-        ],
-        "notation": "縄(なわ)"
+        ]
     },
     {
         "name": "nagatsuduki",
         "trans": [
+            "長続(ながつづ)き",
             "③ 名·自动3  长久保持，持久"
-        ],
-        "notation": "長続(ながつづ)き"
+        ]
     },
     {
         "name": "nan'nimo",
         "trans": [
+            "何(なん)にも",
             "⓪ 副  （后接否定）什么也；一点儿也"
-        ],
-        "notation": "何(なん)にも"
+        ]
     },
     {
         "name": "nyuujou",
         "trans": [
+            "入場(にゅうじょう)",
             "⓪ 名·自动3  入场"
-        ],
-        "notation": "入場(にゅうじょう)"
+        ]
     },
     {
         "name": "niwaka",
         "trans": [
+            "にわか",
             " ① 名·ナ形  突然；马上；临时，暂时"
-        ],
-        "notation": "にわか"
+        ]
     },
     {
         "name": "midika",
         "trans": [
+            "身近(みぢか)",
             "⓪ 名·ナ形  身边；切身"
-        ],
-        "notation": "身近(みぢか)"
+        ]
     },
     {
         "name": "kokumotsu",
         "trans": [
+            "穀物(こくもつ)",
             "② 名  谷物，粮食"
-        ],
-        "notation": "穀物(こくもつ)"
+        ]
     },
     {
         "name": "inshoku",
         "trans": [
+            "飲食(いんしょく)",
             "① 名·自动3  饮食"
-        ],
-        "notation": "飲食(いんしょく)"
+        ]
     },
     {
         "name": "gogen",
         "trans": [
+            "語源(ごげん)",
             "⓪ 名  语源，词源"
-        ],
-        "notation": "語源(ごげん)"
+        ]
     },
     {
         "name": "michigaeru",
         "trans": [
+            "見違(みちが)える",
             "⓪ 他动2  看错；认不出来"
-        ],
-        "notation": "見違(みちが)える"
+        ]
     },
     {
         "name": "geza",
         "trans": [
+            "下座(げざ)",
             "① 名·自动3  下座，末座；跪拜礼"
-        ],
-        "notation": "下座(げざ)"
+        ]
     },
     {
         "name": "nasuriai",
         "trans": [
+            "擦(なす)り合(あ)い",
             "⓪ 名  互相推诿"
-        ],
-        "notation": "擦(なす)り合(あ)い"
+        ]
     },
     {
         "name": "yougo",
         "trans": [
+            "擁護(ようご)",
             "① 名·他动3  拥护，维护"
-        ],
-        "notation": "擁護(ようご)"
+        ]
     },
     {
         "name": "naizou",
         "trans": [
+            "内臓(ないぞう)",
             "⓪ 名  内脏"
-        ],
-        "notation": "内臓(ないぞう)"
+        ]
     },
     {
         "name": "yokosu",
         "trans": [
+            "寄越(よこ)す",
             "② 他动1  寄来，送来；递给，交给"
-        ],
-        "notation": "寄越(よこ)す"
+        ]
     },
     {
         "name": "yosu",
         "trans": [
+            "止(よ)す",
             "① 他动1  停止，作罢；戒掉"
-        ],
-        "notation": "止(よ)す"
+        ]
     },
     {
         "name": "michiru",
         "trans": [
+            "満(み)ちる",
             "② 自动2  满，充满；到期，期满"
-        ],
-        "notation": "満(み)ちる"
+        ]
     },
     {
         "name": "mitsu",
         "trans": [
+            "蜜(みつ)",
             "① 名  蜂蜜；花蜜；糖水"
-        ],
-        "notation": "蜜(みつ)"
+        ]
     },
     {
         "name": "kairan",
         "trans": [
+            "回覧(かいらん)",
             "⓪ 名·他动3  传阅，传看"
-        ],
-        "notation": "回覧(かいらん)"
+        ]
     },
     {
         "name": "mitsumori",
         "trans": [
+            "見積(みつ)もり",
             "⓪ 名  估算，估价"
-        ],
-        "notation": "見積(みつ)もり"
+        ]
     },
     {
         "name": "yomikaesu",
         "trans": [
+            "読(よ)み返(かえ)す",
             "③ 他动1  重新读，重新看，反复读"
-        ],
-        "notation": "読(よ)み返(かえ)す"
+        ]
     },
     {
         "name": "raibu",
         "trans": [
+            "ライブ",
             "① 名  直播，实况播出"
-        ],
-        "notation": "ライブ"
+        ]
     },
     {
         "name": "raifusaiensu",
         "trans": [
+            "ライフサイエンス",
             "④ 名  生命科学"
-        ],
-        "notation": "ライフサイエンス"
+        ]
     },
     {
         "name": "uraguchi",
         "trans": [
+            "裏口(うらぐち)",
             "⓪ 名  后门；小道，走后门"
-        ],
-        "notation": "裏口(うらぐち)"
+        ]
     },
     {
         "name": "rasuto",
         "trans": [
+            "ラスト",
             "① 名  最后，末尾"
-        ],
-        "notation": "ラスト"
+        ]
     },
     {
         "name": "rejume",
         "trans": [
+            "レジュメ",
             " ⓪ 名  摘要，梗概，总结"
-        ],
-        "notation": "レジュメ"
+        ]
     },
     {
         "name": "kouryoku",
         "trans": [
+            "効力(こうりょく)",
             "① 名  效力，效果"
-        ],
-        "notation": "効力(こうりょく)"
+        ]
     },
     {
         "name": "iwaba",
         "trans": [
+            "言(い)わば",
             "① 副  说起来，可以说；比如说"
-        ],
-        "notation": "言(い)わば"
+        ]
     },
     {
         "name": "koureika",
         "trans": [
+            "高齢化(こうれいか)",
             "⓪ 名·自动3  老龄化"
-        ],
-        "notation": "高齢化(こうれいか)"
+        ]
     },
     {
         "name": "retteru",
         "trans": [
+            "レッテル",
             " ⓪ 名  商标，标签"
-        ],
-        "notation": "レッテル"
+        ]
     },
     {
         "name": "rentogen",
         "trans": [
+            "レントゲン",
             " ⓪ 名  X光线，伦琴射线"
-        ],
-        "notation": "レントゲン"
+        ]
     },
     {
         "name": "minareru",
         "trans": [
+            "見慣(みな)れる",
             "⓪ 自动2  司空见惯，眼熟"
-        ],
-        "notation": "見慣(みな)れる"
+        ]
     },
     {
         "name": "minuku",
         "trans": [
+            "見抜(みぬ)く",
             "② 他动1  看穿，看透"
-        ],
-        "notation": "見抜(みぬ)く"
+        ]
     },
     {
         "name": "ranke",
         "trans": [
+            "ランク",
             "① 名·他动3  顺序，名次；排序"
-        ],
-        "notation": "ランク"
+        ]
     },
     {
         "name": "rizo-to",
         "trans": [
+            "リゾート",
             "② 名  休养地，度假地"
-        ],
-        "notation": "リゾート"
+        ]
     },
     {
         "name": "minomawari",
         "trans": [
+            "身(み)の回(まわ)り",
             "⓪ 名  身边的衣物；日常生活"
-        ],
-        "notation": "身(み)の回(まわ)り"
+        ]
     },
     {
         "name": "miburi",
         "trans": [
+            "身振(みぶ)り",
             "① 名  身体姿势，动作"
-        ],
-        "notation": "身振(みぶ)り"
+        ]
     },
     {
         "name": "urayamu",
         "trans": [
+            "羨(うらや)む",
             "③ 他动1  羡慕，嫉妒"
-        ],
-        "notation": "羨(うらや)む"
+        ]
     },
     {
         "name": "mimamoru",
         "trans": [
+            "見守(みまも)る",
             "⓪ 他动1  注视；照顾，照看"
-        ],
-        "notation": "見守(みまも)る"
+        ]
     },
     {
         "name": "ryoushin",
         "trans": [
+            "良心(りょうしん)",
             "① 名  良心，本心"
-        ],
-        "notation": "良心(りょうしん)"
+        ]
     },
     {
         "name": "reinen",
         "trans": [
+            "例年(れいねん)",
             "⓪ 名  往年，历年，常年"
-        ],
-        "notation": "例年(れいねん)"
+        ]
     },
     {
         "name": "mimawasu",
         "trans": [
+            "見回(みまわ)す",
             "⓪ 他动1  环视四周；四下张望"
-        ],
-        "notation": "見回(みまわ)す"
+        ]
     },
     {
         "name": "mimawaru",
         "trans": [
+            "見回(みまわ)る",
             "⓪ 自动1  巡视，巡逻"
-        ],
-        "notation": "見回(みまわ)る"
+        ]
     },
     {
         "name": "miman",
         "trans": [
+            "未満(みまん)",
             "① 名  未满，不满，不足"
-        ],
-        "notation": "未満(みまん)"
+        ]
     },
     {
         "name": "reshipi",
         "trans": [
+            "レシピ",
             "① 名  食谱，烹饪法"
-        ],
-        "notation": "レシピ"
+        ]
     },
     {
         "name": "rougan",
         "trans": [
+            "老眼(ろうがん)",
             "⓪ 名  老花眼"
-        ],
-        "notation": "老眼(ろうがん)"
+        ]
     },
     {
         "name": "risuto",
         "trans": [
+            "リスト",
             "① 名  名单；一览表"
-        ],
-        "notation": "リスト"
+        ]
     },
     {
         "name": "gairon",
         "trans": [
+            "概論(がいろん)",
             "⓪ 名·自动3  概论，概括"
-        ],
-        "notation": "概論(がいろん)"
+        ]
     },
     {
         "name": "roukumi",
         "trans": [
+            "労組(ろうくみ)",
             "⓪ 名  工会"
-        ],
-        "notation": "労組(ろうくみ)"
+        ]
     },
     {
         "name": "naikaku",
         "trans": [
+            "内閣(ないかく)",
             "① 名  内阁"
-        ],
-        "notation": "内閣(ないかく)"
+        ]
     },
     {
         "name": "kouryaku",
         "trans": [
+            "後略(こうりゃく)",
             "① 名·他动3  省略后文，后略"
-        ],
-        "notation": "後略(こうりゃく)"
+        ]
     },
     {
         "name": "kouryo",
         "trans": [
+            "考慮(こうりょ)",
             "① 名·他动3  考虑，思考"
-        ],
-        "notation": "考慮(こうりょ)"
+        ]
     },
     {
         "name": "rokuni",
         "trans": [
+            "ろくに",
             "(后接否定)  ⓪ 副  （后接否定）很好地，令人满意地"
-        ],
-        "notation": "ろくに"
+        ]
     },
     {
         "name": "sunzen",
         "trans": [
+            "寸前(すんぜん)",
             "⓪ 名  临近，就在眼前，近在咫尺"
-        ],
-        "notation": "寸前(すんぜん)"
+        ]
     },
     {
         "name": "toraiaru",
         "trans": [
+            "トライアル",
             "② 名  试行，试运行；预赛"
-        ],
-        "notation": "トライアル"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "回想(かいそう)",
             "⓪ 名·他动3  回忆，回想"
-        ],
-        "notation": "回想(かいそう)"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "緩行(かんこう)",
             "⓪ 名·自动3  缓行，徐行，慢行"
-        ],
-        "notation": "緩行(かんこう)"
+        ]
     },
     {
         "name": "rinyu-aru",
         "trans": [
+            "リニューアル",
             "② 名·他动3  更新；重建 "
-        ],
-        "notation": "リニューアル"
+        ]
     },
     {
         "name": "fainansu",
         "trans": [
+            "ファイナンス",
             "① 名  金融，财政"
-        ],
-        "notation": "ファイナンス"
+        ]
     },
     {
         "name": "shitami",
         "trans": [
+            "下見(したみ)",
             "⓪ 名·他动3  事先查看；预习"
-        ],
-        "notation": "下見(したみ)"
+        ]
     },
     {
         "name": "uraomote",
         "trans": [
+            "裏表(うらおもて)",
             "⓪ 名  表面和里面；正面和反面；表里相反，反穿；表里不一"
-        ],
-        "notation": "裏表(うらおもて)"
+        ]
     },
     {
         "name": "fukkura",
         "trans": [
+            "ふっくら",
             " ③ 副·自动3  柔软而丰满，胖乎乎"
-        ],
-        "notation": "ふっくら"
+        ]
     },
     {
         "name": "jidou",
         "trans": [
+            "児童(じどう)",
             "① 名  儿童；学龄儿童"
-        ],
-        "notation": "児童(じどう)"
+        ]
     },
     {
         "name": "kouzou",
         "trans": [
+            "構造(こうぞう)",
             "⓪ 名  构造，结构"
-        ],
-        "notation": "構造(こうぞう)"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "海藻(かいそう)",
             "⓪ 名  海藻"
-        ],
-        "notation": "海藻(かいそう)"
+        ]
     },
     {
         "name": "kasou",
         "trans": [
+            "仮想(かそう)",
             "⓪ 名·自他动3  假想，设想，虚拟"
-        ],
-        "notation": "仮想(かそう)"
+        ]
     },
     {
         "name": "kokudo",
         "trans": [
+            "国土(こくど)",
             "① 名  国土，领土"
-        ],
-        "notation": "国土(こくど)"
+        ]
     },
     {
         "name": "hokori",
         "trans": [
+            "誇(ほこ)り",
             "⓪ 名  自豪，骄傲"
-        ],
-        "notation": "誇(ほこ)り"
+        ]
     },
     {
         "name": "kokufuku",
         "trans": [
+            "克服(こくふく)",
             "⓪ 名·他动3  克服，征服"
-        ],
-        "notation": "克服(こくふく)"
+        ]
     },
     {
         "name": "kaisou",
         "trans": [
+            "改装(かいそう)",
             "⓪ 名·他动3  改换包装；改换装潢"
-        ],
-        "notation": "改装(かいそう)"
+        ]
     },
     {
         "name": "zenryou",
         "trans": [
+            "善良(ぜんりょう)",
             "⓪ 名·ナ形  善良"
-        ],
-        "notation": "善良(ぜんりょう)"
+        ]
     },
     {
         "name": "riron",
         "trans": [
+            "理論(りろん)",
             "① 名  理论，学说"
-        ],
-        "notation": "理論(りろん)"
+        ]
     },
     {
         "name": "kantei",
         "trans": [
+            "鑑定(かんてい)",
             "⓪ 名·他动3  鉴定，判断；估价"
-        ],
-        "notation": "鑑定(かんてい)"
+        ]
     },
     {
         "name": "shikichi",
         "trans": [
+            "敷地(しきち)",
             "⓪ 名  地基；用地，地皮"
-        ],
-        "notation": "敷地(しきち)"
+        ]
     },
     {
         "name": "kyouretsu",
         "trans": [
+            "強烈(きょうれつ)",
             "⓪ ナ形  强烈的（地震、刺激、作用等）"
-        ],
-        "notation": "強烈(きょうれつ)"
+        ]
     },
     {
         "name": "gesuto",
         "trans": [
+            "ゲスト",
             "① 名  客人；嘉宾"
-        ],
-        "notation": "ゲスト"
+        ]
     },
     {
         "name": "ikyou",
         "trans": [
+            "異郷(いきょう)",
             "⓪ 名  异国，他乡"
-        ],
-        "notation": "異郷(いきょう)"
+        ]
     },
     {
         "name": "haiki",
         "trans": [
+            "排気(はいき)",
             "⓪ 名·自动3  排出空气；排出废气"
-        ],
-        "notation": "排気(はいき)"
+        ]
     },
     {
         "name": "houki",
         "trans": [
+            "法規(ほうき)",
             "① 名  法规，法律，规章"
-        ],
-        "notation": "法規(ほうき)"
+        ]
     },
     {
         "name": "moeagaru",
         "trans": [
+            "燃(も)え上(あ)がる",
             "④ 自动1  燃起来，烧起来"
-        ],
-        "notation": "燃(も)え上(あ)がる"
+        ]
     },
     {
         "name": "jittai",
         "trans": [
+            "実体(じったい)",
             "⓪ 名  实质，本质，真相"
-        ],
-        "notation": "実体(じったい)"
+        ]
     },
     {
         "name": "kaitei",
         "trans": [
+            "海底(かいてい)",
             "⓪ 名  海底"
-        ],
-        "notation": "海底(かいてい)"
+        ]
     },
     {
         "name": "sagi",
         "trans": [
+            "詐欺(さぎ)",
             "① 名  欺诈，欺骗；诈骗"
-        ],
-        "notation": "詐欺(さぎ)"
+        ]
     },
     {
         "name": "kanjou",
         "trans": [
+            "感情(かんじょう)",
             "⓪ 名  感情，情绪"
-        ],
-        "notation": "感情(かんじょう)"
+        ]
     },
     {
         "name": "shisan",
         "trans": [
+            "資産(しさん)",
             "① 名  资产，财产"
-        ],
-        "notation": "資産(しさん)"
+        ]
     },
     {
         "name": "shiji",
         "trans": [
+            "支持(しじ)",
             "① 名·他动3  支持，拥护；支撑，维持"
-        ],
-        "notation": "支持(しじ)"
+        ]
     },
     {
         "name": "komento",
         "trans": [
+            "コメント",
             "⓪ 名·自动3  评论，说明；发表意见"
-        ],
-        "notation": "コメント"
+        ]
     },
     {
         "name": "chisuji",
         "trans": [
+            "血筋(ちすじ)",
             "⓪ 名  血管；血统，血缘"
-        ],
-        "notation": "血筋(ちすじ)"
+        ]
     },
     {
         "name": "genkei",
         "trans": [
+            "原型(げんけい)",
             "⓪ 名  原型，原样"
-        ],
-        "notation": "原型(げんけい)"
+        ]
     },
     {
         "name": "douyou",
         "trans": [
+            "童謡(どうよう)",
             "⓪ 名  童谣，儿歌"
-        ],
-        "notation": "童謡(どうよう)"
+        ]
     },
     {
         "name": "kouyou",
         "trans": [
+            "紅葉(こうよう)",
             "⓪ 名·自动3  红叶；变成红叶"
-        ],
-        "notation": "紅葉(こうよう)"
+        ]
     },
     {
         "name": "doutou",
         "trans": [
+            "同等(どうとう)",
             "⓪ 名·ナ形  同等级；同资格"
-        ],
-        "notation": "同等(どうとう)"
+        ]
     },
     {
         "name": "shikou",
         "trans": [
+            "志向(しこう)",
             "⓪ 名·他动3  志向，意向"
-        ],
-        "notation": "志向(しこう)"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "気管(きかん)",
             "⓪ 名  气管"
-        ],
-        "notation": "気管(きかん)"
+        ]
     },
     {
         "name": "seiron",
         "trans": [
+            "正論(せいろん)",
             "⓪ 名  正确的言论"
-        ],
-        "notation": "正論(せいろん)"
+        ]
     },
     {
         "name": "kankoku",
         "trans": [
+            "勧告(かんこく)",
             "⓪ 名·他动3  劝告"
-        ],
-        "notation": "勧告(かんこく)"
+        ]
     },
     {
         "name": "irekaeru",
         "trans": [
+            "入(い)れ替(か)える",
             "④ 他动2  更换，调换"
-        ],
-        "notation": "入(い)れ替(か)える"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "硬化(こうか)",
             "① 名·自动3  （物质）硬化；（态度）强硬；（股市）坚挺"
-        ],
-        "notation": "硬化(こうか)"
+        ]
     },
     {
         "name": "tounyuu",
         "trans": [
+            "豆乳(とうにゅう)",
             "⓪ 名  豆浆"
-        ],
-        "notation": "豆乳(とうにゅう)"
+        ]
     },
     {
         "name": "shinsei",
         "trans": [
+            "神聖(しんせい)",
             "⓪ 名·ナ形  神圣"
-        ],
-        "notation": "神聖(しんせい)"
+        ]
     },
     {
         "name": "gairai",
         "trans": [
+            "外来(がいらい)",
             "⓪ 名  外来；门诊"
-        ],
-        "notation": "外来(がいらい)"
+        ]
     },
     {
         "name": "shinsou",
         "trans": [
+            "真相(しんそう)",
             "⓪ 名  真相"
-        ],
-        "notation": "真相(しんそう)"
+        ]
     },
     {
         "name": "shinjou",
         "trans": [
+            "心情(しんじょう)",
             "⓪ 名  心情"
-        ],
-        "notation": "心情(しんじょう)"
+        ]
     },
     {
         "name": "hihyou",
         "trans": [
+            "批評(ひひょう)",
             "⓪ 名·他动3  批评；评论；影评"
-        ],
-        "notation": "批評(ひひょう)"
+        ]
     },
     {
         "name": "shobatsu",
         "trans": [
+            "処罰(しょばつ)",
             "① 名·他动3  处罚，处分"
-        ],
-        "notation": "処罰(しょばつ)"
+        ]
     },
     {
         "name": "miyako",
         "trans": [
+            "都(みやこ)",
             "⓪ 名  都城；繁华都市"
-        ],
-        "notation": "都(みやこ)"
+        ]
     },
     {
         "name": "uragiru",
         "trans": [
+            "裏切(うらぎ)る",
             "③ 他动1  背叛；辜负，违背"
-        ],
-        "notation": "裏切(うらぎ)る"
+        ]
     },
     {
         "name": "koutou",
         "trans": [
+            "高等(こうとう)",
             "⓪ 名·ナ形  高等，高级"
-        ],
-        "notation": "高等(こうとう)"
+        ]
     },
     {
         "name": "ko-rasu",
         "trans": [
+            "コーラス",
             "① 名  合唱；合唱团"
-        ],
-        "notation": "コーラス"
+        ]
     },
     {
         "name": "inshu",
         "trans": [
+            "飲酒(いんしゅ)",
             "⓪ 名·自动3  饮酒"
-        ],
-        "notation": "飲酒(いんしゅ)"
+        ]
     },
     {
         "name": "soburi",
         "trans": [
+            "素振(そぶ)り",
             "① 名  态度，举止，样子"
-        ],
-        "notation": "素振(そぶ)り"
+        ]
     },
     {
         "name": "shidou",
         "trans": [
+            "指導(しどう)",
             "⓪ 名·他动3  教导，指导"
-        ],
-        "notation": "指導(しどう)"
+        ]
     },
     {
         "name": "ippan",
         "trans": [
+            "一般(いっぱん)",
             "⓪ 名  一般，寻常；普遍"
-        ],
-        "notation": "一般(いっぱん)"
+        ]
     }
 ]

--- a/assets/dicts/Jap_High-Frequency_N3.json
+++ b/assets/dicts/Jap_High-Frequency_N3.json
@@ -2,13994 +2,13994 @@
     {
         "name": "akachan",
         "trans": [
+            "赤(あか)ちゃん",
             "① 名  婴儿"
-        ],
-        "notation": "赤(あか)ちゃん"
+        ]
     },
     {
         "name": "keijou",
         "trans": [
+            "形状(けいじょう)",
             "⓪ 名  形状"
-        ],
-        "notation": "形状(けいじょう)"
+        ]
     },
     {
         "name": "gaka",
         "trans": [
+            "画家(がか)",
             "⓪ 名  画家"
-        ],
-        "notation": "画家(がか)"
+        ]
     },
     {
         "name": "itameru",
         "trans": [
+            "炒(いた)める",
             "③ 他动2  炒，煎"
-        ],
-        "notation": "炒(いた)める"
+        ]
     },
     {
         "name": "uwasa",
         "trans": [
+            "噂(うわさ)",
             "⓪ 名  传闻，谣言"
-        ],
-        "notation": "噂(うわさ)"
+        ]
     },
     {
         "name": "takeru",
         "trans": [
+            "炊(た)ける",
             "⓪ 自动2  （饭）熟了，煮好了"
-        ],
-        "notation": "炊(た)ける"
+        ]
     },
     {
         "name": "aizu",
         "trans": [
+            "合図(あいず)",
             "① 名·自动3  信号；传递信号"
-        ],
-        "notation": "合図(あいず)"
+        ]
     },
     {
         "name": "tanshin",
         "trans": [
+            "単身(たんしん)",
             "⓪ 名  单身，只身一人"
-        ],
-        "notation": "単身(たんしん)"
+        ]
     },
     {
         "name": "chijin",
         "trans": [
+            "知人(ちじん)",
             "⓪ 名  相识，熟人"
-        ],
-        "notation": "知人(ちじん)"
+        ]
     },
     {
         "name": "tada",
         "trans": [
+            "ただ",
             "① 名·副  免费；普通；只是，仅仅"
-        ],
-        "notation": "ただ"
+        ]
     },
     {
         "name": "mizugi",
         "trans": [
+            "水着(みずぎ)",
             "⓪ 名  泳装，泳衣"
-        ],
-        "notation": "水着(みずぎ)"
+        ]
     },
     {
         "name": "hinto",
         "trans": [
+            "ヒント",
             "① 名  暗示，启发"
-        ],
-        "notation": "ヒント"
+        ]
     },
     {
         "name": "houmon",
         "trans": [
+            "訪問(ほうもん)",
             "⓪ 名·他动3  访问，拜访"
-        ],
-        "notation": "訪問(ほうもん)"
+        ]
     },
     {
         "name": "masuku",
         "trans": [
+            "マスク",
             "① 名  面具；口罩"
-        ],
-        "notation": "マスク"
+        ]
     },
     {
         "name": "shomen",
         "trans": [
+            "書面(しょめん)",
             "⓪ 名  书面形式"
-        ],
-        "notation": "書面(しょめん)"
+        ]
     },
     {
         "name": "koppu",
         "trans": [
+            "コップ",
             "⓪ 名  玻璃杯，杯子"
-        ],
-        "notation": "コップ"
+        ]
     },
     {
         "name": "ase",
         "trans": [
+            "汗(あせ)",
             "① 名  汗水"
-        ],
-        "notation": "汗(あせ)"
+        ]
     },
     {
         "name": "iki",
         "trans": [
+            "息(いき)",
             "① 名  呼吸，喘气；气息"
-        ],
-        "notation": "息(いき)"
+        ]
     },
     {
         "name": "taryou",
         "trans": [
+            "多量(たりょう)",
             "⓪ 名·ナ形  大量，数量多"
-        ],
-        "notation": "多量(たりょう)"
+        ]
     },
     {
         "name": "wataridori",
         "trans": [
+            "渡(わたりど)り鳥()",
             "③ 名  候鸟"
-        ],
-        "notation": "渡(わたりど)り鳥()"
+        ]
     },
     {
         "name": "kakawaru",
         "trans": [
+            "関(かか)わる",
             "③ 自动1  关系到，涉及"
-        ],
-        "notation": "関(かか)わる"
+        ]
     },
     {
         "name": "unkyuu",
         "trans": [
+            "運休(うんきゅう)",
             "⓪ 名·自动3  （交通）停运"
-        ],
-        "notation": "運休(うんきゅう)"
+        ]
     },
     {
         "name": "ikisaki/yukisaki",
         "trans": [
+            "行(いきさき/ゆきさ)き先()",
             "⓪ 名  目的地"
-        ],
-        "notation": "行(いきさき/ゆきさ)き先()"
+        ]
     },
     {
         "name": "musu",
         "trans": [
+            "蒸(む)す",
             "① 自他动1  蒸；闷热"
-        ],
-        "notation": "蒸(む)す"
+        ]
     },
     {
         "name": "yakyuu",
         "trans": [
+            "野球(やきゅう)",
             "⓪ 名  棒球"
-        ],
-        "notation": "野球(やきゅう)"
+        ]
     },
     {
         "name": "shuukanshi",
         "trans": [
+            "週刊誌(しゅうかんし)",
             "③ 名  周刊杂志"
-        ],
-        "notation": "週刊誌(しゅうかんし)"
+        ]
     },
     {
         "name": "akuseru",
         "trans": [
+            "アクセル",
             "① 名  油门，加速器"
-        ],
-        "notation": "アクセル"
+        ]
     },
     {
         "name": "hanhan",
         "trans": [
+            "半々(はんはん)",
             "③ 名  一半一半，各一半"
-        ],
-        "notation": "半々(はんはん)"
+        ]
     },
     {
         "name": "rappu",
         "trans": [
+            "ラップ",
             "① 名  保鲜膜"
-        ],
-        "notation": "ラップ"
+        ]
     },
     {
         "name": "shindoi",
         "trans": [
+            "しんどい",
             "③ イ形  费力的；疲惫的"
-        ],
-        "notation": "しんどい"
+        ]
     },
     {
         "name": "kyoutsuuten",
         "trans": [
+            "共通点(きょうつうてん)",
             "③ 名  共同点"
-        ],
-        "notation": "共通点(きょうつうてん)"
+        ]
     },
     {
         "name": "kakou",
         "trans": [
+            "加工(かこう)",
             "⓪ 名·他动3  加工"
-        ],
-        "notation": "加工(かこう)"
+        ]
     },
     {
         "name": "kachi",
         "trans": [
+            "勝(か)ち",
             "② 名  赢，胜利"
-        ],
-        "notation": "勝(か)ち"
+        ]
     },
     {
         "name": "marude",
         "trans": [
+            "まるで",
             "⓪ 副  好像，仿佛；（后接否定）完全（不）"
-        ],
-        "notation": "まるで"
+        ]
     },
     {
         "name": "guragura",
         "trans": [
+            "ぐらぐら",
             "① 副·自动3  摇晃；犹豫"
-        ],
-        "notation": "ぐらぐら"
+        ]
     },
     {
         "name": "shukkoku",
         "trans": [
+            "出国(しゅっこく)",
             "⓪ 名·自动3  出国，出境"
-        ],
-        "notation": "出国(しゅっこく)"
+        ]
     },
     {
         "name": "tsuyomaru",
         "trans": [
+            "強(つよ)まる",
             "③ 自动1  变强，增强"
-        ],
-        "notation": "強(つよ)まる"
+        ]
     },
     {
         "name": "daidokoro",
         "trans": [
+            "台所(だいどころ)",
             "⓪ 名  厨房"
-        ],
-        "notation": "台所(だいどころ)"
+        ]
     },
     {
         "name": "dango",
         "trans": [
+            "団子(だんご)",
             "⓪ 名  糯米团子，丸子"
-        ],
-        "notation": "団子(だんご)"
+        ]
     },
     {
         "name": "usagi",
         "trans": [
+            "兎(うさぎ)",
             "⓪ 名  兔子"
-        ],
-        "notation": "兎(うさぎ)"
+        ]
     },
     {
         "name": "yaku",
         "trans": [
+            "焼(や)く",
             "⓪ 他动1  烧，烤；（皮肤）晒黑"
-        ],
-        "notation": "焼(や)く"
+        ]
     },
     {
         "name": "make",
         "trans": [
+            "負(ま)け",
             "⓪ 名  输，失败"
-        ],
-        "notation": "負(ま)け"
+        ]
     },
     {
         "name": "kuchibeni",
         "trans": [
+            "口紅(くちべに)",
             "⓪ 名  口红"
-        ],
-        "notation": "口紅(くちべに)"
+        ]
     },
     {
         "name": "itsuka",
         "trans": [
+            "いつか",
             "① 副  不知不觉；迟早，总有一天；曾经"
-        ],
-        "notation": "いつか"
+        ]
     },
     {
         "name": "biyou",
         "trans": [
+            "美容(びよう)",
             "⓪ 名  美容"
-        ],
-        "notation": "美容(びよう)"
+        ]
     },
     {
         "name": "ikeru",
         "trans": [
+            "生(い)ける",
             "② 他动2  插（花）；（把植物）栽（在土里）"
-        ],
-        "notation": "生(い)ける"
+        ]
     },
     {
         "name": "oubou",
         "trans": [
+            "横暴(おうぼう)",
             "⓪ 名·ナ形  蛮横，残暴"
-        ],
-        "notation": "横暴(おうぼう)"
+        ]
     },
     {
         "name": "kakaru",
         "trans": [
+            "罹(かか)る",
             "② 自动1  患（病）；遭受（灾难）"
-        ],
-        "notation": "罹(かか)る"
+        ]
     },
     {
         "name": "kourei",
         "trans": [
+            "高齢(こうれい)",
             "⓪ 名  高龄，年迈"
-        ],
-        "notation": "高齢(こうれい)"
+        ]
     },
     {
         "name": "sageru",
         "trans": [
+            "下(さ)げる",
             "② 他动2  降低；吊着，悬挂"
-        ],
-        "notation": "下(さ)げる"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "～産(さん)",
             " 接尾  ⋯⋯出产（表示产品的产地）"
-        ],
-        "notation": "～産(さん)"
+        ]
     },
     {
         "name": "kansetsuteki",
         "trans": [
+            "間接的(かんせつてき)",
             "⓪ ナ形  间接的"
-        ],
-        "notation": "間接的(かんせつてき)"
+        ]
     },
     {
         "name": "uketoru",
         "trans": [
+            "受(う)け取(と)る",
             "⓪ 他动1  收取，领取；理解，领会"
-        ],
-        "notation": "受(う)け取(と)る"
+        ]
     },
     {
         "name": "meue",
         "trans": [
+            "目上(めうえ)",
             "⓪ 名  长辈；上司"
-        ],
-        "notation": "目上(めうえ)"
+        ]
     },
     {
         "name": "shisshoku",
         "trans": [
+            "失職(しっしょく)",
             "⓪ 名·自动3  失业"
-        ],
-        "notation": "失職(しっしょく)"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "写(うつ)る",
             "② 自动1  照，映"
-        ],
-        "notation": "写(うつ)る"
+        ]
     },
     {
         "name": "nyuuryoku",
         "trans": [
+            "入力(にゅうりょく)",
             "⓪ 名·他动3  输入（数据、电源等）"
-        ],
-        "notation": "入力(にゅうりょく)"
+        ]
     },
     {
         "name": "henka",
         "trans": [
+            "変化(へんか)",
             "① 名·自动3  变化"
-        ],
-        "notation": "変化(へんか)"
+        ]
     },
     {
         "name": "aijou",
         "trans": [
+            "愛情(あいじょう)",
             "⓪ 名  爱情；爱意，热爱"
-        ],
-        "notation": "愛情(あいじょう)"
+        ]
     },
     {
         "name": "kugiru",
         "trans": [
+            "区切(くぎ)る",
             "② 他动1  （文章）分段；隔开，划分"
-        ],
-        "notation": "区切(くぎ)る"
+        ]
     },
     {
         "name": "tomo",
         "trans": [
+            "友(とも)",
             "① 名  朋友"
-        ],
-        "notation": "友(とも)"
+        ]
     },
     {
         "name": "ka-bu",
         "trans": [
+            "カーブ",
             "① 名·自动3  弯曲，转弯"
-        ],
-        "notation": "カーブ"
+        ]
     },
     {
         "name": "yoroshii",
         "trans": [
+            "宜(よろ)しい",
             "③ イ形  好的；可以，没关系"
-        ],
-        "notation": "宜(よろ)しい"
+        ]
     },
     {
         "name": "ifuku",
         "trans": [
+            "衣服(いふく)",
             "① 名  衣服"
-        ],
-        "notation": "衣服(いふく)"
+        ]
     },
     {
         "name": "bon'yari",
         "trans": [
+            "ぼんやり",
             "③ 副·自动3  模糊，看不清；发呆，精神恍惚"
-        ],
-        "notation": "ぼんやり"
+        ]
     },
     {
         "name": "mitsukeru",
         "trans": [
+            "見付(みつ)ける",
             "⓪ 他动2  找到，发现"
-        ],
-        "notation": "見付(みつ)ける"
+        ]
     },
     {
         "name": "change",
         "trans": [
+            "チェンジ",
             "① 名·他动3  交换；兑换（货币）"
-        ],
-        "notation": "チェンジ"
+        ]
     },
     {
         "name": "uketorinin",
         "trans": [
+            "受取人(うけとりにん)",
             "⓪ 名  （邮件等）收件人"
-        ],
-        "notation": "受取人(うけとりにん)"
+        ]
     },
     {
         "name": "hassei",
         "trans": [
+            "発生(はっせい)",
             "⓪ 名·自动3  发生，出现"
-        ],
-        "notation": "発生(はっせい)"
+        ]
     },
     {
         "name": "futsuu",
         "trans": [
+            "普通(ふつう)",
             "⓪ 副·ナ形  一般，普通，平常"
-        ],
-        "notation": "普通(ふつう)"
+        ]
     },
     {
         "name": "~betsu",
         "trans": [
+            "～別(べつ)",
             " 接尾  区别，按⋯⋯的不同"
-        ],
-        "notation": "～別(べつ)"
+        ]
     },
     {
         "name": "sonoue",
         "trans": [
+            "そのうえ",
             "⓪ 接续  而且，又；然后"
-        ],
-        "notation": "そのうえ"
+        ]
     },
     {
         "name": "umu",
         "trans": [
+            "産(う)む",
             "⓪ 他动1  生，生育（孩子、幼崽）；产生（利息、结果等）"
-        ],
-        "notation": "産(う)む"
+        ]
     },
     {
         "name": "maniawaseru",
         "trans": [
+            "間(ま)に合(あ)わせる",
             "⑤ 他动2  赶上，使⋯⋯来得及"
-        ],
-        "notation": "間(ま)に合(あ)わせる"
+        ]
     },
     {
         "name": "unga",
         "trans": [
+            "運河(うんが)",
             "① 名  运河"
-        ],
-        "notation": "運河(うんが)"
+        ]
     },
     {
         "name": "hageru",
         "trans": [
+            "禿(は)げる",
             "② 自动2  脱发；（山）变秃"
-        ],
-        "notation": "禿(は)げる"
+        ]
     },
     {
         "name": "shitsunai",
         "trans": [
+            "室内(しつない)",
             "② 名  室内"
-        ],
-        "notation": "室内(しつない)"
+        ]
     },
     {
         "name": "koboreru",
         "trans": [
+            "零(こぼ)れる",
             "③ 自动2  （液体）洒落，溢出；（笑容等）露出"
-        ],
-        "notation": "零(こぼ)れる"
+        ]
     },
     {
         "name": "yakudateru",
         "trans": [
+            "役立(やくだ)てる",
             "④ 他动2  使⋯⋯有用"
-        ],
-        "notation": "役立(やくだ)てる"
+        ]
     },
     {
         "name": "ke-su",
         "trans": [
+            "ケース",
             "① 名  盒子；事例，案例"
-        ],
-        "notation": "ケース"
+        ]
     },
     {
         "name": "hoikushi",
         "trans": [
+            "保育士(ほいくし)",
             "③ 名  幼师，儿童护理师"
-        ],
-        "notation": "保育士(ほいくし)"
+        ]
     },
     {
         "name": "sakkyokuka",
         "trans": [
+            "作曲家(さっきょくか)",
             "⓪ 名  作曲家"
-        ],
-        "notation": "作曲家(さっきょくか)"
+        ]
     },
     {
         "name": "zettaini",
         "trans": [
+            "絶対(ぜったい)に",
             "⓪ 副  绝对，坚决"
-        ],
-        "notation": "絶対(ぜったい)に"
+        ]
     },
     {
         "name": "jieigyou",
         "trans": [
+            "自営業(じえいぎょう)",
             "② 名  私人经营，个体店"
-        ],
-        "notation": "自営業(じえいぎょう)"
+        ]
     },
     {
         "name": "niseru",
         "trans": [
+            "似(に)せる",
             "⓪ 他动2  模仿，效仿"
-        ],
-        "notation": "似(に)せる"
+        ]
     },
     {
         "name": "hikkakeru",
         "trans": [
+            "引(ひ)っかける",
             "④ 他动2  挂上，挂着"
-        ],
-        "notation": "引(ひ)っかける"
+        ]
     },
     {
         "name": "barabara",
         "trans": [
+            "ぱらぱら",
             "① 副  （雨）淅淅沥沥地降落；稀稀落落"
-        ],
-        "notation": "ぱらぱら"
+        ]
     },
     {
         "name": "fa-sutofu-do",
         "trans": [
+            "ファーストフード",
             "⑤ 名  快餐"
-        ],
-        "notation": "ファーストフード"
+        ]
     },
     {
         "name": "eibun",
         "trans": [
+            "英文(えいぶん)",
             "⓪ 名  英文"
-        ],
-        "notation": "英文(えいぶん)"
+        ]
     },
     {
         "name": "enkai",
         "trans": [
+            "宴会(えんかい)",
             "⓪ 名  宴会"
-        ],
-        "notation": "宴会(えんかい)"
+        ]
     },
     {
         "name": "engeki",
         "trans": [
+            "演劇(えんげき)",
             "⓪ 名  戏剧"
-        ],
-        "notation": "演劇(えんげき)"
+        ]
     },
     {
         "name": "kawaku",
         "trans": [
+            "渇(かわ)く",
             "② 自动1  渴，口渴"
-        ],
-        "notation": "渇(かわ)く"
+        ]
     },
     {
         "name": "ousama",
         "trans": [
+            "王様(おうさま)",
             "⓪ 名  国王"
-        ],
-        "notation": "王様(おうさま)"
+        ]
     },
     {
         "name": "ouji",
         "trans": [
+            "王子(おうじ)",
             "① 名  王子"
-        ],
-        "notation": "王子(おうじ)"
+        ]
     },
     {
         "name": "egao",
         "trans": [
+            "笑顔(えがお)",
             "① 名  笑容"
-        ],
-        "notation": "笑顔(えがお)"
+        ]
     },
     {
         "name": "katto",
         "trans": [
+            "カット",
             "① 名·他动3  切，削，删去；剪发"
-        ],
-        "notation": "カット"
+        ]
     },
     {
         "name": "kikaiteki",
         "trans": [
+            "機械的(きかいてき)",
             "⓪ ナ形  机械的，呆板的"
-        ],
-        "notation": "機械的(きかいてき)"
+        ]
     },
     {
         "name": "o-bun",
         "trans": [
+            "オーブン",
             "① 名  烤箱，烤炉"
-        ],
-        "notation": "オーブン"
+        ]
     },
     {
         "name": "jouhin",
         "trans": [
+            "上品(じょうひん)",
             "③ 名·ナ形  高级品；高雅，典雅"
-        ],
-        "notation": "上品(じょうひん)"
+        ]
     },
     {
         "name": "outo",
         "trans": [
+            "アウト",
             "① 名  外面；出局；出界"
-        ],
-        "notation": "アウト"
+        ]
     },
     {
         "name": "kameraman",
         "trans": [
+            "カメラマン",
             "③ 名  摄影师"
-        ],
-        "notation": "カメラマン"
+        ]
     },
     {
         "name": "pianisuto",
         "trans": [
+            "ピアニスト",
             "③ 名  钢琴家，钢琴演奏者"
-        ],
-        "notation": "ピアニスト"
+        ]
     },
     {
         "name": "gamanduyoi",
         "trans": [
+            "我慢強(がまんづよ)い",
             "⑤ イ形  有忍耐力的，有耐心的"
-        ],
-        "notation": "我慢強(がまんづよ)い"
+        ]
     },
     {
         "name": "kawakasu",
         "trans": [
+            "乾(かわ)かす",
             "③ 他动1  晒干，烘干"
-        ],
-        "notation": "乾(かわ)かす"
+        ]
     },
     {
         "name": "isshun",
         "trans": [
+            "一瞬(いっしゅん)",
             "⓪ 名  一瞬间，一刹那"
-        ],
-        "notation": "一瞬(いっしゅん)"
+        ]
     },
     {
         "name": "ittai",
         "trans": [
+            "一体(いったい)",
             "⓪ 副  到底，究竟；本来，原来"
-        ],
-        "notation": "一体(いったい)"
+        ]
     },
     {
         "name": "okugai",
         "trans": [
+            "屋外(おくがい)",
             "② 名  户外，室外"
-        ],
-        "notation": "屋外(おくがい)"
+        ]
     },
     {
         "name": "okusan",
         "trans": [
+            "奥(おく)さん",
             "① 名  （您的）太太"
-        ],
-        "notation": "奥(おく)さん"
+        ]
     },
     {
         "name": "yurusu",
         "trans": [
+            "許(ゆる)す",
             "② 他动1  允许，准许；原谅"
-        ],
-        "notation": "許(ゆる)す"
+        ]
     },
     {
         "name": "shitagau",
         "trans": [
+            "従(したが)う",
             "⓪ 自动1  跟随；服从，遵从；依据，按照"
-        ],
-        "notation": "従(したが)う"
+        ]
     },
     {
         "name": "kurikku",
         "trans": [
+            "クリック",
             "② 名·他动3  点击（鼠标）"
-        ],
-        "notation": "クリック"
+        ]
     },
     {
         "name": "aidelia/aidea",
         "trans": [
+            "アイディア/アイデア",
             "① 名  想法，主意"
-        ],
-        "notation": "アイディア/アイデア"
+        ]
     },
     {
         "name": "akari",
         "trans": [
+            "明(あ)かり",
             "⓪ 名  光线；灯；希望"
-        ],
-        "notation": "明(あ)かり"
+        ]
     },
     {
         "name": "naka",
         "trans": [
+            "仲(なか)",
             "① 名  关系，交情"
-        ],
-        "notation": "仲(なか)"
+        ]
     },
     {
         "name": "sosogu",
         "trans": [
+            "注(そそ)ぐ",
             "⓪ 自他动1  （液体）注入，流入；倾注，倾倒（液体）"
-        ],
-        "notation": "注(そそ)ぐ"
+        ]
     },
     {
         "name": "dansa-",
         "trans": [
+            "ダンサー",
             "① 名  舞蹈家；舞女"
-        ],
-        "notation": "ダンサー"
+        ]
     },
     {
         "name": "minkan",
         "trans": [
+            "民間(みんかん)",
             "⓪ 名  民间；民营，私营"
-        ],
-        "notation": "民間(みんかん)"
+        ]
     },
     {
         "name": "yogoreru",
         "trans": [
+            "汚(よご)れる",
             "③ 自动2  变脏，被污染"
-        ],
-        "notation": "汚(よご)れる"
+        ]
     },
     {
         "name": "fukanou",
         "trans": [
+            "不可能(ふかのう)",
             "② 名·ナ形  不可能，做不到"
-        ],
-        "notation": "不可能(ふかのう)"
+        ]
     },
     {
         "name": "nidoto",
         "trans": [
+            "ニ度(ど)と",
             "② 副  （后接否定）再（也不）⋯⋯"
-        ],
-        "notation": "ニ度(ど)と"
+        ]
     },
     {
         "name": "namakeru",
         "trans": [
+            "怠(なま)ける",
             "③ 自他动2  懒惰，怠惰"
-        ],
-        "notation": "怠(なま)ける"
+        ]
     },
     {
         "name": "namakemono",
         "trans": [
+            "怠(なま)け者(もの)",
             "⓪ 名  懒人"
-        ],
-        "notation": "怠(なま)け者(もの)"
+        ]
     },
     {
         "name": "anmari",
         "trans": [
+            "あんまり",
             "④ ナ形·副  太，过分"
-        ],
-        "notation": "あんまり"
+        ]
     },
     {
         "name": "shuyou",
         "trans": [
+            "主要(しゅよう)",
             "⓪ ナ形  主要的"
-        ],
-        "notation": "主要(しゅよう)"
+        ]
     },
     {
         "name": "otokonoko",
         "trans": [
+            "男(おとこ)の子(こ)",
             "③ 名  男孩"
-        ],
-        "notation": "男(おとこ)の子(こ)"
+        ]
     },
     {
         "name": "on'nanoko",
         "trans": [
+            "女(おんな)の子(こ)",
             "③ 名  女孩"
-        ],
-        "notation": "女(おんな)の子(こ)"
+        ]
     },
     {
         "name": "opera",
         "trans": [
+            "オペラ",
             "① 名  歌剧"
-        ],
-        "notation": "オペラ"
+        ]
     },
     {
         "name": "choudai",
         "trans": [
+            "頂戴(ちょうだい)",
             "③ 名·他动3  （自谦语）领受，接受；吃，喝"
-        ],
-        "notation": "頂戴(ちょうだい)"
+        ]
     },
     {
         "name": "zemi/zemina-ru",
         "trans": [
+            "ゼミ/ゼミナール",
             "① 名  （大学的）研讨会"
-        ],
-        "notation": "ゼミ/ゼミナール"
+        ]
     },
     {
         "name": "shibireru",
         "trans": [
+            "痺(しび)れる",
             "③ 自动2  （身体）发麻，麻木"
-        ],
-        "notation": "痺(しび)れる"
+        ]
     },
     {
         "name": "kakuyasu",
         "trans": [
+            "格安(かくやす)",
             "⓪ ナ形  特价的，非常便宜的"
-        ],
-        "notation": "格安(かくやす)"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "映(うつ)る",
             "② 自动1  （影像）映，照"
-        ],
-        "notation": "映(うつ)る"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "映(うつ)す",
             "② 他动1  （影像）映，照"
-        ],
-        "notation": "映(うつ)す"
+        ]
     },
     {
         "name": "ekitai",
         "trans": [
+            "液体(えきたい)",
             "⓪ 名  液体"
-        ],
-        "notation": "液体(えきたい)"
+        ]
     },
     {
         "name": "kaisuiyoku",
         "trans": [
+            "海水浴(かいすいよく)",
             "③ 名  海水浴"
-        ],
-        "notation": "海水浴(かいすいよく)"
+        ]
     },
     {
         "name": "raku",
         "trans": [
+            "楽(らく)",
             "② 名·ナ形  （精神、身体）快乐，舒适；容易，简单"
-        ],
-        "notation": "楽(らく)"
+        ]
     },
     {
         "name": "kashi",
         "trans": [
+            "貸(か)し",
             "⓪ 名  借出"
-        ],
-        "notation": "貸(か)し"
+        ]
     },
     {
         "name": "kadenseihin",
         "trans": [
+            "家電製品(かでんせいひん)",
             "④ 名  家用电器"
-        ],
-        "notation": "家電製品(かでんせいひん)"
+        ]
     },
     {
         "name": "tanin",
         "trans": [
+            "他人(たにん)",
             "⓪ 名  别人，外人"
-        ],
-        "notation": "他人(たにん)"
+        ]
     },
     {
         "name": "kanai",
         "trans": [
+            "家内(かない)",
             "① 名  家庭；家属；（自己的）妻子"
-        ],
-        "notation": "家内(かない)"
+        ]
     },
     {
         "name": "wakeru",
         "trans": [
+            "分(わ)ける",
             "② 他动2  分开；划分，区分"
-        ],
-        "notation": "分(わ)ける"
+        ]
     },
     {
         "name": "zengo",
         "trans": [
+            "前後(ぜんご)",
             "① 名·自动3  （时间、空间上的）前和后；前后相继"
-        ],
-        "notation": "前後(ぜんご)"
+        ]
     },
     {
         "name": "jouge",
         "trans": [
+            "上下(じょうげ)",
             "① 名·自动3  上和下；上下移动"
-        ],
-        "notation": "上下(じょうげ)"
+        ]
     },
     {
         "name": "omoni",
         "trans": [
+            "主(おも)に",
             "① 副  主要；大部分"
-        ],
-        "notation": "主(おも)に"
+        ]
     },
     {
         "name": "karakara",
         "trans": [
+            "からから",
             "⓪ 副·自动3  哗啦哗啦响；哈哈大笑；干巴巴；空空如也"
-        ],
-        "notation": "からから"
+        ]
     },
     {
         "name": "me",
         "trans": [
+            "芽(め)",
             "① 名  嫩芽；苗头"
-        ],
-        "notation": "芽(め)"
+        ]
     },
     {
         "name": "aimai",
         "trans": [
+            "曖昧(あいまい)",
             "⓪ ナ形  暧昧的，含糊的"
-        ],
-        "notation": "曖昧(あいまい)"
+        ]
     },
     {
         "name": "konku-ru",
         "trans": [
+            "コンクール",
             "③ 名  （表演、作文等的）竞赛，比赛"
-        ],
-        "notation": "コンクール"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "革(かわ)",
             "② 名  皮革"
-        ],
-        "notation": "革(かわ)"
+        ]
     },
     {
         "name": "shitsubou",
         "trans": [
+            "失望(しつぼう)",
             "⓪ 名·自动3  失望"
-        ],
-        "notation": "失望(しつぼう)"
+        ]
     },
     {
         "name": "juushi",
         "trans": [
+            "重視(じゅうし)",
             "① 名·他动3  重视"
-        ],
-        "notation": "重視(じゅうし)"
+        ]
     },
     {
         "name": "juyou",
         "trans": [
+            "需要(じゅよう)",
             "⓪ 名  需要，需求"
-        ],
-        "notation": "需要(じゅよう)"
+        ]
     },
     {
         "name": "zenkai",
         "trans": [
+            "前回(ぜんかい)",
             "① 名  上次，上回"
-        ],
-        "notation": "前回(ぜんかい)"
+        ]
     },
     {
         "name": "taikin",
         "trans": [
+            "退勤(たいきん)",
             "⓪ 名·自动3  下班"
-        ],
-        "notation": "退勤(たいきん)"
+        ]
     },
     {
         "name": "shinshin",
         "trans": [
+            "心身(しんしん)",
             "① 名  身心，身与心"
-        ],
-        "notation": "心身(しんしん)"
+        ]
     },
     {
         "name": "naosara",
         "trans": [
+            "なおさら",
             "⓪ 副  更加，越发"
-        ],
-        "notation": "なおさら"
+        ]
     },
     {
         "name": "kenryoku",
         "trans": [
+            "権力(けんりょく)",
             "① 名  权力"
-        ],
-        "notation": "権力(けんりょく)"
+        ]
     },
     {
         "name": "kanki",
         "trans": [
+            "寒気(かんき)",
             "① 名  寒气，寒冷"
-        ],
-        "notation": "寒気(かんき)"
+        ]
     },
     {
         "name": "teishoku",
         "trans": [
+            "定食(ていしょく)",
             "⓪ 名  套餐"
-        ],
-        "notation": "定食(ていしょく)"
+        ]
     },
     {
         "name": "ryoushuusho",
         "trans": [
+            "領収書(りょうしゅうしょ)",
             "⓪ 名  收据"
-        ],
-        "notation": "領収書(りょうしゅうしょ)"
+        ]
     },
     {
         "name": "monku",
         "trans": [
+            "文句(もんく)",
             "① 名  不满，牢骚"
-        ],
-        "notation": "文句(もんく)"
+        ]
     },
     {
         "name": "menkyo",
         "trans": [
+            "免許(めんきょ)",
             "① 名·他动3  许可证；批准，许可"
-        ],
-        "notation": "免許(めんきょ)"
+        ]
     },
     {
         "name": "ya",
         "trans": [
+            "矢(や)",
             "① 名  箭"
-        ],
-        "notation": "矢(や)"
+        ]
     },
     {
         "name": "mazushii",
         "trans": [
+            "貧(まず)しい",
             "③ イ形  （金钱上）贫穷的；（经验等）贫乏的，微薄的"
-        ],
-        "notation": "貧(まず)しい"
+        ]
     },
     {
         "name": "furueru",
         "trans": [
+            "震(ふる)える",
             "⓪ 自动2  震动；发抖"
-        ],
-        "notation": "震(ふる)える"
+        ]
     },
     {
         "name": "fukou",
         "trans": [
+            "不幸(ふこう)",
             "② 名·ナ形  不幸，厄运"
-        ],
-        "notation": "不幸(ふこう)"
+        ]
     },
     {
         "name": "hineru",
         "trans": [
+            "捻(ひね)る",
             "② 他动1  拧，扭；扭转"
-        ],
-        "notation": "捻(ひね)る"
+        ]
     },
     {
         "name": "hayameru",
         "trans": [
+            "早(はや)める",
             "③ 他动2  提前"
-        ],
-        "notation": "早(はや)める"
+        ]
     },
     {
         "name": "hayameru",
         "trans": [
+            "速(はや)める",
             "③ 他动2  加速，加快"
-        ],
-        "notation": "速(はや)める"
+        ]
     },
     {
         "name": "nigoru",
         "trans": [
+            "濁(にご)る",
             "② 自动1  （液体、空气）浑浊，污浊；（声音）嘶哑"
-        ],
-        "notation": "濁(にご)る"
+        ]
     },
     {
         "name": "furikaeru",
         "trans": [
+            "振(ふ)り返(かえ)る",
             "③ 自动1  回头看；回顾（往事）"
-        ],
-        "notation": "振(ふ)り返(かえ)る"
+        ]
     },
     {
         "name": "tsukamaru",
         "trans": [
+            "捕(つか)まる",
             "⓪ 自动1  （犯人、动物等）被抓住；抓住，拽住"
-        ],
-        "notation": "捕(つか)まる"
+        ]
     },
     {
         "name": "sentaku",
         "trans": [
+            "選択(せんたく)",
             "⓪ 名·他动3  选择"
-        ],
-        "notation": "選択(せんたく)"
+        ]
     },
     {
         "name": "seisho",
         "trans": [
+            "清書(せいしょ)",
             "⓪ 名·他动3  誊写，抄写清楚"
-        ],
-        "notation": "清書(せいしょ)"
+        ]
     },
     {
         "name": "shoukyokuteki",
         "trans": [
+            "消極的(しょうきょくてき)",
             "⓪ ナ形  消极的"
-        ],
-        "notation": "消極的(しょうきょくてき)"
+        ]
     },
     {
         "name": "sukkiri",
         "trans": [
+            "すっきり",
             "③ 副·自动3  （心情）爽快，痛快；流畅"
-        ],
-        "notation": "すっきり"
+        ]
     },
     {
         "name": "shiri-zu",
         "trans": [
+            "シリーズ",
             "① 名  系列"
-        ],
-        "notation": "シリーズ"
+        ]
     },
     {
         "name": "saiwai",
         "trans": [
+            "幸(さいわ)い",
             "⓪ 名·ナ形·副  幸福，幸运；幸亏，幸好"
-        ],
-        "notation": "幸(さいわ)い"
+        ]
     },
     {
         "name": "kesshin",
         "trans": [
+            "決心(けっしん)",
             "① 名·自动3  决心；下决心"
-        ],
-        "notation": "決心(けっしん)"
+        ]
     },
     {
         "name": "koya",
         "trans": [
+            "小屋(こや)",
             "② 名  小房子；棚子"
-        ],
-        "notation": "小屋(こや)"
+        ]
     },
     {
         "name": "oyaji",
         "trans": [
+            "親父(おやじ)",
             "⓪ 名  （语气随意）父亲，爸爸"
-        ],
-        "notation": "親父(おやじ)"
+        ]
     },
     {
         "name": "enki",
         "trans": [
+            "延期(えんき)",
             "⓪ 名·他动3  延期"
-        ],
-        "notation": "延期(えんき)"
+        ]
     },
     {
         "name": "sairiyou",
         "trans": [
+            "再利用(さいりよう)",
             "③ 名  循环利用"
-        ],
-        "notation": "再利用(さいりよう)"
+        ]
     },
     {
         "name": "konkon",
         "trans": [
+            "こんこん",
             "① 副  比较轻微的咳嗽声"
-        ],
-        "notation": "こんこん"
+        ]
     },
     {
         "name": "asahi",
         "trans": [
+            "朝日(あさひ)",
             "① 名  朝阳"
-        ],
-        "notation": "朝日(あさひ)"
+        ]
     },
     {
         "name": "ubau",
         "trans": [
+            "奪(うば)う",
             "② 他动1  抢夺，剥夺；迷人，强烈吸引"
-        ],
-        "notation": "奪(うば)う"
+        ]
     },
     {
         "name": "ki-bo-do",
         "trans": [
+            "キーボード",
             "③ 名  键盘"
-        ],
-        "notation": "キーボード"
+        ]
     },
     {
         "name": "wanpi-su",
         "trans": [
+            "ワンピース",
             "③ 名  连衣裙"
-        ],
-        "notation": "ワンピース"
+        ]
     },
     {
         "name": "rejibukuro",
         "trans": [
+            "レジ袋(ぶくろ)",
             "③ 名  购物袋，塑料袋"
-        ],
-        "notation": "レジ袋(ぶくろ)"
+        ]
     },
     {
         "name": "ryougae",
         "trans": [
+            "両替(りょうがえ)",
             "⓪ 名·他动3  兑换，换钱"
-        ],
-        "notation": "両替(りょうがえ)"
+        ]
     },
     {
         "name": "yakudatsu",
         "trans": [
+            "役立(やくだ)つ",
             "③ 自动1  有用，起效"
-        ],
-        "notation": "役立(やくだ)つ"
+        ]
     },
     {
         "name": "honmono",
         "trans": [
+            "本物(ほんもの)",
             "⓪ 名  真东西，真货"
-        ],
-        "notation": "本物(ほんもの)"
+        ]
     },
     {
         "name": "kobokobo",
         "trans": [
+            "こぼこぼ",
             "① 副  比较激烈的咳嗽声"
-        ],
-        "notation": "こぼこぼ"
+        ]
     },
     {
         "name": "butsukeru",
         "trans": [
+            "ぶつける",
             "⓪ 他动2  碰上，撞上；扔，投"
-        ],
-        "notation": "ぶつける"
+        ]
     },
     {
         "name": "hyakkaten",
         "trans": [
+            "百貨店(ひゃっかてん)",
             "③ 名  百货商店"
-        ],
-        "notation": "百貨店(ひゃっかてん)"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "張(は)る",
             "⓪ 自他动1  伸展，伸开；拉紧，绷直"
-        ],
-        "notation": "張(は)る"
+        ]
     },
     {
         "name": "nobori",
         "trans": [
+            "上(のぼ)り",
             "⓪ 名  上；上行；上坡；从地方到首都"
-        ],
-        "notation": "上(のぼ)り"
+        ]
     },
     {
         "name": "ji-nsu",
         "trans": [
+            "ジーンズ",
             "① 名  牛仔裤"
-        ],
-        "notation": "ジーンズ"
+        ]
     },
     {
         "name": "totonou",
         "trans": [
+            "整(ととの)う",
             "③ 自动1  （文章、服装、面容等）完整，整齐，端正"
-        ],
-        "notation": "整(ととの)う"
+        ]
     },
     {
         "name": "totonoeru",
         "trans": [
+            "整(ととの)える",
             "④ 他动2  整理，整顿；准备好，备齐"
-        ],
-        "notation": "整(ととの)える"
+        ]
     },
     {
         "name": "jiki",
         "trans": [
+            "直(じき)",
             "⓪ 名·副  直接；（距离）很近；立刻，马上"
-        ],
-        "notation": "直(じき)"
+        ]
     },
     {
         "name": "maido",
         "trans": [
+            "毎度(まいど)",
             "⓪ 名  每次，每回"
-        ],
-        "notation": "毎度(まいど)"
+        ]
     },
     {
         "name": "mei",
         "trans": [
+            "姪(めい)",
             "① 名  侄女；外甥女"
-        ],
-        "notation": "姪(めい)"
+        ]
     },
     {
         "name": "yuukou",
         "trans": [
+            "有効(ゆうこう)",
             "⓪ 名·ナ形  有效"
-        ],
-        "notation": "有効(ゆうこう)"
+        ]
     },
     {
         "name": "yowami",
         "trans": [
+            "弱(よわ)み",
             "③ 名  弱点，缺点"
-        ],
-        "notation": "弱(よわ)み"
+        ]
     },
     {
         "name": "taratara",
         "trans": [
+            "たらたら",
             "① 副  （液体）滴滴答答地"
-        ],
-        "notation": "たらたら"
+        ]
     },
     {
         "name": "imagoro",
         "trans": [
+            "今頃(いまごろ)",
             "⓪ 名  现在，如今"
-        ],
-        "notation": "今頃(いまごろ)"
+        ]
     },
     {
         "name": "mukaiau",
         "trans": [
+            "向(む)かい合(あ)う",
             "④ 自动1  面对面，正对面"
-        ],
-        "notation": "向(む)かい合(あ)う"
+        ]
     },
     {
         "name": "mudadukai",
         "trans": [
+            "無駄遣(むだづか)い",
             "③ 名·他动3  浪费，乱花钱"
-        ],
-        "notation": "無駄遣(むだづか)い"
+        ]
     },
     {
         "name": "kaifuku",
         "trans": [
+            "回復(かいふく)",
             "⓪ 名·自他动3  恢复；康复；收回"
-        ],
-        "notation": "回復(かいふく)"
+        ]
     },
     {
         "name": "arayuru",
         "trans": [
+            "あらゆる",
             "③ 连体  所有，一切"
-        ],
-        "notation": "あらゆる"
+        ]
     },
     {
         "name": "fuukei",
         "trans": [
+            "風景(ふうけい)",
             "① 名  景色，风景"
-        ],
-        "notation": "風景(ふうけい)"
+        ]
     },
     {
         "name": "shibashiba",
         "trans": [
+            "しばしば",
             "① 副  屡次，常常"
-        ],
-        "notation": "しばしば"
+        ]
     },
     {
         "name": "tore-ningu",
         "trans": [
+            "トレーニング",
             "② 名·自动3  练习，训练"
-        ],
-        "notation": "トレーニング"
+        ]
     },
     {
         "name": "densen",
         "trans": [
+            "伝染(でんせん)",
             "⓪ 名·自动3  （疾病、习惯）传染"
-        ],
-        "notation": "伝染(でんせん)"
+        ]
     },
     {
         "name": "kasanaru",
         "trans": [
+            "重(かさ)なる",
             "⓪ 自动1  重叠；重复；赶在一起"
-        ],
-        "notation": "重(かさ)なる"
+        ]
     },
     {
         "name": "kasaneru",
         "trans": [
+            "重(かさ)ねる",
             "⓪ 他动2  摞；再加上；反复，屡次"
-        ],
-        "notation": "重(かさ)ねる"
+        ]
     },
     {
         "name": "uchiawaseru",
         "trans": [
+            "打(う)ち合(あ)わせる",
             "⑤ 他动2  商量，协商"
-        ],
-        "notation": "打(う)ち合(あ)わせる"
+        ]
     },
     {
         "name": "kagayaku",
         "trans": [
+            "輝(かがや)く",
             "③ 自动1  闪耀，放光；充满，洋溢（喜悦等）"
-        ],
-        "notation": "輝(かがや)く"
+        ]
     },
     {
         "name": "tsubusu",
         "trans": [
+            "潰(つぶ)す",
             "⓪ 他动1  压碎，毁坏；打发（时间）；使破产"
-        ],
-        "notation": "潰(つぶ)す"
+        ]
     },
     {
         "name": "tsubureru",
         "trans": [
+            "潰(つぶ)れる",
             "⓪ 自动2  压坏，挤破；（房屋）倒塌；倒闭，破产"
-        ],
-        "notation": "潰(つぶ)れる"
+        ]
     },
     {
         "name": "saishuu",
         "trans": [
+            "最終(さいしゅう)",
             "⓪ 名  最终，最后"
-        ],
-        "notation": "最終(さいしゅう)"
+        ]
     },
     {
         "name": "shikyuu",
         "trans": [
+            "支給(しきゅう)",
             "⓪ 名·他动3  支付"
-        ],
-        "notation": "支給(しきゅう)"
+        ]
     },
     {
         "name": "ichidoni",
         "trans": [
+            "一度(いちど)に",
             "③ 副  同时，一下子"
-        ],
-        "notation": "一度(いちど)に"
+        ]
     },
     {
         "name": "kashikoi",
         "trans": [
+            "賢(かしこ)い",
             "③ イ形  聪明的，伶俐的"
-        ],
-        "notation": "賢(かしこ)い"
+        ]
     },
     {
         "name": "kudaru",
         "trans": [
+            "下(くだ)る",
             "⓪ 自动1  下，下去；下命令；（数字）少于，低于；下台"
-        ],
-        "notation": "下(くだ)る"
+        ]
     },
     {
         "name": "kewashii",
         "trans": [
+            "険(けわ)しい",
             "③ イ形  陡峭的；（情况）艰险的"
-        ],
-        "notation": "険(けわ)しい"
+        ]
     },
     {
         "name": "sa",
         "trans": [
+            "差(さ)",
             "⓪ 名  差别，差异；（数学）差值"
-        ],
-        "notation": "差(さ)"
+        ]
     },
     {
         "name": "buiorin",
         "trans": [
+            "バイオリン",
             "⓪ 名  小提琴"
-        ],
-        "notation": "バイオリン"
+        ]
     },
     {
         "name": "itazura",
         "trans": [
+            "悪戯(いたずら)",
             "⓪ 名·ナ形·自动3  恶作剧；消遣，开玩笑"
-        ],
-        "notation": "悪戯(いたずら)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "欠(か)ける",
             "⓪ 自动2  （物品）有缺口；缺少，空缺"
-        ],
-        "notation": "欠(か)ける"
+        ]
     },
     {
         "name": "shitsugyou",
         "trans": [
+            "失業(しつぎょう)",
             "⓪ 名·自动3  失业"
-        ],
-        "notation": "失業(しつぎょう)"
+        ]
     },
     {
         "name": "shiriau",
         "trans": [
+            "知(し)り合(あ)う",
             "③ 自动1  相识，结识；互相了解"
-        ],
-        "notation": "知(し)り合(あ)う"
+        ]
     },
     {
         "name": "nattoku",
         "trans": [
+            "納得(なっとく)",
             "⓪ 名·他动3  理解；同意，信服"
-        ],
-        "notation": "納得(なっとく)"
+        ]
     },
     {
         "name": "ishiki",
         "trans": [
+            "意識(いしき)",
             "① 名·他动3  意识，知觉；认识，意识到"
-        ],
-        "notation": "意識(いしき)"
+        ]
     },
     {
         "name": "kage",
         "trans": [
+            "陰(かげ)",
             "① 名  背阴处；后面，背后；暗中，暗地"
-        ],
-        "notation": "陰(かげ)"
+        ]
     },
     {
         "name": "nokorazu",
         "trans": [
+            "残(のこ)らず",
             "③ 副  全部，一个不剩"
-        ],
-        "notation": "残(のこ)らず"
+        ]
     },
     {
         "name": "kara-",
         "trans": [
+            "カラー",
             "① 名  颜色，色彩；特色"
-        ],
-        "notation": "カラー"
+        ]
     },
     {
         "name": "tokushoku",
         "trans": [
+            "特色(とくしょく)",
             "⓪ 名  特色，特征"
-        ],
-        "notation": "特色(とくしょく)"
+        ]
     },
     {
         "name": "tsuuchi",
         "trans": [
+            "通知(つうち)",
             "⓪ 名·他动3  通知，告知"
-        ],
-        "notation": "通知(つうち)"
+        ]
     },
     {
         "name": "chidimu",
         "trans": [
+            "縮(ちぢ)む",
             "⓪ 自动1  （物体、身高）收缩，缩小；（衣物）起皱"
-        ],
-        "notation": "縮(ちぢ)む"
+        ]
     },
     {
         "name": "chidimeru",
         "trans": [
+            "縮(ちぢ)める",
             "⓪ 他动2  缩短（时间）；缩小（尺寸）；削减，减少"
-        ],
-        "notation": "縮(ちぢ)める"
+        ]
     },
     {
         "name": "katamaru",
         "trans": [
+            "固(かた)まる",
             "⓪ 自动1  变硬，凝固；固定"
-        ],
-        "notation": "固(かた)まる"
+        ]
     },
     {
         "name": "awatadashii",
         "trans": [
+            "慌(あわ)ただしい",
             "⑤ イ形  慌张的，匆忙的"
-        ],
-        "notation": "慌(あわ)ただしい"
+        ]
     },
     {
         "name": "chidireru",
         "trans": [
+            "縮(ちぢ)れる",
             "⓪ 自动2  （衣物）起皱，（毛发）卷曲"
-        ],
-        "notation": "縮(ちぢ)れる"
+        ]
     },
     {
         "name": "kakkowarui",
         "trans": [
+            "かっこ悪(わる)い",
             "⑤ イ形  （人、行为等）难看的"
-        ],
-        "notation": "かっこ悪(わる)い"
+        ]
     },
     {
         "name": "usugurai",
         "trans": [
+            "薄暗(うすぐら)い",
             "⓪ イ形  微暗的，昏暗的"
-        ],
-        "notation": "薄暗(うすぐら)い"
+        ]
     },
     {
         "name": "fugoukaku",
         "trans": [
+            "不合格(ふごうかく)",
             "② 名  不及格，不合格"
-        ],
-        "notation": "不合格(ふごうかく)"
+        ]
     },
     {
         "name": "taitei",
         "trans": [
+            "大抵(たいてい)",
             "⓪ 副  大部分，大都；大概"
-        ],
-        "notation": "大抵(たいてい)"
+        ]
     },
     {
         "name": "arubamu",
         "trans": [
+            "アルバム",
             "⓪ 名  相册，影集，纪念册"
-        ],
-        "notation": "アルバム"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "現(あらわ)す",
             "③ 他动1  出现，显露"
-        ],
-        "notation": "現(あらわ)す"
+        ]
     },
     {
         "name": "arawareru",
         "trans": [
+            "現(あらわ)れる",
             "④ 自动2  出现"
-        ],
-        "notation": "現(あらわ)れる"
+        ]
     },
     {
         "name": "arawareru",
         "trans": [
+            "表(あらわ)れる",
             "④ 自动2  表现，显出"
-        ],
-        "notation": "表(あらわ)れる"
+        ]
     },
     {
         "name": "sousaku",
         "trans": [
+            "創作(そうさく)",
             "⓪ 名·他动3  创作；创造"
-        ],
-        "notation": "創作(そうさく)"
+        ]
     },
     {
         "name": "zeitaku",
         "trans": [
+            "贅沢(ぜいたく)",
             "③ 名·ナ形  奢侈，浪费；奢望"
-        ],
-        "notation": "贅沢(ぜいたく)"
+        ]
     },
     {
         "name": "myu-jikku",
         "trans": [
+            "ミュージック",
             "① 名  音乐"
-        ],
-        "notation": "ミュージック"
+        ]
     },
     {
         "name": "ukaberu",
         "trans": [
+            "浮(う)かべる",
             "⓪ 他动2  使⋯⋯浮起；使⋯⋯出现；想起，回忆起"
-        ],
-        "notation": "浮(う)かべる"
+        ]
     },
     {
         "name": "reinko-to",
         "trans": [
+            "レインコート",
             "④ 名  雨衣"
-        ],
-        "notation": "レインコート"
+        ]
     },
     {
         "name": "shikushiku",
         "trans": [
+            "しくしく",
             "① 副·自动3  抽抽搭搭地哭泣；（牙或肚子）不剧烈的疼痛"
-        ],
-        "notation": "しくしく"
+        ]
     },
     {
         "name": "iron'na",
         "trans": [
+            "いろんな",
             "⓪ 连体  各种各样"
-        ],
-        "notation": "いろんな"
+        ]
     },
     {
         "name": "ikkini",
         "trans": [
+            "一気(いっき)に",
             "① 副  一口气，一下子"
-        ],
-        "notation": "一気(いっき)に"
+        ]
     },
     {
         "name": "jijo",
         "trans": [
+            "次女(じじょ)",
             "① 名  次女，二女儿"
-        ],
-        "notation": "次女(じじょ)"
+        ]
     },
     {
         "name": "korogaru",
         "trans": [
+            "転(ころ)がる",
             "⓪ 自动1  滚动，滚来滚去；跌倒，倒下"
-        ],
-        "notation": "転(ころ)がる"
+        ]
     },
     {
         "name": "oote",
         "trans": [
+            "大手(おおて)",
             "① 名  大企业，大公司"
-        ],
-        "notation": "大手(おおて)"
+        ]
     },
     {
         "name": "arai",
         "trans": [
+            "粗(あら)い",
             "⓪ イ形  粗大的；粗糙的；粗枝大叶的"
-        ],
-        "notation": "粗(あら)い"
+        ]
     },
     {
         "name": "ogoru",
         "trans": [
+            "奢(おご)る",
             "⓪ 自他动1  奢侈；请客"
-        ],
-        "notation": "奢(おご)る"
+        ]
     },
     {
         "name": "afureru",
         "trans": [
+            "溢(あふ)れる",
             "③ 自动2  （液体等）溢出；（人）挤满；洋溢（喜悦等）"
-        ],
-        "notation": "溢(あふ)れる"
+        ]
     },
     {
         "name": "saidaigen",
         "trans": [
+            "最大限(さいだいげん)",
             "③ 名  最大限度"
-        ],
-        "notation": "最大限(さいだいげん)"
+        ]
     },
     {
         "name": "koremade",
         "trans": [
+            "これまで",
             "③ 连语·副  从前，过去；到这种程度；到此为止"
-        ],
-        "notation": "これまで"
+        ]
     },
     {
         "name": "kontesuto",
         "trans": [
+            "コンテスト",
             "① 名  竞赛，比赛；（文艺）会演"
-        ],
-        "notation": "コンテスト"
+        ]
     },
     {
         "name": "nemuke",
         "trans": [
+            "眠気(ねむけ)",
             "⓪ 名  睡意，困倦"
-        ],
-        "notation": "眠気(ねむけ)"
+        ]
     },
     {
         "name": "nenrei",
         "trans": [
+            "年齢(ねんれい)",
             "⓪ 名  年龄"
-        ],
-        "notation": "年齢(ねんれい)"
+        ]
     },
     {
         "name": "benjo",
         "trans": [
+            "便所(べんじょ)",
             "③ 名  厕所"
-        ],
-        "notation": "便所(べんじょ)"
+        ]
     },
     {
         "name": "houfu",
         "trans": [
+            "豊富(ほうふ)",
             "⓪ 名·ナ形  丰富"
-        ],
-        "notation": "豊富(ほうふ)"
+        ]
     },
     {
         "name": "manten",
         "trans": [
+            "満点(まんてん)",
             "③ 名  满分；完美无缺"
-        ],
-        "notation": "満点(まんてん)"
+        ]
     },
     {
         "name": "~kagiri",
         "trans": [
+            "～限(かぎ)り",
             " 接尾  限于⋯⋯"
-        ],
-        "notation": "～限(かぎ)り"
+        ]
     },
     {
         "name": "kagiri",
         "trans": [
+            "限(かぎ)り",
             "① 名  限度；极限"
-        ],
-        "notation": "限(かぎ)り"
+        ]
     },
     {
         "name": "odorokasu",
         "trans": [
+            "驚(おどろ)かす",
             "④ 他动1  使惊讶；吓唬，使害怕"
-        ],
-        "notation": "驚(おどろ)かす"
+        ]
     },
     {
         "name": "shitagatte",
         "trans": [
+            "したがって",
             "⓪ 接续  因此，因而"
-        ],
-        "notation": "したがって"
+        ]
     },
     {
         "name": "fuman",
         "trans": [
+            "不満(ふまん)",
             "⓪ 名·ナ形  不满足，不满意"
-        ],
-        "notation": "不満(ふまん)"
+        ]
     },
     {
         "name": "kareru",
         "trans": [
+            "枯(か)れる",
             "⓪ 自动2  凋零，枯萎；干枯；（技艺等）成熟，老练"
-        ],
-        "notation": "枯(か)れる"
+        ]
     },
     {
         "name": "otonashii",
         "trans": [
+            "大人(おとな)しい",
             "④ イ形  老实的，温顺的；雅致的"
-        ],
-        "notation": "大人(おとな)しい"
+        ]
     },
     {
         "name": "ayauku",
         "trans": [
+            "危(あや)うく",
             "⓪ 副  好不容易；险些，差一点儿就"
-        ],
-        "notation": "危(あや)うく"
+        ]
     },
     {
         "name": "karori-",
         "trans": [
+            "カロリー",
             "① 名  卡路里，热量"
-        ],
-        "notation": "カロリー"
+        ]
     },
     {
         "name": "kyanpasu",
         "trans": [
+            "キャンパス",
             "① 名  校园"
-        ],
-        "notation": "キャンパス"
+        ]
     },
     {
         "name": "kyouryoku",
         "trans": [
+            "協力(きょうりょく)",
             "⓪ 名·自动3  合作，协助"
-        ],
-        "notation": "協力(きょうりょく)"
+        ]
     },
     {
         "name": "kumiawaseru",
         "trans": [
+            "組(く)み合(あ)わせる",
             "⑤ 他动2  搭配，配合"
-        ],
-        "notation": "組(く)み合(あ)わせる"
+        ]
     },
     {
         "name": "kakezan",
         "trans": [
+            "掛(か)け算(ざん)",
             "② 名  （数学）乘法"
-        ],
-        "notation": "掛(か)け算(ざん)"
+        ]
     },
     {
         "name": "owabi",
         "trans": [
+            "お詫(わ)び",
             "⓪ 名·自动3  道歉"
-        ],
-        "notation": "お詫(わ)び"
+        ]
     },
     {
         "name": "keiyaku",
         "trans": [
+            "契約(けいやく)",
             "⓪ 名·他动3  合约，契约；约定"
-        ],
-        "notation": "契約(けいやく)"
+        ]
     },
     {
         "name": "jitsuyouka",
         "trans": [
+            "実用化(じつようか)",
             "⓪ 名·自他动3  实用化，实际应用"
-        ],
-        "notation": "実用化(じつようか)"
+        ]
     },
     {
         "name": "kudakeru",
         "trans": [
+            "砕(くだ)ける",
             "③ 自动2  破碎；（气势等）受挫"
-        ],
-        "notation": "砕(くだ)ける"
+        ]
     },
     {
         "name": "shihatsueki",
         "trans": [
+            "始発駅(しはつえき)",
             "③ 名  始发站"
-        ],
-        "notation": "始発駅(しはつえき)"
+        ]
     },
     {
         "name": "temoto",
         "trans": [
+            "手元(てもと)",
             "③ 名  手头，手边；身边"
-        ],
-        "notation": "手元(てもと)"
+        ]
     },
     {
         "name": "tokeru",
         "trans": [
+            "溶(と)ける",
             "② 自动2  熔化；融化；溶化"
-        ],
-        "notation": "溶(と)ける"
+        ]
     },
     {
         "name": "onbu",
         "trans": [
+            "負(お)んぶ",
             "① 名·他动3  背（小孩等）；依靠"
-        ],
-        "notation": "負(お)んぶ"
+        ]
     },
     {
         "name": "niramu",
         "trans": [
+            "睨(にら)む",
             "② 他动1  瞪眼；关注（局势）"
-        ],
-        "notation": "睨(にら)む"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "測(はか)る",
             "② 他动1  丈量，测量"
-        ],
-        "notation": "測(はか)る"
+        ]
     },
     {
         "name": "hakaru",
         "trans": [
+            "図(はか)る",
             "② 他动1  图谋，策划"
-        ],
-        "notation": "図(はか)る"
+        ]
     },
     {
         "name": "shimo",
         "trans": [
+            "霜(しも)",
             "② 名  霜"
-        ],
-        "notation": "霜(しも)"
+        ]
     },
     {
         "name": "kamigata",
         "trans": [
+            "髪型(かみがた)",
             "⓪ 名  发型"
-        ],
-        "notation": "髪型(かみがた)"
+        ]
     },
     {
         "name": "ichiba",
         "trans": [
+            "市場(いちば)",
             "① 名  集市，市场"
-        ],
-        "notation": "市場(いちば)"
+        ]
     },
     {
         "name": "airon",
         "trans": [
+            "アイロン",
             "⓪ 名  熨斗"
-        ],
-        "notation": "アイロン"
+        ]
     },
     {
         "name": "ikinari",
         "trans": [
+            "いきなり",
             "⓪ 副  突然，冷不丁"
-        ],
-        "notation": "いきなり"
+        ]
     },
     {
         "name": "kitsui",
         "trans": [
+            "きつい",
             "⓪ イ形  紧的；严厉的；刺激性的"
-        ],
-        "notation": "きつい"
+        ]
     },
     {
         "name": "ureyuki",
         "trans": [
+            "売(う)れ行(ゆ)き",
             "⓪ 名  销路，销售情况"
-        ],
-        "notation": "売(う)れ行(ゆ)き"
+        ]
     },
     {
         "name": "kikkake",
         "trans": [
+            "きっかけ",
             "⓪ 名  开端；机会，契机"
-        ],
-        "notation": "きっかけ"
+        ]
     },
     {
         "name": "ranningu",
         "trans": [
+            "ランニング",
             "⓪ 名  跑步"
-        ],
-        "notation": "ランニング"
+        ]
     },
     {
         "name": "otosu",
         "trans": [
+            "落(お)とす",
             "② 他动1  使降落；丢失；擦掉，去掉；遗漏"
-        ],
-        "notation": "落(お)とす"
+        ]
     },
     {
         "name": "kyuukei",
         "trans": [
+            "休憩(きゅうけい)",
             "⓪ 名·自动3  休息"
-        ],
-        "notation": "休憩(きゅうけい)"
+        ]
     },
     {
         "name": "kurashikku",
         "trans": [
+            "クラシック",
             "③ 名·ナ形  古典音乐；古典的"
-        ],
-        "notation": "クラシック"
+        ]
     },
     {
         "name": "kakudai",
         "trans": [
+            "拡大(かくだい)",
             "⓪ 名·自他动3  扩大"
-        ],
-        "notation": "拡大(かくだい)"
+        ]
     },
     {
         "name": "itamu",
         "trans": [
+            "痛(いた)む",
             "② 自动1  （肉体）疼痛；（精神）痛苦"
-        ],
-        "notation": "痛(いた)む"
+        ]
     },
     {
         "name": "itameru",
         "trans": [
+            "痛(いた)める",
             "③ 他动2  弄疼，使痛苦"
-        ],
-        "notation": "痛(いた)める"
+        ]
     },
     {
         "name": "shako",
         "trans": [
+            "車庫(しゃこ)",
             "① 名  车库"
-        ],
-        "notation": "車庫(しゃこ)"
+        ]
     },
     {
         "name": "koboreru",
         "trans": [
+            "毀(こぼ)れる",
             "③ 自动2  坏，损坏"
-        ],
-        "notation": "毀(こぼ)れる"
+        ]
     },
     {
         "name": "ichiou",
         "trans": [
+            "一応(いちおう)",
             "⓪ 副  大致；姑且"
-        ],
-        "notation": "一応(いちおう)"
+        ]
     },
     {
         "name": "jiyuuseki",
         "trans": [
+            "自由席(じゆうせき)",
             "② 名  自由座位"
-        ],
-        "notation": "自由席(じゆうせき)"
+        ]
     },
     {
         "name": "hetaheta",
         "trans": [
+            "へたへた",
             "④ 副  精疲力竭地瘫下，累趴下"
-        ],
-        "notation": "へたへた"
+        ]
     },
     {
         "name": "kanetsu",
         "trans": [
+            "加熱(かねつ)",
             "⓪ 名·他动3  加热"
-        ],
-        "notation": "加熱(かねつ)"
+        ]
     },
     {
         "name": "izurenishitemo",
         "trans": [
+            "いずれにしても",
             "⑥ 连语  反正，总之"
-        ],
-        "notation": "いずれにしても"
+        ]
     },
     {
         "name": "sawagashii",
         "trans": [
+            "騒(さわ)がしい",
             "④ イ形  吵闹的；议论纷纷的"
-        ],
-        "notation": "騒(さわ)がしい"
+        ]
     },
     {
         "name": "jugyouryou",
         "trans": [
+            "授業料(じゅぎょうりょう)",
             "② 名  学费"
-        ],
-        "notation": "授業料(じゅぎょうりょう)"
+        ]
     },
     {
         "name": "kanarazushimo",
         "trans": [
+            "必(かなら)ずしも",
             "④ 副  （后接否定）不一定，未必"
-        ],
-        "notation": "必(かなら)ずしも"
+        ]
     },
     {
         "name": "juwaki",
         "trans": [
+            "受話器(じゅわき)",
             "② 名  （电话）听筒"
-        ],
-        "notation": "受話器(じゅわき)"
+        ]
     },
     {
         "name": "ijime",
         "trans": [
+            "苛(いじ)め",
             "⓪ 名  欺侮，霸凌"
-        ],
-        "notation": "苛(いじ)め"
+        ]
     },
     {
         "name": "sakujo",
         "trans": [
+            "削除(さくじょ)",
             "① 名·他动3  删除，删掉"
-        ],
-        "notation": "削除(さくじょ)"
+        ]
     },
     {
         "name": "marason",
         "trans": [
+            "マラソン",
             "⓪ 名  马拉松"
-        ],
-        "notation": "マラソン"
+        ]
     },
     {
         "name": "osoroshii",
         "trans": [
+            "恐(おそ)ろしい",
             "④ イ形  可怕的；惊人的，厉害的"
-        ],
-        "notation": "恐(おそ)ろしい"
+        ]
     },
     {
         "name": "ijou",
         "trans": [
+            "異常(いじょう)",
             "⓪ 名·ナ形  异常，反常"
-        ],
-        "notation": "異常(いじょう)"
+        ]
     },
     {
         "name": "oeru",
         "trans": [
+            "終(お)える",
             "⓪ 自他动2  完成，结束"
-        ],
-        "notation": "終(お)える"
+        ]
     },
     {
         "name": "jun",
         "trans": [
+            "順(じゅん)",
             "⓪ 名  顺序，次序"
-        ],
-        "notation": "順(じゅん)"
+        ]
     },
     {
         "name": "konomi",
         "trans": [
+            "好(この)み",
             "① 名  爱好，喜好"
-        ],
-        "notation": "好(この)み"
+        ]
     },
     {
         "name": "saiten",
         "trans": [
+            "採点(さいてん)",
             "⓪ 名·他动3  评分，判分"
-        ],
-        "notation": "採点(さいてん)"
+        ]
     },
     {
         "name": "izureniseyo",
         "trans": [
+            "いずれにせよ",
             "④ 连语  反正，总之"
-        ],
-        "notation": "いずれにせよ"
+        ]
     },
     {
         "name": "saibai",
         "trans": [
+            "栽培(さいばい)",
             "⓪ 名·他动3  栽培，种植"
-        ],
-        "notation": "栽培(さいばい)"
+        ]
     },
     {
         "name": "shitsuren",
         "trans": [
+            "失恋(しつれん)",
             "⓪ 名·自动3  失恋"
-        ],
-        "notation": "失恋(しつれん)"
+        ]
     },
     {
         "name": "jaguchi",
         "trans": [
+            "蛇口(じゃぐち)",
             "⓪ 名  水龙头"
-        ],
-        "notation": "蛇口(じゃぐち)"
+        ]
     },
     {
         "name": "shoppu",
         "trans": [
+            "ショップ",
             "① 名  商店，店铺"
-        ],
-        "notation": "ショップ"
+        ]
     },
     {
         "name": "ukemotsu",
         "trans": [
+            "受(う)け持(も)つ",
             "③ 他动1  掌管，负责；担任（授课老师）"
-        ],
-        "notation": "受(う)け持(も)つ"
+        ]
     },
     {
         "name": "ijiwaru",
         "trans": [
+            "意地悪(いじわる)",
             "③ 名·ナ形  心眼坏；刁难，捉弄"
-        ],
-        "notation": "意地悪(いじわる)"
+        ]
     },
     {
         "name": "oikakeru",
         "trans": [
+            "追(お)いかける",
             "④ 他动2  追赶；紧跟着"
-        ],
-        "notation": "追(お)いかける"
+        ]
     },
     {
         "name": "oshii",
         "trans": [
+            "惜(お)しい",
             "② イ形  可惜的，遗憾的"
-        ],
-        "notation": "惜(お)しい"
+        ]
     },
     {
         "name": "keta",
         "trans": [
+            "桁(けた)",
             "⓪ 名  （建筑物的）横梁；（数字）位数"
-        ],
-        "notation": "桁(けた)"
+        ]
     },
     {
         "name": "osanai",
         "trans": [
+            "幼(おさな)い",
             "③ イ形  幼小的；幼稚的"
-        ],
-        "notation": "幼(おさな)い"
+        ]
     },
     {
         "name": "shuchou",
         "trans": [
+            "主張(しゅちょう)",
             "⓪ 名·他动3  主张"
-        ],
-        "notation": "主張(しゅちょう)"
+        ]
     },
     {
         "name": "enjo",
         "trans": [
+            "援助(えんじょ)",
             "① 名·他动3  援助，帮助"
-        ],
-        "notation": "援助(えんじょ)"
+        ]
     },
     {
         "name": "shimekiru",
         "trans": [
+            "締(し)め切(き)る",
             "③ 他动1  截止，结束"
-        ],
-        "notation": "締(し)め切(き)る"
+        ]
     },
     {
         "name": "shimai",
         "trans": [
+            "終(しま)い",
             "⓪ 名  末尾，终了；结局"
-        ],
-        "notation": "終(しま)い"
+        ]
     },
     {
         "name": "enzetsu",
         "trans": [
+            "演説(えんぜつ)",
             "⓪ 名·自动3  演说，演讲"
-        ],
-        "notation": "演説(えんぜつ)"
+        ]
     },
     {
         "name": "iko-ru",
         "trans": [
+            "イコール",
             "② 名  等于；等号"
-        ],
-        "notation": "イコール"
+        ]
     },
     {
         "name": "oou",
         "trans": [
+            "覆(おお)う",
             "⓪ 他动1  蒙上，盖上；掩盖（事实、缺点）"
-        ],
-        "notation": "覆(おお)う"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "湿(しめ)る",
             "⓪ 自动1  潮湿，发潮"
-        ],
-        "notation": "湿(しめ)る"
+        ]
     },
     {
         "name": "sakuban",
         "trans": [
+            "昨晩(さくばん)",
             "② 名  昨晚"
-        ],
-        "notation": "昨晩(さくばん)"
+        ]
     },
     {
         "name": "pekopeko",
         "trans": [
+            "ぺこぺこ",
             "① 名·ナ形·自动3  瘪瘪的；肚子饿；点头哈腰"
-        ],
-        "notation": "ぺこぺこ"
+        ]
     },
     {
         "name": "hon'no",
         "trans": [
+            "本(ほん)の",
             "⓪ 连体  仅仅，少许，一点点"
-        ],
-        "notation": "本(ほん)の"
+        ]
     },
     {
         "name": "mabushii",
         "trans": [
+            "眩(まぶ)しい",
             "③ イ形  晃眼的，耀眼的；光彩夺目的"
-        ],
-        "notation": "眩(まぶ)しい"
+        ]
     },
     {
         "name": "meiwaku",
         "trans": [
+            "迷惑(めいわく)",
             "① 名·自动3  麻烦，烦恼；为难，添麻烦"
-        ],
-        "notation": "迷惑(めいわく)"
+        ]
     },
     {
         "name": "yakamashii",
         "trans": [
+            "やかましい",
             "④ イ形  吵闹的，嘈杂的；（手续）麻烦的"
-        ],
-        "notation": "やかましい"
+        ]
     },
     {
         "name": "shouyu",
         "trans": [
+            "醤油(しょうゆ)",
             "⓪ 名  酱油"
-        ],
-        "notation": "醤油(しょうゆ)"
+        ]
     },
     {
         "name": "okasu",
         "trans": [
+            "犯(おか)す",
             "② 他动1  违反（法律）；冒犯"
-        ],
-        "notation": "犯(おか)す"
+        ]
     },
     {
         "name": "igi",
         "trans": [
+            "意義(いぎ)",
             "① 名  意义，价值"
-        ],
-        "notation": "意義(いぎ)"
+        ]
     },
     {
         "name": "shinpojiwamu",
         "trans": [
+            "シンポジウム",
             "④ 名  讨论会，座谈会"
-        ],
-        "notation": "シンポジウム"
+        ]
     },
     {
         "name": "boyaboya",
         "trans": [
+            "ぼやぼや",
             "① 副·自动3  发呆"
-        ],
-        "notation": "ぼやぼや"
+        ]
     },
     {
         "name": "makkuro",
         "trans": [
+            "真(ま)っ黒(くろ)",
             "③ 名·ナ形  乌黑，漆黑"
-        ],
-        "notation": "真(ま)っ黒(くろ)"
+        ]
     },
     {
         "name": "masshiro",
         "trans": [
+            "真(ま)っ白(しろ)",
             "③ 名·ナ形  雪白，纯白"
-        ],
-        "notation": "真(ま)っ白(しろ)"
+        ]
     },
     {
         "name": "shiyouryou",
         "trans": [
+            "使用料(しようりょう)",
             "② 名  使用费"
-        ],
-        "notation": "使用料(しようりょう)"
+        ]
     },
     {
         "name": "batabata",
         "trans": [
+            "ばたばた",
             "① 副  吧嗒吧嗒声；相继倒下；慌张的样子"
-        ],
-        "notation": "ばたばた"
+        ]
     },
     {
         "name": "ba-gen/ba-gense-ru",
         "trans": [
+            "バーゲン/バーゲンセール",
             "① 名  大减价"
-        ],
-        "notation": "バーゲン/バーゲンセール"
+        ]
     },
     {
         "name": "hirogeru",
         "trans": [
+            "広(ひろ)げる",
             "⓪ 他动2  打开，展开；扩大，扩张"
-        ],
-        "notation": "広(ひろ)げる"
+        ]
     },
     {
         "name": "anki",
         "trans": [
+            "暗記(あんき)",
             "⓪ 名·他动3  记住，背诵"
-        ],
-        "notation": "暗記(あんき)"
+        ]
     },
     {
         "name": "byoudou",
         "trans": [
+            "平等(びょうどう)",
             "⓪ 名·ナ形  平等，同等"
-        ],
-        "notation": "平等(びょうどう)"
+        ]
     },
     {
         "name": "noroi",
         "trans": [
+            "鈍(のろ)い",
             "② イ形  缓慢的；迟钝的；磨蹭的"
-        ],
-        "notation": "鈍(のろ)い"
+        ]
     },
     {
         "name": "oouridashi",
         "trans": [
+            "大売出(おおうりだ)し",
             "③ 名  大减价，大甩卖"
-        ],
-        "notation": "大売出(おおうりだ)し"
+        ]
     },
     {
         "name": "toranpu",
         "trans": [
+            "トランプ",
             "② 名  扑克牌"
-        ],
-        "notation": "トランプ"
+        ]
     },
     {
         "name": "toriatsukau",
         "trans": [
+            "取(と)り扱(あつか)う",
             "⑤ 他动1  对待（人）；操作（机器）；处理（事务）"
-        ],
-        "notation": "取(と)り扱(あつか)う"
+        ]
     },
     {
         "name": "oubei",
         "trans": [
+            "欧米(おうべい)",
             "⓪ 名  欧美"
-        ],
-        "notation": "欧米(おうべい)"
+        ]
     },
     {
         "name": "urikireru",
         "trans": [
+            "売(う)り切(き)れる",
             "④ 自动2  全部售完，售罄"
-        ],
-        "notation": "売(う)り切(き)れる"
+        ]
     },
     {
         "name": "shoku",
         "trans": [
+            "職(しょく)",
             "⓪ 名  职务；职业，工作"
-        ],
-        "notation": "職(しょく)"
+        ]
     },
     {
         "name": "anshoubangou",
         "trans": [
+            "暗証番号(あんしょうばんごう)",
             "⑤ 名  密码"
-        ],
-        "notation": "暗証番号(あんしょうばんごう)"
+        ]
     },
     {
         "name": "hossori",
         "trans": [
+            "ほっそり",
             "③ 副·自动3  （物体）细长，（人）纤细苗条"
-        ],
-        "notation": "ほっそり"
+        ]
     },
     {
         "name": "donaru",
         "trans": [
+            "怒鳴(どな)る",
             "② 自动1  大声喊叫；大声训斥"
-        ],
-        "notation": "怒鳴(どな)る"
+        ]
     },
     {
         "name": "dentou",
         "trans": [
+            "伝統(でんとう)",
             "⓪ 名  传统"
-        ],
-        "notation": "伝統(でんとう)"
+        ]
     },
     {
         "name": "umeru",
         "trans": [
+            "埋(う)める",
             "⓪ 他动2  填，掩埋；填补（空缺）"
-        ],
-        "notation": "埋(う)める"
+        ]
     },
     {
         "name": "toiawaseru",
         "trans": [
+            "問(と)い合(あ)わせる",
             "⑤ 他动2  打听，询问"
-        ],
-        "notation": "問(と)い合(あ)わせる"
+        ]
     },
     {
         "name": "souzoushii",
         "trans": [
+            "騒々しい(そうぞうしい)",
             "⑤ イ形  吵闹的；（社会）不安宁的"
-        ],
-        "notation": "騒々しい(そうぞうしい)"
+        ]
     },
     {
         "name": "shinkoku",
         "trans": [
+            "深刻(しんこく)",
             "⓪ ナ形  深刻的；严重的，重大的"
-        ],
-        "notation": "深刻(しんこく)"
+        ]
     },
     {
         "name": "shomotsu",
         "trans": [
+            "書物(しょもつ)",
             "① 名  书籍"
-        ],
-        "notation": "書物(しょもつ)"
+        ]
     },
     {
         "name": "junchou",
         "trans": [
+            "順調(じゅんちょう)",
             "⓪ 名·ナ形  顺利，顺畅"
-        ],
-        "notation": "順調(じゅんちょう)"
+        ]
     },
     {
         "name": "utagau",
         "trans": [
+            "疑(うたが)う",
             "⓪ 他动1  怀疑；猜测"
-        ],
-        "notation": "疑(うたが)う"
+        ]
     },
     {
         "name": "shuppan",
         "trans": [
+            "出版(しゅっぱん)",
             "⓪ 名·他动3  出版"
-        ],
-        "notation": "出版(しゅっぱん)"
+        ]
     },
     {
         "name": "juutai",
         "trans": [
+            "渋滞(じゅうたい)",
             "⓪ 名·自动3  （交通）堵塞；进展不顺利"
-        ],
-        "notation": "渋滞(じゅうたい)"
+        ]
     },
     {
         "name": "pokapoka",
         "trans": [
+            "ぽかぽか",
             "① 副·自动3  暖和，舒服"
-        ],
-        "notation": "ぽかぽか"
+        ]
     },
     {
         "name": "arata",
         "trans": [
+            "新(あら)た",
             "① ナ形  新的；重新"
-        ],
-        "notation": "新(あら)た"
+        ]
     },
     {
         "name": "setsuyaku",
         "trans": [
+            "節約(せつやく)",
             "⓪ 名·他动3  节约，节省"
-        ],
-        "notation": "節約(せつやく)"
+        ]
     },
     {
         "name": "senkyo",
         "trans": [
+            "選挙(せんきょ)",
             "① 名·他动3  选举，推选"
-        ],
-        "notation": "選挙(せんきょ)"
+        ]
     },
     {
         "name": "ukaru",
         "trans": [
+            "受(う)かる",
             "② 自动1  （考试）及格，考上"
-        ],
-        "notation": "受(う)かる"
+        ]
     },
     {
         "name": "chikayoru",
         "trans": [
+            "近寄(ちかよ)る",
             "③ 自动1  挨近，靠近"
-        ],
-        "notation": "近寄(ちかよ)る"
+        ]
     },
     {
         "name": "chirakaru",
         "trans": [
+            "散(ち)らかる",
             "⓪ 自动1  零乱，到处都是"
-        ],
-        "notation": "散(ち)らかる"
+        ]
     },
     {
         "name": "shiro",
         "trans": [
+            "城(しろ)",
             "⓪ 名  城池，城堡"
-        ],
-        "notation": "城(しろ)"
+        ]
     },
     {
         "name": "chiru",
         "trans": [
+            "散(ち)る",
             "⓪ 自动1  凋谢；散落，分散"
-        ],
-        "notation": "散(ち)る"
+        ]
     },
     {
         "name": "su-pu",
         "trans": [
+            "スープ",
             "① 名  汤"
-        ],
-        "notation": "スープ"
+        ]
     },
     {
         "name": "ribinguru-mu",
         "trans": [
+            "リビングルーム",
             "⑤ 名  起居室"
-        ],
-        "notation": "リビングルーム"
+        ]
     },
     {
         "name": "odayaka",
         "trans": [
+            "穏(おだ)やか",
             "② ナ形  平稳的；温和的"
-        ],
-        "notation": "穏(おだ)やか"
+        ]
     },
     {
         "name": "arai",
         "trans": [
+            "荒(あら)い",
             "⓪ イ形  剧烈的；粗暴的；乱来的"
-        ],
-        "notation": "荒(あら)い"
+        ]
     },
     {
         "name": "tsukaru",
         "trans": [
+            "浸(つ)かる",
             "⓪ 自动1  浸泡；泡澡"
-        ],
-        "notation": "浸(つ)かる"
+        ]
     },
     {
         "name": "tsukaru",
         "trans": [
+            "漬(つ)かる",
             "⓪ 自动1  （咸菜）腌好，腌透"
-        ],
-        "notation": "漬(つ)かる"
+        ]
     },
     {
         "name": "kakunin",
         "trans": [
+            "確認(かくにん)",
             "⓪ 名·他动3  确认"
-        ],
-        "notation": "確認(かくにん)"
+        ]
     },
     {
         "name": "te-ma",
         "trans": [
+            "テーマ",
             "① 名  主题；论文题目，课题"
-        ],
-        "notation": "テーマ"
+        ]
     },
     {
         "name": "katte",
         "trans": [
+            "勝手(かって)",
             "⓪ 名·ナ形  任意，随便"
-        ],
-        "notation": "勝手(かって)"
+        ]
     },
     {
         "name": "son",
         "trans": [
+            "損(そん)",
             "① 名·ナ形  亏损；吃亏，不利"
-        ],
-        "notation": "損(そん)"
+        ]
     },
     {
         "name": "chuumoku",
         "trans": [
+            "注目(ちゅうもく)",
             "⓪ 名·自他动3  注视，瞩目"
-        ],
-        "notation": "注目(ちゅうもく)"
+        ]
     },
     {
         "name": "toosu",
         "trans": [
+            "通(とお)す",
             "① 他动1  通过，穿过；连续，始终"
-        ],
-        "notation": "通(とお)す"
+        ]
     },
     {
         "name": "sutando",
         "trans": [
+            "スタンド",
             "⓪ 名  看台；（放置物品）台，座"
-        ],
-        "notation": "スタンド"
+        ]
     },
     {
         "name": "nikui",
         "trans": [
+            "憎(にく)い",
             "② イ形  可憎的，可恶的；令人佩服的"
-        ],
-        "notation": "憎(にく)い"
+        ]
     },
     {
         "name": "nikurashii",
         "trans": [
+            "憎(にく)らしい",
             "④ イ形  可憎的，可恶的"
-        ],
-        "notation": "憎(にく)らしい"
+        ]
     },
     {
         "name": "aruiha",
         "trans": [
+            "或(ある)いは",
             "② 接续  或者；或是"
-        ],
-        "notation": "或(ある)いは"
+        ]
     },
     {
         "name": "kaba-",
         "trans": [
+            "カバー",
             "① 名·他动3  外皮，套子；弥补"
-        ],
-        "notation": "カバー"
+        ]
     },
     {
         "name": "nurasu",
         "trans": [
+            "濡(ぬ)らす",
             "⓪ 他动1  弄湿，沾湿"
-        ],
-        "notation": "濡(ぬ)らす"
+        ]
     },
     {
         "name": "nureru",
         "trans": [
+            "濡(ぬ)れる",
             "⓪ 自动2  淋湿，沾湿"
-        ],
-        "notation": "濡(ぬ)れる"
+        ]
     },
     {
         "name": "hatake",
         "trans": [
+            "畑(はたけ)",
             "⓪ 名  田地；专业领域"
-        ],
-        "notation": "畑(はたけ)"
+        ]
     },
     {
         "name": "hihan",
         "trans": [
+            "批判(ひはん)",
             "⓪ 名·他动3  批评，评论"
-        ],
-        "notation": "批判(ひはん)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "掛(か)ける",
             "② 他动2  悬挂；戴上；浇（水）；花费；开动（机器）"
-        ],
-        "notation": "掛(か)ける"
+        ]
     },
     {
         "name": "akogareru",
         "trans": [
+            "憧(あこが)れる",
             "⓪ 自动2  憧憬，向往"
-        ],
-        "notation": "憧(あこが)れる"
+        ]
     },
     {
         "name": "kakaru",
         "trans": [
+            "架(か)かる",
             "② 自动1  架设，安装"
-        ],
-        "notation": "架(か)かる"
+        ]
     },
     {
         "name": "hikiokosu",
         "trans": [
+            "引(ひ)き起(お)こす",
             "④ 他动1  引起（问题）；拉起，拽起"
-        ],
-        "notation": "引(ひ)き起(お)こす"
+        ]
     },
     {
         "name": "ushinau",
         "trans": [
+            "失(うしな)う",
             "⓪ 他动1  失去，丢失；迷失（方向）"
-        ],
-        "notation": "失(うしな)う"
+        ]
     },
     {
         "name": "hisho",
         "trans": [
+            "秘書(ひしょ)",
             "② 名  秘书"
-        ],
-        "notation": "秘書(ひしょ)"
+        ]
     },
     {
         "name": "iyaringu",
         "trans": [
+            "イヤリング",
             "① 名  耳环，耳饰"
-        ],
-        "notation": "イヤリング"
+        ]
     },
     {
         "name": "ajimi",
         "trans": [
+            "味見(あじみ)",
             "⓪ 名·他动3  尝口味，尝咸淡"
-        ],
-        "notation": "味見(あじみ)"
+        ]
     },
     {
         "name": "okiwasureru",
         "trans": [
+            "置(お)き忘(わす)れる",
             "⑤ 他动2  （把物品放在某处）忘记拿，遗失"
-        ],
-        "notation": "置(お)き忘(わす)れる"
+        ]
     },
     {
         "name": "fujiyuu",
         "trans": [
+            "不自由(ふじゆう)",
             "① 名·ナ形  不自由；（手脚）不方便；不方便"
-        ],
-        "notation": "不自由(ふじゆう)"
+        ]
     },
     {
         "name": "namaiki",
         "trans": [
+            "生意気(なまいき)",
             "⓪ 名·ナ形  自大，傲慢，狂妄"
-        ],
-        "notation": "生意気(なまいき)"
+        ]
     },
     {
         "name": "osaeru",
         "trans": [
+            "抑(おさ)える",
             "③ 他动2  压住，按住；控制；忍住"
-        ],
-        "notation": "抑(おさ)える"
+        ]
     },
     {
         "name": "osen",
         "trans": [
+            "汚染(おせん)",
             "⓪ 名·自他动3  污染"
-        ],
-        "notation": "汚染(おせん)"
+        ]
     },
     {
         "name": "togaru",
         "trans": [
+            "尖(とが)る",
             "② 自动1  尖，锐利；（神经）紧张"
-        ],
-        "notation": "尖(とが)る"
+        ]
     },
     {
         "name": "tehai",
         "trans": [
+            "手配(てはい)",
             "① 名·他动3  筹备，安排"
-        ],
-        "notation": "手配(てはい)"
+        ]
     },
     {
         "name": "oshare",
         "trans": [
+            "お洒落(しゃれ)",
             "② 名·ナ形  时尚，讲究穿戴"
-        ],
-        "notation": "お洒落(しゃれ)"
+        ]
     },
     {
         "name": "urayamashii",
         "trans": [
+            "うらやましい",
             "⑤ イ形  羡慕的，眼红的"
-        ],
-        "notation": "うらやましい"
+        ]
     },
     {
         "name": "daunro-do",
         "trans": [
+            "ダウンロード",
             "④ 名·他动3  下载"
-        ],
-        "notation": "ダウンロード"
+        ]
     },
     {
         "name": "ashimoto",
         "trans": [
+            "足元(あしもと)",
             "③ 名  脚下，身边；脚步"
-        ],
-        "notation": "足元(あしもと)"
+        ]
     },
     {
         "name": "sotto",
         "trans": [
+            "そっと",
             "⓪ 副  悄悄地，轻轻地"
-        ],
-        "notation": "そっと"
+        ]
     },
     {
         "name": "uramu",
         "trans": [
+            "恨(うら)む",
             "② 他动1  恨，怨恨，抱怨"
-        ],
-        "notation": "恨(うら)む"
+        ]
     },
     {
         "name": "urami",
         "trans": [
+            "恨(うら)み",
             "③ 名  恨，怨恨，仇恨"
-        ],
-        "notation": "恨(うら)み"
+        ]
     },
     {
         "name": "atesaki",
         "trans": [
+            "宛先(あてさき)",
             "⓪ 名  收件人的姓名、地址"
-        ],
-        "notation": "宛先(あてさき)"
+        ]
     },
     {
         "name": "atena",
         "trans": [
+            "宛名(あてな)",
             "⓪ 名  收件人的姓名"
-        ],
-        "notation": "宛名(あてな)"
+        ]
     },
     {
         "name": "taishita",
         "trans": [
+            "たいした",
             "① 连体  了不起的；（后接否定）不值一提的"
-        ],
-        "notation": "たいした"
+        ]
     },
     {
         "name": "houru",
         "trans": [
+            "放(ほう)る",
             "⓪ 他动1  抛，扔；置之不顾"
-        ],
-        "notation": "放(ほう)る"
+        ]
     },
     {
         "name": "machigau",
         "trans": [
+            "間違(まちが)う",
             "③ 自他动1  错；弄错，搞错"
-        ],
-        "notation": "間違(まちが)う"
+        ]
     },
     {
         "name": "machigaeru",
         "trans": [
+            "間違(まちが)える",
             "④ 他动2  弄错，搞错"
-        ],
-        "notation": "間違(まちが)える"
+        ]
     },
     {
         "name": "adobaisu",
         "trans": [
+            "アドバイス",
             "① 名·他动3  建议，忠告"
-        ],
-        "notation": "アドバイス"
+        ]
     },
     {
         "name": "shouchi",
         "trans": [
+            "招致(しょうち)",
             "① 名·他动3  招揽，聘请"
-        ],
-        "notation": "招致(しょうち)"
+        ]
     },
     {
         "name": "infuruenza",
         "trans": [
+            "インフルエンザ",
             "⑤ 名  流行性感冒"
-        ],
-        "notation": "インフルエンザ"
+        ]
     },
     {
         "name": "fusegu",
         "trans": [
+            "防(ふせ)ぐ",
             "② 他动1  防御，防守；预防"
-        ],
-        "notation": "防(ふせ)ぐ"
+        ]
     },
     {
         "name": "binkan",
         "trans": [
+            "敏感(びんかん)",
             "⓪ 名·ナ形  敏感，感觉敏锐"
-        ],
-        "notation": "敏感(びんかん)"
+        ]
     },
     {
         "name": "atsukau",
         "trans": [
+            "扱(あつか)う",
             "⓪ 他动1  对待（人）；处理（事情）；操作（机械）"
-        ],
-        "notation": "扱(あつか)う"
+        ]
     },
     {
         "name": "urimono",
         "trans": [
+            "売(う)り物(もの)",
             "⓪ 名  商品；招牌，幌子"
-        ],
-        "notation": "売(う)り物(もの)"
+        ]
     },
     {
         "name": "hikkurikaesu",
         "trans": [
+            "ひっくり返(かえ)す",
             "⑤ 他动1  弄倒；翻过来；推翻"
-        ],
-        "notation": "ひっくり返(かえ)す"
+        ]
     },
     {
         "name": "hazusu",
         "trans": [
+            "外(はず)す",
             "⓪ 他动1  取下，卸下；错过（目标、时机等）"
-        ],
-        "notation": "外(はず)す"
+        ]
     },
     {
         "name": "hazureru",
         "trans": [
+            "外(はず)れる",
             "⓪ 自动2  脱落，掉下；落选，落空"
-        ],
-        "notation": "外(はず)れる"
+        ]
     },
     {
         "name": "ule-ta-",
         "trans": [
+            "ウェーター",
             "⓪ 名  男服务员"
-        ],
-        "notation": "ウェーター"
+        ]
     },
     {
         "name": "haisha",
         "trans": [
+            "歯医者(はいしゃ)",
             "① 名  牙科医生"
-        ],
-        "notation": "歯医者(はいしゃ)"
+        ]
     },
     {
         "name": "toritsukeru",
         "trans": [
+            "取(と)り付(つ)ける",
             "④ 他动2  安装（设备）"
-        ],
-        "notation": "取(と)り付(つ)ける"
+        ]
     },
     {
         "name": "tanki",
         "trans": [
+            "短気(たんき)",
             "① 名·ナ形  性子急，没有耐性"
-        ],
-        "notation": "短気(たんき)"
+        ]
     },
     {
         "name": "unazuku",
         "trans": [
+            "頷(うなず)く",
             "③ 自动1  点头，首肯"
-        ],
-        "notation": "頷(うなず)く"
+        ]
     },
     {
         "name": "chippi",
         "trans": [
+            "チップ",
             "① 名  小费"
-        ],
-        "notation": "チップ"
+        ]
     },
     {
         "name": "soroeru",
         "trans": [
+            "揃(そろ)える",
             "③ 他动2  凑齐；使⋯⋯一致"
-        ],
-        "notation": "揃(そろ)える"
+        ]
     },
     {
         "name": "shinrui",
         "trans": [
+            "親類(しんるい)",
             "⓪ 名  亲戚；同类"
-        ],
-        "notation": "親類(しんるい)"
+        ]
     },
     {
         "name": "shoutotsu",
         "trans": [
+            "衝突(しょうとつ)",
             "⓪ 名·自动3  撞上，相撞；冲突，矛盾"
-        ],
-        "notation": "衝突(しょうとつ)"
+        ]
     },
     {
         "name": "oide",
         "trans": [
+            "おいで",
             "⓪ 名  （尊他语）来；去；在"
-        ],
-        "notation": "おいで"
+        ]
     },
     {
         "name": "shoubu",
         "trans": [
+            "勝負(しょうぶ)",
             "① 名·自动3  胜负；比赛"
-        ],
-        "notation": "勝負(しょうぶ)"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "縁(えん)",
             "① 名  缘分；关系"
-        ],
-        "notation": "縁(えん)"
+        ]
     },
     {
         "name": "shinpo",
         "trans": [
+            "進歩(しんぽ)",
             "① 名·自动3  进步"
-        ],
-        "notation": "進歩(しんぽ)"
+        ]
     },
     {
         "name": "shinchou",
         "trans": [
+            "身長(しんちょう)",
             "⓪ 名  身高"
-        ],
-        "notation": "身長(しんちょう)"
+        ]
     },
     {
         "name": "seijika",
         "trans": [
+            "政治家(せいじか)",
             "⓪ 名  政治家"
-        ],
-        "notation": "政治家(せいじか)"
+        ]
     },
     {
         "name": "setsu",
         "trans": [
+            "説(せつ)",
             "① 名  学说；见解"
-        ],
-        "notation": "説(せつ)"
+        ]
     },
     {
         "name": "seigen",
         "trans": [
+            "制限(せいげん)",
             "③ 名·他动3  限制"
-        ],
-        "notation": "制限(せいげん)"
+        ]
     },
     {
         "name": "zenjitsu",
         "trans": [
+            "前日(ぜんじつ)",
             "⓪ 名  前一天"
-        ],
-        "notation": "前日(ぜんじつ)"
+        ]
     },
     {
         "name": "tashizan",
         "trans": [
+            "足(た)し算(ざん)",
             "② 名  （数学）加法"
-        ],
-        "notation": "足(た)し算(ざん)"
+        ]
     },
     {
         "name": "chuushoku",
         "trans": [
+            "昼食(ちゅうしょく)",
             "⓪ 名  午饭"
-        ],
-        "notation": "昼食(ちゅうしょく)"
+        ]
     },
     {
         "name": "yashoku",
         "trans": [
+            "夜食(やしょく)",
             "⓪ 名  晚饭"
-        ],
-        "notation": "夜食(やしょく)"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "就(つ)く",
             "① 自动1  就座；就职；师从"
-        ],
-        "notation": "就(つ)く"
+        ]
     },
     {
         "name": "ouen",
         "trans": [
+            "応援(おうえん)",
             "⓪ 名·他动3  声援；支援，援助"
-        ],
-        "notation": "応援(おうえん)"
+        ]
     },
     {
         "name": "choujou",
         "trans": [
+            "頂上(ちょうじょう)",
             "③ 名  顶峰，山顶；顶点"
-        ],
-        "notation": "頂上(ちょうじょう)"
+        ]
     },
     {
         "name": "anaunsu",
         "trans": [
+            "アナウンス",
             "③ 名·他动3  广播"
-        ],
-        "notation": "アナウンス"
+        ]
     },
     {
         "name": "teiin",
         "trans": [
+            "定員(ていいん)",
             "⓪ 名  定员，规定的人数"
-        ],
-        "notation": "定員(ていいん)"
+        ]
     },
     {
         "name": "~doori",
         "trans": [
+            "～通(どお)り",
             " 接尾  按照⋯⋯；⋯⋯大街"
-        ],
-        "notation": "～通(どお)り"
+        ]
     },
     {
         "name": "guru-pu",
         "trans": [
+            "グループ",
             "② 名  团体，小组"
-        ],
-        "notation": "グループ"
+        ]
     },
     {
         "name": "nagameru",
         "trans": [
+            "眺(なが)める",
             "③ 他动2  眺望；注视"
-        ],
-        "notation": "眺(なが)める"
+        ]
     },
     {
         "name": "osoreru",
         "trans": [
+            "恐(おそ)れる",
             "③ 自动2  害怕；担心"
-        ],
-        "notation": "恐(おそ)れる"
+        ]
     },
     {
         "name": "totan",
         "trans": [
+            "途端(とたん)",
             "⓪ 名  正当⋯⋯的时候，刚一⋯⋯就"
-        ],
-        "notation": "途端(とたん)"
+        ]
     },
     {
         "name": "dezain",
         "trans": [
+            "デザイン",
             "② 名·他动3  设计"
-        ],
-        "notation": "デザイン"
+        ]
     },
     {
         "name": "gaido",
         "trans": [
+            "ガイド",
             "① 名·他动3  向导；指南；引导"
-        ],
-        "notation": "ガイド"
+        ]
     },
     {
         "name": "chousa",
         "trans": [
+            "調査(ちょうさ)",
             "① 名·他动3  调查"
-        ],
-        "notation": "調査(ちょうさ)"
+        ]
     },
     {
         "name": "tabitabi",
         "trans": [
+            "度々(たびたび)",
             "⓪ 副  屡次，再三"
-        ],
-        "notation": "度々(たびたび)"
+        ]
     },
     {
         "name": "sokudo",
         "trans": [
+            "速度(そくど)",
             "① 名  速度"
-        ],
-        "notation": "速度(そくど)"
+        ]
     },
     {
         "name": "ou",
         "trans": [
+            "追(お)う",
             "⓪ 他动1  追，赶；追求；赶开，赶走"
-        ],
-        "notation": "追(お)う"
+        ]
     },
     {
         "name": "sounyuu",
         "trans": [
+            "挿入(そうにゅう)",
             "⓪ 名·他动3  插入，装入"
-        ],
-        "notation": "挿入(そうにゅう)"
+        ]
     },
     {
         "name": "shinchou",
         "trans": [
+            "慎重(しんちょう)",
             "⓪ 名·ナ形  慎重，谨慎"
-        ],
-        "notation": "慎重(しんちょう)"
+        ]
     },
     {
         "name": "purofesshonaru",
         "trans": [
+            "プロフェッショナル",
             "③ ナ形  职业的，专业的"
-        ],
-        "notation": "プロフェッショナル"
+        ]
     },
     {
         "name": "shinto",
         "trans": [
+            "しんと",
             "⓪ 副·自动3  平静下来，鸦雀无声"
-        ],
-        "notation": "しんと"
+        ]
     },
     {
         "name": "orosu",
         "trans": [
+            "下(お)ろす",
             "② 他动1  取下；卸货；使⋯⋯下（车、船等）"
-        ],
-        "notation": "下(お)ろす"
+        ]
     },
     {
         "name": "shokuba",
         "trans": [
+            "職場(しょくば)",
             "⓪ 名  工作单位"
-        ],
-        "notation": "職場(しょくば)"
+        ]
     },
     {
         "name": "omotedoori",
         "trans": [
+            "表通(おもてどお)り",
             "④ 名  主要街道，大马路"
-        ],
-        "notation": "表通(おもてどお)り"
+        ]
     },
     {
         "name": "mainasu",
         "trans": [
+            "マイナス",
             "⓪ 名·他动3  负面，不利；减号，负数；减去"
-        ],
-        "notation": "マイナス"
+        ]
     },
     {
         "name": "kakasu",
         "trans": [
+            "欠(か)かす",
             "⓪ 他动1  缺少"
-        ],
-        "notation": "欠(か)かす"
+        ]
     },
     {
         "name": "juken",
         "trans": [
+            "受験(じゅけん)",
             "⓪ 名·自动3  参加考试"
-        ],
-        "notation": "受験(じゅけん)"
+        ]
     },
     {
         "name": "shouji",
         "trans": [
+            "障子(しょうじ)",
             "⓪ 名  （日式房屋的）拉门，隔扇"
-        ],
-        "notation": "障子(しょうじ)"
+        ]
     },
     {
         "name": "kakitoru",
         "trans": [
+            "書(か)き取(と)る",
             "③ 他动1  记录；抄录；听写"
-        ],
-        "notation": "書(か)き取(と)る"
+        ]
     },
     {
         "name": "sukikirai",
         "trans": [
+            "好(すき)き嫌(ら)い",
             "② 名  好恶；挑剔"
-        ],
-        "notation": "好(すき)き嫌(ら)い"
+        ]
     },
     {
         "name": "senden",
         "trans": [
+            "宣伝(せんでん)",
             "⓪ 名·他动3  宣传"
-        ],
-        "notation": "宣伝(せんでん)"
+        ]
     },
     {
         "name": "gakumon",
         "trans": [
+            "学問(がくもん)",
             "② 名  学问，学识"
-        ],
-        "notation": "学問(がくもん)"
+        ]
     },
     {
         "name": "iikaeru",
         "trans": [
+            "言(い)い換(か)える",
             "③ 他动2  换句话说，改变说法"
-        ],
-        "notation": "言(い)い換(か)える"
+        ]
     },
     {
         "name": "daiku",
         "trans": [
+            "大工(だいく)",
             "① 名  木匠；木工活儿"
-        ],
-        "notation": "大工(だいく)"
+        ]
     },
     {
         "name": "kakureru",
         "trans": [
+            "隠(かく)れる",
             "③ 自动2  隐藏，躲藏；埋没"
-        ],
-        "notation": "隠(かく)れる"
+        ]
     },
     {
         "name": "toppu",
         "trans": [
+            "トップ",
             "① 名  最高级；第一位；（报纸）头条"
-        ],
-        "notation": "トップ"
+        ]
     },
     {
         "name": "tsukiatari",
         "trans": [
+            "突(つ)き当(あ)たり",
             "⓪ 名  撞上，碰上；（道路）尽头"
-        ],
-        "notation": "突(つ)き当(あ)たり"
+        ]
     },
     {
         "name": "kakomu",
         "trans": [
+            "囲(かこ)む",
             "⓪ 他动1  包围，围绕"
-        ],
-        "notation": "囲(かこ)む"
+        ]
     },
     {
         "name": "iikagen",
         "trans": [
+            "いい加減(かげん)",
             "⓪ ナ形  合适的，适当的；敷衍的，搪塞的"
-        ],
-        "notation": "いい加減(かげん)"
+        ]
     },
     {
         "name": "tema",
         "trans": [
+            "手間(てま)",
             "② 名  工夫，劳力和时间"
-        ],
-        "notation": "手間(てま)"
+        ]
     },
     {
         "name": "dokomademo",
         "trans": [
+            "どこまでも",
             "① 副  到哪里都；直到最后，始终"
-        ],
-        "notation": "どこまでも"
+        ]
     },
     {
         "name": "nagasu",
         "trans": [
+            "流(なが)す",
             "② 他动1  冲走；流（汗、泪）；传播，散布"
-        ],
-        "notation": "流(なが)す"
+        ]
     },
     {
         "name": "nigiru",
         "trans": [
+            "握(にぎ)る",
             "⓪ 他动1  抓，握；掌握；攥（饭团、寿司）"
-        ],
-        "notation": "握(にぎ)る"
+        ]
     },
     {
         "name": "kakaku",
         "trans": [
+            "価格(かかく)",
             "⓪ 名  价格"
-        ],
-        "notation": "価格(かかく)"
+        ]
     },
     {
         "name": "ule-toresu",
         "trans": [
+            "ウェートレス",
             "② 名  女服务员"
-        ],
-        "notation": "ウェートレス"
+        ]
     },
     {
         "name": "nichijou",
         "trans": [
+            "日常(にちじょう)",
             "⓪ 名  日常，平时"
-        ],
-        "notation": "日常(にちじょう)"
+        ]
     },
     {
         "name": "dentatsu",
         "trans": [
+            "伝達(でんたつ)",
             "⓪ 名·他动3  传达，转达"
-        ],
-        "notation": "伝達(でんたつ)"
+        ]
     },
     {
         "name": "tsunagaru",
         "trans": [
+            "繋(つな)がる",
             "⓪ 自动1  连接，相连；牵连，有关联"
-        ],
-        "notation": "繋(つな)がる"
+        ]
     },
     {
         "name": "tsunagu",
         "trans": [
+            "繋(つな)ぐ",
             "⓪ 他动1  系，拴；连接；维持（生命、希望等）"
-        ],
-        "notation": "繋(つな)ぐ"
+        ]
     },
     {
         "name": "intabyu-",
         "trans": [
+            "インタビュー",
             "① 名·自动3  采访，访问"
-        ],
-        "notation": "インタビュー"
+        ]
     },
     {
         "name": "tairyou",
         "trans": [
+            "大量(たいりょう)",
             "⓪ 名·ナ形  大量"
-        ],
-        "notation": "大量(たいりょう)"
+        ]
     },
     {
         "name": "senkou",
         "trans": [
+            "専攻(せんこう)",
             "⓪ 名·他动3  专业，专攻"
-        ],
-        "notation": "専攻(せんこう)"
+        ]
     },
     {
         "name": "seikaku",
         "trans": [
+            "性格(せいかく)",
             "⓪ 名  性格"
-        ],
-        "notation": "性格(せいかく)"
+        ]
     },
     {
         "name": "uketori",
         "trans": [
+            "受(う)け取(と)り",
             "⓪ 名  收取，领取；收据"
-        ],
-        "notation": "受(う)け取(と)り"
+        ]
     },
     {
         "name": "idaku",
         "trans": [
+            "抱(いだ)く",
             "② 他动1  抱，怀抱；（心里）怀有，怀抱"
-        ],
-        "notation": "抱(いだ)く"
+        ]
     },
     {
         "name": "unchin",
         "trans": [
+            "運賃(うんちん)",
             "① 名  运费"
-        ],
-        "notation": "運賃(うんちん)"
+        ]
     },
     {
         "name": "shingaku",
         "trans": [
+            "進学(しんがく)",
             "⓪ 名·自动3  升学"
-        ],
-        "notation": "進学(しんがく)"
+        ]
     },
     {
         "name": "shimei",
         "trans": [
+            "氏名(しめい)",
             "① 名  姓名"
-        ],
-        "notation": "氏名(しめい)"
+        ]
     },
     {
         "name": "samasu",
         "trans": [
+            "冷(さ)ます",
             "② 他动1  冷却，弄凉；扫兴，泼冷水"
-        ],
-        "notation": "冷(さ)ます"
+        ]
     },
     {
         "name": "sameru",
         "trans": [
+            "冷(さ)める",
             "② 自动2  变凉；（热情等）减退"
-        ],
-        "notation": "冷(さ)める"
+        ]
     },
     {
         "name": "eiyou",
         "trans": [
+            "栄養(えいよう)",
             "⓪ 名  营养"
-        ],
-        "notation": "栄養(えいよう)"
+        ]
     },
     {
         "name": "omoigakenai",
         "trans": [
+            "思(おも)いがけない",
             "⑤ イ形  意想不到的，意外的"
-        ],
-        "notation": "思(おも)いがけない"
+        ]
     },
     {
         "name": "kotonaru",
         "trans": [
+            "異(こと)なる",
             "③ 自动1  不同，不一样"
-        ],
-        "notation": "異(こと)なる"
+        ]
     },
     {
         "name": "ko-chi",
         "trans": [
+            "コーチ",
             "① 名  教练，技术指导"
-        ],
-        "notation": "コーチ"
+        ]
     },
     {
         "name": "kouryuu",
         "trans": [
+            "交流(こうりゅう)",
             "⓪ 名·自动3  交流，往来"
-        ],
-        "notation": "交流(こうりゅう)"
+        ]
     },
     {
         "name": "usotsuki",
         "trans": [
+            "嘘(うそ)つき",
             "② 名  说谎；爱撒谎的人"
-        ],
-        "notation": "嘘(うそ)つき"
+        ]
     },
     {
         "name": "kenkyo",
         "trans": [
+            "謙虚(けんきょ)",
             "① ナ形  谦虚的，谦和的"
-        ],
-        "notation": "謙虚(けんきょ)"
+        ]
     },
     {
         "name": "kuri-ningu",
         "trans": [
+            "クリーニング",
             "② 名  洗衣服，干洗"
-        ],
-        "notation": "クリーニング"
+        ]
     },
     {
         "name": "uketsukeru",
         "trans": [
+            "受(う)け付(つ)ける",
             "④ 他动2  接受，受理（申请等）"
-        ],
-        "notation": "受(う)け付(つ)ける"
+        ]
     },
     {
         "name": "ikuranandemo",
         "trans": [
+            "いくらなんでも",
             "① 副  无论怎么，即使⋯⋯也⋯⋯"
-        ],
-        "notation": "いくらなんでも"
+        ]
     },
     {
         "name": "keizaiteki",
         "trans": [
+            "経済的(けいざいてき)",
             "⓪ ナ形  经济方面的；节约的"
-        ],
-        "notation": "経済的(けいざいてき)"
+        ]
     },
     {
         "name": "kosu",
         "trans": [
+            "越(こ)す",
             "⓪ 自他动1  越过，跨过（高处）；度过（时间）；超过，胜过"
-        ],
-        "notation": "越(こ)す"
+        ]
     },
     {
         "name": "oudan",
         "trans": [
+            "横断(おうだん)",
             "⓪ 名·他动3  横穿，横渡；横着切"
-        ],
-        "notation": "横断(おうだん)"
+        ]
     },
     {
         "name": "kaigyou",
         "trans": [
+            "改行(かいぎょう)",
             "⓪ 名·自动3  （文章）另起一行，换行"
-        ],
-        "notation": "改行(かいぎょう)"
+        ]
     },
     {
         "name": "ikimono",
         "trans": [
+            "生(い)き物(もの)",
             "③ 名  生物；有生命的东西"
-        ],
-        "notation": "生(い)き物(もの)"
+        ]
     },
     {
         "name": "kosuru",
         "trans": [
+            "擦(こす)る",
             "② 他动1  擦，揉，搓"
-        ],
-        "notation": "擦(こす)る"
+        ]
     },
     {
         "name": "gakki",
         "trans": [
+            "学期(がっき)",
             "⓪ 名  学期"
-        ],
-        "notation": "学期(がっき)"
+        ]
     },
     {
         "name": "shimesu",
         "trans": [
+            "示(しめ)す",
             "② 他动1  展示，出示；表示；指示"
-        ],
-        "notation": "示(しめ)す"
+        ]
     },
     {
         "name": "daitouryou",
         "trans": [
+            "大統領(だいとうりょう)",
             "③ 名  总统"
-        ],
-        "notation": "大統領(だいとうりょう)"
+        ]
     },
     {
         "name": "katsudou",
         "trans": [
+            "活動(かつどう)",
             "⓪ 名·自动3  活动"
-        ],
-        "notation": "活動(かつどう)"
+        ]
     },
     {
         "name": "isoide",
         "trans": [
+            "急(いそ)いで",
             "② 副  赶紧，急忙"
-        ],
-        "notation": "急(いそ)いで"
+        ]
     },
     {
         "name": "ayashii",
         "trans": [
+            "怪(あや)しい",
             "⓪ イ形  可疑的，奇怪的；靠不住的"
-        ],
-        "notation": "怪(あや)しい"
+        ]
     },
     {
         "name": "shushou",
         "trans": [
+            "首相(しゅしょう)",
             "⓪ 名  首相"
-        ],
-        "notation": "首相(しゅしょう)"
+        ]
     },
     {
         "name": "iryou",
         "trans": [
+            "医療(いりょう)",
             "① 名  医疗，治疗"
-        ],
-        "notation": "医療(いりょう)"
+        ]
     },
     {
         "name": "nenjuu",
         "trans": [
+            "年中(ねんじゅう)",
             "① 名·副  全年，整年；一年到头，经常地"
-        ],
-        "notation": "年中(ねんじゅう)"
+        ]
     },
     {
         "name": "hasamu",
         "trans": [
+            "挟(はさ)む",
             "② 他动1  插，插入；夹；隔着"
-        ],
-        "notation": "挟(はさ)む"
+        ]
     },
     {
         "name": "hasamaru",
         "trans": [
+            "挟(はさ)まる",
             "③ 自动1  夹在⋯⋯之间"
-        ],
-        "notation": "挟(はさ)まる"
+        ]
     },
     {
         "name": "purattoho-mu",
         "trans": [
+            "プラットホーム",
             "⑤ 名  站台，月台"
-        ],
-        "notation": "プラットホーム"
+        ]
     },
     {
         "name": "machiawaseru",
         "trans": [
+            "待(ま)ち合(あ)わせる",
             "⑤ 自他动2  碰头，会面"
-        ],
-        "notation": "待(ま)ち合(あ)わせる"
+        ]
     },
     {
         "name": "otoshidama",
         "trans": [
+            "お年玉(としだま)",
             "⓪ 名  压岁钱"
-        ],
-        "notation": "お年玉(としだま)"
+        ]
     },
     {
         "name": "horu",
         "trans": [
+            "掘(ほ)る",
             "① 他动1  挖，挖掘，刨"
-        ],
-        "notation": "掘(ほ)る"
+        ]
     },
     {
         "name": "hameru",
         "trans": [
+            "嵌(は)める",
             "⓪ 他动2  镶嵌；戴上；欺骗，使⋯⋯陷入"
-        ],
-        "notation": "嵌(は)める"
+        ]
     },
     {
         "name": "ochiba",
         "trans": [
+            "落(お)ち葉(ば)",
             "① 名  落叶"
-        ],
-        "notation": "落(お)ち葉(ば)"
+        ]
     },
     {
         "name": "arasou",
         "trans": [
+            "争(あらそ)う",
             "③ 他动1  争夺；斗争；争论"
-        ],
-        "notation": "争(あらそ)う"
+        ]
     },
     {
         "name": "nurui",
         "trans": [
+            "温(ぬる)い",
             "② イ形  微温的；温和的，不严厉的"
-        ],
-        "notation": "温(ぬる)い"
+        ]
     },
     {
         "name": "se-rusu",
         "trans": [
+            "セールス",
             "① 名  推销，销售"
-        ],
-        "notation": "セールス"
+        ]
     },
     {
         "name": "tsumaru",
         "trans": [
+            "詰(つ)まる",
             "② 自动1  堵塞；挤满，塞满"
-        ],
-        "notation": "詰(つ)まる"
+        ]
     },
     {
         "name": "tsumeru",
         "trans": [
+            "詰(つ)める",
             "② 他动2  填，塞；挤紧"
-        ],
-        "notation": "詰(つ)める"
+        ]
     },
     {
         "name": "tatakau",
         "trans": [
+            "戦(たたか)う",
             "⓪ 自动1  战斗；比赛；与⋯⋯斗争"
-        ],
-        "notation": "戦(たたか)う"
+        ]
     },
     {
         "name": "sunawachi",
         "trans": [
+            "すなわち",
             "② 接续  换言之，也就是；正是，即是"
-        ],
-        "notation": "すなわち"
+        ]
     },
     {
         "name": "anke-to",
         "trans": [
+            "アンケート",
             "① 名  问卷调查"
-        ],
-        "notation": "アンケート"
+        ]
     },
     {
         "name": "juuten",
         "trans": [
+            "重点(じゅうてん)",
             "③ 名  重点"
-        ],
-        "notation": "重点(じゅうてん)"
+        ]
     },
     {
         "name": "shitashii",
         "trans": [
+            "親(した)しい",
             "③ イ形  亲密的，亲切的；熟悉的"
-        ],
-        "notation": "親(した)しい"
+        ]
     },
     {
         "name": "konzatsu",
         "trans": [
+            "混雑(こんざつ)",
             "① 名·自动3  混乱，拥挤"
-        ],
-        "notation": "混雑(こんざつ)"
+        ]
     },
     {
         "name": "kenmei",
         "trans": [
+            "懸命(けんめい)",
             "⓪ ナ形  拼命的，奋力的"
-        ],
-        "notation": "懸命(けんめい)"
+        ]
     },
     {
         "name": "ochitsuku",
         "trans": [
+            "落(お)ち着(つ)く",
             "⓪ 自动1  沉着，镇静；稳定；定居"
-        ],
-        "notation": "落(お)ち着(つ)く"
+        ]
     },
     {
         "name": "kezuru",
         "trans": [
+            "削(けず)る",
             "⓪ 他动1  （用刀）削，刨；削减，删去"
-        ],
-        "notation": "削(けず)る"
+        ]
     },
     {
         "name": "kiraku",
         "trans": [
+            "気楽(きらく)",
             "⓪ 名·ナ形  舒适，安逸"
-        ],
-        "notation": "気楽(きらく)"
+        ]
     },
     {
         "name": "mushiatsui",
         "trans": [
+            "蒸(む)し暑(あつ)い",
             "④ イ形  闷热的"
-        ],
-        "notation": "蒸(む)し暑(あつ)い"
+        ]
     },
     {
         "name": "demukaeru",
         "trans": [
+            "出迎(でむか)える",
             "④ 他动2  迎接"
-        ],
-        "notation": "出迎(でむか)える"
+        ]
     },
     {
         "name": "sentakuki",
         "trans": [
+            "洗濯機(せんたくき)",
             "④ 名  洗衣机"
-        ],
-        "notation": "洗濯機(せんたくき)"
+        ]
     },
     {
         "name": "doraibu",
         "trans": [
+            "ドライブ",
             "② 名·自动3  开车兜风"
-        ],
-        "notation": "ドライブ"
+        ]
     },
     {
         "name": "doraiba-",
         "trans": [
+            "ドライバー",
             "⓪ 名  司机"
-        ],
-        "notation": "ドライバー"
+        ]
     },
     {
         "name": "kaizen",
         "trans": [
+            "改善(かいぜん)",
             "⓪ 名·他动3  改善，改进"
-        ],
-        "notation": "改善(かいぜん)"
+        ]
     },
     {
         "name": "fukumu",
         "trans": [
+            "含(ふく)む",
             "② 他动1  包含，包括；怀有"
-        ],
-        "notation": "含(ふく)む"
+        ]
     },
     {
         "name": "fukumeru",
         "trans": [
+            "含(ふく)める",
             "③ 他动2  包含，包括"
-        ],
-        "notation": "含(ふく)める"
+        ]
     },
     {
         "name": "yorokobashii",
         "trans": [
+            "喜(よろこ)ばしい",
             "⑤ イ形  喜悦的，令人高兴的"
-        ],
-        "notation": "喜(よろこ)ばしい"
+        ]
     },
     {
         "name": "warukuchi",
         "trans": [
+            "悪口(わるくち)",
             "② 名  坏话，诽谤"
-        ],
-        "notation": "悪口(わるくち)"
+        ]
     },
     {
         "name": "jikken",
         "trans": [
+            "実験(じっけん)",
             "⓪ 名·他动3  实验；实际体验"
-        ],
-        "notation": "実験(じっけん)"
+        ]
     },
     {
         "name": "shitsukoi",
         "trans": [
+            "しつこい",
             "③ イ形  （气味）浓厚的，腻人的；执拗的，纠缠不休的"
-        ],
-        "notation": "しつこい"
+        ]
     },
     {
         "name": "abareru",
         "trans": [
+            "暴(あば)れる",
             "⓪ 自动2  胡闹，乱闹；横冲直撞"
-        ],
-        "notation": "暴(あば)れる"
+        ]
     },
     {
         "name": "jitto",
         "trans": [
+            "じっと",
             "⓪ 副·自动3  一动不动；聚精会神地（听、看等）"
-        ],
-        "notation": "じっと"
+        ]
     },
     {
         "name": "shibaru",
         "trans": [
+            "縛(しば)る",
             "② 他动1  捆，绑；束缚，限制"
-        ],
-        "notation": "縛(しば)る"
+        ]
     },
     {
         "name": "komyunike-shon",
         "trans": [
+            "コミュニケーション",
             "④ 名  交流，沟通"
-        ],
-        "notation": "コミュニケーション"
+        ]
     },
     {
         "name": "kekkin",
         "trans": [
+            "欠勤(けっきん)",
             "⓪ 名·自动3  缺勤，请假"
-        ],
-        "notation": "欠勤(けっきん)"
+        ]
     },
     {
         "name": "kaikaishiki",
         "trans": [
+            "開会式(かいかいしき)",
             "③ 名  开幕式"
-        ],
-        "notation": "開会式(かいかいしき)"
+        ]
     },
     {
         "name": "kinodoku",
         "trans": [
+            "気(き)の毒(どく)",
             "③ 名·ナ形  可怜，可悲；可惜，遗憾"
-        ],
-        "notation": "気(き)の毒(どく)"
+        ]
     },
     {
         "name": "niru",
         "trans": [
+            "煮(に)る",
             "⓪ 他动2  煮，炖，熬"
-        ],
-        "notation": "煮(に)る"
+        ]
     },
     {
         "name": "nobasu",
         "trans": [
+            "伸(の)ばす",
             "② 他动1  延长，拉长；伸展；发挥（才能）"
-        ],
-        "notation": "伸(の)ばす"
+        ]
     },
     {
         "name": "nobiru",
         "trans": [
+            "伸(の)びる",
             "② 自动2  变长，伸长；（褶皱）展开；扩大，增加"
-        ],
-        "notation": "伸(の)びる"
+        ]
     },
     {
         "name": "nobasu",
         "trans": [
+            "延(の)ばす",
             "② 他动1  延缓，拖延"
-        ],
-        "notation": "延(の)ばす"
+        ]
     },
     {
         "name": "nobiru",
         "trans": [
+            "延(の)びる",
             "② 自动2  （时间）延长，延期"
-        ],
-        "notation": "延(の)びる"
+        ]
     },
     {
         "name": "uriage",
         "trans": [
+            "売(う)り上(あ)げ",
             "⓪ 名  销售额，营业额"
-        ],
-        "notation": "売(う)り上(あ)げ"
+        ]
     },
     {
         "name": "itoko",
         "trans": [
+            "いとこ",
             "② 名  堂兄弟（姐妹）；表兄弟（姐妹）"
-        ],
-        "notation": "いとこ"
+        ]
     },
     {
         "name": "fuyukai",
         "trans": [
+            "不愉快(ふゆかい)",
             "② ナ形  不愉快的，不高兴的"
-        ],
-        "notation": "不愉快(ふゆかい)"
+        ]
     },
     {
         "name": "inemuri",
         "trans": [
+            "居眠(いねむ)り",
             "③ 名·自动3  瞌睡，打盹儿"
-        ],
-        "notation": "居眠(いねむ)り"
+        ]
     },
     {
         "name": "ibiki",
         "trans": [
+            "鼾(いびき)",
             "③ 名  鼾声"
-        ],
-        "notation": "鼾(いびき)"
+        ]
     },
     {
         "name": "tameru",
         "trans": [
+            "貯(た)める",
             "⓪ 他动2  存储，积蓄"
-        ],
-        "notation": "貯(た)める"
+        ]
     },
     {
         "name": "sukkari",
         "trans": [
+            "すっかり",
             "③ 副  全部，完全"
-        ],
-        "notation": "すっかり"
+        ]
     },
     {
         "name": "shokugyou",
         "trans": [
+            "職業(しょくぎょう)",
             "② 名  职业"
-        ],
-        "notation": "職業(しょくぎょう)"
+        ]
     },
     {
         "name": "kuyashii",
         "trans": [
+            "悔(くや)しい",
             "③ イ形  遗憾的，懊悔的"
-        ],
-        "notation": "悔(くや)しい"
+        ]
     },
     {
         "name": "kuyashigaru",
         "trans": [
+            "悔(くや)しがる",
             "④ 自动1  遗憾，懊悔"
-        ],
-        "notation": "悔(くや)しがる"
+        ]
     },
     {
         "name": "kuyamu",
         "trans": [
+            "悔(く)やむ",
             "② 他动1  后悔，遗憾"
-        ],
-        "notation": "悔(く)やむ"
+        ]
     },
     {
         "name": "kinchou",
         "trans": [
+            "緊張(きんちょう)",
             "⓪ 名·自动3  紧张"
-        ],
-        "notation": "緊張(きんちょう)"
+        ]
     },
     {
         "name": "uchigawa",
         "trans": [
+            "内側(うちがわ)",
             "⓪ 名  内侧，里面"
-        ],
-        "notation": "内側(うちがわ)"
+        ]
     },
     {
         "name": "nozomu",
         "trans": [
+            "望(のぞ)む",
             "⓪ 他动1  眺望；希望，期望"
-        ],
-        "notation": "望(のぞ)む"
+        ]
     },
     {
         "name": "nemaki",
         "trans": [
+            "寝巻(ねま)き",
             "⓪ 名  睡衣"
-        ],
-        "notation": "寝巻(ねま)き"
+        ]
     },
     {
         "name": "mazeru",
         "trans": [
+            "混(ま)ぜる",
             "② 他动2  混合；搅拌"
-        ],
-        "notation": "混(ま)ぜる"
+        ]
     },
     {
         "name": "susumeru",
         "trans": [
+            "勧(すす)める",
             "⓪ 他动2  劝告，劝诱"
-        ],
-        "notation": "勧(すす)める"
+        ]
     },
     {
         "name": "fusoku",
         "trans": [
+            "不足(ふそく)",
             "⓪ 名·ナ形·自动3  不足，缺乏"
-        ],
-        "notation": "不足(ふそく)"
+        ]
     },
     {
         "name": "yoyuu",
         "trans": [
+            "余裕(よゆう)",
             "⓪ 名  富余；充裕，从容"
-        ],
-        "notation": "余裕(よゆう)"
+        ]
     },
     {
         "name": "sumasu",
         "trans": [
+            "済(す)ます",
             "② 他动1  做完，办完；凑合，将就"
-        ],
-        "notation": "済(す)ます"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "済(す)む",
             "① 自动1  结束，完了；解决，过得去"
-        ],
-        "notation": "済(す)む"
+        ]
     },
     {
         "name": "amayakasu",
         "trans": [
+            "甘(あま)やかす",
             "⓪ 他动1  娇纵，放任"
-        ],
-        "notation": "甘(あま)やかす"
+        ]
     },
     {
         "name": "seisaku",
         "trans": [
+            "製作(せいさく)",
             "⓪ 名·他动3  制造，生产（工业产品）"
-        ],
-        "notation": "製作(せいさく)"
+        ]
     },
     {
         "name": "handobukke",
         "trans": [
+            "ハンドブック",
             "④ 名  手册，指南"
-        ],
-        "notation": "ハンドブック"
+        ]
     },
     {
         "name": "miageru",
         "trans": [
+            "見上(みあ)げる",
             "⓪ 他动2  仰视，抬头看；尊重，敬佩"
-        ],
-        "notation": "見上(みあ)げる"
+        ]
     },
     {
         "name": "miorosu",
         "trans": [
+            "見下(みお)ろす",
             "⓪ 他动1  俯视，向下看；轻视，蔑视"
-        ],
-        "notation": "見下(みお)ろす"
+        ]
     },
     {
         "name": "yoake",
         "trans": [
+            "夜明(よあ)け",
             "③ 名  拂晓，黎明"
-        ],
-        "notation": "夜明(よあ)け"
+        ]
     },
     {
         "name": "unaru",
         "trans": [
+            "唸(うな)る",
             "② 自动1  （动物）吼叫；呻吟；（机器）轰鸣，（狂风）呼啸"
-        ],
-        "notation": "唸(うな)る"
+        ]
     },
     {
         "name": "soubetsukai",
         "trans": [
+            "送別会(そうべつかい)",
             "⓪ 名  欢送会，送别会"
-        ],
-        "notation": "送別会(そうべつかい)"
+        ]
     },
     {
         "name": "kogoeru",
         "trans": [
+            "凍(こご)える",
             "⓪ 自动2  冻僵"
-        ],
-        "notation": "凍(こご)える"
+        ]
     },
     {
         "name": "gimon",
         "trans": [
+            "疑問(ぎもん)",
             "⓪ 名  疑问"
-        ],
-        "notation": "疑問(ぎもん)"
+        ]
     },
     {
         "name": "ihan",
         "trans": [
+            "違反(いはん)",
             "⓪ 名·自动3  违反"
-        ],
-        "notation": "違反(いはん)"
+        ]
     },
     {
         "name": "gimu",
         "trans": [
+            "義務(ぎむ)",
             "① 名  义务"
-        ],
-        "notation": "義務(ぎむ)"
+        ]
     },
     {
         "name": "sotsugyoushiki",
         "trans": [
+            "卒業式(そつぎょうしき)",
             "③ 名  毕业典礼"
-        ],
-        "notation": "卒業式(そつぎょうしき)"
+        ]
     },
     {
         "name": "bakarashii",
         "trans": [
+            "馬鹿(ばか)らしい",
             "④ イ形  愚蠢的；无聊的；不值得的"
-        ],
-        "notation": "馬鹿(ばか)らしい"
+        ]
     },
     {
         "name": "jikyuu",
         "trans": [
+            "時給(じきゅう)",
             "⓪ 名  时薪"
-        ],
-        "notation": "時給(じきゅう)"
+        ]
     },
     {
         "name": "noriokureru",
         "trans": [
+            "乗(の)り遅(おく)れる",
             "⑤ 自动2  没赶上（交通工具）；跟不上（潮流）"
-        ],
-        "notation": "乗(の)り遅(おく)れる"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "蒔(ま)く",
             "① 他动1  播，种"
-        ],
-        "notation": "蒔(ま)く"
+        ]
     },
     {
         "name": "ippoutsuukou",
         "trans": [
+            "一方通行(いっぽうつうこう)",
             "⑤ 名  单向通行"
-        ],
-        "notation": "一方通行(いっぽうつうこう)"
+        ]
     },
     {
         "name": "tenjou",
         "trans": [
+            "天井(てんじょう)",
             "⓪ 名  天花板，顶棚"
-        ],
-        "notation": "天井(てんじょう)"
+        ]
     },
     {
         "name": "shishutsu",
         "trans": [
+            "支出(ししゅつ)",
             "⓪ 名·他动3  支出，开支"
-        ],
-        "notation": "支出(ししゅつ)"
+        ]
     },
     {
         "name": "kiyoi",
         "trans": [
+            "清(きよ)い",
             "② イ形  清澈的；纯洁的"
-        ],
-        "notation": "清(きよ)い"
+        ]
     },
     {
         "name": "kansuru",
         "trans": [
+            "関(かん)する",
             "③ 自动3  与⋯⋯有关，关于"
-        ],
-        "notation": "関(かん)する"
+        ]
     },
     {
         "name": "karai",
         "trans": [
+            "辛(から)い",
             "② イ形  辣的"
-        ],
-        "notation": "辛(から)い"
+        ]
     },
     {
         "name": "hyouban",
         "trans": [
+            "評判(ひょうばん)",
             "⓪ 名  评论，评价；出名，有名"
-        ],
-        "notation": "評判(ひょうばん)"
+        ]
     },
     {
         "name": "mijime",
         "trans": [
+            "惨(みじ)め",
             "① ナ形  凄惨的，悲惨的"
-        ],
-        "notation": "惨(みじ)め"
+        ]
     },
     {
         "name": "reji",
         "trans": [
+            "レジ",
             "① 名  收银员；收银台"
-        ],
-        "notation": "レジ"
+        ]
     },
     {
         "name": "chirakasu",
         "trans": [
+            "散(ち)らかす",
             "⓪ 他动1  弄乱，乱扔"
-        ],
-        "notation": "散(ち)らかす"
+        ]
     },
     {
         "name": "tsui",
         "trans": [
+            "つい",
             "① 副  无意中，不由得；（时间、距离）相隔不远"
-        ],
-        "notation": "つい"
+        ]
     },
     {
         "name": "ippanteki",
         "trans": [
+            "一般的(いっぱんてき)",
             "⓪ ナ形  一般的"
-        ],
-        "notation": "一般的(いっぱんてき)"
+        ]
     },
     {
         "name": "ippan",
         "trans": [
+            "一般(いっぱん)",
             "⓪ 名·ナ形  普通；普遍"
-        ],
-        "notation": "一般(いっぱん)"
+        ]
     },
     {
         "name": "chuumon",
         "trans": [
+            "注文(ちゅうもん)",
             "⓪ 名·他动3  订货，订购，点餐；要求"
-        ],
-        "notation": "注文(ちゅうもん)"
+        ]
     },
     {
         "name": "shuukan",
         "trans": [
+            "週間(しゅうかん)",
             "⓪ 名  一周，一个星期"
-        ],
-        "notation": "週間(しゅうかん)"
+        ]
     },
     {
         "name": "kabuseru",
         "trans": [
+            "被(かぶ)せる",
             "③ 他动2  戴上；盖上，蒙上"
-        ],
-        "notation": "被(かぶ)せる"
+        ]
     },
     {
         "name": "todana",
         "trans": [
+            "戸棚(とだな)",
             "⓪ 名  橱，柜"
-        ],
-        "notation": "戸棚(とだな)"
+        ]
     },
     {
         "name": "hanashiau",
         "trans": [
+            "話(はな)し合(あ)う",
             "④ 自动1  谈话，对话；商量"
-        ],
-        "notation": "話(はな)し合(あ)う"
+        ]
     },
     {
         "name": "taisuru",
         "trans": [
+            "対(たい)する",
             "③ 自动3  对于；对待；面向，面对"
-        ],
-        "notation": "対(たい)する"
+        ]
     },
     {
         "name": "baiku",
         "trans": [
+            "バイク",
             "① 名  摩托车"
-        ],
-        "notation": "バイク"
+        ]
     },
     {
         "name": "waru",
         "trans": [
+            "割(わ)る",
             "⓪ 他动1  弄碎；分，切；分配"
-        ],
-        "notation": "割(わ)る"
+        ]
     },
     {
         "name": "wareru",
         "trans": [
+            "割(わ)れる",
             "⓪ 自动2  碎，坏；分裂"
-        ],
-        "notation": "割(わ)れる"
+        ]
     },
     {
         "name": "chuugata",
         "trans": [
+            "中型(ちゅうがた)",
             "⓪ 名  中型，中等大小"
-        ],
-        "notation": "中型(ちゅうがた)"
+        ]
     },
     {
         "name": "kazari",
         "trans": [
+            "飾(かざ)り",
             "⓪ 名  装饰，饰品；粉饰，华而不实"
-        ],
-        "notation": "飾(かざ)り"
+        ]
     },
     {
         "name": "wakasu",
         "trans": [
+            "沸(わ)かす",
             "⓪ 他动1  烧开，烧热；使⋯⋯激动"
-        ],
-        "notation": "沸(わ)かす"
+        ]
     },
     {
         "name": "waku",
         "trans": [
+            "沸(わ)く",
             "⓪ 自动1  （液体）沸腾；激动"
-        ],
-        "notation": "沸(わ)く"
+        ]
     },
     {
         "name": "taiseki",
         "trans": [
+            "体積(たいせき)",
             "① 名  体积"
-        ],
-        "notation": "体積(たいせき)"
+        ]
     },
     {
         "name": "joutai",
         "trans": [
+            "状態(じょうたい)",
             "⓪ 名  状态，情况"
-        ],
-        "notation": "状態(じょうたい)"
+        ]
     },
     {
         "name": "kyougi",
         "trans": [
+            "競技(きょうぎ)",
             "① 名·自动3  竞技，比赛"
-        ],
-        "notation": "競技(きょうぎ)"
+        ]
     },
     {
         "name": "shitaku",
         "trans": [
+            "支度(したく)",
             "⓪ 名·自动3  准备；打扮，装束"
-        ],
-        "notation": "支度(したく)"
+        ]
     },
     {
         "name": "kontakutorenzu",
         "trans": [
+            "コンタクトレンズ",
             "⑥ 名  隐形眼镜"
-        ],
-        "notation": "コンタクトレンズ"
+        ]
     },
     {
         "name": "shizumu",
         "trans": [
+            "沈(しず)む",
             "⓪ 自动1  沉入水中；下沉；（精神）消沉"
-        ],
-        "notation": "沈(しず)む"
+        ]
     },
     {
         "name": "seiritsu",
         "trans": [
+            "成立(せいりつ)",
             "⓪ 名·自动3  成立，完成，实现"
-        ],
-        "notation": "成立(せいりつ)"
+        ]
     },
     {
         "name": "tsuuyaku",
         "trans": [
+            "通訳(つうやく)",
             "① 名·他动3  口译；译员"
-        ],
-        "notation": "通訳(つうやく)"
+        ]
     },
     {
         "name": "teido",
         "trans": [
+            "程度(ていど)",
             "① 名  程度，水平"
-        ],
-        "notation": "程度(ていど)"
+        ]
     },
     {
         "name": "doitsu",
         "trans": [
+            "どいつ",
             "① 代  （语气蔑视）哪个家伙"
-        ],
-        "notation": "どいつ"
+        ]
     },
     {
         "name": "happyou",
         "trans": [
+            "発表(はっぴょう)",
             "⓪ 名·他动3  发表，发布；宣布"
-        ],
-        "notation": "発表(はっぴょう)"
+        ]
     },
     {
         "name": "fuyasu",
         "trans": [
+            "増(ふ)やす",
             "② 他动1  增加"
-        ],
-        "notation": "増(ふ)やす"
+        ]
     },
     {
         "name": "purasu",
         "trans": [
+            "プラス",
             "① 名·他动3  正面，有利；加号，正数；加上"
-        ],
-        "notation": "プラス"
+        ]
     },
     {
         "name": "migoto",
         "trans": [
+            "見事(みごと)",
             "① ナ形  美丽的；精彩的；彻底，完全"
-        ],
-        "notation": "見事(みごと)"
+        ]
     },
     {
         "name": "mo-ta-",
         "trans": [
+            "モーター",
             "① 名  发动机"
-        ],
-        "notation": "モーター"
+        ]
     },
     {
         "name": "okawari",
         "trans": [
+            "お代(か)わり",
             "② 名·自动3  再来一份，再添一碗"
-        ],
-        "notation": "お代(か)わり"
+        ]
     },
     {
         "name": "mittomonai",
         "trans": [
+            "みっともない",
             "⑤ イ形  不像样的，不体面的"
-        ],
-        "notation": "みっともない"
+        ]
     },
     {
         "name": "tsugou",
         "trans": [
+            "都合(つごう)",
             "① 名  情况；方便，合适"
-        ],
-        "notation": "都合(つごう)"
+        ]
     },
     {
         "name": "nayamashii",
         "trans": [
+            "悩(なや)ましい",
             "④ イ形  烦恼的，苦恼的"
-        ],
-        "notation": "悩(なや)ましい"
+        ]
     },
     {
         "name": "kudaku",
         "trans": [
+            "砕(くだ)く",
             "② 他动1  打碎，粉碎；摧毁"
-        ],
-        "notation": "砕(くだ)く"
+        ]
     },
     {
         "name": "kyuukou",
         "trans": [
+            "休講(きゅうこう)",
             "⓪ 名·自动3  教师因故停课"
-        ],
-        "notation": "休講(きゅうこう)"
+        ]
     },
     {
         "name": "sappari",
         "trans": [
+            "さっぱり",
             "③ 副·自动3  完全，彻底；整洁，利落；直爽，坦率；清淡"
-        ],
-        "notation": "さっぱり"
+        ]
     },
     {
         "name": "sodachi",
         "trans": [
+            "育(そだ)ち",
             "③ 名  发育，成长；教育"
-        ],
-        "notation": "育(そだ)ち"
+        ]
     },
     {
         "name": "torikesu",
         "trans": [
+            "取(と)り消(け)す",
             "⓪ 他动1  取消，作废"
-        ],
-        "notation": "取(と)り消(け)す"
+        ]
     },
     {
         "name": "dorehodo",
         "trans": [
+            "どれほど",
             "⓪ 副  多少；多么，如何"
-        ],
-        "notation": "どれほど"
+        ]
     },
     {
         "name": "ojigi",
         "trans": [
+            "お辞儀(じぎ)",
             "⓪ 名·自动3  行礼，鞠躬"
-        ],
-        "notation": "お辞儀(じぎ)"
+        ]
     },
     {
         "name": "naika",
         "trans": [
+            "内科(ないか)",
             "⓪ 名  内科"
-        ],
-        "notation": "内科(ないか)"
+        ]
     },
     {
         "name": "taizai",
         "trans": [
+            "滞在(たいざい)",
             "⓪ 名·自动3  停留，逗留"
-        ],
-        "notation": "滞在(たいざい)"
+        ]
     },
     {
         "name": "sukuu",
         "trans": [
+            "掬(すく)う",
             "⓪ 他动1  掬，捞，捧"
-        ],
-        "notation": "掬(すく)う"
+        ]
     },
     {
         "name": "enjinia",
         "trans": [
+            "エンジニア",
             "③ 名  工程师"
-        ],
-        "notation": "エンジニア"
+        ]
     },
     {
         "name": "zabuton",
         "trans": [
+            "座布団(ざぶとん)",
             "② 名  坐垫"
-        ],
-        "notation": "座布団(ざぶとん)"
+        ]
     },
     {
         "name": "sangurasu",
         "trans": [
+            "サングラス",
             "③ 名  墨镜，太阳镜"
-        ],
-        "notation": "サングラス"
+        ]
     },
     {
         "name": "teishutsu",
         "trans": [
+            "提出(ていしゅつ)",
             "⓪ 名·他动3  上交，提交"
-        ],
-        "notation": "提出(ていしゅつ)"
+        ]
     },
     {
         "name": "tensou",
         "trans": [
+            "転送(てんそう)",
             "⓪ 名·他动3  转送，转寄"
-        ],
-        "notation": "転送(てんそう)"
+        ]
     },
     {
         "name": "toi",
         "trans": [
+            "問(と)い",
             "⓪ 名  提问，问题"
-        ],
-        "notation": "問(と)い"
+        ]
     },
     {
         "name": "toriireru",
         "trans": [
+            "取(と)り入(い)れる",
             "④ 他动2  采用，引进；拿进来；收割（作物）"
-        ],
-        "notation": "取(と)り入(い)れる"
+        ]
     },
     {
         "name": "nanba-",
         "trans": [
+            "ナンバー",
             "① 名  数字，号码；号码牌"
-        ],
-        "notation": "ナンバー"
+        ]
     },
     {
         "name": "hohoemu",
         "trans": [
+            "微笑(ほほえ)む",
             "③ 自动1  微笑；（花蕾）绽放"
-        ],
-        "notation": "微笑(ほほえ)む"
+        ]
     },
     {
         "name": "boshuu",
         "trans": [
+            "募集(ぼしゅう)",
             "⓪ 名·他动3  征募，募集"
-        ],
-        "notation": "募集(ぼしゅう)"
+        ]
     },
     {
         "name": "memai",
         "trans": [
+            "眩暈(めまい)",
             "② 名  头晕，目眩"
-        ],
-        "notation": "眩暈(めまい)"
+        ]
     },
     {
         "name": "motomoto",
         "trans": [
+            "もともと",
             "⓪ 副  本来，根本"
-        ],
-        "notation": "もともと"
+        ]
     },
     {
         "name": "yuugure",
         "trans": [
+            "夕暮(ゆうぐ)れ",
             "⓪ 名  黄昏，傍晚"
-        ],
-        "notation": "夕暮(ゆうぐ)れ"
+        ]
     },
     {
         "name": "yokubaru",
         "trans": [
+            "欲張(よくば)る",
             "③ 自动1  贪婪，贪得无厌"
-        ],
-        "notation": "欲張(よくば)る"
+        ]
     },
     {
         "name": "yakuwari",
         "trans": [
+            "役割(やくわり)",
             "⓪ 名  任务，职务；作用"
-        ],
-        "notation": "役割(やくわり)"
+        ]
     },
     {
         "name": "battari",
         "trans": [
+            "ばったり",
             "③ 副  突然倒下；偶然相遇；戛然而止"
-        ],
-        "notation": "ばったり"
+        ]
     },
     {
         "name": "hanamuko",
         "trans": [
+            "花婿(はなむこ)",
             "② 名  新郎"
-        ],
-        "notation": "花婿(はなむこ)"
+        ]
     },
     {
         "name": "sumanai",
         "trans": [
+            "すまない",
             "③ 连语  对不起，抱歉"
-        ],
-        "notation": "すまない"
+        ]
     },
     {
         "name": "jinji",
         "trans": [
+            "人事(じんじ)",
             "① 名  人能做到的事；（职务）人事"
-        ],
-        "notation": "人事(じんじ)"
+        ]
     },
     {
         "name": "oshaberi",
         "trans": [
+            "おしゃべり",
             "② 名·ナ形·自动3  爱说话，健谈；闲谈"
-        ],
-        "notation": "おしゃべり"
+        ]
     },
     {
         "name": "gekou",
         "trans": [
+            "下校(げこう)",
             "⓪ 名·自动3  放学"
-        ],
-        "notation": "下校(げこう)"
+        ]
     },
     {
         "name": "tabi",
         "trans": [
+            "度(たび)",
             "② 名  次，回；次数"
-        ],
-        "notation": "度(たび)"
+        ]
     },
     {
         "name": "zouka",
         "trans": [
+            "増加(ぞうか)",
             "⓪ 名·自他动3  增加，增多"
-        ],
-        "notation": "増加(ぞうか)"
+        ]
     },
     {
         "name": "tachiagaru",
         "trans": [
+            "立(た)ち上(あ)がる",
             "⓪ 自动1  站起来；恢复，重振"
-        ],
-        "notation": "立(た)ち上(あ)がる"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "掃(は)く",
             "① 他动1  扫，打扫"
-        ],
-        "notation": "掃(は)く"
+        ]
     },
     {
         "name": "tamaranai",
         "trans": [
+            "たまらない",
             "⓪ イ形·连语  ⋯⋯得不得了；难耐的，忍受不了的"
-        ],
-        "notation": "たまらない"
+        ]
     },
     {
         "name": "osoraku",
         "trans": [
+            "恐(おそ)らく",
             "② 副  恐怕，或许"
-        ],
-        "notation": "恐(おそ)らく"
+        ]
     },
     {
         "name": "amari",
         "trans": [
+            "余(あま)り",
             "③ 名  剩余，剩下"
-        ],
-        "notation": "余(あま)り"
+        ]
     },
     {
         "name": "iinaosu",
         "trans": [
+            "言(い)い直(なお)す",
             "④ 他动1  重说，换个说法"
-        ],
-        "notation": "言(い)い直(なお)す"
+        ]
     },
     {
         "name": "ofu",
         "trans": [
+            "オフ",
             "① 名  关掉，停止"
-        ],
-        "notation": "オフ"
+        ]
     },
     {
         "name": "hiyou",
         "trans": [
+            "費用(ひよう)",
             "① 名  费用"
-        ],
-        "notation": "費用(ひよう)"
+        ]
     },
     {
         "name": "danshi",
         "trans": [
+            "男子(だんし)",
             "① 名  男性，男孩子"
-        ],
-        "notation": "男子(だんし)"
+        ]
     },
     {
         "name": "sonouchi",
         "trans": [
+            "そのうち",
             "⓪ 副  不久，过几天；其中，之中"
-        ],
-        "notation": "そのうち"
+        ]
     },
     {
         "name": "kooru",
         "trans": [
+            "凍(こお)る",
             "⓪ 自动1  冻，结冰"
-        ],
-        "notation": "凍(こお)る"
+        ]
     },
     {
         "name": "sentou",
         "trans": [
+            "銭湯(せんとう)",
             "① 名  澡堂，公共浴池"
-        ],
-        "notation": "銭湯(せんとう)"
+        ]
     },
     {
         "name": "omowazu",
         "trans": [
+            "思(おも)わず",
             "② 副  不由得，禁不住"
-        ],
-        "notation": "思(おも)わず"
+        ]
     },
     {
         "name": "tobikomu",
         "trans": [
+            "飛(と)び込(こ)む",
             "③ 自动1  跳入；突然进入"
-        ],
-        "notation": "飛(と)び込(こ)む"
+        ]
     },
     {
         "name": "fukamaru",
         "trans": [
+            "深(ふか)まる",
             "③ 自动1  加深，变深，深入"
-        ],
-        "notation": "深(ふか)まる"
+        ]
     },
     {
         "name": "fukameru",
         "trans": [
+            "深(ふか)める",
             "③ 他动2  加深，加强"
-        ],
-        "notation": "深(ふか)める"
+        ]
     },
     {
         "name": "danchi",
         "trans": [
+            "団地(だんち)",
             "⓪ 名  住宅区，社区"
-        ],
-        "notation": "団地(だんち)"
+        ]
     },
     {
         "name": "houki",
         "trans": [
+            "箒(ほうき)",
             "⓪ 名  扫帚"
-        ],
-        "notation": "箒(ほうき)"
+        ]
     },
     {
         "name": "hoppeta",
         "trans": [
+            "ほっぺた",
             "③ 名  脸颊，脸蛋"
-        ],
-        "notation": "ほっぺた"
+        ]
     },
     {
         "name": "wabiru",
         "trans": [
+            "詫(わ)びる",
             "⓪ 他动2  道歉"
-        ],
-        "notation": "詫(わ)びる"
+        ]
     },
     {
         "name": "zehitomo",
         "trans": [
+            "ぜひとも",
             "① 副  一定，务必"
-        ],
-        "notation": "ぜひとも"
+        ]
     },
     {
         "name": "chigainai",
         "trans": [
+            "違(ちが)いない",
             "④ 连语  一定，肯定"
-        ],
-        "notation": "違(ちが)いない"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "意志(いし)",
             "① 名  意志，意愿"
-        ],
-        "notation": "意志(いし)"
+        ]
     },
     {
         "name": "dokushin",
         "trans": [
+            "独身(どくしん)",
             "⓪ 名  单身"
-        ],
-        "notation": "独身(どくしん)"
+        ]
     },
     {
         "name": "chiji",
         "trans": [
+            "知事(ちじ)",
             "① 名  知事（日本都、道、府、县的长官）"
-        ],
-        "notation": "知事(ちじ)"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "振(ふ)る",
             "⓪ 他动1  挥，摇，摆；拒绝，甩"
-        ],
-        "notation": "振(ふ)る"
+        ]
     },
     {
         "name": "hekomu",
         "trans": [
+            "凹(へこ)む",
             "⓪ 自动1  凹下，陷下；屈服"
-        ],
-        "notation": "凹(へこ)む"
+        ]
     },
     {
         "name": "tsuuka",
         "trans": [
+            "通過(つうか)",
             "⓪ 名·自动3  通过，经过"
-        ],
-        "notation": "通過(つうか)"
+        ]
     },
     {
         "name": "chiketto",
         "trans": [
+            "チケット",
             "② 名  票，券"
-        ],
-        "notation": "チケット"
+        ]
     },
     {
         "name": "tantou",
         "trans": [
+            "担当(たんとう)",
             "⓪ 名·他动3  担任，负责"
-        ],
-        "notation": "担当(たんとう)"
+        ]
     },
     {
         "name": "kabushiki",
         "trans": [
+            "株式(かぶしき)",
             "② 名  股票，股份"
-        ],
-        "notation": "株式(かぶしき)"
+        ]
     },
     {
         "name": "joukyuu",
         "trans": [
+            "上級(じょうきゅう)",
             "⓪ 名  上一级；（学校里）高年级"
-        ],
-        "notation": "上級(じょうきゅう)"
+        ]
     },
     {
         "name": "tatoe",
         "trans": [
+            "たとえ",
             "⓪ 副  即使，尽管"
-        ],
-        "notation": "たとえ"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "放(はな)す",
             "② 他动1  放开，放走"
-        ],
-        "notation": "放(はな)す"
+        ]
     },
     {
         "name": "baransu",
         "trans": [
+            "バランス",
             "⓪ 名  平衡"
-        ],
-        "notation": "バランス"
+        ]
     },
     {
         "name": "chinou",
         "trans": [
+            "知能(ちのう)",
             "① 名  智力，智慧"
-        ],
-        "notation": "知能(ちのう)"
+        ]
     },
     {
         "name": "kobosu",
         "trans": [
+            "零(こぼ)す",
             "② 他动1  洒（液体），撒（颗粒状物体）"
-        ],
-        "notation": "零(こぼ)す"
+        ]
     },
     {
         "name": "tameiki",
         "trans": [
+            "ため息(いき)",
             "③ 名  叹气"
-        ],
-        "notation": "ため息(いき)"
+        ]
     },
     {
         "name": "pikapika",
         "trans": [
+            "ぴかぴか",
             "⓪ 副·自动3  闪闪发光"
-        ],
-        "notation": "ぴかぴか"
+        ]
     },
     {
         "name": "hageshii",
         "trans": [
+            "激(はげ)しい",
             "③ イ形  激烈的，剧烈的"
-        ],
-        "notation": "激(はげ)しい"
+        ]
     },
     {
         "name": "chuujun",
         "trans": [
+            "中旬(ちゅうじゅん)",
             "⓪ 名  中旬"
-        ],
-        "notation": "中旬(ちゅうじゅん)"
+        ]
     },
     {
         "name": "haitatsu",
         "trans": [
+            "配達(はいたつ)",
             "⓪ 名·他动3  配送，投递"
-        ],
-        "notation": "配達(はいたつ)"
+        ]
     },
     {
         "name": "nouryoku",
         "trans": [
+            "能力(のうりょく)",
             "① 名  能力"
-        ],
-        "notation": "能力(のうりょく)"
+        ]
     },
     {
         "name": "nikkori",
         "trans": [
+            "にっこり",
             "③ 副·自动3  微微一笑"
-        ],
-        "notation": "にっこり"
+        ]
     },
     {
         "name": "mikakeru",
         "trans": [
+            "見掛(みか)ける",
             "⓪ 他动2  偶然看到；刚开始看"
-        ],
-        "notation": "見掛(みか)ける"
+        ]
     },
     {
         "name": "omoide",
         "trans": [
+            "思(おも)い出(で)",
             "⓪ 名  回忆"
-        ],
-        "notation": "思(おも)い出(で)"
+        ]
     },
     {
         "name": "omoidasu",
         "trans": [
+            "思(おも)い出(だ)す",
             "④ 他动1  想起来，回忆起"
-        ],
-        "notation": "思(おも)い出(だ)す"
+        ]
     },
     {
         "name": "minoru",
         "trans": [
+            "実(みの)る",
             "② 自动1  （植物）成熟，结果；（努力）有成果"
-        ],
-        "notation": "実(みの)る"
+        ]
     },
     {
         "name": "someru",
         "trans": [
+            "染(そ)める",
             "⓪ 他动2  染色；脸发红"
-        ],
-        "notation": "染(そ)める"
+        ]
     },
     {
         "name": "sofutowea",
         "trans": [
+            "ソフトウェア",
             "④ 名  软件"
-        ],
-        "notation": "ソフトウェア"
+        ]
     },
     {
         "name": "geietto",
         "trans": [
+            "ダイエット",
             "① 名·自动3  节食，减肥"
-        ],
-        "notation": "ダイエット"
+        ]
     },
     {
         "name": "tanki",
         "trans": [
+            "短期(たんき)",
             "① 名  短期"
-        ],
-        "notation": "短期(たんき)"
+        ]
     },
     {
         "name": "fukikomu",
         "trans": [
+            "吹(ふ)き込(こ)む",
             "③ 自他动1  （风、雪等）刮进，吹进；灌输（想法）"
-        ],
-        "notation": "吹(ふ)き込(こ)む"
+        ]
     },
     {
         "name": "mendoukusai",
         "trans": [
+            "面倒(めんどう)くさい",
             "⑥ イ形  非常麻烦的"
-        ],
-        "notation": "面倒(めんどう)くさい"
+        ]
     },
     {
         "name": "mendou",
         "trans": [
+            "面倒(めんどう)",
             "③ 名·ナ形  麻烦，费事；照顾，照料"
-        ],
-        "notation": "面倒(めんどう)"
+        ]
     },
     {
         "name": "rounen",
         "trans": [
+            "老年(ろうねん)",
             "⓪ 名  老年"
-        ],
-        "notation": "老年(ろうねん)"
+        ]
     },
     {
         "name": "soredemo",
         "trans": [
+            "それでも",
             "③ 接续  尽管如此，即使⋯⋯还是⋯⋯"
-        ],
-        "notation": "それでも"
+        ]
     },
     {
         "name": "soremade",
         "trans": [
+            "それまで",
             "③ 连语  到那时，在那以前；无话可说了"
-        ],
-        "notation": "それまで"
+        ]
     },
     {
         "name": "kon'nan",
         "trans": [
+            "困難(こんなん)",
             "① 名·ナ形  困难；贫穷"
-        ],
-        "notation": "困難(こんなん)"
+        ]
     },
     {
         "name": "oyayubi",
         "trans": [
+            "親指(おやゆび)",
             "⓪ 名  大拇指"
-        ],
-        "notation": "親指(おやゆび)"
+        ]
     },
     {
         "name": "ichiichi",
         "trans": [
+            "いちいち",
             "② 副  逐一，一个一个地"
-        ],
-        "notation": "いちいち"
+        ]
     },
     {
         "name": "saigai",
         "trans": [
+            "災害(さいがい)",
             "⓪ 名  灾害，灾祸"
-        ],
-        "notation": "災害(さいがい)"
+        ]
     },
     {
         "name": "sokkuri",
         "trans": [
+            "そっくり",
             "③ 副·ナ形  一模一样；全部，完全"
-        ],
-        "notation": "そっくり"
+        ]
     },
     {
         "name": "sonkei",
         "trans": [
+            "尊敬(そんけい)",
             "⓪ 名·他动3  尊敬"
-        ],
-        "notation": "尊敬(そんけい)"
+        ]
     },
     {
         "name": "atatamaru",
         "trans": [
+            "暖(あたた)まる",
             "④ 自动1  暖和，温暖"
-        ],
-        "notation": "暖(あたた)まる"
+        ]
     },
     {
         "name": "atatameru",
         "trans": [
+            "暖(あたた)める",
             "④ 他动2  加热，使变暖"
-        ],
-        "notation": "暖(あたた)める"
+        ]
     },
     {
         "name": "otsuri",
         "trans": [
+            "お釣(つ)り",
             "⓪ 名  找的零钱"
-        ],
-        "notation": "お釣(つ)り"
+        ]
     },
     {
         "name": "sosen",
         "trans": [
+            "祖先(そせん)",
             "① 名  祖先"
-        ],
-        "notation": "祖先(そせん)"
+        ]
     },
     {
         "name": "choujo",
         "trans": [
+            "長女(ちょうじょ)",
             "① 名  长女，大女儿"
-        ],
-        "notation": "長女(ちょうじょ)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "留(と)める",
             "⓪ 他动2  固定；留下；留心"
-        ],
-        "notation": "留(と)める"
+        ]
     },
     {
         "name": "hayari",
         "trans": [
+            "流行(はやり)",
             "③ 名  流行，时尚；（疾病）蔓延"
-        ],
-        "notation": "流行(はやり)"
+        ]
     },
     {
         "name": "oyoso",
         "trans": [
+            "およそ",
             "⓪ 副  大概，大约，大体上"
-        ],
-        "notation": "およそ"
+        ]
     },
     {
         "name": "haraimodosu",
         "trans": [
+            "払(はら)い戻(もど)す",
             "⑤ 他动1  退还，返还"
-        ],
-        "notation": "払(はら)い戻(もど)す"
+        ]
     },
     {
         "name": "onchuu",
         "trans": [
+            "御中(おんちゅう)",
             "① 名  （书信）公启，收启"
-        ],
-        "notation": "御中(おんちゅう)"
+        ]
     },
     {
         "name": "pantsu",
         "trans": [
+            "パンツ",
             "① 名  短裤，内裤"
-        ],
-        "notation": "パンツ"
+        ]
     },
     {
         "name": "shirushi",
         "trans": [
+            "印(しるし)",
             "⓪ 名  符号，记号；象征；证据"
-        ],
-        "notation": "印(しるし)"
+        ]
     },
     {
         "name": "seou",
         "trans": [
+            "背負(せお)う",
             "② 他动1  背（人或物体）；承担（责任）"
-        ],
-        "notation": "背負(せお)う"
+        ]
     },
     {
         "name": "shibafu",
         "trans": [
+            "芝生(しばふ)",
             "⓪ 名  草坪，草地"
-        ],
-        "notation": "芝生(しばふ)"
+        ]
     },
     {
         "name": "shiharau",
         "trans": [
+            "支払(しはら)う",
             "③ 他动1  支付，付款"
-        ],
-        "notation": "支払(しはら)う"
+        ]
     },
     {
         "name": "jisseki",
         "trans": [
+            "実績(じっせき)",
             "⓪ 名  实际成绩"
-        ],
-        "notation": "実績(じっせき)"
+        ]
     },
     {
         "name": "gyougi",
         "trans": [
+            "行儀(ぎょうぎ)",
             "⓪ 名  举止，礼貌"
-        ],
-        "notation": "行儀(ぎょうぎ)"
+        ]
     },
     {
         "name": "tsumi",
         "trans": [
+            "罪(つみ)",
             "① 名  犯罪，罪行"
-        ],
-        "notation": "罪(つみ)"
+        ]
     },
     {
         "name": "oshiri",
         "trans": [
+            "お尻(しり)",
             "⓪ 名  屁股；后边"
-        ],
-        "notation": "お尻(しり)"
+        ]
     },
     {
         "name": "geijutsu",
         "trans": [
+            "芸術(げいじゅつ)",
             "⓪ 名  艺术"
-        ],
-        "notation": "芸術(げいじゅつ)"
+        ]
     },
     {
         "name": "tsuideni",
         "trans": [
+            "ついでに",
             "⓪ 副  顺便，顺手"
-        ],
-        "notation": "ついでに"
+        ]
     },
     {
         "name": "noronoro",
         "trans": [
+            "のろのろ",
             "① 副·自动3  迟缓，慢吞吞地"
-        ],
-        "notation": "のろのろ"
+        ]
     },
     {
         "name": "fumoto",
         "trans": [
+            "麓(ふもと)",
             "③ 名  山脚，山麓"
-        ],
-        "notation": "麓(ふもと)"
+        ]
     },
     {
         "name": "moriagaru",
         "trans": [
+            "盛(も)り上(あ)がる",
             "④ 自动1  凸起；涌起；（气氛）热烈，高涨"
-        ],
-        "notation": "盛(も)り上(あ)がる"
+        ]
     },
     {
         "name": "yuderu",
         "trans": [
+            "茹(ゆ)でる",
             "② 他动2  （用开水）煮，烫，焯"
-        ],
-        "notation": "茹(ゆ)でる"
+        ]
     },
     {
         "name": "deai",
         "trans": [
+            "出会(であ)い",
             "⓪ 名  相遇"
-        ],
-        "notation": "出会(であ)い"
+        ]
     },
     {
         "name": "junsui",
         "trans": [
+            "純粋(じゅんすい)",
             "⓪ 名·ナ形  纯粹，纯真"
-        ],
-        "notation": "純粋(じゅんすい)"
+        ]
     },
     {
         "name": "shashou",
         "trans": [
+            "車掌(しゃしょう)",
             "⓪ 名  乘务员，列车员"
-        ],
-        "notation": "車掌(しゃしょう)"
+        ]
     },
     {
         "name": "genjitsu",
         "trans": [
+            "現実(げんじつ)",
             "⓪ 名  现实"
-        ],
-        "notation": "現実(げんじつ)"
+        ]
     },
     {
         "name": "keshou",
         "trans": [
+            "化粧(けしょう)",
             "② 名·自动3  化妆，打扮"
-        ],
-        "notation": "化粧(けしょう)"
+        ]
     },
     {
         "name": "kusuriyubi",
         "trans": [
+            "薬指(くすりゆび)",
             "③ 名  无名指"
-        ],
-        "notation": "薬指(くすりゆび)"
+        ]
     },
     {
         "name": "girigiri",
         "trans": [
+            "ぎりぎり",
             "⓪ 名·副·自动3  最大限度，极限；紧紧地缠绕"
-        ],
-        "notation": "ぎりぎり"
+        ]
     },
     {
         "name": "naderu",
         "trans": [
+            "撫(な)でる",
             "② 他动2  抚摸"
-        ],
-        "notation": "撫(な)でる"
+        ]
     },
     {
         "name": "oni",
         "trans": [
+            "鬼(おに)",
             "② 名  鬼怪；残暴的人"
-        ],
-        "notation": "鬼(おに)"
+        ]
     },
     {
         "name": "attoiumani",
         "trans": [
+            "あっという間(ま)に",
             "⓪ 副  一瞬间，转眼间"
-        ],
-        "notation": "あっという間(ま)に"
+        ]
     },
     {
         "name": "shiku",
         "trans": [
+            "敷(し)く",
             "⓪ 他动1  铺，垫上；铺设"
-        ],
-        "notation": "敷(し)く"
+        ]
     },
     {
         "name": "sasaru",
         "trans": [
+            "刺(さ)さる",
             "② 自动1  扎，刺入"
-        ],
-        "notation": "刺(さ)さる"
+        ]
     },
     {
         "name": "toumei",
         "trans": [
+            "透明(とうめい)",
             "⓪ 名·ナ形  透明；纯洁"
-        ],
-        "notation": "透明(とうめい)"
+        ]
     },
     {
         "name": "teikiken",
         "trans": [
+            "定期券(ていきけん)",
             "③ 名  月票，定期票"
-        ],
-        "notation": "定期券(ていきけん)"
+        ]
     },
     {
         "name": "o-tome-shon",
         "trans": [
+            "オートメーション",
             "④ 名  自动化"
-        ],
-        "notation": "オートメーション"
+        ]
     },
     {
         "name": "awaseru",
         "trans": [
+            "合(あ)わせる",
             "③ 他动2  合并；加在一起；配合，调和，使适应"
-        ],
-        "notation": "合(あ)わせる"
+        ]
     },
     {
         "name": "nieru",
         "trans": [
+            "煮(に)える",
             "⓪ 自动2  煮熟"
-        ],
-        "notation": "煮(に)える"
+        ]
     },
     {
         "name": "fuchuui",
         "trans": [
+            "不注意(ふちゅうい)",
             "② 名·ナ形  不注意，不小心"
-        ],
-        "notation": "不注意(ふちゅうい)"
+        ]
     },
     {
         "name": "hyoujou",
         "trans": [
+            "表情(ひょうじょう)",
             "③ 名  表情"
-        ],
-        "notation": "表情(ひょうじょう)"
+        ]
     },
     {
         "name": "hareagaru",
         "trans": [
+            "晴(は)れ上(あ)がる",
             "④ 自动1  晴朗，晴空万里"
-        ],
-        "notation": "晴(は)れ上(あ)がる"
+        ]
     },
     {
         "name": "baiten",
         "trans": [
+            "売店(ばいてん)",
             "⓪ 名  小卖部"
-        ],
-        "notation": "売店(ばいてん)"
+        ]
     },
     {
         "name": "nibui",
         "trans": [
+            "鈍(にぶ)い",
             "② イ形  钝的；迟钝的，迟缓的"
-        ],
-        "notation": "鈍(にぶ)い"
+        ]
     },
     {
         "name": "oi",
         "trans": [
+            "甥(おい)",
             "⓪ 名  侄子；外甥"
-        ],
-        "notation": "甥(おい)"
+        ]
     },
     {
         "name": "fukeru",
         "trans": [
+            "更(ふ)ける",
             "② 自动2  （季节）变深；（夜）深了"
-        ],
-        "notation": "更(ふ)ける"
+        ]
     },
     {
         "name": "taikutsu",
         "trans": [
+            "退屈(たいくつ)",
             "⓪ 名·ナ形·自动3  无聊，寂寞"
-        ],
-        "notation": "退屈(たいくつ)"
+        ]
     },
     {
         "name": "urouro",
         "trans": [
+            "うろうろ",
             "① 副·自动3  彷徨，惊慌失措"
-        ],
-        "notation": "うろうろ"
+        ]
     },
     {
         "name": "ikiiki",
         "trans": [
+            "生(い)き生(い)き",
             "③ 副·自动3  生动，栩栩如生"
-        ],
-        "notation": "生(い)き生(い)き"
+        ]
     },
     {
         "name": "dekiagari",
         "trans": [
+            "出来上(できあ)がり",
             "⓪ 名  完成；完成的结果"
-        ],
-        "notation": "出来上(できあ)がり"
+        ]
     },
     {
         "name": "sarari-man",
         "trans": [
+            "サラリーマン",
             "③ 名  工薪阶层，公司职员"
-        ],
-        "notation": "サラリーマン"
+        ]
     },
     {
         "name": "ooini",
         "trans": [
+            "大(おお)いに",
             "① 副  大大地，很，颇"
-        ],
-        "notation": "大(おお)いに"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "掻(か)く",
             "① 他动1  挠；出（汗）"
-        ],
-        "notation": "掻(か)く"
+        ]
     },
     {
         "name": "susumeru",
         "trans": [
+            "進(すす)める",
             "⓪ 他动2  使⋯⋯前进；推进，促进"
-        ],
-        "notation": "進(すす)める"
+        ]
     },
     {
         "name": "dejikame",
         "trans": [
+            "デジカメ",
             "⓪ 名  数码相机"
-        ],
-        "notation": "デジカメ"
+        ]
     },
     {
         "name": "fusagaru",
         "trans": [
+            "塞(ふさ)がる",
             "⓪ 自动1  关闭；堵塞，占满"
-        ],
-        "notation": "塞(ふさ)がる"
+        ]
     },
     {
         "name": "mamoru",
         "trans": [
+            "守(まも)る",
             "② 他动1  保护，守卫，维护；遵守；保持"
-        ],
-        "notation": "守(まも)る"
+        ]
     },
     {
         "name": "rasshuawa-",
         "trans": [
+            "ラッシュアワー",
             "④ 名  交通拥挤时段"
-        ],
-        "notation": "ラッシュアワー"
+        ]
     },
     {
         "name": "rizumu",
         "trans": [
+            "リズム",
             "① 名  节奏，韵律"
-        ],
-        "notation": "リズム"
+        ]
     },
     {
         "name": "reitou",
         "trans": [
+            "冷凍(れいとう)",
             "⓪ 名·他动3  冷冻"
-        ],
-        "notation": "冷凍(れいとう)"
+        ]
     },
     {
         "name": "waraeru",
         "trans": [
+            "笑(わら)える",
             "③ 自动2  值得一笑；不由得笑起来"
-        ],
-        "notation": "笑(わら)える"
+        ]
     },
     {
         "name": "joshi",
         "trans": [
+            "女子(じょし)",
             "① 名  女性，女孩子"
-        ],
-        "notation": "女子(じょし)"
+        ]
     },
     {
         "name": "jouken",
         "trans": [
+            "条件(じょうけん)",
             "③ 名  条件"
-        ],
-        "notation": "条件(じょうけん)"
+        ]
     },
     {
         "name": "shuuryou",
         "trans": [
+            "終了(しゅうりょう)",
             "⓪ 名·自他动3  结束，终了"
-        ],
-        "notation": "終了(しゅうりょう)"
+        ]
     },
     {
         "name": "iwayuru",
         "trans": [
+            "いわゆる",
             "③ 连体  所谓，常说的"
-        ],
-        "notation": "いわゆる"
+        ]
     },
     {
         "name": "igo",
         "trans": [
+            "以後(いご)",
             "① 名  以后，之后"
-        ],
-        "notation": "以後(いご)"
+        ]
     },
     {
         "name": "inshou",
         "trans": [
+            "印象(いんしょう)",
             "⓪ 名  印象"
-        ],
-        "notation": "印象(いんしょう)"
+        ]
     },
     {
         "name": "juuryou",
         "trans": [
+            "重量(じゅうりょう)",
             "③ 名  重量"
-        ],
-        "notation": "重量(じゅうりょう)"
+        ]
     },
     {
         "name": "shukujitsu",
         "trans": [
+            "祝日(しゅくじつ)",
             "⓪ 名  节日"
-        ],
-        "notation": "祝日(しゅくじつ)"
+        ]
     },
     {
         "name": "hiduke",
         "trans": [
+            "日付(ひづけ)",
             "⓪ 名  日期，年月日"
-        ],
-        "notation": "日付(ひづけ)"
+        ]
     },
     {
         "name": "wain",
         "trans": [
+            "ワイン",
             "① 名  葡萄酒"
-        ],
-        "notation": "ワイン"
+        ]
     },
     {
         "name": "ro-maji",
         "trans": [
+            "ローマ字(じ)",
             "⓪ 名  罗马字"
-        ],
-        "notation": "ローマ字(じ)"
+        ]
     },
     {
         "name": "yahari",
         "trans": [
+            "やはり",
             "② 副  果然；毕竟还是；仍然"
-        ],
-        "notation": "やはり"
+        ]
     },
     {
         "name": "yosou",
         "trans": [
+            "予想(よそう)",
             "⓪ 名·他动3  预想，预料"
-        ],
-        "notation": "予想(よそう)"
+        ]
     },
     {
         "name": "zurasu",
         "trans": [
+            "ずらす",
             "② 他动1  挪动（位置）；错开（时间）"
-        ],
-        "notation": "ずらす"
+        ]
     },
     {
         "name": "insatsu",
         "trans": [
+            "印刷(いんさつ)",
             "⓪ 名·他动3  印刷"
-        ],
-        "notation": "印刷(いんさつ)"
+        ]
     },
     {
         "name": "oikosu",
         "trans": [
+            "追(お)い越(こ)す",
             "③ 他动1  赶过，超过"
-        ],
-        "notation": "追(お)い越(こ)す"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "医師(いし)",
             "① 名  医生，大夫"
-        ],
-        "notation": "医師(いし)"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "最(もっと)も",
             "③ 副  最，顶"
-        ],
-        "notation": "最(もっと)も"
+        ]
     },
     {
         "name": "takaramono",
         "trans": [
+            "宝物(たからもの)",
             "⓪ 名  宝物，宝贝"
-        ],
-        "notation": "宝物(たからもの)"
+        ]
     },
     {
         "name": "shoumei",
         "trans": [
+            "証明(しょうめい)",
             "⓪ 名·他动3  证明"
-        ],
-        "notation": "証明(しょうめい)"
+        ]
     },
     {
         "name": "ensou",
         "trans": [
+            "演奏(えんそう)",
             "⓪ 名·他动3  演奏，弹奏"
-        ],
-        "notation": "演奏(えんそう)"
+        ]
     },
     {
         "name": "shiinto",
         "trans": [
+            "しいんと",
             "⓪ 副·自动3  静悄悄地，鸦雀无声"
-        ],
-        "notation": "しいんと"
+        ]
     },
     {
         "name": "giron",
         "trans": [
+            "議論(ぎろん)",
             "① 名·他动3  议论，讨论"
-        ],
-        "notation": "議論(ぎろん)"
+        ]
     },
     {
         "name": "chousetsu",
         "trans": [
+            "調節(ちょうせつ)",
             "⓪ 名·他动3  调节，调整"
-        ],
-        "notation": "調節(ちょうせつ)"
+        ]
     },
     {
         "name": "deau",
         "trans": [
+            "出会(であ)う",
             "② 自动1  相遇，碰见"
-        ],
-        "notation": "出会(であ)う"
+        ]
     },
     {
         "name": "osatsu",
         "trans": [
+            "お札(さつ)",
             "⓪ 名  纸币，钞票"
-        ],
-        "notation": "お札(さつ)"
+        ]
     },
     {
         "name": "pasu",
         "trans": [
+            "パス",
             "① 名·自动3  票，券；合格，通过"
-        ],
-        "notation": "パス"
+        ]
     },
     {
         "name": "hikidasu",
         "trans": [
+            "引(ひ)き出(だ)す",
             "③ 他动1  抽出；引导出来；取钱"
-        ],
-        "notation": "引(ひ)き出(だ)す"
+        ]
     },
     {
         "name": "tettei",
         "trans": [
+            "徹底(てってい)",
             "⓪ 名·自动3  彻底，贯彻始终"
-        ],
-        "notation": "徹底(てってい)"
+        ]
     },
     {
         "name": "kaisatsuguchi",
         "trans": [
+            "改札口(かいさつぐち)",
             "④ 名  检票口"
-        ],
-        "notation": "改札口(かいさつぐち)"
+        ]
     },
     {
         "name": "taisaku",
         "trans": [
+            "対策(たいさく)",
             "⓪ 名  对策"
-        ],
-        "notation": "対策(たいさく)"
+        ]
     },
     {
         "name": "komeru",
         "trans": [
+            "込(こ)める",
             "② 他动2  包括在内；集中（精神）"
-        ],
-        "notation": "込(こ)める"
+        ]
     },
     {
         "name": "gokai",
         "trans": [
+            "誤解(ごかい)",
             "⓪ 名·他动3  误解，误会"
-        ],
-        "notation": "誤解(ごかい)"
+        ]
     },
     {
         "name": "tenshi",
         "trans": [
+            "天使(てんし)",
             "① 名  天使"
-        ],
-        "notation": "天使(てんし)"
+        ]
     },
     {
         "name": "kaihatsu",
         "trans": [
+            "開発(かいはつ)",
             "⓪ 名·他动3  开发"
-        ],
-        "notation": "開発(かいはつ)"
+        ]
     },
     {
         "name": "kokyuu",
         "trans": [
+            "呼吸(こきゅう)",
             "⓪ 名·自动3  呼吸；（做事）步调，节奏"
-        ],
-        "notation": "呼吸(こきゅう)"
+        ]
     },
     {
         "name": "demo",
         "trans": [
+            "デモ",
             "① 名  游行示威"
-        ],
-        "notation": "デモ"
+        ]
     },
     {
         "name": "doku",
         "trans": [
+            "退(ど)く",
             "⓪ 自动1  躲开，让开"
-        ],
-        "notation": "退(ど)く"
+        ]
     },
     {
         "name": "denshadai",
         "trans": [
+            "電車代(でんしゃだい)",
             "⓪ 名  车费"
-        ],
-        "notation": "電車代(でんしゃだい)"
+        ]
     },
     {
         "name": "denwadai",
         "trans": [
+            "電話代(でんわだい)",
             "⓪ 名  电话费"
-        ],
-        "notation": "電話代(でんわだい)"
+        ]
     },
     {
         "name": "nonki",
         "trans": [
+            "のんき",
             "① 名·ナ形  安闲，悠闲；不慌不忙"
-        ],
-        "notation": "のんき"
+        ]
     },
     {
         "name": "heijitsu",
         "trans": [
+            "平日(へいじつ)",
             "⓪ 名  工作日；平日，平时"
-        ],
-        "notation": "平日(へいじつ)"
+        ]
     },
     {
         "name": "boushi",
         "trans": [
+            "防止(ぼうし)",
             "⓪ 名·他动3  防止"
-        ],
-        "notation": "防止(ぼうし)"
+        ]
     },
     {
         "name": "hoeru",
         "trans": [
+            "吠(ほ)える",
             "② 自动2  （动物）叫，吼"
-        ],
-        "notation": "吠(ほ)える"
+        ]
     },
     {
         "name": "naniyori",
         "trans": [
+            "何(なに)より",
             "① 副  最好，比什么都好"
-        ],
-        "notation": "何(なに)より"
+        ]
     },
     {
         "name": "doushi",
         "trans": [
+            "動詞(どうし)",
             "⓪ 名  动词"
-        ],
-        "notation": "動詞(どうし)"
+        ]
     },
     {
         "name": "~nareru",
         "trans": [
+            "～慣(な)れる",
             " 接尾  ⋯⋯惯了"
-        ],
-        "notation": "～慣(な)れる"
+        ]
     },
     {
         "name": "toukou",
         "trans": [
+            "登校(とうこう)",
             "⓪ 名·自动3  上学"
-        ],
-        "notation": "登校(とうこう)"
+        ]
     },
     {
         "name": "toudai",
         "trans": [
+            "灯台(とうだい)",
             "⓪ 名  烛台；灯塔"
-        ],
-        "notation": "灯台(とうだい)"
+        ]
     },
     {
         "name": "shokumotsu",
         "trans": [
+            "食物(しょくもつ)",
             "② 名  食物，食品"
-        ],
-        "notation": "食物(しょくもつ)"
+        ]
     },
     {
         "name": "shokuhi",
         "trans": [
+            "食費(しょくひ)",
             "⓪ 名  伙食费"
-        ],
-        "notation": "食費(しょくひ)"
+        ]
     },
     {
         "name": "shokuyoku",
         "trans": [
+            "食欲(しょくよく)",
             "⓪ 名  食欲"
-        ],
-        "notation": "食欲(しょくよく)"
+        ]
     },
     {
         "name": "shokuryou",
         "trans": [
+            "食料(しょくりょう)",
             "② 名  食材，食物"
-        ],
-        "notation": "食料(しょくりょう)"
+        ]
     },
     {
         "name": "shokuryou",
         "trans": [
+            "食糧(しょくりょう)",
             "② 名  粮食"
-        ],
-        "notation": "食糧(しょくりょう)"
+        ]
     },
     {
         "name": "shoten",
         "trans": [
+            "書店(しょてん)",
             "⓪ 名  书店"
-        ],
-        "notation": "書店(しょてん)"
+        ]
     },
     {
         "name": "tounan'ajia",
         "trans": [
+            "東南(とうなん)アジア",
             "⑤ 名  东南亚"
-        ],
-        "notation": "東南(とうなん)アジア"
+        ]
     },
     {
         "name": "kaette",
         "trans": [
+            "却(かえ)って",
             "① 副  反倒，反而"
-        ],
-        "notation": "却(かえ)って"
+        ]
     },
     {
         "name": "tokoroga",
         "trans": [
+            "ところが",
             "③ 接续  可是，然而"
-        ],
-        "notation": "ところが"
+        ]
     },
     {
         "name": "honten",
         "trans": [
+            "本店(ほんてん)",
             "⓪ 名  总店"
-        ],
-        "notation": "本店(ほんてん)"
+        ]
     },
     {
         "name": "dehajimeru",
         "trans": [
+            "出始(ではじ)める",
             "④ 自动2  开始出现；刚上市"
-        ],
-        "notation": "出始(ではじ)める"
+        ]
     },
     {
         "name": "sakeru",
         "trans": [
+            "避(さ)ける",
             "② 他动2  避开，躲避，逃避"
-        ],
-        "notation": "避(さ)ける"
+        ]
     },
     {
         "name": "korosu",
         "trans": [
+            "殺(ころ)す",
             "⓪ 他动1  杀死；牺牲，糟蹋"
-        ],
-        "notation": "殺(ころ)す"
+        ]
     },
     {
         "name": "soru",
         "trans": [
+            "剃(そ)る",
             "① 他动1  剃，刮"
-        ],
-        "notation": "剃(そ)る"
+        ]
     },
     {
         "name": "ten'in",
         "trans": [
+            "店員(てんいん)",
             "⓪ 名  店员，售货员"
-        ],
-        "notation": "店員(てんいん)"
+        ]
     },
     {
         "name": "hotto",
         "trans": [
+            "ほっと",
             "⓪ 副·自动3  放心，安心；叹气"
-        ],
-        "notation": "ほっと"
+        ]
     },
     {
         "name": "kaihou",
         "trans": [
+            "開放(かいほう)",
             "⓪ 名·他动3  开放，公开；打开"
-        ],
-        "notation": "開放(かいほう)"
+        ]
     },
     {
         "name": "izuremo",
         "trans": [
+            "いずれも",
             "⓪ 连语  无论是谁，全都"
-        ],
-        "notation": "いずれも"
+        ]
     },
     {
         "name": "arukimawaru",
         "trans": [
+            "歩(ある)き回(まわ)る",
             "⑤ 自动1  到处走，走遍"
-        ],
-        "notation": "歩(ある)き回(まわ)る"
+        ]
     },
     {
         "name": "hoshuu",
         "trans": [
+            "補修(ほしゅう)",
             "⓪ 名·他动3  修补，维修"
-        ],
-        "notation": "補修(ほしゅう)"
+        ]
     },
     {
         "name": "herasu",
         "trans": [
+            "減(へ)らす",
             "⓪ 他动1  减少，缩减；饿肚子"
-        ],
-        "notation": "減(へ)らす"
+        ]
     },
     {
         "name": "jousha",
         "trans": [
+            "乗車(じょうしゃ)",
             "⓪ 名·自动3  乘车，上车"
-        ],
-        "notation": "乗車(じょうしゃ)"
+        ]
     },
     {
         "name": "joukyaku",
         "trans": [
+            "乗客(じょうきゃく)",
             "⓪ 名  乘客"
-        ],
-        "notation": "乗客(じょうきゃく)"
+        ]
     },
     {
         "name": "juukyo",
         "trans": [
+            "住居(じゅうきょ)",
             "① 名  住所，住宅"
-        ],
-        "notation": "住居(じゅうきょ)"
+        ]
     },
     {
         "name": "kaesu",
         "trans": [
+            "帰(かえ)す",
             "① 他动1  让⋯⋯回去"
-        ],
-        "notation": "帰(かえ)す"
+        ]
     },
     {
         "name": "denryuu",
         "trans": [
+            "電流(でんりゅう)",
             "⓪ 名  电流"
-        ],
-        "notation": "電流(でんりゅう)"
+        ]
     },
     {
         "name": "denchuu",
         "trans": [
+            "電柱(でんちゅう)",
             "⓪ 名  电线杆"
-        ],
-        "notation": "電柱(でんちゅう)"
+        ]
     },
     {
         "name": "den'atsu",
         "trans": [
+            "電圧(でんあつ)",
             "⓪ 名  电压"
-        ],
-        "notation": "電圧(でんあつ)"
+        ]
     },
     {
         "name": "denkigama",
         "trans": [
+            "電気釜(でんきがま)",
             "③ 名  电饭锅"
-        ],
-        "notation": "電気釜(でんきがま)"
+        ]
     },
     {
         "name": "denkyuu",
         "trans": [
+            "電球(でんきゅう)",
             "⓪ 名  电灯泡"
-        ],
-        "notation": "電球(でんきゅう)"
+        ]
     },
     {
         "name": "dengen",
         "trans": [
+            "電源(でんげん)",
             "③ 名  电源"
-        ],
-        "notation": "電源(でんげん)"
+        ]
     },
     {
         "name": "denshi",
         "trans": [
+            "電子(でんし)",
             "① 名  电子"
-        ],
-        "notation": "電子(でんし)"
+        ]
     },
     {
         "name": "denshirenji",
         "trans": [
+            "電子(でんし)レンジ",
             "④ 名  微波炉"
-        ],
-        "notation": "電子(でんし)レンジ"
+        ]
     },
     {
         "name": "densen",
         "trans": [
+            "電線(でんせん)",
             "⓪ 名  电线，电缆"
-        ],
-        "notation": "電線(でんせん)"
+        ]
     },
     {
         "name": "dekiagaru",
         "trans": [
+            "出来上(できあ)がる",
             "⓪ 自动1  做完，完成"
-        ],
-        "notation": "出来上(できあ)がる"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "代(か)える",
             "⓪ 他动2  代替，替换"
-        ],
-        "notation": "代(か)える"
+        ]
     },
     {
         "name": "toshitsuki",
         "trans": [
+            "年月(としつき)",
             "② 名  岁月，光阴"
-        ],
-        "notation": "年月(としつき)"
+        ]
     },
     {
         "name": "arekurai/aregurai",
         "trans": [
+            "あれくらい/あれぐらい",
             "⓪ 名·副  那么，那种程度"
-        ],
-        "notation": "あれくらい/あれぐらい"
+        ]
     },
     {
         "name": "arekore",
         "trans": [
+            "あれこれ",
             "② 代·副  这个那个，种种"
-        ],
-        "notation": "あれこれ"
+        ]
     },
     {
         "name": "arehodo",
         "trans": [
+            "あれほど",
             "⓪ 副  那样，那么"
-        ],
-        "notation": "あれほど"
+        ]
     },
     {
         "name": "dokeru",
         "trans": [
+            "退(ど)ける",
             "⓪ 他动2  挪开，移开"
-        ],
-        "notation": "退(ど)ける"
+        ]
     },
     {
         "name": "dekoboko",
         "trans": [
+            "凸凹(でこぼこ)",
             "⓪ ナ形·自动3  凹凸不平；不平均"
-        ],
-        "notation": "凸凹(でこぼこ)"
+        ]
     },
     {
         "name": "iidasu",
         "trans": [
+            "言(い)い出(だ)す",
             "③ 他动1  开始说；说出口"
-        ],
-        "notation": "言(い)い出(だ)す"
+        ]
     },
     {
         "name": "tojiru",
         "trans": [
+            "閉(と)じる",
             "② 自他动2  关闭，合上；结束"
-        ],
-        "notation": "閉(と)じる"
+        ]
     },
     {
         "name": "ten'nen",
         "trans": [
+            "天然(てんねん)",
             "⓪ 名  天然，自然"
-        ],
-        "notation": "天然(てんねん)"
+        ]
     },
     {
         "name": "tsunami",
         "trans": [
+            "津波(つなみ)",
             "⓪ 名  海啸"
-        ],
-        "notation": "津波(つなみ)"
+        ]
     },
     {
         "name": "souzou",
         "trans": [
+            "想像(そうぞう)",
             "⓪ 名·他动3  想象"
-        ],
-        "notation": "想像(そうぞう)"
+        ]
     },
     {
         "name": "soushitara",
         "trans": [
+            "そうしたら",
             "④ 接续  要是那样的话"
-        ],
-        "notation": "そうしたら"
+        ]
     },
     {
         "name": "suma-to",
         "trans": [
+            "スマート",
             "② ナ形  漂亮的；苗条的；潇洒的"
-        ],
-        "notation": "スマート"
+        ]
     },
     {
         "name": "seichou",
         "trans": [
+            "成長(せいちょう)",
             "⓪ 名·自动3  成长，发育；增长，发展"
-        ],
-        "notation": "成長(せいちょう)"
+        ]
     },
     {
         "name": "sonchou",
         "trans": [
+            "尊重(そんちょう)",
             "⓪ 名·他动3  尊重，重视"
-        ],
-        "notation": "尊重(そんちょう)"
+        ]
     },
     {
         "name": "doraiya-",
         "trans": [
+            "ドライヤー",
             "⓪ 名  吹风机；干燥剂"
-        ],
-        "notation": "ドライヤー"
+        ]
     },
     {
         "name": "haiyuu",
         "trans": [
+            "俳優(はいゆう)",
             "⓪ 名  演员"
-        ],
-        "notation": "俳優(はいゆう)"
+        ]
     },
     {
         "name": "maigo",
         "trans": [
+            "迷子(まいご)",
             "① 名  迷路；走丢的人"
-        ],
-        "notation": "迷子(まいご)"
+        ]
     },
     {
         "name": "dorama",
         "trans": [
+            "ドラマ",
             "① 名  电视剧；戏剧"
-        ],
-        "notation": "ドラマ"
+        ]
     },
     {
         "name": "muku",
         "trans": [
+            "向(む)く",
             "⓪ 自他动1  向，朝；倾向；适合"
-        ],
-        "notation": "向(む)く"
+        ]
     },
     {
         "name": "okazu",
         "trans": [
+            "おかず",
             "⓪ 名  小菜，菜肴"
-        ],
-        "notation": "おかず"
+        ]
     },
     {
         "name": "matomaru",
         "trans": [
+            "纏(まと)まる",
             "⓪ 自动1  汇集；解决，谈妥；总结起来；一致，统一"
-        ],
-        "notation": "纏(まと)まる"
+        ]
     },
     {
         "name": "matomeru",
         "trans": [
+            "纏(まと)める",
             "⓪ 他动2  汇集；解决，谈妥；总结；使一致"
-        ],
-        "notation": "纏(まと)める"
+        ]
     },
     {
         "name": "honba",
         "trans": [
+            "本場(ほんば)",
             "⓪ 名  原产地；正宗，地道"
-        ],
-        "notation": "本場(ほんば)"
+        ]
     },
     {
         "name": "souon",
         "trans": [
+            "騒音(そうおん)",
             "⓪ 名  噪声"
-        ],
-        "notation": "騒音(そうおん)"
+        ]
     },
     {
         "name": "seihoukei",
         "trans": [
+            "正方形(せいほうけい)",
             "⓪ 名  正方形"
-        ],
-        "notation": "正方形(せいほうけい)"
+        ]
     },
     {
         "name": "suimin",
         "trans": [
+            "睡眠(すいみん)",
             "⓪ 名·自动3  睡眠，睡觉；休眠"
-        ],
-        "notation": "睡眠(すいみん)"
+        ]
     },
     {
         "name": "nakanaori",
         "trans": [
+            "仲直(なかなお)り",
             "③ 名·自动3  和好"
-        ],
-        "notation": "仲直(なかなお)り"
+        ]
     },
     {
         "name": "windo-",
         "trans": [
+            "ウィンドー",
             "① 名  窗户；（电脑）窗口"
-        ],
-        "notation": "ウィンドー"
+        ]
     },
     {
         "name": "tetsuduki",
         "trans": [
+            "手続(てつづ)き",
             "② 名  手续"
-        ],
-        "notation": "手続(てつづ)き"
+        ]
     },
     {
         "name": "dousa",
         "trans": [
+            "動作(どうさ)",
             "① 名  动作"
-        ],
-        "notation": "動作(どうさ)"
+        ]
     },
     {
         "name": "hikiukeru",
         "trans": [
+            "引(ひ)き受(う)ける",
             "④ 他动2  接受，承担（责任）"
-        ],
-        "notation": "引(ひ)き受(う)ける"
+        ]
     },
     {
         "name": "touan",
         "trans": [
+            "答案(とうあん)",
             "⓪ 名  答案；试卷"
-        ],
-        "notation": "答案(とうあん)"
+        ]
     },
     {
         "name": "shikamo",
         "trans": [
+            "しかも",
             "② 接续  而且，并且"
-        ],
-        "notation": "しかも"
+        ]
     },
     {
         "name": "shiasatte",
         "trans": [
+            "しあさって",
             "③ 名  大后天"
-        ],
-        "notation": "しあさって"
+        ]
     },
     {
         "name": "entotsu",
         "trans": [
+            "煙突(えんとつ)",
             "⓪ 名  烟囱"
-        ],
-        "notation": "煙突(えんとつ)"
+        ]
     },
     {
         "name": "nazo",
         "trans": [
+            "謎(なぞ)",
             "⓪ 名  谜语；谜；暗示"
-        ],
-        "notation": "謎(なぞ)"
+        ]
     },
     {
         "name": "sabiru",
         "trans": [
+            "錆(さ)びる",
             "② 自动2  生锈"
-        ],
-        "notation": "錆(さ)びる"
+        ]
     },
     {
         "name": "jimoto",
         "trans": [
+            "地元(じもと)",
             "③ 名  当地，本地"
-        ],
-        "notation": "地元(じもと)"
+        ]
     },
     {
         "name": "u-man",
         "trans": [
+            "ウーマン",
             "① 名  妇女，女性"
-        ],
-        "notation": "ウーマン"
+        ]
     },
     {
         "name": "tokuten",
         "trans": [
+            "得点(とくてん)",
             "⓪ 名  分数，得分"
-        ],
-        "notation": "得点(とくてん)"
+        ]
     },
     {
         "name": "dokomade",
         "trans": [
+            "どこまで",
             "① 副  到哪里；达到什么程度"
-        ],
-        "notation": "どこまで"
+        ]
     },
     {
         "name": "piza",
         "trans": [
+            "ピザ",
             "① 名  比萨饼"
-        ],
-        "notation": "ピザ"
+        ]
     },
     {
         "name": "miokuru",
         "trans": [
+            "見送(みおく)る",
             "⓪ 他动1  目送，送别；搁置"
-        ],
-        "notation": "見送(みおく)る"
+        ]
     },
     {
         "name": "shotaimen",
         "trans": [
+            "初対面(しょたいめん)",
             "② 名  初次见面"
-        ],
-        "notation": "初対面(しょたいめん)"
+        ]
     },
     {
         "name": "shoshinsha",
         "trans": [
+            "初心者(しょしんしゃ)",
             "② 名  初学者"
-        ],
-        "notation": "初心者(しょしんしゃ)"
+        ]
     },
     {
         "name": "toshiyori",
         "trans": [
+            "年寄(としよ)り",
             "③ 名  老人"
-        ],
-        "notation": "年寄(としよ)り"
+        ]
     },
     {
         "name": "ayumi",
         "trans": [
+            "歩(あゆ)み",
             "③ 名  步伐，脚步；发展历程"
-        ],
-        "notation": "歩(あゆ)み"
+        ]
     },
     {
         "name": "noberu",
         "trans": [
+            "述(の)べる",
             "② 他动2  叙述，说明"
-        ],
-        "notation": "述(の)べる"
+        ]
     },
     {
         "name": "seikyuu",
         "trans": [
+            "請求(せいきゅう)",
             "⓪ 名·他动3  请求，要求"
-        ],
-        "notation": "請求(せいきゅう)"
+        ]
     },
     {
         "name": "joukyou",
         "trans": [
+            "状況(じょうきょう)",
             "⓪ 名  情况，状况"
-        ],
-        "notation": "状況(じょうきょう)"
+        ]
     },
     {
         "name": "ketsuron",
         "trans": [
+            "結論(けつろん)",
             "⓪ 名·自动3  结论"
-        ],
-        "notation": "結論(けつろん)"
+        ]
     },
     {
         "name": "keru",
         "trans": [
+            "蹴(け)る",
             "① 他动1  踢"
-        ],
-        "notation": "蹴(け)る"
+        ]
     },
     {
         "name": "kyoka",
         "trans": [
+            "許可(きょか)",
             "① 名·他动3  许可，准许"
-        ],
-        "notation": "許可(きょか)"
+        ]
     },
     {
         "name": "ousetsu",
         "trans": [
+            "応接(おうせつ)",
             "⓪ 名·自动3  接待"
-        ],
-        "notation": "応接(おうせつ)"
+        ]
     },
     {
         "name": "koukyuu",
         "trans": [
+            "高級(こうきゅう)",
             "⓪ 名·ナ形  等级高；高级，上等"
-        ],
-        "notation": "高級(こうきゅう)"
+        ]
     },
     {
         "name": "chikaduku",
         "trans": [
+            "近(ちか)づく",
             "③ 自动1  接近，靠近；亲近"
-        ],
-        "notation": "近(ちか)づく"
+        ]
     },
     {
         "name": "chikadukeru",
         "trans": [
+            "近(ちか)づける",
             "⓪ 他动2  使⋯⋯靠近；亲近"
-        ],
-        "notation": "近(ちか)づける"
+        ]
     },
     {
         "name": "danbou",
         "trans": [
+            "暖房(だんぼう)",
             "⓪ 名  供暖设备"
-        ],
-        "notation": "暖房(だんぼう)"
+        ]
     },
     {
         "name": "oitsuku",
         "trans": [
+            "追(お)い付(つ)く",
             "③ 自动1  赶上，追上；来得及"
-        ],
-        "notation": "追(お)い付(つ)く"
+        ]
     },
     {
         "name": "chounan",
         "trans": [
+            "長男(ちょうなん)",
             "① 名  长子，大儿子"
-        ],
-        "notation": "長男(ちょうなん)"
+        ]
     },
     {
         "name": "hon'nin",
         "trans": [
+            "本人(ほんにん)",
             "① 名  本人"
-        ],
-        "notation": "本人(ほんにん)"
+        ]
     },
     {
         "name": "maikorohon",
         "trans": [
+            "マイクロホン",
             "④ 名  麦克风"
-        ],
-        "notation": "マイクロホン"
+        ]
     },
     {
         "name": "warikan",
         "trans": [
+            "割(わ)り勘(かん)",
             "⓪ 名  均摊费用"
-        ],
-        "notation": "割(わ)り勘(かん)"
+        ]
     },
     {
         "name": "warizan",
         "trans": [
+            "割(わ)り算(ざん)",
             "② 名  （数学）除法"
-        ],
-        "notation": "割(わ)り算(ざん)"
+        ]
     },
     {
         "name": "norikaeru",
         "trans": [
+            "乗(の)り換(か)える",
             "④ 自他动2  换车，换乘"
-        ],
-        "notation": "乗(の)り換(か)える"
+        ]
     },
     {
         "name": "tsuika",
         "trans": [
+            "追加(ついか)",
             "⓪ 名·他动3  追加"
-        ],
-        "notation": "追加(ついか)"
+        ]
     },
     {
         "name": "shoujiki",
         "trans": [
+            "正直(しょうじき)",
             "③ 名·ナ形·副  老实，正直"
-        ],
-        "notation": "正直(しょうじき)"
+        ]
     },
     {
         "name": "inta-netto",
         "trans": [
+            "インターネット",
             "⑤ 名  互联网"
-        ],
-        "notation": "インターネット"
+        ]
     },
     {
         "name": "ga-do",
         "trans": [
+            "ガード",
             "① 名  警卫；防卫"
-        ],
-        "notation": "ガード"
+        ]
     },
     {
         "name": "uragaesu",
         "trans": [
+            "裏返(うらがえ)す",
             "③ 他动1  翻过来"
-        ],
-        "notation": "裏返(うらがえ)す"
+        ]
     },
     {
         "name": "asekusai",
         "trans": [
+            "汗臭(あせくさ)い",
             "④ イ形  有汗味儿的"
-        ],
-        "notation": "汗臭(あせくさ)い"
+        ]
     },
     {
         "name": "kinmu",
         "trans": [
+            "勤務(きんむ)",
             "① 名·自动3  工作，上班"
-        ],
-        "notation": "勤務(きんむ)"
+        ]
     },
     {
         "name": "kashimiya",
         "trans": [
+            "カシミヤ",
             "⓪ 名  山羊绒"
-        ],
-        "notation": "カシミヤ"
+        ]
     },
     {
         "name": "torakku",
         "trans": [
+            "トラック",
             "② 名  卡车"
-        ],
-        "notation": "トラック"
+        ]
     },
     {
         "name": "douka",
         "trans": [
+            "どうか",
             "① 副  请；设法，想办法"
-        ],
-        "notation": "どうか"
+        ]
     },
     {
         "name": "hikoushi",
         "trans": [
+            "飛行士(ひこうし)",
             "② 名  飞行员"
-        ],
-        "notation": "飛行士(ひこうし)"
+        ]
     },
     {
         "name": "waiwai",
         "trans": [
+            "わいわい",
             "① 副  大声吵嚷"
-        ],
-        "notation": "わいわい"
+        ]
     },
     {
         "name": "nagasode",
         "trans": [
+            "長袖(ながそで)",
             "⓪ 名  长袖，长袖衣服"
-        ],
-        "notation": "長袖(ながそで)"
+        ]
     },
     {
         "name": "jun'en",
         "trans": [
+            "順延(じゅんえん)",
             "⓪ 名·他动3  顺延，依次延期"
-        ],
-        "notation": "順延(じゅんえん)"
+        ]
     },
     {
         "name": "kurisumasu",
         "trans": [
+            "クリスマス",
             "③ 名  圣诞节"
-        ],
-        "notation": "クリスマス"
+        ]
     },
     {
         "name": "zuuzuushii",
         "trans": [
+            "図々しい(ずうずうしい)",
             "⑤ イ形  厚脸皮的，无耻的"
-        ],
-        "notation": "図々しい(ずうずうしい)"
+        ]
     },
     {
         "name": "ireru",
         "trans": [
+            "入(い)れる",
             "⓪ 他动2  装进，放入；收进"
-        ],
-        "notation": "入(い)れる"
+        ]
     },
     {
         "name": "goran",
         "trans": [
+            "ご覧(らん)",
             "⓪ 名  （尊他语）看，观赏"
-        ],
-        "notation": "ご覧(らん)"
+        ]
     },
     {
         "name": "shukuhaku",
         "trans": [
+            "宿泊(しゅくはく)",
             "⓪ 名·自动3  投宿，住宿"
-        ],
-        "notation": "宿泊(しゅくはく)"
+        ]
     },
     {
         "name": "jinkou",
         "trans": [
+            "人口(じんこう)",
             "⓪ 名  人口"
-        ],
-        "notation": "人口(じんこう)"
+        ]
     },
     {
         "name": "hanashikakeru",
         "trans": [
+            "話(はな)し掛(か)ける",
             "⑤ 自动2  搭话，打招呼；刚要说话"
-        ],
-        "notation": "話(はな)し掛(か)ける"
+        ]
     },
     {
         "name": "futo",
         "trans": [
+            "ふと",
             "⓪ 副  偶然，突然"
-        ],
-        "notation": "ふと"
+        ]
     },
     {
         "name": "inkan",
         "trans": [
+            "印鑑(いんかん)",
             "③ 名  印章"
-        ],
-        "notation": "印鑑(いんかん)"
+        ]
     },
     {
         "name": "fujin",
         "trans": [
+            "婦人(ふじん)",
             "⓪ 名  妇女，女士"
-        ],
-        "notation": "婦人(ふじん)"
+        ]
     },
     {
         "name": "chikaraduyoi",
         "trans": [
+            "力強(ちからづよ)い",
             "⑤ イ形  强有力的；有信心的"
-        ],
-        "notation": "力強(ちからづよ)い"
+        ]
     },
     {
         "name": "chaimu",
         "trans": [
+            "チャイム",
             "① 名  门铃；编钟"
-        ],
-        "notation": "チャイム"
+        ]
     },
     {
         "name": "fuzakeru",
         "trans": [
+            "ふざける",
             "③ 自动2  开玩笑；愚弄，捉弄"
-        ],
-        "notation": "ふざける"
+        ]
     },
     {
         "name": "insutanto",
         "trans": [
+            "インスタント～",
             " 接头  速成，速食"
-        ],
-        "notation": "インスタント～"
+        ]
     },
     {
         "name": "hiromaru",
         "trans": [
+            "広(ひろ)まる",
             "③ 自动1  扩大，普及；传播"
-        ],
-        "notation": "広(ひろ)まる"
+        ]
     },
     {
         "name": "hiromeru",
         "trans": [
+            "広(ひろ)める",
             "③ 他动2  扩大，普及；传播"
-        ],
-        "notation": "広(ひろ)める"
+        ]
     },
     {
         "name": "han'nin",
         "trans": [
+            "犯人(はんにん)",
             "① 名  犯人"
-        ],
-        "notation": "犯人(はんにん)"
+        ]
     },
     {
         "name": "nentou",
         "trans": [
+            "年頭(ねんとう)",
             "⓪ 名  年初"
-        ],
-        "notation": "年頭(ねんとう)"
+        ]
     },
     {
         "name": "atarimae",
         "trans": [
+            "当(あ)たり前(まえ)",
             "⓪ ナ形  当然的，理所应当的"
-        ],
-        "notation": "当(あ)たり前(まえ)"
+        ]
     },
     {
         "name": "haneru",
         "trans": [
+            "跳(は)ねる",
             "② 自动2  跳，跳起；（液体）飞溅"
-        ],
-        "notation": "跳(は)ねる"
+        ]
     },
     {
         "name": "tsutsumigami",
         "trans": [
+            "包(つつみが)み紙()",
             "③ 名  包装纸"
-        ],
-        "notation": "包(つつみが)み紙()"
+        ]
     },
     {
         "name": "sashidashinin",
         "trans": [
+            "差出人(さしだしにん)",
             "⓪ 名  （邮件等）寄件人"
-        ],
-        "notation": "差出人(さしだしにん)"
+        ]
     },
     {
         "name": "gussuri",
         "trans": [
+            "ぐっすり",
             "③ 副  酣睡，熟睡"
-        ],
-        "notation": "ぐっすり"
+        ]
     },
     {
         "name": "kanzen",
         "trans": [
+            "完全(かんぜん)",
             "⓪ 名·ナ形  完全，完整，完美"
-        ],
-        "notation": "完全(かんぜん)"
+        ]
     },
     {
         "name": "kayui",
         "trans": [
+            "痒(かゆ)い",
             "② イ形  痒的，发痒的"
-        ],
-        "notation": "痒(かゆ)い"
+        ]
     },
     {
         "name": "yakuin",
         "trans": [
+            "役員(やくいん)",
             "② 名  负责人，干部；公司董事"
-        ],
-        "notation": "役員(やくいん)"
+        ]
     },
     {
         "name": "nantonaku",
         "trans": [
+            "何(なん)となく",
             "④ 副  总觉得，不由得"
-        ],
-        "notation": "何(なん)となく"
+        ]
     },
     {
         "name": "nantoka",
         "trans": [
+            "何(なん)とか",
             "① 副  想办法，设法"
-        ],
-        "notation": "何(なん)とか"
+        ]
     },
     {
         "name": "deza-to",
         "trans": [
+            "デザート",
             "② 名  甜点"
-        ],
-        "notation": "デザート"
+        ]
     },
     {
         "name": "tsugu",
         "trans": [
+            "注(つ)ぐ",
             "⓪ 他动1  斟，倒（茶、酒等）"
-        ],
-        "notation": "注(つ)ぐ"
+        ]
     },
     {
         "name": "atsumari",
         "trans": [
+            "集(あつ)まり",
             "④ 名  集会，会合"
-        ],
-        "notation": "集(あつ)まり"
+        ]
     },
     {
         "name": "uramon",
         "trans": [
+            "裏門(うらもん)",
             "⓪ 名  后门"
-        ],
-        "notation": "裏門(うらもん)"
+        ]
     },
     {
         "name": "chousho",
         "trans": [
+            "長所(ちょうしょ)",
             "① 名  长处，优点"
-        ],
-        "notation": "長所(ちょうしょ)"
+        ]
     },
     {
         "name": "yusayusa",
         "trans": [
+            "ゆさゆさ",
             "① 副·自动3  （树木、建筑物）大幅度摇晃"
-        ],
-        "notation": "ゆさゆさ"
+        ]
     },
     {
         "name": "semento",
         "trans": [
+            "セメント",
             "⓪ 名  水泥"
-        ],
-        "notation": "セメント"
+        ]
     },
     {
         "name": "tachiyoru",
         "trans": [
+            "立(た)ち寄(よ)る",
             "⓪ 自动1  靠近；顺路去"
-        ],
-        "notation": "立(た)ち寄(よ)る"
+        ]
     },
     {
         "name": "namagomi",
         "trans": [
+            "生(なま)ゴミ",
             "⓪ 名  厨余垃圾"
-        ],
-        "notation": "生(なま)ゴミ"
+        ]
     },
     {
         "name": "niou",
         "trans": [
+            "匂(にお)う",
             "② 自动1  发出气味；散发香味"
-        ],
-        "notation": "匂(にお)う"
+        ]
     },
     {
         "name": "nuku",
         "trans": [
+            "抜(ぬ)く",
             "⓪ 他动1  抽出，拔出；选出；省略"
-        ],
-        "notation": "抜(ぬ)く"
+        ]
     },
     {
         "name": "nukeru",
         "trans": [
+            "抜(ぬ)ける",
             "⓪ 自动2  脱落；漏掉；穿过；退出"
-        ],
-        "notation": "抜(ぬ)ける"
+        ]
     },
     {
         "name": "tagaini",
         "trans": [
+            "互(たが)いに",
             "⓪ 副  互相，相互"
-        ],
-        "notation": "互(たが)いに"
+        ]
     },
     {
         "name": "zokusuru",
         "trans": [
+            "属(ぞく)する",
             "③ 自动3  属于"
-        ],
-        "notation": "属(ぞく)する"
+        ]
     },
     {
         "name": "sekitan",
         "trans": [
+            "石炭(せきたん)",
             "③ 名  煤炭"
-        ],
-        "notation": "石炭(せきたん)"
+        ]
     },
     {
         "name": "sekiyu",
         "trans": [
+            "石油(せきゆ)",
             "⓪ 名  石油"
-        ],
-        "notation": "石油(せきゆ)"
+        ]
     },
     {
         "name": "sue",
         "trans": [
+            "末(すえ)",
             "⓪ 名  末尾；最小的孩子"
-        ],
-        "notation": "末(すえ)"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "資格(しかく)",
             "⓪ 名  资格"
-        ],
-        "notation": "資格(しかく)"
+        ]
     },
     {
         "name": "naname",
         "trans": [
+            "斜(なな)め",
             "② 名·ナ形  倾斜"
-        ],
-        "notation": "斜(なな)め"
+        ]
     },
     {
         "name": "heiki",
         "trans": [
+            "平気(へいき)",
             "⓪ 名·ナ形  沉着，冷静；不在乎，不介意，无动于衷"
-        ],
-        "notation": "平気(へいき)"
+        ]
     },
     {
         "name": "puroguramu",
         "trans": [
+            "プログラム",
             "③ 名  计划，进程；程序"
-        ],
-        "notation": "プログラム"
+        ]
     },
     {
         "name": "arigatai",
         "trans": [
+            "有難(ありがた)い",
             "④ イ形  难得的；值得感激的"
-        ],
-        "notation": "有難(ありがた)い"
+        ]
     },
     {
         "name": "egaku",
         "trans": [
+            "描(えが)く",
             "② 他动1  画，描绘；描写"
-        ],
-        "notation": "描(えが)く"
+        ]
     },
     {
         "name": "pinpon",
         "trans": [
+            "ピンポン",
             "① 名  乒乓球"
-        ],
-        "notation": "ピンポン"
+        ]
     },
     {
         "name": "outai",
         "trans": [
+            "応対(おうたい)",
             "⓪ 名·自动3  接待，应酬"
-        ],
-        "notation": "応対(おうたい)"
+        ]
     },
     {
         "name": "hitosashiyubi",
         "trans": [
+            "人差(ひとさ)し指(ゆび)",
             "④ 名  食指"
-        ],
-        "notation": "人差(ひとさ)し指(ゆび)"
+        ]
     },
     {
         "name": "shougakukin",
         "trans": [
+            "奨学金(しょうがくきん)",
             "⓪ 名  奖学金"
-        ],
-        "notation": "奨学金(しょうがくきん)"
+        ]
     },
     {
         "name": "goutou",
         "trans": [
+            "強盗(ごうとう)",
             "⓪ 名  强盗，抢劫"
-        ],
-        "notation": "強盗(ごうとう)"
+        ]
     },
     {
         "name": "dantai",
         "trans": [
+            "団体(だんたい)",
             "⓪ 名  团体，集团"
-        ],
-        "notation": "団体(だんたい)"
+        ]
     },
     {
         "name": "tsuushinhanbai",
         "trans": [
+            "通信販売(つうしんはんばい)",
             "⑤ 名  邮购，网购"
-        ],
-        "notation": "通信販売(つうしんはんばい)"
+        ]
     },
     {
         "name": "toriaezu",
         "trans": [
+            "とりあえず",
             "③ 副  暂且，姑且；急忙，匆忙"
-        ],
-        "notation": "とりあえず"
+        ]
     },
     {
         "name": "hyougen",
         "trans": [
+            "表現(ひょうげん)",
             "③ 名·他动3  表现，表达"
-        ],
-        "notation": "表現(ひょうげん)"
+        ]
     },
     {
         "name": "hyouji",
         "trans": [
+            "表示(ひょうじ)",
             "⓪ 名·他动3  表示，表明"
-        ],
-        "notation": "表示(ひょうじ)"
+        ]
     },
     {
         "name": "basutei",
         "trans": [
+            "バス停(てい)",
             "⓪ 名  公交车站"
-        ],
-        "notation": "バス停(てい)"
+        ]
     },
     {
         "name": "nihonshu",
         "trans": [
+            "日本酒(にほんしゅ)",
             "⓪ 名  清酒，日本酒"
-        ],
-        "notation": "日本酒(にほんしゅ)"
+        ]
     },
     {
         "name": "nadaraka",
         "trans": [
+            "なだらか",
             "② ナ形  坡度小的，平稳的；（情况）顺利的"
-        ],
-        "notation": "なだらか"
+        ]
     },
     {
         "name": "douji",
         "trans": [
+            "同時(どうじ)",
             "⓪ 名  同时"
-        ],
-        "notation": "同時(どうじ)"
+        ]
     },
     {
         "name": "tabi",
         "trans": [
+            "足袋(たび)",
             "① 名  日式短袜"
-        ],
-        "notation": "足袋(たび)"
+        ]
     },
     {
         "name": "negai",
         "trans": [
+            "願(ねが)い",
             "② 名  愿望，请求"
-        ],
-        "notation": "願(ねが)い"
+        ]
     },
     {
         "name": "kufuu",
         "trans": [
+            "工夫(くふう)",
             "⓪ 名·他动3  设法，想办法"
-        ],
-        "notation": "工夫(くふう)"
+        ]
     },
     {
         "name": "fureai",
         "trans": [
+            "触(ふ)れ合(あ)い",
             "⓪ 名  接触"
-        ],
-        "notation": "触(ふ)れ合(あ)い"
+        ]
     },
     {
         "name": "kawaru",
         "trans": [
+            "代(か)わる",
             "⓪ 自动1  更换，代替"
-        ],
-        "notation": "代(か)わる"
+        ]
     },
     {
         "name": "kankyou",
         "trans": [
+            "環境(かんきょう)",
             "⓪ 名  环境"
-        ],
-        "notation": "環境(かんきょう)"
+        ]
     },
     {
         "name": "teki",
         "trans": [
+            "敵(てき)",
             "⓪ 名  敌人，对手"
-        ],
-        "notation": "敵(てき)"
+        ]
     },
     {
         "name": "itsunomanika",
         "trans": [
+            "いつの間(ま)にか",
             "⑤ 副  不知不觉中"
-        ],
-        "notation": "いつの間(ま)にか"
+        ]
     },
     {
         "name": "tekubi",
         "trans": [
+            "手首(てくび)",
             "① 名  手腕"
-        ],
-        "notation": "手首(てくび)"
+        ]
     },
     {
         "name": "ikuji",
         "trans": [
+            "育児(いくじ)",
             "① 名·自动3  育儿"
-        ],
-        "notation": "育児(いくじ)"
+        ]
     },
     {
         "name": "shiboru",
         "trans": [
+            "絞(しぼ)る",
             "② 他动1  拧，挤；绞尽脑汁"
-        ],
-        "notation": "絞(しぼ)る"
+        ]
     },
     {
         "name": "gure-",
         "trans": [
+            "グレー",
             "② 名  灰色"
-        ],
-        "notation": "グレー"
+        ]
     },
     {
         "name": "cho-ku",
         "trans": [
+            "チョーク",
             "① 名  粉笔"
-        ],
-        "notation": "チョーク"
+        ]
     },
     {
         "name": "kamisori",
         "trans": [
+            "剃刀(かみそり)",
             "③ 名  剃刀"
-        ],
-        "notation": "剃刀(かみそり)"
+        ]
     },
     {
         "name": "itsukaraka",
         "trans": [
+            "いつからか",
             "① 副  不知从何时起"
-        ],
-        "notation": "いつからか"
+        ]
     },
     {
         "name": "suiji",
         "trans": [
+            "炊事(すいじ)",
             "⓪ 名·自动3  做饭，烹调"
-        ],
-        "notation": "炊事(すいじ)"
+        ]
     },
     {
         "name": "sudeni",
         "trans": [
+            "すでに",
             "① 副  已经，早就"
-        ],
-        "notation": "すでに"
+        ]
     },
     {
         "name": "tsuneni",
         "trans": [
+            "常(つね)に",
             "① 副  经常，时常"
-        ],
-        "notation": "常(つね)に"
+        ]
     },
     {
         "name": "nigiyaka",
         "trans": [
+            "賑(にぎ)やか",
             "② ナ形  热闹的，繁华的；极其开朗的"
-        ],
-        "notation": "賑(にぎ)やか"
+        ]
     },
     {
         "name": "norikosu",
         "trans": [
+            "乗(の)り越(こ)す",
             "③ 他动1  坐过站"
-        ],
-        "notation": "乗(の)り越(こ)す"
+        ]
     },
     {
         "name": "hitode",
         "trans": [
+            "人手(ひとで)",
             "⓪ 名  帮手，外援；人手"
-        ],
-        "notation": "人手(ひとで)"
+        ]
     },
     {
         "name": "ugoki",
         "trans": [
+            "動(うご)き",
             "③ 名  活动；动向"
-        ],
-        "notation": "動(うご)き"
+        ]
     },
     {
         "name": "fubo",
         "trans": [
+            "父母(ふぼ)",
             "① 名  父母"
-        ],
-        "notation": "父母(ふぼ)"
+        ]
     },
     {
         "name": "obon",
         "trans": [
+            "お盆(ぼん)",
             "② 名  盂兰盆节"
-        ],
-        "notation": "お盆(ぼん)"
+        ]
     },
     {
         "name": "mausu",
         "trans": [
+            "マウス",
             "① 名  老鼠；鼠标"
-        ],
-        "notation": "マウス"
+        ]
     },
     {
         "name": "~tarazu",
         "trans": [
+            "～足(た)らず",
             " 接尾  ⋯⋯不足"
-        ],
-        "notation": "～足(た)らず"
+        ]
     },
     {
         "name": "kontoro-ru",
         "trans": [
+            "コントロール",
             "④ 名·他动3  控制，管理"
-        ],
-        "notation": "コントロール"
+        ]
     },
     {
         "name": "kaiteki",
         "trans": [
+            "快適(かいてき)",
             "⓪ ナ形  舒适的，舒服的"
-        ],
-        "notation": "快適(かいてき)"
+        ]
     },
     {
         "name": "sutairu",
         "trans": [
+            "スタイル",
             "② 名  样式，形式；（人的）姿势，风采"
-        ],
-        "notation": "スタイル"
+        ]
     },
     {
         "name": "jagaimo",
         "trans": [
+            "ジャガ芋(いも)",
             "⓪ 名  马铃薯，土豆"
-        ],
-        "notation": "ジャガ芋(いも)"
+        ]
     },
     {
         "name": "nendai",
         "trans": [
+            "年代(ねんだい)",
             "⓪ 名  年代"
-        ],
-        "notation": "年代(ねんだい)"
+        ]
     },
     {
         "name": "~kaeru",
         "trans": [
+            "～換(か)える",
             " 接尾  改⋯⋯，换⋯⋯"
-        ],
-        "notation": "～換(か)える"
+        ]
     },
     {
         "name": "chikyuu",
         "trans": [
+            "地球(ちきゅう)",
             "⓪ 名  地球"
-        ],
-        "notation": "地球(ちきゅう)"
+        ]
     },
     {
         "name": "kirakira",
         "trans": [
+            "きらきら",
             "① 副·自动3  闪闪发光，闪耀"
-        ],
-        "notation": "きらきら"
+        ]
     },
     {
         "name": "dakko",
         "trans": [
+            "抱(だ)っこ",
             "① 名·他动3  抱（小孩）"
-        ],
-        "notation": "抱(だ)っこ"
+        ]
     },
     {
         "name": "nyoubou",
         "trans": [
+            "女房(にょうぼう)",
             "① 名  妻子"
-        ],
-        "notation": "女房(にょうぼう)"
+        ]
     },
     {
         "name": "hedateru",
         "trans": [
+            "隔(へだ)てる",
             "③ 他动2  隔开，间隔"
-        ],
-        "notation": "隔(へだ)てる"
+        ]
     },
     {
         "name": "kossetsu",
         "trans": [
+            "骨折(こっせつ)",
             "⓪ 名·自动3  骨折"
-        ],
-        "notation": "骨折(こっせつ)"
+        ]
     },
     {
         "name": "kakeru",
         "trans": [
+            "架(か)ける",
             "② 他动2  架上；铺设"
-        ],
-        "notation": "架(か)ける"
+        ]
     },
     {
         "name": "teiryuujo",
         "trans": [
+            "停留所(ていりゅうじょ)",
             "⓪ 名  车站，公共汽车站"
-        ],
-        "notation": "停留所(ていりゅうじょ)"
+        ]
     },
     {
         "name": "tsukamu",
         "trans": [
+            "掴(つか)む",
             "② 他动1  抓住；掌握，理解"
-        ],
-        "notation": "掴(つか)む"
+        ]
     },
     {
         "name": "kinkyuu",
         "trans": [
+            "緊急(きんきゅう)",
             "⓪ 名·ナ形  紧急，急迫"
-        ],
-        "notation": "緊急(きんきゅう)"
+        ]
     },
     {
         "name": "kashikari",
         "trans": [
+            "貸(か)し借(か)り",
             "② 名·他动3  借出和借入"
-        ],
-        "notation": "貸(か)し借(か)り"
+        ]
     },
     {
         "name": "hizashi",
         "trans": [
+            "日差(ひざ)し",
             "⓪ 名  阳光，阳光照射"
-        ],
-        "notation": "日差(ひざ)し"
+        ]
     },
     {
         "name": "feri-",
         "trans": [
+            "フェリー",
             "① 名  渡口；渡船"
-        ],
-        "notation": "フェリー"
+        ]
     },
     {
         "name": "nochi",
         "trans": [
+            "後(のち)",
             "② 名  之后，以后；今后，将来"
-        ],
-        "notation": "後(のち)"
+        ]
     },
     {
         "name": "betsuni",
         "trans": [
+            "別(べつ)に",
             "⓪ 副  分开；（后接否定）并（不）"
-        ],
-        "notation": "別(べつ)に"
+        ]
     },
     {
         "name": "kataashi",
         "trans": [
+            "片足(かたあし)",
             "⓪ 名  一条腿；一只鞋；一只袜子"
-        ],
-        "notation": "片足(かたあし)"
+        ]
     },
     {
         "name": "meijin",
         "trans": [
+            "名人(めいじん)",
             "③ 名  专家；（围棋等的最高等级）国手"
-        ],
-        "notation": "名人(めいじん)"
+        ]
     },
     {
         "name": "meibutsu",
         "trans": [
+            "名物(めいぶつ)",
             "① 名  特产，有名的东西"
-        ],
-        "notation": "名物(めいぶつ)"
+        ]
     },
     {
         "name": "samasu",
         "trans": [
+            "覚(さ)ます",
             "② 他动1  弄醒，使⋯⋯清醒"
-        ],
-        "notation": "覚(さ)ます"
+        ]
     },
     {
         "name": "kachi",
         "trans": [
+            "価値(かち)",
             "① 名  价值"
-        ],
-        "notation": "価値(かち)"
+        ]
     },
     {
         "name": "zenryoku",
         "trans": [
+            "全力(ぜんりょく)",
             "⓪ 名  全力，全部力量"
-        ],
-        "notation": "全力(ぜんりょく)"
+        ]
     },
     {
         "name": "daikin",
         "trans": [
+            "代金(だいきん)",
             "① 名  价款，货款"
-        ],
-        "notation": "代金(だいきん)"
+        ]
     },
     {
         "name": "chikaraippai",
         "trans": [
+            "力(ちから)いっぱい",
             "④ 副  竭尽全力"
-        ],
-        "notation": "力(ちから)いっぱい"
+        ]
     },
     {
         "name": "joujun",
         "trans": [
+            "上旬(じょうじゅん)",
             "⓪ 名  上旬"
-        ],
-        "notation": "上旬(じょうじゅん)"
+        ]
     },
     {
         "name": "doryoku",
         "trans": [
+            "努力(どりょく)",
             "① 名·自动3  努力"
-        ],
-        "notation": "努力(どりょく)"
+        ]
     },
     {
         "name": "nanishiro",
         "trans": [
+            "何(なに)しろ",
             "① 副  无论怎样，总之"
-        ],
-        "notation": "何(なに)しろ"
+        ]
     },
     {
         "name": "bare-bo-ru",
         "trans": [
+            "バレーボール",
             "④ 名  排球"
-        ],
-        "notation": "バレーボール"
+        ]
     },
     {
         "name": "haiiro",
         "trans": [
+            "灰色(はいいろ)",
             "⓪ 名  灰色"
-        ],
-        "notation": "灰色(はいいろ)"
+        ]
     },
     {
         "name": "warini",
         "trans": [
+            "割(わり)に",
             "③ 副  比较；格外，出乎意料"
-        ],
-        "notation": "割(わり)に"
+        ]
     },
     {
         "name": "kakkoii",
         "trans": [
+            "かっこいい",
             "④ イ形  帅气的；很棒的"
-        ],
-        "notation": "かっこいい"
+        ]
     },
     {
         "name": "piipu",
         "trans": [
+            "パイプ",
             "⓪ 名  管子，管道"
-        ],
-        "notation": "パイプ"
+        ]
     },
     {
         "name": "ji-pan",
         "trans": [
+            "ジーパン",
             "⓪ 名  牛仔裤"
-        ],
-        "notation": "ジーパン"
+        ]
     },
     {
         "name": "zurui",
         "trans": [
+            "ずるい",
             "② イ形  狡猾的，滑头的"
-        ],
-        "notation": "ずるい"
+        ]
     },
     {
         "name": "toshin",
         "trans": [
+            "都心(としん)",
             "⓪ 名  市中心"
-        ],
-        "notation": "都心(としん)"
+        ]
     },
     {
         "name": "bassuru",
         "trans": [
+            "罰(ばっ)する",
             "⓪ 他动3  处罚，责罚"
-        ],
-        "notation": "罰(ばっ)する"
+        ]
     },
     {
         "name": "hakken",
         "trans": [
+            "発見(はっけん)",
             "⓪ 名·他动3  发现"
-        ],
-        "notation": "発見(はっけん)"
+        ]
     },
     {
         "name": "hassou",
         "trans": [
+            "発想(はっそう)",
             "⓪ 名·自他动3  主意，想法，构思；表现"
-        ],
-        "notation": "発想(はっそう)"
+        ]
     },
     {
         "name": "hattatsu",
         "trans": [
+            "発達(はったつ)",
             "⓪ 名·自动3  发达，发展；发育；（规模）扩大"
-        ],
-        "notation": "発達(はったつ)"
+        ]
     },
     {
         "name": "hatsubai",
         "trans": [
+            "発売(はつばい)",
             "⓪ 名·他动3  发售，出售"
-        ],
-        "notation": "発売(はつばい)"
+        ]
     },
     {
         "name": "hatsumei",
         "trans": [
+            "発明(はつめい)",
             "⓪ 名·他动3  发明"
-        ],
-        "notation": "発明(はつめい)"
+        ]
     },
     {
         "name": "koin",
         "trans": [
+            "コイン",
             "① 名  硬币"
-        ],
-        "notation": "コイン"
+        ]
     },
     {
         "name": "butai",
         "trans": [
+            "舞台(ぶたい)",
             "① 名  舞台"
-        ],
-        "notation": "舞台(ぶたい)"
+        ]
     },
     {
         "name": "mogumogu",
         "trans": [
+            "もぐもぐ",
             "① 副·自动3  闭着嘴咀嚼；蠕动"
-        ],
-        "notation": "もぐもぐ"
+        ]
     },
     {
         "name": "yoso",
         "trans": [
+            "余所(よそ)",
             "② 名  别处；漠不关心，不顾"
-        ],
-        "notation": "余所(よそ)"
+        ]
     },
     {
         "name": "tsugitsugi",
         "trans": [
+            "次々(つぎつぎ)",
             "② 副  连续不断，一个接一个"
-        ],
-        "notation": "次々(つぎつぎ)"
+        ]
     },
     {
         "name": "hyottoshitara",
         "trans": [
+            "ひょっとしたら",
             "⑤ 副  或许，说不定"
-        ],
-        "notation": "ひょっとしたら"
+        ]
     },
     {
         "name": "katsuyaku",
         "trans": [
+            "活躍(かつやく)",
             "⓪ 名·自动3  活跃，活动"
-        ],
-        "notation": "活躍(かつやく)"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "端(はし)",
             "⓪ 名  端，头儿，边缘；开端"
-        ],
-        "notation": "端(はし)"
+        ]
     },
     {
         "name": "jidou",
         "trans": [
+            "児童(じどう)",
             "① 名  儿童"
-        ],
-        "notation": "児童(じどう)"
+        ]
     },
     {
         "name": "soreru",
         "trans": [
+            "逸(そ)れる",
             "② 自动2  偏离，错开"
-        ],
-        "notation": "逸(そ)れる"
+        ]
     },
     {
         "name": "fushizen",
         "trans": [
+            "不自然(ふしぜん)",
             "② 名·ナ形  不自然，做作"
-        ],
-        "notation": "不自然(ふしぜん)"
+        ]
     },
     {
         "name": "taido",
         "trans": [
+            "態度(たいど)",
             "① 名  态度"
-        ],
-        "notation": "態度(たいど)"
+        ]
     },
     {
         "name": "kanou",
         "trans": [
+            "可能(かのう)",
             "⓪ 名·ナ形  可能，可行"
-        ],
-        "notation": "可能(かのう)"
+        ]
     },
     {
         "name": "tsukiau",
         "trans": [
+            "付(つ)き合(あ)う",
             "③ 自动1  交际，交往；陪同"
-        ],
-        "notation": "付(つ)き合(あ)う"
+        ]
     },
     {
         "name": "shitetsu",
         "trans": [
+            "私鉄(してつ)",
             "⓪ 名  私营铁路"
-        ],
-        "notation": "私鉄(してつ)"
+        ]
     },
     {
         "name": "kasai",
         "trans": [
+            "火災(かさい)",
             "⓪ 名  火灾"
-        ],
-        "notation": "火災(かさい)"
+        ]
     },
     {
         "name": "shiagaru",
         "trans": [
+            "仕上(しあ)がる",
             "③ 自动1  做完，完成"
-        ],
-        "notation": "仕上(しあ)がる"
+        ]
     },
     {
         "name": "shiageru",
         "trans": [
+            "仕上(しあ)げる",
             "③ 他动2  做完，完成"
-        ],
-        "notation": "仕上(しあ)げる"
+        ]
     },
     {
         "name": "hata",
         "trans": [
+            "旗(はた)",
             "② 名  旗帜"
-        ],
-        "notation": "旗(はた)"
+        ]
     },
     {
         "name": "juudai",
         "trans": [
+            "重大(じゅうだい)",
             "⓪ ナ形  重大的，重要的；严重的"
-        ],
-        "notation": "重大(じゅうだい)"
+        ]
     },
     {
         "name": "taishoku",
         "trans": [
+            "退職(たいしょく)",
             "⓪ 名·自动3  退休，离职"
-        ],
-        "notation": "退職(たいしょく)"
+        ]
     },
     {
         "name": "tekido",
         "trans": [
+            "適度(てきど)",
             "① 名·ナ形  适度，适当"
-        ],
-        "notation": "適度(てきど)"
+        ]
     },
     {
         "name": "hakari",
         "trans": [
+            "秤(はかり)",
             "③ 名  秤，天平"
-        ],
-        "notation": "秤(はかり)"
+        ]
     },
     {
         "name": "baggu",
         "trans": [
+            "バッグ",
             "① 名  手提包"
-        ],
-        "notation": "バッグ"
+        ]
     },
     {
         "name": "byounin",
         "trans": [
+            "病人(びょうにん)",
             "⓪ 名  病人，患者"
-        ],
-        "notation": "病人(びょうにん)"
+        ]
     },
     {
         "name": "taiiku",
         "trans": [
+            "体育(たいいく)",
             "① 名  体育"
-        ],
-        "notation": "体育(たいいく)"
+        ]
     },
     {
         "name": "hanashiai",
         "trans": [
+            "話(はな)し合(あ)い",
             "⓪ 名  商量，商议"
-        ],
-        "notation": "話(はな)し合(あ)い"
+        ]
     },
     {
         "name": "ainiku",
         "trans": [
+            "あいにく",
             "⓪ 副·ナ形  不凑巧，遗憾"
-        ],
-        "notation": "あいにく"
+        ]
     },
     {
         "name": "shiji",
         "trans": [
+            "指示(しじ)",
             "① 名·他动3  指示，命令"
-        ],
-        "notation": "指示(しじ)"
+        ]
     },
     {
         "name": "kigae",
         "trans": [
+            "着替(きが)え",
             "⓪ 名·自动3  替换的衣服；换衣服"
-        ],
-        "notation": "着替(きが)え"
+        ]
     },
     {
         "name": "kigaeru",
         "trans": [
+            "着替(きが)える",
             "③ 他动2  换衣服"
-        ],
-        "notation": "着替(きが)える"
+        ]
     },
     {
         "name": "omoeru",
         "trans": [
+            "思(おも)える",
             "③ 自动2  感到"
-        ],
-        "notation": "思(おも)える"
+        ]
     },
     {
         "name": "kokke",
         "trans": [
+            "コック",
             "① 名  厨师"
-        ],
-        "notation": "コック"
+        ]
     },
     {
         "name": "kangofu",
         "trans": [
+            "看護婦(かんごふ)",
             "③ 名  护士"
-        ],
-        "notation": "看護婦(かんごふ)"
+        ]
     },
     {
         "name": "muzumuzu",
         "trans": [
+            "むずむず",
             "① 副·自动3  痒痒；急得慌，跃跃欲试"
-        ],
-        "notation": "むずむず"
+        ]
     },
     {
         "name": "kotton",
         "trans": [
+            "コットン",
             "① 名  棉花，棉布"
-        ],
-        "notation": "コットン"
+        ]
     },
     {
         "name": "doushitemo",
         "trans": [
+            "どうしても",
             "④ 副  （后接否定）怎么也（不）⋯⋯；务必，一定"
-        ],
-        "notation": "どうしても"
+        ]
     },
     {
         "name": "hayanehayaoki",
         "trans": [
+            "早寝早起(はやねはやお)き",
             "⑥ 名·自动3  早睡早起"
-        ],
-        "notation": "早寝早起(はやねはやお)き"
+        ]
     },
     {
         "name": "doresu",
         "trans": [
+            "ドレス",
             "① 名  女士礼服"
-        ],
-        "notation": "ドレス"
+        ]
     },
     {
         "name": "shitagaki",
         "trans": [
+            "下書(したが)き",
             "⓪ 名·他动3  草稿；打草稿"
-        ],
-        "notation": "下書(したが)き"
+        ]
     },
     {
         "name": "zatto",
         "trans": [
+            "ざっと",
             "⓪ 副  粗略地，大致"
-        ],
-        "notation": "ざっと"
+        ]
     },
     {
         "name": "hara",
         "trans": [
+            "原(はら)",
             "① 名  平原；荒原"
-        ],
-        "notation": "原(はら)"
+        ]
     },
     {
         "name": "sonraku",
         "trans": [
+            "村落(そんらく)",
             "① 名  村庄"
-        ],
-        "notation": "村落(そんらく)"
+        ]
     },
     {
         "name": "kaisuuken",
         "trans": [
+            "回数券(かいすうけん)",
             "③ 名  回数券（用一次撕一张的票）"
-        ],
-        "notation": "回数券(かいすうけん)"
+        ]
     },
     {
         "name": "akirameru",
         "trans": [
+            "諦(あきら)める",
             "④ 他动2  死心，放弃"
-        ],
-        "notation": "諦(あきら)める"
+        ]
     },
     {
         "name": "sonzai",
         "trans": [
+            "存在(そんざい)",
             "⓪ 名·自动3  存在"
-        ],
-        "notation": "存在(そんざい)"
+        ]
     },
     {
         "name": "samuke",
         "trans": [
+            "寒気(さむけ)",
             "③ 名  寒气；身体发冷"
-        ],
-        "notation": "寒気(さむけ)"
+        ]
     },
     {
         "name": "kouritsu",
         "trans": [
+            "効率(こうりつ)",
             "⓪ 名  效率"
-        ],
-        "notation": "効率(こうりつ)"
+        ]
     },
     {
         "name": "hansuu",
         "trans": [
+            "半数(はんすう)",
             "③ 名  半数"
-        ],
-        "notation": "半数(はんすう)"
+        ]
     },
     {
         "name": "higaeri",
         "trans": [
+            "日帰(ひがえ)り",
             "⓪ 名  当天去当天回"
-        ],
-        "notation": "日帰(ひがえ)り"
+        ]
     },
     {
         "name": "hitorikko",
         "trans": [
+            "一人(ひとり)っ子(こ)",
             "③ 名  独生子女"
-        ],
-        "notation": "一人(ひとり)っ子(こ)"
+        ]
     },
     {
         "name": "soujiki",
         "trans": [
+            "掃除機(そうじき)",
             "③ 名  吸尘器"
-        ],
-        "notation": "掃除機(そうじき)"
+        ]
     },
     {
         "name": "seishiki",
         "trans": [
+            "正式(せいしき)",
             "⓪ 名·ナ形  正式，正规"
-        ],
-        "notation": "正式(せいしき)"
+        ]
     },
     {
         "name": "shinrin",
         "trans": [
+            "森林(しんりん)",
             "⓪ 名  森林"
-        ],
-        "notation": "森林(しんりん)"
+        ]
     },
     {
         "name": "shoujou",
         "trans": [
+            "症状(しょうじょう)",
             "③ 名  症状，病情"
-        ],
-        "notation": "症状(しょうじょう)"
+        ]
     },
     {
         "name": "shagamu",
         "trans": [
+            "しゃがむ",
             "⓪ 自动1  蹲下"
-        ],
-        "notation": "しゃがむ"
+        ]
     },
     {
         "name": "odekake",
         "trans": [
+            "お出(で)かけ",
             "⓪ 名  出门"
-        ],
-        "notation": "お出(で)かけ"
+        ]
     },
     {
         "name": "issakujitsu",
         "trans": [
+            "一昨日(いっさくじつ)",
             "④ 名  前天"
-        ],
-        "notation": "一昨日(いっさくじつ)"
+        ]
     },
     {
         "name": "issakunen",
         "trans": [
+            "一昨年(いっさくねん)",
             "⓪ 名  前年"
-        ],
-        "notation": "一昨年(いっさくねん)"
+        ]
     },
     {
         "name": "techou",
         "trans": [
+            "手帳(てちょう)",
             "⓪ 名  笔记本，记事本"
-        ],
-        "notation": "手帳(てちょう)"
+        ]
     },
     {
         "name": "jouki",
         "trans": [
+            "蒸気(じょうき)",
             "① 名  蒸汽，水蒸气"
-        ],
-        "notation": "蒸気(じょうき)"
+        ]
     },
     {
         "name": "kentou",
         "trans": [
+            "検討(けんとう)",
             "⓪ 名·他动3  讨论，探讨"
-        ],
-        "notation": "検討(けんとう)"
+        ]
     },
     {
         "name": "hankou",
         "trans": [
+            "反抗(はんこう)",
             "⓪ 名·自动3  反抗，对抗"
-        ],
-        "notation": "反抗(はんこう)"
+        ]
     },
     {
         "name": "saiensu",
         "trans": [
+            "サイエンス",
             "① 名  科学"
-        ],
-        "notation": "サイエンス"
+        ]
     },
     {
         "name": "chousei",
         "trans": [
+            "調整(ちょうせい)",
             "⓪ 名·他动3  调整，调节"
-        ],
-        "notation": "調整(ちょうせい)"
+        ]
     },
     {
         "name": "jumyou",
         "trans": [
+            "寿命(じゅみょう)",
             "⓪ 名  寿命"
-        ],
-        "notation": "寿命(じゅみょう)"
+        ]
     },
     {
         "name": "moru",
         "trans": [
+            "盛(も)る",
             "⓪ 他动1  盛，装满；堆高，堆起来"
-        ],
-        "notation": "盛(も)る"
+        ]
     },
     {
         "name": "bimyou",
         "trans": [
+            "微妙(びみょう)",
             "⓪ ナ形  微妙的"
-        ],
-        "notation": "微妙(びみょう)"
+        ]
     },
     {
         "name": "ine",
         "trans": [
+            "稲(いね)",
             "① 名  稻子"
-        ],
-        "notation": "稲(いね)"
+        ]
     },
     {
         "name": "himo",
         "trans": [
+            "紐(ひも)",
             "⓪ 名  带子，细绳"
-        ],
-        "notation": "紐(ひも)"
+        ]
     },
     {
         "name": "hanzai",
         "trans": [
+            "犯罪(はんざい)",
             "⓪ 名  犯罪"
-        ],
-        "notation": "犯罪(はんざい)"
+        ]
     },
     {
         "name": "suta-",
         "trans": [
+            "スター",
             "② 名  星星；明星"
-        ],
-        "notation": "スター"
+        ]
     },
     {
         "name": "joutatsu",
         "trans": [
+            "上達(じょうたつ)",
             "⓪ 名·自动3  进步，长进"
-        ],
-        "notation": "上達(じょうたつ)"
+        ]
     },
     {
         "name": "nokorimono",
         "trans": [
+            "残(のこ)り物(もの)",
             "⓪ 名  剩下的东西"
-        ],
-        "notation": "残(のこ)り物(もの)"
+        ]
     },
     {
         "name": "chiiki",
         "trans": [
+            "地域(ちいき)",
             "① 名  地域，地区"
-        ],
-        "notation": "地域(ちいき)"
+        ]
     },
     {
         "name": "bure-ki",
         "trans": [
+            "ブレーキ",
             "② 名  刹车，制动器；阻碍"
-        ],
-        "notation": "ブレーキ"
+        ]
     },
     {
         "name": "fuwafuwa",
         "trans": [
+            "ふわふわ",
             "① 副·自动3  轻飘飘；心神不宁"
-        ],
-        "notation": "ふわふわ"
+        ]
     },
     {
         "name": "yabuku",
         "trans": [
+            "破(やぶ)く",
             "② 他动1  弄破"
-        ],
-        "notation": "破(やぶ)く"
+        ]
     },
     {
         "name": "handobaggu",
         "trans": [
+            "ハンドバッグ",
             "④ 名  （女用）手提包"
-        ],
-        "notation": "ハンドバッグ"
+        ]
     },
     {
         "name": "taku",
         "trans": [
+            "炊(た)く",
             "⓪ 他动1  煮（饭），烧（菜）"
-        ],
-        "notation": "炊(た)く"
+        ]
     },
     {
         "name": "seifu",
         "trans": [
+            "政府(せいふ)",
             "① 名  政府"
-        ],
-        "notation": "政府(せいふ)"
+        ]
     },
     {
         "name": "shounen",
         "trans": [
+            "少年(しょうねん)",
             "⓪ 名  少年"
-        ],
-        "notation": "少年(しょうねん)"
+        ]
     },
     {
         "name": "kongari",
         "trans": [
+            "こんがり",
             "③ 副·自动3  （烤得）恰到好处"
-        ],
-        "notation": "こんがり"
+        ]
     },
     {
         "name": "sayuu",
         "trans": [
+            "左右(さゆう)",
             "① 名·他动3  左边和右边；身边；控制，操纵"
-        ],
-        "notation": "左右(さゆう)"
+        ]
     },
     {
         "name": "goukei",
         "trans": [
+            "合計(ごうけい)",
             "⓪ 名·他动3  共计，合计"
-        ],
-        "notation": "合計(ごうけい)"
+        ]
     },
     {
         "name": "sukizuki",
         "trans": [
+            "好(す)き好(ず)き",
             "② 名  各有所好"
-        ],
-        "notation": "好(す)き好(ず)き"
+        ]
     },
     {
         "name": "shinrai",
         "trans": [
+            "信頼(しんらい)",
             "⓪ 名·他动3  信赖"
-        ],
-        "notation": "信頼(しんらい)"
+        ]
     },
     {
         "name": "tsurusu",
         "trans": [
+            "吊(つる)す",
             "⓪ 他动1  吊，悬，挂"
-        ],
-        "notation": "吊(つる)す"
+        ]
     },
     {
         "name": "handoru",
         "trans": [
+            "ハンドル",
             "⓪ 名  方向盘"
-        ],
-        "notation": "ハンドル"
+        ]
     },
     {
         "name": "iyahon",
         "trans": [
+            "イヤホン",
             "② 名  耳机"
-        ],
-        "notation": "イヤホン"
+        ]
     },
     {
         "name": "saraigetsu",
         "trans": [
+            "再来月(さらいげつ)",
             "⓪ 名  下下个月"
-        ],
-        "notation": "再来月(さらいげつ)"
+        ]
     },
     {
         "name": "saraishuu",
         "trans": [
+            "再来週(さらいしゅう)",
             "⓪ 名  下下个星期"
-        ],
-        "notation": "再来週(さらいしゅう)"
+        ]
     },
     {
         "name": "sarainen",
         "trans": [
+            "再来年(さらいねん)",
             "⓪ 名  后年"
-        ],
-        "notation": "再来年(さらいねん)"
+        ]
     },
     {
         "name": "tounan",
         "trans": [
+            "盗難(とうなん)",
             "⓪ 名  失窃，被盗"
-        ],
-        "notation": "盗難(とうなん)"
+        ]
     },
     {
         "name": "insei",
         "trans": [
+            "院生(いんせい)",
             "① 名  研究生"
-        ],
-        "notation": "院生(いんせい)"
+        ]
     },
     {
         "name": "ugai",
         "trans": [
+            "嗽(うがい)",
             "⓪ 名·自动3  漱口"
-        ],
-        "notation": "嗽(うがい)"
+        ]
     },
     {
         "name": "hiji",
         "trans": [
+            "肘(ひじ)",
             "② 名  胳膊肘"
-        ],
-        "notation": "肘(ひじ)"
+        ]
     },
     {
         "name": "hikki",
         "trans": [
+            "筆記(ひっき)",
             "⓪ 名·他动3  笔记；记下来"
-        ],
-        "notation": "筆記(ひっき)"
+        ]
     },
     {
         "name": "inazuma",
         "trans": [
+            "稲妻(いなずま)",
             "⓪ 名  闪电；飞快，如闪电一般"
-        ],
-        "notation": "稲妻(いなずま)"
+        ]
     },
     {
         "name": "kaisetsu",
         "trans": [
+            "解説(かいせつ)",
             "⓪ 名·他动3  解说"
-        ],
-        "notation": "解説(かいせつ)"
+        ]
     },
     {
         "name": "kaitou",
         "trans": [
+            "解答(かいとう)",
             "⓪ 名·自动3  解答，回答"
-        ],
-        "notation": "解答(かいとう)"
+        ]
     },
     {
         "name": "kaihou",
         "trans": [
+            "解放(かいほう)",
             "⓪ 名·他动3  解放，摆脱"
-        ],
-        "notation": "解放(かいほう)"
+        ]
     },
     {
         "name": "teire",
         "trans": [
+            "手入(てい)れ",
             "③ 名·他动3  修整，维护"
-        ],
-        "notation": "手入(てい)れ"
+        ]
     },
     {
         "name": "ashioto",
         "trans": [
+            "足音(あしおと)",
             "③ 名  脚步声"
-        ],
-        "notation": "足音(あしおと)"
+        ]
     },
     {
         "name": "subi-ka-",
         "trans": [
+            "スピーカー",
             "② 名  扩音器"
-        ],
-        "notation": "スピーカー"
+        ]
     },
     {
         "name": "rouka",
         "trans": [
+            "廊下(ろうか)",
             "⓪ 名  走廊"
-        ],
-        "notation": "廊下(ろうか)"
+        ]
     },
     {
         "name": "gomu",
         "trans": [
+            "ゴム",
             "① 名  橡胶"
-        ],
-        "notation": "ゴム"
+        ]
     },
     {
         "name": "gomuwa",
         "trans": [
+            "ゴム輪(わ)",
             "⓪ 名  橡皮圈；橡胶车轮"
-        ],
-        "notation": "ゴム輪(わ)"
+        ]
     },
     {
         "name": "fukidasu",
         "trans": [
+            "吹(ふ)き出(だ)す",
             "③ 自他动1  开始刮风；吹出，喷出"
-        ],
-        "notation": "吹(ふ)き出(だ)す"
+        ]
     },
     {
         "name": "yuzuru",
         "trans": [
+            "譲(ゆず)る",
             "⓪ 他动1  转让；让步，谦让"
-        ],
-        "notation": "譲(ゆず)る"
+        ]
     },
     {
         "name": "muchuu",
         "trans": [
+            "夢中(むちゅう)",
             "⓪ 名·ナ形  睡梦中；热衷，着迷"
-        ],
-        "notation": "夢中(むちゅう)"
+        ]
     },
     {
         "name": "tento",
         "trans": [
+            "テント",
             "① 名  帐篷"
-        ],
-        "notation": "テント"
+        ]
     },
     {
         "name": "sensengetsu",
         "trans": [
+            "先々(さきざき)月(つき)",
             "③ 名  上上个月"
-        ],
-        "notation": "先々(さきざき)月(つき)"
+        ]
     },
     {
         "name": "sensenshuu",
         "trans": [
+            "先々(さきざき)週(しゅう)",
             "⓪ 名  上上个星期"
-        ],
-        "notation": "先々(さきざき)週(しゅう)"
+        ]
     },
     {
         "name": "shuuten",
         "trans": [
+            "終点(しゅうてん)",
             "⓪ 名  终点"
-        ],
-        "notation": "終点(しゅうてん)"
+        ]
     },
     {
         "name": "sanpiru",
         "trans": [
+            "サンプル",
             "① 名  样品，样本"
-        ],
-        "notation": "サンプル"
+        ]
     },
     {
         "name": "konkuri-to",
         "trans": [
+            "コンクリート",
             "④ 名  混凝土"
-        ],
-        "notation": "コンクリート"
+        ]
     },
     {
         "name": "koshikakeru",
         "trans": [
+            "腰掛(こしか)ける",
             "④ 自动2  坐下"
-        ],
-        "notation": "腰掛(こしか)ける"
+        ]
     },
     {
         "name": "koshi",
         "trans": [
+            "腰(こし)",
             "⓪ 名  腰"
-        ],
-        "notation": "腰(こし)"
+        ]
     },
     {
         "name": "hitokoto",
         "trans": [
+            "一言(ひとこと)",
             "② 名  一句话，只言片语"
-        ],
-        "notation": "一言(ひとこと)"
+        ]
     },
     {
         "name": "supein",
         "trans": [
+            "スペイン",
             "③ 名  西班牙"
-        ],
-        "notation": "スペイン"
+        ]
     },
     {
         "name": "hirune",
         "trans": [
+            "昼寝(ひるね)",
             "⓪ 名·自动3  午睡"
-        ],
-        "notation": "昼寝(ひるね)"
+        ]
     },
     {
         "name": "hosonagai",
         "trans": [
+            "細長(ほそなが)い",
             "④ イ形  细长的"
-        ],
-        "notation": "細長(ほそなが)い"
+        ]
     },
     {
         "name": "kaitsuu",
         "trans": [
+            "開通(かいつう)",
             "⓪ 名·自动3  开通，通车"
-        ],
-        "notation": "開通(かいつう)"
+        ]
     },
     {
         "name": "hitoyasumi",
         "trans": [
+            "一休(ひとやす)み",
             "② 名·自动3  休息片刻，歇一会儿"
-        ],
-        "notation": "一休(ひとやす)み"
+        ]
     },
     {
         "name": "ba-",
         "trans": [
+            "バー",
             "① 名  酒吧，（西式）酒馆"
-        ],
-        "notation": "バー"
+        ]
     },
     {
         "name": "nakusu",
         "trans": [
+            "無(な)くす",
             "⓪ 他动1  丢失，丢掉；消灭，去掉"
-        ],
-        "notation": "無(な)くす"
+        ]
     },
     {
         "name": "kaigai",
         "trans": [
+            "海外(かいがい)",
             "① 名  海外，国外"
-        ],
-        "notation": "海外(かいがい)"
+        ]
     },
     {
         "name": "kouka",
         "trans": [
+            "硬貨(こうか)",
             "① 名  硬币"
-        ],
-        "notation": "硬貨(こうか)"
+        ]
     },
     {
         "name": "kenshuu",
         "trans": [
+            "研修(けんしゅう)",
             "⓪ 名·他动3  研究；进修"
-        ],
-        "notation": "研修(けんしゅう)"
+        ]
     },
     {
         "name": "kumitateru",
         "trans": [
+            "組(く)み立(た)てる",
             "④ 他动2  装配（零件），组织，构成"
-        ],
-        "notation": "組(く)み立(た)てる"
+        ]
     },
     {
         "name": "sube-su",
         "trans": [
+            "スペース",
             "② 名  空间；空白"
-        ],
-        "notation": "スペース"
+        ]
     },
     {
         "name": "~gurashi",
         "trans": [
+            "～暮(く)らし",
             " 接尾  ⋯⋯生活"
-        ],
-        "notation": "～暮(く)らし"
+        ]
     },
     {
         "name": "iwa",
         "trans": [
+            "岩(いわ)",
             "② 名  岩石"
-        ],
-        "notation": "岩(いわ)"
+        ]
     },
     {
         "name": "chuusha",
         "trans": [
+            "注射(ちゅうしゃ)",
             "⓪ 名·他动3  注射，打针"
-        ],
-        "notation": "注射(ちゅうしゃ)"
+        ]
     },
     {
         "name": "choumiryou",
         "trans": [
+            "調味料(ちょうみりょう)",
             "③ 名  调料"
-        ],
-        "notation": "調味料(ちょうみりょう)"
+        ]
     },
     {
         "name": "nakayubi",
         "trans": [
+            "中指(なかゆび)",
             "② 名  中指"
-        ],
-        "notation": "中指(なかゆび)"
+        ]
     },
     {
         "name": "hikaku",
         "trans": [
+            "比較(ひかく)",
             "⓪ 名·他动3  比较"
-        ],
-        "notation": "比較(ひかく)"
+        ]
     },
     {
         "name": "buta",
         "trans": [
+            "豚(ぶた)",
             "⓪ 名  猪"
-        ],
-        "notation": "豚(ぶた)"
+        ]
     },
     {
         "name": "mochiageru",
         "trans": [
+            "持(も)ち上(あ)げる",
             "⓪ 他动2  举起，拿起，抬起"
-        ],
-        "notation": "持(も)ち上(あ)げる"
+        ]
     },
     {
         "name": "kakuekiteisha",
         "trans": [
+            "各駅停車(かくえきていしゃ)",
             "⑤ 名  慢车，各站停车"
-        ],
-        "notation": "各駅停車(かくえきていしゃ)"
+        ]
     },
     {
         "name": "mottainai",
         "trans": [
+            "勿体無(もったいな)い",
             "⑤ イ形  可惜的，浪费的；不胜感激的"
-        ],
-        "notation": "勿体無(もったいな)い"
+        ]
     },
     {
         "name": "gakusha",
         "trans": [
+            "学者(がくしゃ)",
             "⓪ 名  学者"
-        ],
-        "notation": "学者(がくしゃ)"
+        ]
     },
     {
         "name": "gakuhi",
         "trans": [
+            "学費(がくひ)",
             "⓪ 名  学费"
-        ],
-        "notation": "学費(がくひ)"
+        ]
     },
     {
         "name": "gakubu",
         "trans": [
+            "学部(がくぶ)",
             "⓪ 名  系，学院"
-        ],
-        "notation": "学部(がくぶ)"
+        ]
     },
     {
         "name": "gakuryoku",
         "trans": [
+            "学力(がくりょく)",
             "② 名  学习实力，学习能力"
-        ],
-        "notation": "学力(がくりょく)"
+        ]
     },
     {
         "name": "gakureki",
         "trans": [
+            "学歴(がくれき)",
             "⓪ 名  学历"
-        ],
-        "notation": "学歴(がくれき)"
+        ]
     },
     {
         "name": "minaosu",
         "trans": [
+            "見直(みなお)す",
             "⓪ 他动1  重新看，重新认识；重新估价"
-        ],
-        "notation": "見直(みなお)す"
+        ]
     },
     {
         "name": "hitori",
         "trans": [
+            "独(ひと)り",
             "② 名  独身，独自一人"
-        ],
-        "notation": "独(ひと)り"
+        ]
     },
     {
         "name": "akiraka",
         "trans": [
+            "明(あき)らか",
             "② ナ形  明亮的；明显的，显然的"
-        ],
-        "notation": "明(あき)らか"
+        ]
     },
     {
         "name": "daun",
         "trans": [
+            "ダウン",
             "① 名·自动3  下降，落下；倒下"
-        ],
-        "notation": "ダウン"
+        ]
     },
     {
         "name": "hifu",
         "trans": [
+            "皮膚(ひふ)",
             "① 名  皮肤"
-        ],
-        "notation": "皮膚(ひふ)"
+        ]
     },
     {
         "name": "kanesonaeru",
         "trans": [
+            "兼(か)ね備(そな)える",
             "⑤ 他动2  （二者）兼备"
-        ],
-        "notation": "兼(か)ね備(そな)える"
+        ]
     },
     {
         "name": "saji",
         "trans": [
+            "匙(さじ)",
             "① 名  勺子"
-        ],
-        "notation": "匙(さじ)"
+        ]
     },
     {
         "name": "koshou",
         "trans": [
+            "胡椒(こしょう)",
             "② 名  胡椒"
-        ],
-        "notation": "胡椒(こしょう)"
+        ]
     },
     {
         "name": "kakuchi",
         "trans": [
+            "各地(かくち)",
             "① 名  各地"
-        ],
-        "notation": "各地(かくち)"
+        ]
     },
     {
         "name": "kongakki",
         "trans": [
+            "今学期(こんがっき)",
             "③ 名  本学期"
-        ],
-        "notation": "今学期(こんがっき)"
+        ]
     },
     {
         "name": "hitorimusuko",
         "trans": [
+            "一人息子(ひとりむすこ)",
             "④ 名  独生子"
-        ],
-        "notation": "一人息子(ひとりむすこ)"
+        ]
     },
     {
         "name": "shi-tsu",
         "trans": [
+            "シーツ",
             "① 名  床单，被单"
-        ],
-        "notation": "シーツ"
+        ]
     },
     {
         "name": "hakihaki",
         "trans": [
+            "はきはき",
             "① 副·自动3  干脆，爽快；敏捷，麻利"
-        ],
-        "notation": "はきはき"
+        ]
     },
     {
         "name": "fushigi",
         "trans": [
+            "不思議(ふしぎ)",
             "⓪ 名·ナ形  不可思议，难以想象"
-        ],
-        "notation": "不思議(ふしぎ)"
+        ]
     },
     {
         "name": "nougyou",
         "trans": [
+            "農業(のうぎょう)",
             "① 名  农业"
-        ],
-        "notation": "農業(のうぎょう)"
+        ]
     },
     {
         "name": "nouka",
         "trans": [
+            "農家(のうか)",
             "① 名  农家，农户"
-        ],
-        "notation": "農家(のうか)"
+        ]
     },
     {
         "name": "nousakubutsu",
         "trans": [
+            "農作物(のうさくぶつ)",
             "④ 名  农作物"
-        ],
-        "notation": "農作物(のうさくぶつ)"
+        ]
     },
     {
         "name": "nousanbutsu",
         "trans": [
+            "農産物(のうさんぶつ)",
             "③ 名  农产品"
-        ],
-        "notation": "農産物(のうさんぶつ)"
+        ]
     },
     {
         "name": "noujou",
         "trans": [
+            "農場(のうじょう)",
             "⓪ 名  农场"
-        ],
-        "notation": "農場(のうじょう)"
+        ]
     },
     {
         "name": "nouson",
         "trans": [
+            "農村(のうそん)",
             "⓪ 名  农村"
-        ],
-        "notation": "農村(のうそん)"
+        ]
     },
     {
         "name": "noumin",
         "trans": [
+            "農民(のうみん)",
             "⓪ 名  农民"
-        ],
-        "notation": "農民(のうみん)"
+        ]
     },
     {
         "name": "hitorimusume",
         "trans": [
+            "一人娘(ひとりむすめ)",
             "④ 名  独生女"
-        ],
-        "notation": "一人娘(ひとりむすめ)"
+        ]
     },
     {
         "name": "susuru",
         "trans": [
+            "すする",
             "⓪ 他动1  小口喝，啜饮"
-        ],
-        "notation": "すする"
+        ]
     },
     {
         "name": "kataru",
         "trans": [
+            "語(かた)る",
             "⓪ 他动1  讲述，谈"
-        ],
-        "notation": "語(かた)る"
+        ]
     },
     {
         "name": "taimu",
         "trans": [
+            "タイム",
             "① 名  时间"
-        ],
-        "notation": "タイム"
+        ]
     },
     {
         "name": "tetsudou",
         "trans": [
+            "鉄道(てつどう)",
             "⓪ 名  铁路，铁道"
-        ],
-        "notation": "鉄道(てつどう)"
+        ]
     },
     {
         "name": "hara",
         "trans": [
+            "腹(はら)",
             "② 名  肚子；内心，想法"
-        ],
-        "notation": "腹(はら)"
+        ]
     },
     {
         "name": "fude",
         "trans": [
+            "筆(ふで)",
             "⓪ 名  笔，毛笔"
-        ],
-        "notation": "筆(ふで)"
+        ]
     },
     {
         "name": "to-ku",
         "trans": [
+            "トーク",
             "① 名  谈话，闲谈"
-        ],
-        "notation": "トーク"
+        ]
     },
     {
         "name": "youyaku",
         "trans": [
+            "ようやく",
             "⓪ 副  好不容易，总算；渐渐"
-        ],
-        "notation": "ようやく"
+        ]
     },
     {
         "name": "raion",
         "trans": [
+            "ライオン",
             "⓪ 名  狮子"
-        ],
-        "notation": "ライオン"
+        ]
     },
     {
         "name": "bindume",
         "trans": [
+            "瓶詰(びんづ)め",
             "⓪ 名  瓶装"
-        ],
-        "notation": "瓶詰(びんづ)め"
+        ]
     },
     {
         "name": "gakka",
         "trans": [
+            "学科(がっか)",
             "⓪ 名  学科"
-        ],
-        "notation": "学科(がっか)"
+        ]
     },
     {
         "name": "gakkyuu",
         "trans": [
+            "学級(がっきゅう)",
             "⓪ 名  学级，班级"
-        ],
-        "notation": "学級(がっきゅう)"
+        ]
     },
     {
         "name": "ton",
         "trans": [
+            "トン",
             "① 量  吨"
-        ],
-        "notation": "トン"
+        ]
     },
     {
         "name": "suka-fu",
         "trans": [
+            "スカーフ",
             "② 名  围巾，披肩"
-        ],
-        "notation": "スカーフ"
+        ]
     },
     {
         "name": "shingou",
         "trans": [
+            "信号(しんごう)",
             "⓪ 名  信号；红绿灯"
-        ],
-        "notation": "信号(しんごう)"
+        ]
     },
     {
         "name": "jinkou",
         "trans": [
+            "人工(じんこう)",
             "⓪ 名  人工，人造"
-        ],
-        "notation": "人工(じんこう)"
+        ]
     },
     {
         "name": "katate",
         "trans": [
+            "片手(かたて)",
             "⓪ 名  一只手"
-        ],
-        "notation": "片手(かたて)"
+        ]
     },
     {
         "name": "daihyou",
         "trans": [
+            "代表(だいひょう)",
             "⓪ 名·他动3  代表"
-        ],
-        "notation": "代表(だいひょう)"
+        ]
     },
     {
         "name": "naito",
         "trans": [
+            "ナイト",
             "① 名  夜晚，晚上"
-        ],
-        "notation": "ナイト"
+        ]
     },
     {
         "name": "shiwa",
         "trans": [
+            "皺(しわ)",
             "⓪ 名  皱纹；褶皱，褶子"
-        ],
-        "notation": "皺(しわ)"
+        ]
     },
     {
         "name": "tsukaisute",
         "trans": [
+            "使(つか)い捨(す)て",
             "⓪ 名  一次性，用完就扔"
-        ],
-        "notation": "使(つか)い捨(す)て"
+        ]
     },
     {
         "name": "tsubasa",
         "trans": [
+            "翼(つばさ)",
             "⓪ 名  翅膀；机翼"
-        ],
-        "notation": "翼(つばさ)"
+        ]
     },
     {
         "name": "hyouka",
         "trans": [
+            "評価(ひょうか)",
             "① 名·他动3  评价；估价"
-        ],
-        "notation": "評価(ひょうか)"
+        ]
     },
     {
         "name": "mimau",
         "trans": [
+            "見舞(みま)う",
             "⓪ 他动1  探望，慰问；遭受（灾害）"
-        ],
-        "notation": "見舞(みま)う"
+        ]
     },
     {
         "name": "moukaru",
         "trans": [
+            "儲(もう)かる",
             "③ 自动1  赚钱，获利"
-        ],
-        "notation": "儲(もう)かる"
+        ]
     },
     {
         "name": "moukeru",
         "trans": [
+            "儲(もう)ける",
             "③ 他动2  赚钱，获利"
-        ],
-        "notation": "儲(もう)ける"
+        ]
     },
     {
         "name": "messe-ji",
         "trans": [
+            "メッセージ",
             "① 名  消息，信息"
-        ],
-        "notation": "メッセージ"
+        ]
     },
     {
         "name": "geppu",
         "trans": [
+            "げっぷ",
             "⓪ 名  打嗝儿"
-        ],
-        "notation": "げっぷ"
+        ]
     },
     {
         "name": "kishou",
         "trans": [
+            "起床(きしょう)",
             "⓪ 名·自动3  起床"
-        ],
-        "notation": "起床(きしょう)"
+        ]
     },
     {
         "name": "kanadukai",
         "trans": [
+            "仮名遣(かなづか)い",
             "③ 名  假名用法"
-        ],
-        "notation": "仮名遣(かなづか)い"
+        ]
     },
     {
         "name": "kichou",
         "trans": [
+            "貴重(きちょう)",
             "⓪ ナ形  贵重的，宝贵的"
-        ],
-        "notation": "貴重(きちょう)"
+        ]
     },
     {
         "name": "kantoku",
         "trans": [
+            "監督(かんとく)",
             "⓪ 名·他动3  管理人，导演；监督"
-        ],
-        "notation": "監督(かんとく)"
+        ]
     },
     {
         "name": "douiu",
         "trans": [
+            "どういう",
             "① 连体  什么样的"
-        ],
-        "notation": "どういう"
+        ]
     },
     {
         "name": "furimuku",
         "trans": [
+            "振(ふ)り向(む)く",
             "③ 自动1  回头；理睬"
-        ],
-        "notation": "振(ふ)り向(む)く"
+        ]
     },
     {
         "name": "meijiru",
         "trans": [
+            "命(めい)じる",
             "⓪ 他动2  命令；任命"
-        ],
-        "notation": "命(めい)じる"
+        ]
     },
     {
         "name": "modosu",
         "trans": [
+            "戻(もど)す",
             "② 他动1  返还，归还；退回；使⋯⋯倒退"
-        ],
-        "notation": "戻(もど)す"
+        ]
     },
     {
         "name": "kabi",
         "trans": [
+            "黴(かび)",
             "⓪ 名  霉；陈旧，陈腐"
-        ],
-        "notation": "黴(かび)"
+        ]
     },
     {
         "name": "monosugoi",
         "trans": [
+            "物凄(ものすご)い",
             "④ イ形  可怕的；惊人的，不得了的"
-        ],
-        "notation": "物凄(ものすご)い"
+        ]
     },
     {
         "name": "kappumen",
         "trans": [
+            "カップ麺(めん)",
             "③ 名  杯装方便面"
-        ],
-        "notation": "カップ麺(めん)"
+        ]
     },
     {
         "name": "ippen",
         "trans": [
+            "一遍(いっぺん)",
             "③ 名  一遍，一回"
-        ],
-        "notation": "一遍(いっぺん)"
+        ]
     },
     {
         "name": "akiru",
         "trans": [
+            "飽(あ)きる",
             "② 自动2  腻烦，厌烦"
-        ],
-        "notation": "飽(あ)きる"
+        ]
     },
     {
         "name": "medetai",
         "trans": [
+            "めでたい",
             "③ イ形  值得祝贺的；顺利的"
-        ],
-        "notation": "めでたい"
+        ]
     },
     {
         "name": "mizuwari",
         "trans": [
+            "水割(みずわ)り",
             "⓪ 名  掺水，兑水"
-        ],
-        "notation": "水割(みずわ)り"
+        ]
     },
     {
         "name": "idou",
         "trans": [
+            "移動(いどう)",
             "⓪ 名·自他动3  移动；转移"
-        ],
-        "notation": "移動(いどう)"
+        ]
     },
     {
         "name": "masaka",
         "trans": [
+            "まさか",
             "① 副  万一；怎能，怎会，不会是⋯⋯吧"
-        ],
-        "notation": "まさか"
+        ]
     },
     {
         "name": "hotoke",
         "trans": [
+            "仏(ほとけ)",
             "③ 名  佛祖，佛像"
-        ],
-        "notation": "仏(ほとけ)"
+        ]
     },
     {
         "name": "fusagu",
         "trans": [
+            "塞(ふさ)ぐ",
             "⓪ 自他动1  堵，塞；郁闷"
-        ],
-        "notation": "塞(ふさ)ぐ"
+        ]
     },
     {
         "name": "taiken",
         "trans": [
+            "体験(たいけん)",
             "⓪ 名·他动3  体验，亲身经验"
-        ],
-        "notation": "体験(たいけん)"
+        ]
     },
     {
         "name": "soutou",
         "trans": [
+            "相当(そうとう)",
             "⓪ 副·ナ形·自动3  相当，颇；适合，相称；相当于"
-        ],
-        "notation": "相当(そうとう)"
+        ]
     },
     {
         "name": "furikomi",
         "trans": [
+            "振(ふ)り込(こ)み",
             "⓪ 名  存钱，汇款"
-        ],
-        "notation": "振(ふ)り込(こ)み"
+        ]
     },
     {
         "name": "junjo",
         "trans": [
+            "順序(じゅんじょ)",
             "① 名  顺序，步骤"
-        ],
-        "notation": "順序(じゅんじょ)"
+        ]
     },
     {
         "name": "bunsuu",
         "trans": [
+            "分数(ぶんすう)",
             "③ 名  （数学）分数"
-        ],
-        "notation": "分数(ぶんすう)"
+        ]
     },
     {
         "name": "jikayousha",
         "trans": [
+            "自家用車(じかようしゃ)",
             "③ 名  私人汽车"
-        ],
-        "notation": "自家用車(じかようしゃ)"
+        ]
     },
     {
         "name": "akusento",
         "trans": [
+            "アクセント",
             "① 名  语调，口音；重音；重点"
-        ],
-        "notation": "アクセント"
+        ]
     },
     {
         "name": "geta",
         "trans": [
+            "下駄(げた)",
             "⓪ 名  木屐"
-        ],
-        "notation": "下駄(げた)"
+        ]
     },
     {
         "name": "shousuu",
         "trans": [
+            "小数(しょうすう)",
             "③ 名  数额小；（数学）小数"
-        ],
-        "notation": "小数(しょうすう)"
+        ]
     },
     {
         "name": "nairon",
         "trans": [
+            "ナイロン",
             "① 名  尼龙"
-        ],
-        "notation": "ナイロン"
+        ]
     },
     {
         "name": "hei",
         "trans": [
+            "塀(へい)",
             "⓪ 名  围墙，院墙"
-        ],
-        "notation": "塀(へい)"
+        ]
     },
     {
         "name": "nazenaraba",
         "trans": [
+            "なぜならば",
             "① 接续  因为，理由是"
-        ],
-        "notation": "なぜならば"
+        ]
     },
     {
         "name": "nokku",
         "trans": [
+            "ノック",
             "① 名·自动3  敲门；敲打"
-        ],
-        "notation": "ノック"
+        ]
     },
     {
         "name": "furoshiki",
         "trans": [
+            "風呂敷(ふろしき)",
             "⓪ 名  包东西用的方巾"
-        ],
-        "notation": "風呂敷(ふろしき)"
+        ]
     },
     {
         "name": "medatsu",
         "trans": [
+            "目立(めだ)つ",
             "② 自动1  显眼，显著"
-        ],
-        "notation": "目立(めだ)つ"
+        ]
     },
     {
         "name": "zeikin",
         "trans": [
+            "税金(ぜいきん)",
             "⓪ 名  税款"
-        ],
-        "notation": "税金(ぜいきん)"
+        ]
     },
     {
         "name": "saitei",
         "trans": [
+            "最低(さいてい)",
             "⓪ 名·ナ形  最低；最坏"
-        ],
-        "notation": "最低(さいてい)"
+        ]
     },
     {
         "name": "iyagaru",
         "trans": [
+            "嫌(いや)がる",
             "③ 他动1  讨厌，嫌弃"
-        ],
-        "notation": "嫌(いや)がる"
+        ]
     },
     {
         "name": "shinsatsu",
         "trans": [
+            "診察(しんさつ)",
             "⓪ 名·他动3  看病，检查"
-        ],
-        "notation": "診察(しんさつ)"
+        ]
     },
     {
         "name": "shindan",
         "trans": [
+            "診断(しんだん)",
             "⓪ 名·他动3  诊断"
-        ],
-        "notation": "診断(しんだん)"
+        ]
     },
     {
         "name": "datte",
         "trans": [
+            "だって",
             "① 接续  但是，可是"
-        ],
-        "notation": "だって"
+        ]
     },
     {
         "name": "teikou",
         "trans": [
+            "抵抗(ていこう)",
             "⓪ 名·自动3  抵抗，反抗；反感"
-        ],
-        "notation": "抵抗(ていこう)"
+        ]
     },
     {
         "name": "douse",
         "trans": [
+            "どうせ",
             "⓪ 副  终归，反正"
-        ],
-        "notation": "どうせ"
+        ]
     },
     {
         "name": "hashirimawaru",
         "trans": [
+            "走(はし)り回(まわ)る",
             "⑤ 自动1  到处跑，四处奔走"
-        ],
-        "notation": "走(はし)り回(まわ)る"
+        ]
     },
     {
         "name": "fairu",
         "trans": [
+            "ファイル",
             "① 名  文件夹"
-        ],
-        "notation": "ファイル"
+        ]
     },
     {
         "name": "ikka",
         "trans": [
+            "一家(いっか)",
             "① 名  一家，一户；一家人"
-        ],
-        "notation": "一家(いっか)"
+        ]
     },
     {
         "name": "beikoku",
         "trans": [
+            "米国(べいこく)",
             "⓪ 名  美国"
-        ],
-        "notation": "米国(べいこく)"
+        ]
     },
     {
         "name": "gamen",
         "trans": [
+            "画面(がめん)",
             "① 名  画面"
-        ],
-        "notation": "画面(がめん)"
+        ]
     },
     {
         "name": "saru",
         "trans": [
+            "猿(さる)",
             "① 名  猴子"
-        ],
-        "notation": "猿(さる)"
+        ]
     },
     {
         "name": "juuden",
         "trans": [
+            "充電(じゅうでん)",
             "⓪ 名·自动3  充电"
-        ],
-        "notation": "充電(じゅうでん)"
+        ]
     },
     {
         "name": "toutou",
         "trans": [
+            "とうとう",
             "① 副  终于，终究"
-        ],
-        "notation": "とうとう"
+        ]
     },
     {
         "name": "norisugosu",
         "trans": [
+            "乗(の)り過(す)ごす",
             "④ 自动1  坐过站"
-        ],
-        "notation": "乗(の)り過(す)ごす"
+        ]
     },
     {
         "name": "iremono",
         "trans": [
+            "入(い)れ物(もの)",
             "⓪ 名  容器，器皿"
-        ],
-        "notation": "入(い)れ物(もの)"
+        ]
     },
     {
         "name": "haikei",
         "trans": [
+            "拝啓(はいけい)",
             "① 名  （书信）敬启"
-        ],
-        "notation": "拝啓(はいけい)"
+        ]
     },
     {
         "name": "sode",
         "trans": [
+            "袖(そで)",
             "⓪ 名  袖子"
-        ],
-        "notation": "袖(そで)"
+        ]
     },
     {
         "name": "bounenkai",
         "trans": [
+            "忘年会(ぼうねんかい)",
             "③ 名  年终联欢会"
-        ],
-        "notation": "忘年会(ぼうねんかい)"
+        ]
     },
     {
         "name": "chouhoukei",
         "trans": [
+            "長方形(ちょうほうけい)",
             "③ 名  长方形"
-        ],
-        "notation": "長方形(ちょうほうけい)"
+        ]
     },
     {
         "name": "sakihodo",
         "trans": [
+            "先(さき)ほど",
             "⓪ 副  刚才，方才"
-        ],
-        "notation": "先(さき)ほど"
+        ]
     },
     {
         "name": "u-ru",
         "trans": [
+            "ウール",
             "① 名  羊毛，毛织品"
-        ],
-        "notation": "ウール"
+        ]
     },
     {
         "name": "sasaeru",
         "trans": [
+            "支(ささ)える",
             "⓪ 他动2  支，支撑；维持"
-        ],
-        "notation": "支(ささ)える"
+        ]
     },
     {
         "name": "keikou",
         "trans": [
+            "傾向(けいこう)",
             "⓪ 名  倾向，趋势"
-        ],
-        "notation": "傾向(けいこう)"
+        ]
     },
     {
         "name": "takamaru",
         "trans": [
+            "高(たか)まる",
             "③ 自动1  高涨，提高"
-        ],
-        "notation": "高(たか)まる"
+        ]
     },
     {
         "name": "takameru",
         "trans": [
+            "高(たか)める",
             "③ 他动2  提高"
-        ],
-        "notation": "高(たか)める"
+        ]
     },
     {
         "name": "choukou",
         "trans": [
+            "聴講(ちょうこう)",
             "⓪ 名·他动3  听课；旁听"
-        ],
-        "notation": "聴講(ちょうこう)"
+        ]
     },
     {
         "name": "asu",
         "trans": [
+            "明日(あす)",
             "⓪ 名  明天"
-        ],
-        "notation": "明日(あす)"
+        ]
     },
     {
         "name": "urite",
         "trans": [
+            "売(う)り手(て)",
             "⓪ 名  卖方"
-        ],
-        "notation": "売(う)り手(て)"
+        ]
     },
     {
         "name": "tsumu",
         "trans": [
+            "積(つ)む",
             "⓪ 自他动1  堆积；装载；积累"
-        ],
-        "notation": "積(つ)む"
+        ]
     },
     {
         "name": "joushiki",
         "trans": [
+            "常識(じょうしき)",
             "⓪ 名  常识"
-        ],
-        "notation": "常識(じょうしき)"
+        ]
     },
     {
         "name": "teisha",
         "trans": [
+            "停車(ていしゃ)",
             "⓪ 名·自动3  停车"
-        ],
-        "notation": "停車(ていしゃ)"
+        ]
     },
     {
         "name": "nanigoto",
         "trans": [
+            "何事(なにごと)",
             "⓪ 名  什么事情；怎么回事"
-        ],
-        "notation": "何事(なにごと)"
+        ]
     },
     {
         "name": "jikkan",
         "trans": [
+            "実感(じっかん)",
             "⓪ 名·他动3  真实体会，体会到"
-        ],
-        "notation": "実感(じっかん)"
+        ]
     },
     {
         "name": "jitsugen",
         "trans": [
+            "実現(じつげん)",
             "⓪ 名·自他动3  实现"
-        ],
-        "notation": "実現(じつげん)"
+        ]
     },
     {
         "name": "jikkou",
         "trans": [
+            "実行(じっこう)",
             "⓪ 名·他动3  实行，执行"
-        ],
-        "notation": "実行(じっこう)"
+        ]
     },
     {
         "name": "jisshuu",
         "trans": [
+            "実習(じっしゅう)",
             "⓪ 名·他动3  实习，见习"
-        ],
-        "notation": "実習(じっしゅう)"
+        ]
     },
     {
         "name": "jisseikatsu",
         "trans": [
+            "実生活(じっせいかつ)",
             "③ 名  实际生活"
-        ],
-        "notation": "実生活(じっせいかつ)"
+        ]
     },
     {
         "name": "jisshakai",
         "trans": [
+            "実社会(じっしゃかい)",
             "③ 名  现实社会"
-        ],
-        "notation": "実社会(じっしゃかい)"
+        ]
     },
     {
         "name": "suekko",
         "trans": [
+            "末(すえ)っ子(こ)",
             "⓪ 名  最小的孩子"
-        ],
-        "notation": "末(すえ)っ子(こ)"
+        ]
     },
     {
         "name": "zenki",
         "trans": [
+            "前期(ぜんき)",
             "① 名  初期"
-        ],
-        "notation": "前期(ぜんき)"
+        ]
     },
     {
         "name": "tsureru",
         "trans": [
+            "連(つ)れる",
             "⓪ 他动2  带，领"
-        ],
-        "notation": "連(つ)れる"
+        ]
     },
     {
         "name": "tokuisaki",
         "trans": [
+            "得意先(とくいさき)",
             "⓪ 名  主顾，客户"
-        ],
-        "notation": "得意先(とくいさき)"
+        ]
     },
     {
         "name": "ma-ketto",
         "trans": [
+            "マーケット",
             "① 名  商场；（经济学）市场"
-        ],
-        "notation": "マーケット"
+        ]
     },
     {
         "name": "beranda",
         "trans": [
+            "ベランダ",
             "⓪ 名  阳台"
-        ],
-        "notation": "ベランダ"
+        ]
     },
     {
         "name": "musubu",
         "trans": [
+            "結(むす)ぶ",
             "⓪ 他动1  系，绑；缔结，建立关系"
-        ],
-        "notation": "結(むす)ぶ"
+        ]
     },
     {
         "name": "bo-i",
         "trans": [
+            "ボーイ",
             "⓪ 名  男孩；男服务员"
-        ],
-        "notation": "ボーイ"
+        ]
     },
     {
         "name": "kuzureru",
         "trans": [
+            "崩(くず)れる",
             "③ 自动2  坍塌；走样；被打垮；换成零钱"
-        ],
-        "notation": "崩(くず)れる"
+        ]
     },
     {
         "name": "kuzusu",
         "trans": [
+            "崩(くず)す",
             "② 他动1  拆毁；打乱，搅乱；换成零钱"
-        ],
-        "notation": "崩(くず)す"
+        ]
     },
     {
         "name": "tokeru",
         "trans": [
+            "解(と)ける",
             "② 自动2  解开；消（气）；解除"
-        ],
-        "notation": "解(と)ける"
+        ]
     },
     {
         "name": "habuku",
         "trans": [
+            "省(はぶ)く",
             "② 他动1  省，节省；省略"
-        ],
-        "notation": "省(はぶ)く"
+        ]
     },
     {
         "name": "fasshon",
         "trans": [
+            "ファッション",
             "① 名  流行，时尚"
-        ],
-        "notation": "ファッション"
+        ]
     },
     {
         "name": "betsubetsu",
         "trans": [
+            "別(べつ)々",
             "⓪ 名·ナ形  分别，各自"
-        ],
-        "notation": "別(べつ)々"
+        ]
     },
     {
         "name": "kensa",
         "trans": [
+            "検査(けんさ)",
             "① 名·他动3  检查，检验"
-        ],
-        "notation": "検査(けんさ)"
+        ]
     },
     {
         "name": "kenjou",
         "trans": [
+            "謙譲(けんじょう)",
             "⓪ 名·ナ形  谦让，谦逊"
-        ],
-        "notation": "謙譲(けんじょう)"
+        ]
     },
     {
         "name": "shidou",
         "trans": [
+            "指導(しどう)",
             "⓪ 名·他动3  指导，教导"
-        ],
-        "notation": "指導(しどう)"
+        ]
     },
     {
         "name": "tashikameru",
         "trans": [
+            "確(たし)かめる",
             "④ 他动2  弄清，查明"
-        ],
-        "notation": "確(たし)かめる"
+        ]
     },
     {
         "name": "detarame",
         "trans": [
+            "出鱈目(でたらめ)",
             "⓪ 名·ナ形  胡来，荒唐"
-        ],
-        "notation": "出鱈目(でたらめ)"
+        ]
     },
     {
         "name": "higai",
         "trans": [
+            "被害(ひがい)",
             "① 名  受害，受灾；损失"
-        ],
-        "notation": "被害(ひがい)"
+        ]
     },
     {
         "name": "ho-mu",
         "trans": [
+            "ホーム",
             "① 名  家，家庭；疗养院"
-        ],
-        "notation": "ホーム"
+        ]
     },
     {
         "name": "barabara",
         "trans": [
+            "ばらばら",
             "⓪ 副  分散，零乱"
-        ],
-        "notation": "ばらばら"
+        ]
     },
     {
         "name": "kougai",
         "trans": [
+            "公害(こうがい)",
             "⓪ 名  公害"
-        ],
-        "notation": "公害(こうがい)"
+        ]
     },
     {
         "name": "kesseki",
         "trans": [
+            "欠席(けっせき)",
             "⓪ 名·自动3  缺席"
-        ],
-        "notation": "欠席(けっせき)"
+        ]
     },
     {
         "name": "sokutatsu",
         "trans": [
+            "速達(そくたつ)",
             "⓪ 名  快件；快信"
-        ],
-        "notation": "速達(そくたつ)"
+        ]
     },
     {
         "name": "pa-to",
         "trans": [
+            "パート",
             "① 名  部分；打零工"
-        ],
-        "notation": "パート"
+        ]
     },
     {
         "name": "sute-shon",
         "trans": [
+            "ステーション",
             "② 名  车站，火车站"
-        ],
-        "notation": "ステーション"
+        ]
     },
     {
         "name": "shaberu",
         "trans": [
+            "しゃべる",
             "② 他动1  说，讲；喋喋不休"
-        ],
-        "notation": "しゃべる"
+        ]
     },
     {
         "name": "shiokuri",
         "trans": [
+            "仕送(しおく)り",
             "⓪ 名·自他动3  汇寄（生活费）"
-        ],
-        "notation": "仕送(しおく)り"
+        ]
     },
     {
         "name": "bocchan",
         "trans": [
+            "坊(ぼっ)ちゃん",
             "① 名  小弟弟，小朋友；大少爷，公子哥"
-        ],
-        "notation": "坊(ぼっ)ちゃん"
+        ]
     },
     {
         "name": "toujou",
         "trans": [
+            "登場(とうじょう)",
             "⓪ 名·自动3  登场，出场"
-        ],
-        "notation": "登場(とうじょう)"
+        ]
     },
     {
         "name": "nengajou",
         "trans": [
+            "年賀状(ねんがじょう)",
             "③ 名  贺年卡"
-        ],
-        "notation": "年賀状(ねんがじょう)"
+        ]
     },
     {
         "name": "hikizan",
         "trans": [
+            "引(ひ)き算(ざん)",
             "② 名  （数学）减法"
-        ],
-        "notation": "引(ひ)き算(ざん)"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "拭(ふ)く",
             "⓪ 他动1  擦，拭"
-        ],
-        "notation": "拭(ふ)く"
+        ]
     },
     {
         "name": "maniau",
         "trans": [
+            "間(ま)に合(あ)う",
             "③ 自动1  赶得上，来得及；够用"
-        ],
-        "notation": "間(ま)に合(あ)う"
+        ]
     },
     {
         "name": "muku",
         "trans": [
+            "剥(む)く",
             "⓪ 他动1  剥，削皮"
-        ],
-        "notation": "剥(む)く"
+        ]
     },
     {
         "name": "shori",
         "trans": [
+            "処理(しょり)",
             "① 名·他动3  处理，处置"
-        ],
-        "notation": "処理(しょり)"
+        ]
     },
     {
         "name": "shujutsu",
         "trans": [
+            "手術(しゅじゅつ)",
             "① 名  手术"
-        ],
-        "notation": "手術(しゅじゅつ)"
+        ]
     },
     {
         "name": "hoho/hoo",
         "trans": [
+            "頬(ほほ/ほお)",
             "① 名  脸颊"
-        ],
-        "notation": "頬(ほほ/ほお)"
+        ]
     },
     {
         "name": "ketten",
         "trans": [
+            "欠点(けってん)",
             "③ 名  缺点"
-        ],
-        "notation": "欠点(けってん)"
+        ]
     },
     {
         "name": "keitaidenwa",
         "trans": [
+            "携帯電話(けいたいでんわ)",
             "⑤ 名  手机"
-        ],
-        "notation": "携帯電話(けいたいでんわ)"
+        ]
     },
     {
         "name": "kurikaesu",
         "trans": [
+            "繰(く)り返(かえ)す",
             "③ 他动1  反复，重复"
-        ],
-        "notation": "繰(く)り返(かえ)す"
+        ]
     },
     {
         "name": "amido",
         "trans": [
+            "網戸(あみど)",
             "② 名  纱窗，纱门"
-        ],
-        "notation": "網戸(あみど)"
+        ]
     },
     {
         "name": "kurumu",
         "trans": [
+            "包(くる)む",
             "② 他动1  包，裹"
-        ],
-        "notation": "包(くる)む"
+        ]
     },
     {
         "name": "susunde",
         "trans": [
+            "進(すす)んで",
             "④ 副  主动地，积极地"
-        ],
-        "notation": "進(すす)んで"
+        ]
     },
     {
         "name": "pachinko",
         "trans": [
+            "パチンコ",
             "⓪ 名  弹珠游戏"
-        ],
-        "notation": "パチンコ"
+        ]
     },
     {
         "name": "migoro",
         "trans": [
+            "見頃(みごろ)",
             "⓪ 名  （景色）正好看的时候"
-        ],
-        "notation": "見頃(みごろ)"
+        ]
     },
     {
         "name": "nuu",
         "trans": [
+            "縫(ぬ)う",
             "① 他动1  缝；缝合；刺绣"
-        ],
-        "notation": "縫(ぬ)う"
+        ]
     },
     {
         "name": "bakkin",
         "trans": [
+            "罰金(ばっきん)",
             "⓪ 名  罚款"
-        ],
-        "notation": "罰金(ばっきん)"
+        ]
     },
     {
         "name": "hitai",
         "trans": [
+            "額(ひたい)",
             "⓪ 名  额头"
-        ],
-        "notation": "額(ひたい)"
+        ]
     },
     {
         "name": "epuron",
         "trans": [
+            "エプロン",
             "① 名  围裙"
-        ],
-        "notation": "エプロン"
+        ]
     },
     {
         "name": "muda",
         "trans": [
+            "無駄(むだ)",
             "⓪ 名·ナ形  无用，浪费"
-        ],
-        "notation": "無駄(むだ)"
+        ]
     },
     {
         "name": "shikai",
         "trans": [
+            "司会(しかい)",
             "⓪ 名·自动3  司仪；主持会议"
-        ],
-        "notation": "司会(しかい)"
+        ]
     },
     {
         "name": "kaiga",
         "trans": [
+            "絵画(かいが)",
             "① 名  绘画"
-        ],
-        "notation": "絵画(かいが)"
+        ]
     },
     {
         "name": "hawai",
         "trans": [
+            "ハワイ",
             "① 名  夏威夷"
-        ],
-        "notation": "ハワイ"
+        ]
     },
     {
         "name": "sakusei",
         "trans": [
+            "作製(さくせい)",
             "⓪ 名·他动3  制造，制作"
-        ],
-        "notation": "作製(さくせい)"
+        ]
     },
     {
         "name": "~sho",
         "trans": [
+            "～書(しょ)",
             " 接尾  ⋯⋯书"
-        ],
-        "notation": "～書(しょ)"
+        ]
     },
     {
         "name": "tatoeru",
         "trans": [
+            "例(たと)える",
             "③ 他动2  比喻，比方"
-        ],
-        "notation": "例(たと)える"
+        ]
     },
     {
         "name": "yobikata",
         "trans": [
+            "呼(よ)び方(かた)",
             "④ 名  叫法，称呼的方法"
-        ],
-        "notation": "呼(よ)び方(かた)"
+        ]
     },
     {
         "name": "ka-nabi",
         "trans": [
+            "カーナビ",
             "⓪ 名  汽车导航仪"
-        ],
-        "notation": "カーナビ"
+        ]
     },
     {
         "name": "gaishoku",
         "trans": [
+            "外食(がいしょく)",
             "⓪ 名·自动3  在外面吃饭"
-        ],
-        "notation": "外食(がいしょく)"
+        ]
     },
     {
         "name": "tonai",
         "trans": [
+            "都内(とない)",
             "① 名  整个东京都，东京都中心区"
-        ],
-        "notation": "都内(とない)"
+        ]
     },
     {
         "name": "sutoresu",
         "trans": [
+            "ストレス",
             "② 名  紧张，精神压力"
-        ],
-        "notation": "ストレス"
+        ]
     },
     {
         "name": "shinri",
         "trans": [
+            "心理(しんり)",
             "① 名  心理"
-        ],
-        "notation": "心理(しんり)"
+        ]
     },
     {
         "name": "shusshin",
         "trans": [
+            "出身(しゅっしん)",
             "⓪ 名  出生地，籍贯；毕业学校"
-        ],
-        "notation": "出身(しゅっしん)"
+        ]
     },
     {
         "name": "geka",
         "trans": [
+            "外科(げか)",
             "⓪ 名  外科"
-        ],
-        "notation": "外科(げか)"
+        ]
     },
     {
         "name": "kubetsu",
         "trans": [
+            "区別(くべつ)",
             "① 名·他动3  区别，差异，辨别"
-        ],
-        "notation": "区別(くべつ)"
+        ]
     },
     {
         "name": "mago",
         "trans": [
+            "孫(まご)",
             "② 名  孙子；孙女"
-        ],
-        "notation": "孫(まご)"
+        ]
     },
     {
         "name": "konomu",
         "trans": [
+            "好(この)む",
             "② 他动1  爱好，喜欢"
-        ],
-        "notation": "好(この)む"
+        ]
     },
     {
         "name": "kushami",
         "trans": [
+            "くしゃみ",
             "② 名  喷嚏"
-        ],
-        "notation": "くしゃみ"
+        ]
     },
     {
         "name": "doushi",
         "trans": [
+            "～どうし(どうし)",
             " 接尾  ⋯⋯同伴，⋯⋯伙伴"
-        ],
-        "notation": "～どうし(どうし)"
+        ]
     },
     {
         "name": "kaori",
         "trans": [
+            "香(かお)り",
             "⓪ 名  香气，芬芳"
-        ],
-        "notation": "香(かお)り"
+        ]
     },
     {
         "name": "hikareru",
         "trans": [
+            "引(ひ)かれる",
             "⓪ 自动2  被吸引住，被迷住"
-        ],
-        "notation": "引(ひ)かれる"
+        ]
     },
     {
         "name": "handan",
         "trans": [
+            "判断(はんだん)",
             "① 名·他动3  判断，推断"
-        ],
-        "notation": "判断(はんだん)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "自身(じしん)",
             "① 名  自己，自身"
-        ],
-        "notation": "自身(じしん)"
+        ]
     },
     {
         "name": "shitashimu",
         "trans": [
+            "親(した)しむ",
             "③ 自动1  亲切，亲密；爱好，喜好"
-        ],
-        "notation": "親(した)しむ"
+        ]
     },
     {
         "name": "kion",
         "trans": [
+            "気温(きおん)",
             "⓪ 名  气温"
-        ],
-        "notation": "気温(きおん)"
+        ]
     },
     {
         "name": "masuta-",
         "trans": [
+            "マスター",
             "① 名·他动3  老板；掌握，精通"
-        ],
-        "notation": "マスター"
+        ]
     },
     {
         "name": "seikaku",
         "trans": [
+            "正確(せいかく)",
             "⓪ 名·ナ形  正确，准确"
-        ],
-        "notation": "正確(せいかく)"
+        ]
     },
     {
         "name": "kounyuu",
         "trans": [
+            "購入(こうにゅう)",
             "⓪ 名·他动3  购买，采购"
-        ],
-        "notation": "購入(こうにゅう)"
+        ]
     },
     {
         "name": "yuujin",
         "trans": [
+            "友人(ゆうじん)",
             "⓪ 名  朋友，友人"
-        ],
-        "notation": "友人(ゆうじん)"
+        ]
     },
     {
         "name": "yurui",
         "trans": [
+            "緩(ゆる)い",
             "② イ形  宽松的；缓慢的；不严格的"
-        ],
-        "notation": "緩(ゆる)い"
+        ]
     },
     {
         "name": "yakume",
         "trans": [
+            "役目(やくめ)",
             "③ 名  任务，职责"
-        ],
-        "notation": "役目(やくめ)"
+        ]
     },
     {
         "name": "sonokawari",
         "trans": [
+            "その代(か)わり",
             "⓪ 接续  但是，另一方面"
-        ],
-        "notation": "その代(か)わり"
+        ]
     },
     {
         "name": "suta-to",
         "trans": [
+            "スタート",
             "② 名·自动3  出发点，起点；开始"
-        ],
-        "notation": "スタート"
+        ]
     },
     {
         "name": "sankou",
         "trans": [
+            "参考(さんこう)",
             "⓪ 名·他动3  参考，借鉴"
-        ],
-        "notation": "参考(さんこう)"
+        ]
     },
     {
         "name": "junban",
         "trans": [
+            "順番(じゅんばん)",
             "⓪ 名  顺序，轮流"
-        ],
-        "notation": "順番(じゅんばん)"
+        ]
     },
     {
         "name": "tataku",
         "trans": [
+            "叩(たた)く",
             "② 他动1  敲，叩"
-        ],
-        "notation": "叩(たた)く"
+        ]
     },
     {
         "name": "shuuchuu",
         "trans": [
+            "集中(しゅうちゅう)",
             "⓪ 名·自他动3  集中"
-        ],
-        "notation": "集中(しゅうちゅう)"
+        ]
     },
     {
         "name": "kechi",
         "trans": [
+            "けち",
             "① 名·ナ形  小气，吝啬"
-        ],
-        "notation": "けち"
+        ]
     },
     {
         "name": "kiyou",
         "trans": [
+            "器用(きよう)",
             "① 名·ナ形  灵巧，精巧；巧妙"
-        ],
-        "notation": "器用(きよう)"
+        ]
     },
     {
         "name": "kandume",
         "trans": [
+            "缶詰(かんづめ)",
             "③ 名  罐头"
-        ],
-        "notation": "缶詰(かんづめ)"
+        ]
     },
     {
         "name": "damasu",
         "trans": [
+            "騙(だま)す",
             "② 他动1  欺骗，哄骗"
-        ],
-        "notation": "騙(だま)す"
+        ]
     },
     {
         "name": "menrui",
         "trans": [
+            "麺類(めんるい)",
             "① 名  面条类"
-        ],
-        "notation": "麺類(めんるい)"
+        ]
     },
     {
         "name": "mitsumeru",
         "trans": [
+            "見(み)つめる",
             "⓪ 他动2  凝视，注视"
-        ],
-        "notation": "見(み)つめる"
+        ]
     },
     {
         "name": "infome-shon",
         "trans": [
+            "インフォメーション",
             "④ 名  信息，消息；问讯处"
-        ],
-        "notation": "インフォメーション"
+        ]
     },
     {
         "name": "yosougai",
         "trans": [
+            "予想外(よそうがい)",
             "② 名·ナ形  出乎意料"
-        ],
-        "notation": "予想外(よそうがい)"
+        ]
     },
     {
         "name": "tamaru",
         "trans": [
+            "溜(た)まる",
             "⓪ 自动1  积攒，积存"
-        ],
-        "notation": "溜(た)まる"
+        ]
     },
     {
         "name": "ishokujuu",
         "trans": [
+            "衣食住(いしょくじゅう)",
             "③ 名  吃穿住"
-        ],
-        "notation": "衣食住(いしょくじゅう)"
+        ]
     },
     {
         "name": "kakinaosu",
         "trans": [
+            "書(か)き直(なお)す",
             "④ 他动1  重写，改写"
-        ],
-        "notation": "書(か)き直(なお)す"
+        ]
     },
     {
         "name": "zentai",
         "trans": [
+            "全体(ぜんたい)",
             "⓪ 名  全体，整体"
-        ],
-        "notation": "全体(ぜんたい)"
+        ]
     },
     {
         "name": "jitsuni",
         "trans": [
+            "実(じつ)に",
             "② 副  实在，确实，的确"
-        ],
-        "notation": "実(じつ)に"
+        ]
     },
     {
         "name": "saidai",
         "trans": [
+            "最大(さいだい)",
             "⓪ 名  最大"
-        ],
-        "notation": "最大(さいだい)"
+        ]
     },
     {
         "name": "shouhi",
         "trans": [
+            "消費(しょうひ)",
             "⓪ 名·他动3  消费，花费"
-        ],
-        "notation": "消費(しょうひ)"
+        ]
     },
     {
         "name": "chikarashigoto",
         "trans": [
+            "力仕事(ちからしごと)",
             "④ 名  体力劳动，力气活儿"
-        ],
-        "notation": "力仕事(ちからしごと)"
+        ]
     },
     {
         "name": "niau",
         "trans": [
+            "似合(にあ)う",
             "② 自动1  合适，相称"
-        ],
-        "notation": "似合(にあ)う"
+        ]
     },
     {
         "name": "hyou",
         "trans": [
+            "表(ひょう)",
             "⓪ 名  表格，图表"
-        ],
-        "notation": "表(ひょう)"
+        ]
     },
     {
         "name": "meshi",
         "trans": [
+            "飯(めし)",
             "② 名  饭；饭碗，生计"
-        ],
-        "notation": "飯(めし)"
+        ]
     },
     {
         "name": "pinku",
         "trans": [
+            "ピンク",
             "① 名  粉红色"
-        ],
-        "notation": "ピンク"
+        ]
     },
     {
         "name": "yubiwa",
         "trans": [
+            "指輪(ゆびわ)",
             "⓪ 名  戒指"
-        ],
-        "notation": "指輪(ゆびわ)"
+        ]
     },
     {
         "name": "kako",
         "trans": [
+            "過去(かこ)",
             "① 名  过去"
-        ],
-        "notation": "過去(かこ)"
+        ]
     },
     {
         "name": "yatou",
         "trans": [
+            "雇(やと)う",
             "② 他动1  雇，雇佣"
-        ],
-        "notation": "雇(やと)う"
+        ]
     },
     {
         "name": "momu",
         "trans": [
+            "揉(も)む",
             "⓪ 他动1  揉，搓；捏（肩）；争论，纠纷"
-        ],
-        "notation": "揉(も)む"
+        ]
     },
     {
         "name": "mushi",
         "trans": [
+            "無視(むし)",
             "① 名·他动3  无视，忽视"
-        ],
-        "notation": "無視(むし)"
+        ]
     },
     {
         "name": "mugi",
         "trans": [
+            "麦(むぎ)",
             "① 名  麦子，小麦"
-        ],
-        "notation": "麦(むぎ)"
+        ]
     },
     {
         "name": "madoguchi",
         "trans": [
+            "窓口(まどぐち)",
             "② 名  （办理业务的）窗口"
-        ],
-        "notation": "窓口(まどぐち)"
+        ]
     },
     {
         "name": "hoshou",
         "trans": [
+            "保証(ほしょう)",
             "⓪ 名·他动3  保证，担保"
-        ],
-        "notation": "保証(ほしょう)"
+        ]
     },
     {
         "name": "kago",
         "trans": [
+            "籠(かご)",
             "⓪ 名  筐，篮，笼子"
-        ],
-        "notation": "籠(かご)"
+        ]
     },
     {
         "name": "temae",
         "trans": [
+            "手前(てまえ)",
             "⓪ 名  眼前，靠近自己的一边"
-        ],
-        "notation": "手前(てまえ)"
+        ]
     },
     {
         "name": "firumu",
         "trans": [
+            "フィルム",
             "① 名  （相机）胶卷；影片；薄膜"
-        ],
-        "notation": "フィルム"
+        ]
     },
     {
         "name": "~kasho",
         "trans": [
+            "～箇所(かしょ)",
             " 接尾  ⋯⋯处，⋯⋯的地方"
-        ],
-        "notation": "～箇所(かしょ)"
+        ]
     },
     {
         "name": "shanai",
         "trans": [
+            "社内(しゃない)",
             "① 名  公司内部"
-        ],
-        "notation": "社内(しゃない)"
+        ]
     },
     {
         "name": "jitsuryoku",
         "trans": [
+            "実力(じつりょく)",
             "⓪ 名  实力"
-        ],
-        "notation": "実力(じつりょく)"
+        ]
     },
     {
         "name": "mikake",
         "trans": [
+            "見掛(みか)け",
             "⓪ 名  外观，外表"
-        ],
-        "notation": "見掛(みか)け"
+        ]
     },
     {
         "name": "seimei",
         "trans": [
+            "生命(せいめい)",
             "① 名  生命"
-        ],
-        "notation": "生命(せいめい)"
+        ]
     },
     {
         "name": "taezu",
         "trans": [
+            "絶(た)えず",
             "① 副  不断地，总是"
-        ],
-        "notation": "絶(た)えず"
+        ]
     },
     {
         "name": "darashinai",
         "trans": [
+            "だらしない",
             "④ イ形  散漫的；没出息的，不争气的"
-        ],
-        "notation": "だらしない"
+        ]
     },
     {
         "name": "kashu",
         "trans": [
+            "歌手(かしゅ)",
             "① 名  歌手"
-        ],
-        "notation": "歌手(かしゅ)"
+        ]
     },
     {
         "name": "zoukin",
         "trans": [
+            "雑巾(ぞうきん)",
             "⓪ 名  抹布"
-        ],
-        "notation": "雑巾(ぞうきん)"
+        ]
     },
     {
         "name": "setto",
         "trans": [
+            "セット",
             "① 名·他动3  一组，一套；组装"
-        ],
-        "notation": "セット"
+        ]
     },
     {
         "name": "shin'yuu",
         "trans": [
+            "親友(しんゆう)",
             "⓪ 名  好友，亲密的朋友"
-        ],
-        "notation": "親友(しんゆう)"
+        ]
     },
     {
         "name": "jishuu",
         "trans": [
+            "自習(じしゅう)",
             "⓪ 名·他动3  自习，自学"
-        ],
-        "notation": "自習(じしゅう)"
+        ]
     },
     {
         "name": "bu-tsu",
         "trans": [
+            "ブーツ",
             "① 名  长筒靴"
-        ],
-        "notation": "ブーツ"
+        ]
     },
     {
         "name": "kon",
         "trans": [
+            "紺(こん)",
             "① 名  藏青，藏蓝"
-        ],
-        "notation": "紺(こん)"
+        ]
     },
     {
         "name": "tarinai",
         "trans": [
+            "足(た)りない",
             "⓪ 连语  不足，不够"
-        ],
-        "notation": "足(た)りない"
+        ]
     },
     {
         "name": "tariru",
         "trans": [
+            "足(た)りる",
             "⓪ 自动2  足够；值得"
-        ],
-        "notation": "足(た)りる"
+        ]
     },
     {
         "name": "dokutoku",
         "trans": [
+            "独特(どくとく)",
             "⓪ ナ形  独特的，独有的"
-        ],
-        "notation": "独特(どくとく)"
+        ]
     },
     {
         "name": "kazan",
         "trans": [
+            "火山(かざん)",
             "① 名  火山"
-        ],
-        "notation": "火山(かざん)"
+        ]
     },
     {
         "name": "fuantei",
         "trans": [
+            "不安定(ふあんてい)",
             "② 名·ナ形  不稳定，不安定"
-        ],
-        "notation": "不安定(ふあんてい)"
+        ]
     },
     {
         "name": "burajiru",
         "trans": [
+            "ブラジル",
             "⓪ 名  巴西"
-        ],
-        "notation": "ブラジル"
+        ]
     },
     {
         "name": "hokori",
         "trans": [
+            "埃(ほこり)",
             "⓪ 名  灰尘"
-        ],
-        "notation": "埃(ほこり)"
+        ]
     },
     {
         "name": "mabuta",
         "trans": [
+            "瞼(まぶた)",
             "① 名  眼睑，眼皮"
-        ],
-        "notation": "瞼(まぶた)"
+        ]
     },
     {
         "name": "mukae",
         "trans": [
+            "迎(むか)え",
             "⓪ 名  迎接"
-        ],
-        "notation": "迎(むか)え"
+        ]
     },
     {
         "name": "nuru",
         "trans": [
+            "塗(ぬ)る",
             "⓪ 他动1  涂（颜料），擦，抹"
-        ],
-        "notation": "塗(ぬ)る"
+        ]
     },
     {
         "name": "kanbyou",
         "trans": [
+            "看病(かんびょう)",
             "① 名·他动3  护理，看护"
-        ],
-        "notation": "看病(かんびょう)"
+        ]
     },
     {
         "name": "kabuki",
         "trans": [
+            "歌舞伎(かぶき)",
             "⓪ 名  歌舞伎"
-        ],
-        "notation": "歌舞伎(かぶき)"
+        ]
     },
     {
         "name": "sankakukei/sankakkei",
         "trans": [
+            "三角形(さんかくけい/さんかっけい)",
             "③ 名  三角形"
-        ],
-        "notation": "三角形(さんかくけい/さんかっけい)"
+        ]
     },
     {
         "name": "shi-toberuto",
         "trans": [
+            "シートベルト",
             "④ 名  安全带"
-        ],
-        "notation": "シートベルト"
+        ]
     },
     {
         "name": "otetsudaisan",
         "trans": [
+            "お手伝(てつだ)いさん",
             "② 名  保姆，家政人员"
-        ],
-        "notation": "お手伝(てつだ)いさん"
+        ]
     },
     {
         "name": "tayoru",
         "trans": [
+            "頼(たよ)る",
             "② 自动1  依靠，依赖"
-        ],
-        "notation": "頼(たよ)る"
+        ]
     },
     {
         "name": "hikikaesu",
         "trans": [
+            "引(ひ)き返(かえ)す",
             "③ 自动1  返回，折回"
-        ],
-        "notation": "引(ひ)き返(かえ)す"
+        ]
     },
     {
         "name": "tanomi",
         "trans": [
+            "頼(たの)み",
             "③ 名  请求，恳求；依靠，依赖"
-        ],
-        "notation": "頼(たの)み"
+        ]
     },
     {
         "name": "o-pun",
         "trans": [
+            "オープン",
             "① 名·自动3  开业；开放"
-        ],
-        "notation": "オープン"
+        ]
     },
     {
         "name": "sekkei",
         "trans": [
+            "設計(せっけい)",
             "⓪ 名·他动3  设计；计划，规划"
-        ],
-        "notation": "設計(せっけい)"
+        ]
     },
     {
         "name": "mitsu",
         "trans": [
+            "密(みつ)",
             "① 名·ナ形  秘密；紧密；周密"
-        ],
-        "notation": "密(みつ)"
+        ]
     },
     {
         "name": "uku",
         "trans": [
+            "浮(う)く",
             "⓪ 自动1  漂浮；浮起"
-        ],
-        "notation": "浮(う)く"
+        ]
     },
     {
         "name": "min'na",
         "trans": [
+            "皆(みんな)",
             "③ 名  大家，全体"
-        ],
-        "notation": "皆(みんな)"
+        ]
     },
     {
         "name": "kitaku",
         "trans": [
+            "帰宅(きたく)",
             "⓪ 名·自动3  回家"
-        ],
-        "notation": "帰宅(きたく)"
+        ]
     },
     {
         "name": "donichi",
         "trans": [
+            "土日(どにち)",
             "⓪ 名  周六和周日，周末"
-        ],
-        "notation": "土日(どにち)"
+        ]
     },
     {
         "name": "shiteiseki",
         "trans": [
+            "指定席(していせき)",
             "② 名  指定席位"
-        ],
-        "notation": "指定席(していせき)"
+        ]
     },
     {
         "name": "shakkin",
         "trans": [
+            "借金(しゃっきん)",
             "③ 名·自动3  借钱，欠债"
-        ],
-        "notation": "借金(しゃっきん)"
+        ]
     },
     {
         "name": "seizon",
         "trans": [
+            "生存(せいぞん)",
             "⓪ 名·自动3  生存"
-        ],
-        "notation": "生存(せいぞん)"
+        ]
     },
     {
         "name": "meshita",
         "trans": [
+            "目下(めした)",
             "③ 名  晚辈；下属"
-        ],
-        "notation": "目下(めした)"
+        ]
     },
     {
         "name": "chikadika",
         "trans": [
+            "近々(ちかぢか)",
             "⓪ 副  不久，过几天"
-        ],
-        "notation": "近々(ちかぢか)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "解(と)く",
             "① 他动1  解开；解除；解答"
-        ],
-        "notation": "解(と)く"
+        ]
     },
     {
         "name": "namiki",
         "trans": [
+            "並木(なみき)",
             "⓪ 名  街道上成排的树"
-        ],
-        "notation": "並木(なみき)"
+        ]
     },
     {
         "name": "nikibi",
         "trans": [
+            "にきび",
             "① 名  痤疮，粉刺"
-        ],
-        "notation": "にきび"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "轢(ひ)く",
             "⓪ 他动1  （汽车）轧"
-        ],
-        "notation": "轢(ひ)く"
+        ]
     },
     {
         "name": "fureru",
         "trans": [
+            "触(ふ)れる",
             "⓪ 自他动2  接触，触碰；涉及，提到；感觉到"
-        ],
-        "notation": "触(ふ)れる"
+        ]
     },
     {
         "name": "tesuuryou",
         "trans": [
+            "手数料(てすうりょう)",
             "② 名  手续费"
-        ],
-        "notation": "手数料(てすうりょう)"
+        ]
     },
     {
         "name": "douryou",
         "trans": [
+            "同僚(どうりょう)",
             "⓪ 名  同事"
-        ],
-        "notation": "同僚(どうりょう)"
+        ]
     },
     {
         "name": "nakami",
         "trans": [
+            "中身(なかみ)",
             "② 名  内容，装在里面的东西"
-        ],
-        "notation": "中身(なかみ)"
+        ]
     },
     {
         "name": "netto",
         "trans": [
+            "ネット",
             "① 名  网；球网"
-        ],
-        "notation": "ネット"
+        ]
     },
     {
         "name": "hakike",
         "trans": [
+            "吐(は)き気(け)",
             "③ 名  恶心，想吐"
-        ],
-        "notation": "吐(は)き気(け)"
+        ]
     },
     {
         "name": "hitode",
         "trans": [
+            "人出(ひとで)",
             "⓪ 名  外出的人群"
-        ],
-        "notation": "人出(ひとで)"
+        ]
     },
     {
         "name": "fukyuu",
         "trans": [
+            "普及(ふきゅう)",
             "⓪ 名·自动3  普及"
-        ],
-        "notation": "普及(ふきゅう)"
+        ]
     },
     {
         "name": "houchou",
         "trans": [
+            "包丁(ほうちょう)",
             "⓪ 名  菜刀"
-        ],
-        "notation": "包丁(ほうちょう)"
+        ]
     },
     {
         "name": "ido",
         "trans": [
+            "井戸(いど)",
             "① 名  井"
-        ],
-        "notation": "井戸(いど)"
+        ]
     },
     {
         "name": "moushikomisha",
         "trans": [
+            "申込者(もうしこみしゃ)",
             "⑤ 名  申请者"
-        ],
-        "notation": "申込者(もうしこみしゃ)"
+        ]
     },
     {
         "name": "furansu",
         "trans": [
+            "フランス",
             "⓪ 名  法国"
-        ],
-        "notation": "フランス"
+        ]
     },
     {
         "name": "chikamichi",
         "trans": [
+            "近道(ちかみち)",
             "② 名  近路，近道"
-        ],
-        "notation": "近道(ちかみち)"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "刺(さ)す",
             "① 他动1  刺，扎"
-        ],
-        "notation": "刺(さ)す"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "挿(さ)す",
             "① 他动1  插，插入"
-        ],
-        "notation": "挿(さ)す"
+        ]
     },
     {
         "name": "jijitsu",
         "trans": [
+            "事実(じじつ)",
             "① 名·副  事实；实际上"
-        ],
-        "notation": "事実(じじつ)"
+        ]
     },
     {
         "name": "kirai",
         "trans": [
+            "嫌(きら)い",
             "⓪ 名·ナ形  讨厌，厌恶；有⋯⋯之嫌"
-        ],
-        "notation": "嫌(きら)い"
+        ]
     },
     {
         "name": "kirau",
         "trans": [
+            "嫌(きら)う",
             "⓪ 他动1  讨厌，厌恶"
-        ],
-        "notation": "嫌(きら)う"
+        ]
     },
     {
         "name": "keisan",
         "trans": [
+            "計算(けいさん)",
             "⓪ 名·他动3  计算；考虑，估计"
-        ],
-        "notation": "計算(けいさん)"
+        ]
     },
     {
         "name": "keishiki",
         "trans": [
+            "形式(けいしき)",
             "⓪ 名  形式"
-        ],
-        "notation": "形式(けいしき)"
+        ]
     },
     {
         "name": "~gou",
         "trans": [
+            "～号(ごう)",
             " 接尾  （车、飞机等）号；（杂志等）号，期"
-        ],
-        "notation": "～号(ごう)"
+        ]
     },
     {
         "name": "kokyou",
         "trans": [
+            "故郷(こきょう)",
             "① 名  故乡"
-        ],
-        "notation": "故郷(こきょう)"
+        ]
     },
     {
         "name": "sakaba",
         "trans": [
+            "酒場(さかば)",
             "⓪ 名  酒馆，酒吧"
-        ],
-        "notation": "酒場(さかば)"
+        ]
     },
     {
         "name": "~saki",
         "trans": [
+            "～先(さき)",
             " 接尾  ⋯⋯地点，⋯⋯目的地"
-        ],
-        "notation": "～先(さき)"
+        ]
     },
     {
         "name": "jidou",
         "trans": [
+            "自動(じどう)",
             "⓪ 名  自动"
-        ],
-        "notation": "自動(じどう)"
+        ]
     },
     {
         "name": "shihatsu",
         "trans": [
+            "始発(しはつ)",
             "⓪ 名  始发；首班车"
-        ],
-        "notation": "始発(しはつ)"
+        ]
     },
     {
         "name": "shojun",
         "trans": [
+            "初旬(しょじゅん)",
             "⓪ 名  上旬"
-        ],
-        "notation": "初旬(しょじゅん)"
+        ]
     },
     {
         "name": "tekisuru",
         "trans": [
+            "適(てき)する",
             "③ 自动3  适合，适于"
-        ],
-        "notation": "適(てき)する"
+        ]
     },
     {
         "name": "nakigoe",
         "trans": [
+            "泣(な)き声(ごえ)",
             "③ 名  哭声"
-        ],
-        "notation": "泣(な)き声(ごえ)"
+        ]
     },
     {
         "name": "burabura",
         "trans": [
+            "ぶらぶら",
             "① 副·自动3  摇晃；溜达；无所事事"
-        ],
-        "notation": "ぶらぶら"
+        ]
     },
     {
         "name": "daikon",
         "trans": [
+            "大根(だいこん)",
             "⓪ 名  白萝卜"
-        ],
-        "notation": "大根(だいこん)"
+        ]
     },
     {
         "name": "souiu",
         "trans": [
+            "そういう",
             "⓪ 连体  那种，那样"
-        ],
-        "notation": "そういう"
+        ]
     },
     {
         "name": "kouiu",
         "trans": [
+            "こういう",
             "⓪ 连体  这种，这样"
-        ],
-        "notation": "こういう"
+        ]
     },
     {
         "name": "koukan",
         "trans": [
+            "交換(こうかん)",
             "⓪ 名·他动3  交换，互换"
-        ],
-        "notation": "交換(こうかん)"
+        ]
     },
     {
         "name": "kyouchou",
         "trans": [
+            "強調(きょうちょう)",
             "⓪ 名·他动3  强调"
-        ],
-        "notation": "強調(きょうちょう)"
+        ]
     },
     {
         "name": "insuto-ru",
         "trans": [
+            "インストール",
             "④ 名·他动3  安装（计算机软件）"
-        ],
-        "notation": "インストール"
+        ]
     },
     {
         "name": "ato",
         "trans": [
+            "跡(あと)",
             "① 名  痕迹；迹象；行踪"
-        ],
-        "notation": "跡(あと)"
+        ]
     },
     {
         "name": "kyuuka",
         "trans": [
+            "休暇(きゅうか)",
             "⓪ 名  休假"
-        ],
-        "notation": "休暇(きゅうか)"
+        ]
     },
     {
         "name": "kiki",
         "trans": [
+            "機器(きき)",
             "① 名  机械，器具"
-        ],
-        "notation": "機器(きき)"
+        ]
     },
     {
         "name": "kankaku",
         "trans": [
+            "間隔(かんかく)",
             "⓪ 名  间隔，距离"
-        ],
-        "notation": "間隔(かんかく)"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "機嫌(きげん)",
             "⓪ 名  心情，情绪；畅快，痛快"
-        ],
-        "notation": "機嫌(きげん)"
+        ]
     },
     {
         "name": "shakuya",
         "trans": [
+            "借家(しゃくや)",
             "⓪ 名·自动3  租房"
-        ],
-        "notation": "借家(しゃくや)"
+        ]
     },
     {
         "name": "junsa",
         "trans": [
+            "巡査(じゅんさ)",
             "① 名  警察，巡警"
-        ],
-        "notation": "巡査(じゅんさ)"
+        ]
     },
     {
         "name": "shokuin",
         "trans": [
+            "職員(しょくいん)",
             "② 名  职员"
-        ],
-        "notation": "職員(しょくいん)"
+        ]
     },
     {
         "name": "tatamu",
         "trans": [
+            "畳(たた)む",
             "⓪ 他动1  叠，折叠；合上"
-        ],
-        "notation": "畳(たた)む"
+        ]
     },
     {
         "name": "chanoma",
         "trans": [
+            "茶(ちゃ)の間(ま)",
             "⓪ 名  餐厅；茶室"
-        ],
-        "notation": "茶(ちゃ)の間(ま)"
+        ]
     },
     {
         "name": "toukei",
         "trans": [
+            "統計(とうけい)",
             "⓪ 名·他动3  统计"
-        ],
-        "notation": "統計(とうけい)"
+        ]
     },
     {
         "name": "tobidasu",
         "trans": [
+            "飛(と)び出(だ)す",
             "③ 自动1  飞起来，跳出来；突然出现"
-        ],
-        "notation": "飛(と)び出(だ)す"
+        ]
     },
     {
         "name": "noseru",
         "trans": [
+            "乗(の)せる",
             "⓪ 他动2  装载，使搭乘；骗人"
-        ],
-        "notation": "乗(の)せる"
+        ]
     },
     {
         "name": "soushite",
         "trans": [
+            "そうして",
             "⓪ 接续  然后，于是；而且"
-        ],
-        "notation": "そうして"
+        ]
     },
     {
         "name": "uchuu",
         "trans": [
+            "宇宙(うちゅう)",
             "① 名  宇宙"
-        ],
-        "notation": "宇宙(うちゅう)"
+        ]
     },
     {
         "name": "suku-ru",
         "trans": [
+            "スクール",
             "② 名  学校"
-        ],
-        "notation": "スクール"
+        ]
     },
     {
         "name": "kogeru",
         "trans": [
+            "焦(こ)げる",
             "② 自动2  焦，糊；晒褪色"
-        ],
-        "notation": "焦(こ)げる"
+        ]
     },
     {
         "name": "kudari",
         "trans": [
+            "下(くだ)り",
             "⓪ 名  下；下行；下坡；从首都到地方"
-        ],
-        "notation": "下(くだ)り"
+        ]
     },
     {
         "name": "kuchibiru",
         "trans": [
+            "唇(くちびる)",
             "⓪ 名  嘴唇"
-        ],
-        "notation": "唇(くちびる)"
+        ]
     },
     {
         "name": "uru",
         "trans": [
+            "得(う)る",
             "① 他动2·接尾  得到，获得；能够，可能"
-        ],
-        "notation": "得(う)る"
+        ]
     },
     {
         "name": "guri-n",
         "trans": [
+            "グリーン",
             "② 名  绿色；草地"
-        ],
-        "notation": "グリーン"
+        ]
     },
     {
         "name": "moshimo",
         "trans": [
+            "もしも",
             "① 副  假如，万一"
-        ],
-        "notation": "もしも"
+        ]
     },
     {
         "name": "kingaku",
         "trans": [
+            "金額(きんがく)",
             "⓪ 名  金额"
-        ],
-        "notation": "金額(きんがく)"
+        ]
     },
     {
         "name": "kinsen",
         "trans": [
+            "金銭(きんせん)",
             "① 名  金钱"
-        ],
-        "notation": "金銭(きんせん)"
+        ]
     },
     {
         "name": "kinzoku",
         "trans": [
+            "金属(きんぞく)",
             "① 名  金属"
-        ],
-        "notation": "金属(きんぞく)"
+        ]
     },
     {
         "name": "kinben",
         "trans": [
+            "勤勉(きんべん)",
             "⓪ 名·ナ形  勤勉，勤劳"
-        ],
-        "notation": "勤勉(きんべん)"
+        ]
     },
     {
         "name": "koyubi",
         "trans": [
+            "小指(こゆび)",
             "⓪ 名  小指"
-        ],
-        "notation": "小指(こゆび)"
+        ]
     },
     {
         "name": "shuudensha",
         "trans": [
+            "終電車(しゅうでんしゃ)",
             "③ 名  末班电车"
-        ],
-        "notation": "終電車(しゅうでんしゃ)"
+        ]
     },
     {
         "name": "shoushou",
         "trans": [
+            "少々(しょうしょう)",
             "① 副  少许，稍微"
-        ],
-        "notation": "少々(しょうしょう)"
+        ]
     },
     {
         "name": "tamatama",
         "trans": [
+            "たまたま",
             "⓪ 副  偶尔，有时；偶然，碰巧"
-        ],
-        "notation": "たまたま"
+        ]
     },
     {
         "name": "tsukihi",
         "trans": [
+            "月日(つきひ)",
             "② 名  月亮和太阳；时光，岁月"
-        ],
-        "notation": "月日(つきひ)"
+        ]
     },
     {
         "name": "teinen",
         "trans": [
+            "定年(ていねん)",
             "⓪ 名  退休，退休年龄"
-        ],
-        "notation": "定年(ていねん)"
+        ]
     },
     {
         "name": "tonikaku",
         "trans": [
+            "とにかく",
             "① 副  总之，姑且，暂且不论"
-        ],
-        "notation": "とにかく"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "尤(もっと)も",
             "③ 接续  话虽如此，不过"
-        ],
-        "notation": "尤(もっと)も"
+        ]
     },
     {
         "name": "hau",
         "trans": [
+            "這(は)う",
             "① 自动1  爬行；（植物）攀缘，爬"
-        ],
-        "notation": "這(は)う"
+        ]
     },
     {
         "name": "fusai",
         "trans": [
+            "夫妻(ふさい)",
             "② 名  夫妻"
-        ],
-        "notation": "夫妻(ふさい)"
+        ]
     },
     {
         "name": "furaipan",
         "trans": [
+            "フライパン",
             "⓪ 名  平底锅，煎锅"
-        ],
-        "notation": "フライパン"
+        ]
     },
     {
         "name": "henkou",
         "trans": [
+            "変更(へんこう)",
             "⓪ 名·他动3  变更，更改"
-        ],
-        "notation": "変更(へんこう)"
+        ]
     },
     {
         "name": "etsuranshitsu",
         "trans": [
+            "閲覧室(えつらんしつ)",
             "③ 名  阅览室"
-        ],
-        "notation": "閲覧室(えつらんしつ)"
+        ]
     },
     {
         "name": "ryouhou",
         "trans": [
+            "両方(りょうほう)",
             "③ 名  双方"
-        ],
-        "notation": "両方(りょうほう)"
+        ]
     },
     {
         "name": "furi-",
         "trans": [
+            "フリー",
             "② 名·ナ形  自由；免费"
-        ],
-        "notation": "フリー"
+        ]
     },
     {
         "name": "maneku",
         "trans": [
+            "招(まね)く",
             "② 他动1  招呼；招待，宴请；聘请；招致"
-        ],
-        "notation": "招(まね)く"
+        ]
     },
     {
         "name": "mane",
         "trans": [
+            "真似(まね)",
             "⓪ 名·自他动3  举止，动作；模仿，效仿"
-        ],
-        "notation": "真似(まね)"
+        ]
     },
     {
         "name": "maneru",
         "trans": [
+            "真似(まね)る",
             "⓪ 他动2  模仿，效仿"
-        ],
-        "notation": "真似(まね)る"
+        ]
     },
     {
         "name": "shinzou",
         "trans": [
+            "心臓(しんぞう)",
             "⓪ 名  心脏"
-        ],
-        "notation": "心臓(しんぞう)"
+        ]
     },
     {
         "name": "jiman",
         "trans": [
+            "自慢(じまん)",
             "⓪ 名·他动3  骄傲，夸耀，炫耀"
-        ],
-        "notation": "自慢(じまん)"
+        ]
     },
     {
         "name": "sakizaki",
         "trans": [
+            "先々(さきざき)",
             "② 名  将来，日后；所到之处；很早之前"
-        ],
-        "notation": "先々(さきざき)"
+        ]
     },
     {
         "name": "getsumatsu",
         "trans": [
+            "月末(げつまつ)",
             "⓪ 名  月底"
-        ],
-        "notation": "月末(げつまつ)"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "組(く)む",
             "① 自他动1  合伙；组成组；扭打；交叉"
-        ],
-        "notation": "組(く)む"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "汲(く)む",
             "⓪ 他动1  打水；斟，倒（茶、酒等）"
-        ],
-        "notation": "汲(く)む"
+        ]
     },
     {
         "name": "kumu",
         "trans": [
+            "酌(く)む",
             "⓪ 他动1  体谅，理解"
-        ],
-        "notation": "酌(く)む"
+        ]
     },
     {
         "name": "kyoushuku",
         "trans": [
+            "恐縮(きょうしゅく)",
             "⓪ 名·自动3  惶恐；不好意思"
-        ],
-        "notation": "恐縮(きょうしゅく)"
+        ]
     },
     {
         "name": "kizamu",
         "trans": [
+            "刻(きざ)む",
             "⓪ 他动1  刻，雕刻；铭记"
-        ],
-        "notation": "刻(きざ)む"
+        ]
     },
     {
         "name": "kangei",
         "trans": [
+            "歓迎(かんげい)",
             "⓪ 名·他动3  欢迎"
-        ],
-        "notation": "歓迎(かんげい)"
+        ]
     },
     {
         "name": "nakeru",
         "trans": [
+            "泣(な)ける",
             "⓪ 自动2  禁不住哭出来"
-        ],
-        "notation": "泣(な)ける"
+        ]
     },
     {
         "name": "noru",
         "trans": [
+            "載(の)る",
             "⓪ 自动1  放，搁；刊载，登载"
-        ],
-        "notation": "載(の)る"
+        ]
     },
     {
         "name": "bamen",
         "trans": [
+            "場面(ばめん)",
             "① 名  场面，场景"
-        ],
-        "notation": "場面(ばめん)"
+        ]
     },
     {
         "name": "moushiwakenai",
         "trans": [
+            "申(もう)し訳(わけ)ない",
             "⑥ イ形  对不起"
-        ],
-        "notation": "申(もう)し訳(わけ)ない"
+        ]
     },
     {
         "name": "yuushuu",
         "trans": [
+            "優秀(ゆうしゅう)",
             "⓪ 名·ナ形  优秀"
-        ],
-        "notation": "優秀(ゆうしゅう)"
+        ]
     },
     {
         "name": "youshitsu",
         "trans": [
+            "洋室(ようしつ)",
             "⓪ 名  西式房间"
-        ],
-        "notation": "洋室(ようしつ)"
+        ]
     },
     {
         "name": "youshoku",
         "trans": [
+            "洋食(ようしょく)",
             "⓪ 名  西餐"
-        ],
-        "notation": "洋食(ようしょく)"
+        ]
     },
     {
         "name": "chuusha",
         "trans": [
+            "駐車(ちゅうしゃ)",
             "⓪ 名·自动3  停车"
-        ],
-        "notation": "駐車(ちゅうしゃ)"
+        ]
     },
     {
         "name": "seinou",
         "trans": [
+            "性能(せいのう)",
             "⓪ 名  性能"
-        ],
-        "notation": "性能(せいのう)"
+        ]
     },
     {
         "name": "shouten",
         "trans": [
+            "商店(しょうてん)",
             "① 名  商店"
-        ],
-        "notation": "商店(しょうてん)"
+        ]
     },
     {
         "name": "janken",
         "trans": [
+            "じゃんけん",
             "③ 名·自动3  猜拳，划拳"
-        ],
-        "notation": "じゃんけん"
+        ]
     },
     {
         "name": "daku",
         "trans": [
+            "抱(だ)く",
             "⓪ 他动1  抱"
-        ],
-        "notation": "抱(だ)く"
+        ]
     },
     {
         "name": "tokasu",
         "trans": [
+            "溶(と)かす",
             "② 他动1  熔化，融化，溶化"
-        ],
-        "notation": "溶(と)かす"
+        ]
     },
     {
         "name": "fujuubun",
         "trans": [
+            "不十分(ふじゅうぶん)",
             "② 名·ナ形  不充足，不够"
-        ],
-        "notation": "不十分(ふじゅうぶん)"
+        ]
     },
     {
         "name": "mukanshin",
         "trans": [
+            "無関心(むかんしん)",
             "② 名·ナ形  不关心，不感兴趣"
-        ],
-        "notation": "無関心(むかんしん)"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "元(もと)",
             "① 名  以前，原来"
-        ],
-        "notation": "元(もと)"
+        ]
     },
     {
         "name": "moto",
         "trans": [
+            "元(もと)",
             "② 名  根源；根本；原因"
-        ],
-        "notation": "元(もと)"
+        ]
     },
     {
         "name": "shippo",
         "trans": [
+            "尻尾(しっぽ)",
             "③ 名  尾巴；末端"
-        ],
-        "notation": "尻尾(しっぽ)"
+        ]
     },
     {
         "name": "keiki",
         "trans": [
+            "景気(けいき)",
             "⓪ 名  （经济）景气，繁荣"
-        ],
-        "notation": "景気(けいき)"
+        ]
     },
     {
         "name": "kikikaesu",
         "trans": [
+            "聞(き)き返(かえ)す",
             "③ 他动1  反复听；反复问；反问"
-        ],
-        "notation": "聞(き)き返(かえ)す"
+        ]
     },
     {
         "name": "garagara",
         "trans": [
+            "がらがら",
             "⓪ ナ形·副·自动3  轰隆声；性格直爽；人很少，空荡荡"
-        ],
-        "notation": "がらがら"
+        ]
     },
     {
         "name": "oufuku",
         "trans": [
+            "往復(おうふく)",
             "⓪ 名·自动3  往返，来回"
-        ],
-        "notation": "往復(おうふく)"
+        ]
     },
     {
         "name": "karu",
         "trans": [
+            "刈(か)る",
             "⓪ 他动1  割，修剪"
-        ],
-        "notation": "刈(か)る"
+        ]
     },
     {
         "name": "ju-su",
         "trans": [
+            "ジュース",
             "① 名  果汁，蔬菜汁"
-        ],
-        "notation": "ジュース"
+        ]
     },
     {
         "name": "tatakai",
         "trans": [
+            "戦(たたか)い",
             "⓪ 名  战争；战斗；比赛"
-        ],
-        "notation": "戦(たたか)い"
+        ]
     },
     {
         "name": "touroku",
         "trans": [
+            "登録(とうろく)",
             "⓪ 名·他动3  登记，注册"
-        ],
-        "notation": "登録(とうろく)"
+        ]
     },
     {
         "name": "hosu",
         "trans": [
+            "干(ほ)す",
             "① 他动1  晒干，烘干；喝完"
-        ],
-        "notation": "干(ほ)す"
+        ]
     },
     {
         "name": "moushikomu",
         "trans": [
+            "申(もう)し込(こ)む",
             "④ 他动1  提议；报名；预约"
-        ],
-        "notation": "申(もう)し込(こ)む"
+        ]
     },
     {
         "name": "mushiba",
         "trans": [
+            "虫歯(むしば)",
             "⓪ 名  虫牙，龋齿"
-        ],
-        "notation": "虫歯(むしば)"
+        ]
     },
     {
         "name": "shamoji",
         "trans": [
+            "しゃもじ",
             "① 名  勺子，饭勺"
-        ],
-        "notation": "しゃもじ"
+        ]
     },
     {
         "name": "sakunen",
         "trans": [
+            "昨年(さくねん)",
             "⓪ 名  去年"
-        ],
-        "notation": "昨年(さくねん)"
+        ]
     },
     {
         "name": "kikitoru",
         "trans": [
+            "聞(き)き取(と)る",
             "③ 他动1  听见；听懂；听取"
-        ],
-        "notation": "聞(き)き取(と)る"
+        ]
     },
     {
         "name": "dantei",
         "trans": [
+            "断定(だんてい)",
             "⓪ 名·他动3  断定，判断"
-        ],
-        "notation": "断定(だんてい)"
+        ]
     },
     {
         "name": "engan",
         "trans": [
+            "沿岸(えんがん)",
             "⓪ 名  沿岸，沿海"
-        ],
-        "notation": "沿岸(えんがん)"
+        ]
     },
     {
         "name": "monooto",
         "trans": [
+            "物音(ものおと)",
             "③ 名  声音，声响"
-        ],
-        "notation": "物音(ものおと)"
+        ]
     },
     {
         "name": "kanryou",
         "trans": [
+            "完了(かんりょう)",
             "⓪ 名·自他动3  完结，完毕"
-        ],
-        "notation": "完了(かんりょう)"
+        ]
     },
     {
         "name": "kawaigaru",
         "trans": [
+            "可愛(かわい)がる",
             "④ 他动1  喜爱，疼爱"
-        ],
-        "notation": "可愛(かわい)がる"
+        ]
     },
     {
         "name": "kifu",
         "trans": [
+            "寄付(きふ)",
             "① 名·他动3  捐献，捐赠"
-        ],
-        "notation": "寄付(きふ)"
+        ]
     },
     {
         "name": "kuwaeru",
         "trans": [
+            "加(くわ)える",
             "⓪ 他动2  加上；附加；包括；施加"
-        ],
-        "notation": "加(くわ)える"
+        ]
     },
     {
         "name": "koudou",
         "trans": [
+            "行動(こうどう)",
             "⓪ 名·自动3  行动，行为"
-        ],
-        "notation": "行動(こうどう)"
+        ]
     },
     {
         "name": "kouhei",
         "trans": [
+            "公平(こうへい)",
             "⓪ 名·ナ形  公平，公正"
-        ],
-        "notation": "公平(こうへい)"
+        ]
     },
     {
         "name": "korehodo",
         "trans": [
+            "これほど",
             "⓪ 副  这样，这么"
-        ],
-        "notation": "これほど"
+        ]
     },
     {
         "name": "saidomira-",
         "trans": [
+            "サイドミラー",
             "④ 名  （汽车两侧）后视镜"
-        ],
-        "notation": "サイドミラー"
+        ]
     },
     {
         "name": "tedukuri",
         "trans": [
+            "手作(てづく)り",
             "② 名  自制，亲手做"
-        ],
-        "notation": "手作(てづく)り"
+        ]
     },
     {
         "name": "nidotofutatabi",
         "trans": [
+            "二度(にど)と再(ふたた)び",
             "② 副  （后接否定）再（也不）"
-        ],
-        "notation": "二度(にど)と再(ふたた)び"
+        ]
     },
     {
         "name": "man'in",
         "trans": [
+            "満員(まんいん)",
             "⓪ 名  满员；名额已满"
-        ],
-        "notation": "満員(まんいん)"
+        ]
     },
     {
         "name": "mankai",
         "trans": [
+            "満開(まんかい)",
             "⓪ 名·自动3  （花）盛开"
-        ],
-        "notation": "満開(まんかい)"
+        ]
     },
     {
         "name": "manseki",
         "trans": [
+            "満席(まんせき)",
             "⓪ 名  满座，没有空座"
-        ],
-        "notation": "満席(まんせき)"
+        ]
     },
     {
         "name": "buro-chi",
         "trans": [
+            "ブローチ",
             "② 名  别针，胸针"
-        ],
-        "notation": "ブローチ"
+        ]
     },
     {
         "name": "yuudachi",
         "trans": [
+            "夕立(ゆうだち)",
             "⓪ 名  （夏季傍晚下的）骤雨，雷阵雨"
-        ],
-        "notation": "夕立(ゆうだち)"
+        ]
     },
     {
         "name": "shiraga",
         "trans": [
+            "白髪(しらが)",
             "③ 名  白发"
-        ],
-        "notation": "白髪(しらが)"
+        ]
     },
     {
         "name": "~jou",
         "trans": [
+            "～畳(たたみ)",
             " 接尾  （计算榻榻米的单位）⋯⋯张"
-        ],
-        "notation": "～畳(たたみ)"
+        ]
     },
     {
         "name": "jibiki",
         "trans": [
+            "字引(じびき)",
             "③ 名  字典，词典"
-        ],
-        "notation": "字引(じびき)"
+        ]
     },
     {
         "name": "sakujitsu",
         "trans": [
+            "昨日(さくじつ)",
             "② 名  昨天"
-        ],
-        "notation": "昨日(さくじつ)"
+        ]
     },
     {
         "name": "monogoto",
         "trans": [
+            "物事(ものごと)",
             "② 名  事物，事情"
-        ],
-        "notation": "物事(ものごと)"
+        ]
     },
     {
         "name": "gesha",
         "trans": [
+            "下車(げしゃ)",
             "① 名·自动3  下车"
-        ],
-        "notation": "下車(げしゃ)"
+        ]
     },
     {
         "name": "kyouzai",
         "trans": [
+            "教材(きょうざい)",
             "⓪ 名  教材"
-        ],
-        "notation": "教材(きょうざい)"
+        ]
     },
     {
         "name": "kandenchi",
         "trans": [
+            "乾電池(かんでんち)",
             "③ 名  干电池"
-        ],
-        "notation": "乾電池(かんでんち)"
+        ]
     },
     {
         "name": "kamikuzu",
         "trans": [
+            "紙(かみ)くず",
             "③ 名  废纸"
-        ],
-        "notation": "紙(かみ)くず"
+        ]
     },
     {
         "name": "taishou",
         "trans": [
+            "対象(たいしょう)",
             "⓪ 名  对象"
-        ],
-        "notation": "対象(たいしょう)"
+        ]
     },
     {
         "name": "tsukuridasu",
         "trans": [
+            "作(つく)り出(だ)す",
             "④ 他动1  开始做；制造；创作"
-        ],
-        "notation": "作(つく)り出(だ)す"
+        ]
     },
     {
         "name": "nessuru",
         "trans": [
+            "熱(ねっ)する",
             "⓪ 自他动3  变热；加热；热衷"
-        ],
-        "notation": "熱(ねっ)する"
+        ]
     },
     {
         "name": "fasuna-",
         "trans": [
+            "ファスナー",
             "① 名  拉链，拉锁"
-        ],
-        "notation": "ファスナー"
+        ]
     },
     {
         "name": "ho-ru",
         "trans": [
+            "ホール",
             "① 名  大厅，礼堂"
-        ],
-        "notation": "ホール"
+        ]
     },
     {
         "name": "massao",
         "trans": [
+            "真(ま)っ青(さお)",
             "③ 名·ナ形  蔚蓝，深蓝；（脸色）苍白"
-        ],
-        "notation": "真(ま)っ青(さお)"
+        ]
     },
     {
         "name": "massaki",
         "trans": [
+            "真(ま)っ先(さき)",
             "③ 名·ナ形  最先，首先"
-        ],
-        "notation": "真(ま)っ先(さき)"
+        ]
     },
     {
         "name": "moyasu",
         "trans": [
+            "燃(も)やす",
             "⓪ 他动1  燃烧；激发（情感）"
-        ],
-        "notation": "燃(も)やす"
+        ]
     },
     {
         "name": "yoseru",
         "trans": [
+            "寄(よ)せる",
             "⓪ 自他动2  使⋯⋯靠近；聚集；寄托"
-        ],
-        "notation": "寄(よ)せる"
+        ]
     },
     {
         "name": "rikou",
         "trans": [
+            "利口(りこう)",
             "⓪ ナ形  聪明的，伶俐的"
-        ],
-        "notation": "利口(りこう)"
+        ]
     },
     {
         "name": "ana",
         "trans": [
+            "穴(あな)",
             "② 名  洞，孔，穴"
-        ],
-        "notation": "穴(あな)"
+        ]
     },
     {
         "name": "rika",
         "trans": [
+            "理科(りか)",
             "① 名  理科"
-        ],
-        "notation": "理科(りか)"
+        ]
     },
     {
         "name": "wazuka",
         "trans": [
+            "わずか",
             "① 名·ナ形·副  一点点；稍微"
-        ],
-        "notation": "わずか"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "寄(よ)る",
             "⓪ 自动1  靠近，挨近；集中；顺路去"
-        ],
-        "notation": "寄(よ)る"
+        ]
     },
     {
         "name": "yuushou",
         "trans": [
+            "優勝(ゆうしょう)",
             "⓪ 名·自动3  冠军；优胜，获胜"
-        ],
-        "notation": "優勝(ゆうしょう)"
+        ]
     },
     {
         "name": "media",
         "trans": [
+            "メディア",
             "① 名  媒体；手段，媒介"
-        ],
-        "notation": "メディア"
+        ]
     },
     {
         "name": "matsuru",
         "trans": [
+            "祭(まつ)る",
             "⓪ 他动1  祭奠，供奉"
-        ],
-        "notation": "祭(まつ)る"
+        ]
     },
     {
         "name": "heru",
         "trans": [
+            "減(へ)る",
             "⓪ 自动1  减少；饿肚子"
-        ],
-        "notation": "減(へ)る"
+        ]
     },
     {
         "name": "fukin",
         "trans": [
+            "付近(ふきん)",
             "① 名  附近"
-        ],
-        "notation": "付近(ふきん)"
+        ]
     },
     {
         "name": "hitorihitori",
         "trans": [
+            "一人一人(ひとりひとり)",
             "⑤ 副  每个人，各自"
-        ],
-        "notation": "一人一人(ひとりひとり)"
+        ]
     },
     {
         "name": "hankagai",
         "trans": [
+            "繁華街(はんかがい)",
             "③ 名  繁华街区"
-        ],
-        "notation": "繁華街(はんかがい)"
+        ]
     },
     {
         "name": "torikaeru",
         "trans": [
+            "取(と)り替(か)える",
             "⓪ 他动2  交换，互换；更换，换成新的"
-        ],
-        "notation": "取(と)り替(か)える"
+        ]
     },
     {
         "name": "ouyou",
         "trans": [
+            "応用(おうよう)",
             "⓪ 名·他动3  应用，运用"
-        ],
-        "notation": "応用(おうよう)"
+        ]
     },
     {
         "name": "yado",
         "trans": [
+            "宿(やど)",
             "① 名  房屋；旅馆"
-        ],
-        "notation": "宿(やど)"
+        ]
     },
     {
         "name": "setsubi",
         "trans": [
+            "設備(せつび)",
             "① 名  设备"
-        ],
-        "notation": "設備(せつび)"
+        ]
     },
     {
         "name": "shinakazu",
         "trans": [
+            "品数(しなかず)",
             "⓪ 名  物品的品种或数量"
-        ],
-        "notation": "品数(しなかず)"
+        ]
     },
     {
         "name": "kosame",
         "trans": [
+            "小雨(こさめ)",
             "⓪ 名  小雨"
-        ],
-        "notation": "小雨(こさめ)"
+        ]
     },
     {
         "name": "kekkyoku",
         "trans": [
+            "結局(けっきょく)",
             "⓪ 名·副  结果；到底，终究"
-        ],
-        "notation": "結局(けっきょく)"
+        ]
     },
     {
         "name": "kiji",
         "trans": [
+            "生地(きじ)",
             "① 名  质地，布料；本来面目"
-        ],
-        "notation": "生地(きじ)"
+        ]
     },
     {
         "name": "kanningu",
         "trans": [
+            "カンニング",
             "⓪ 名·自动3  （考试）作弊"
-        ],
-        "notation": "カンニング"
+        ]
     },
     {
         "name": "kareshi",
         "trans": [
+            "彼氏(かれし)",
             "① 名·代  男朋友；他"
-        ],
-        "notation": "彼氏(かれし)"
+        ]
     },
     {
         "name": "bebi-",
         "trans": [
+            "ベビー",
             "① 名  婴儿"
-        ],
-        "notation": "ベビー"
+        ]
     },
     {
         "name": "mochi",
         "trans": [
+            "餅(もち)",
             "⓪ 名  年糕"
-        ],
-        "notation": "餅(もち)"
+        ]
     },
     {
         "name": "yu-moa",
         "trans": [
+            "ユーモア",
             "① 名  幽默，滑稽"
-        ],
-        "notation": "ユーモア"
+        ]
     },
     {
         "name": "furuku",
         "trans": [
+            "古(ふる)く",
             "① 名·副  以前"
-        ],
-        "notation": "古(ふる)く"
+        ]
     },
     {
         "name": "fan",
         "trans": [
+            "ファン",
             "① 名  风扇；粉丝，爱好者"
-        ],
-        "notation": "ファン"
+        ]
     },
     {
         "name": "panda",
         "trans": [
+            "パンダ",
             "① 名  熊猫"
-        ],
-        "notation": "パンダ"
+        ]
     },
     {
         "name": "nakayoshi",
         "trans": [
+            "仲良(なかよ)し",
             "② 名  好朋友；关系好"
-        ],
-        "notation": "仲良(なかよ)し"
+        ]
     },
     {
         "name": "tameshini",
         "trans": [
+            "試(ため)しに",
             "③ 副  尝试，试着"
-        ],
-        "notation": "試(ため)しに"
+        ]
     },
     {
         "name": "shirokuro",
         "trans": [
+            "白黒(しろくろ)",
             "⓪ 名  白与黑；是非曲直；黑白（电视等）"
-        ],
-        "notation": "白黒(しろくろ)"
+        ]
     },
     {
         "name": "sentakumono",
         "trans": [
+            "洗濯物(せんたくもの)",
             "⓪ 名  要洗的衣服；洗过的衣服"
-        ],
-        "notation": "洗濯物(せんたくもの)"
+        ]
     },
     {
         "name": "tanbo",
         "trans": [
+            "田圃(たんぼ)",
             "⓪ 名  田地，庄稼地"
-        ],
-        "notation": "田圃(たんぼ)"
+        ]
     },
     {
         "name": "toorisugiru",
         "trans": [
+            "通(とお)り過(す)ぎる",
             "⑤ 自动2  走过，经过"
-        ],
-        "notation": "通(とお)り過(す)ぎる"
+        ]
     },
     {
         "name": "tozan",
         "trans": [
+            "登山(とざん)",
             "① 名·自动3  登山，爬山"
-        ],
-        "notation": "登山(とざん)"
+        ]
     },
     {
         "name": "tayori",
         "trans": [
+            "便(たよ)り",
             "① 名  消息，音信"
-        ],
-        "notation": "便(たよ)り"
+        ]
     },
     {
         "name": "sutoppu",
         "trans": [
+            "ストップ",
             "② 名·自他动3  停止，终止；停下"
-        ],
-        "notation": "ストップ"
+        ]
     },
     {
         "name": "hiatari",
         "trans": [
+            "日当(ひあ)たり",
             "⓪ 名  向阳处，阳光照射处"
-        ],
-        "notation": "日当(ひあ)たり"
+        ]
     },
     {
         "name": "buru-",
         "trans": [
+            "ブルー",
             "② 名  蓝色"
-        ],
-        "notation": "ブルー"
+        ]
     },
     {
         "name": "yuubin",
         "trans": [
+            "郵便(ゆうびん)",
             "⓪ 名  邮政，邮件"
-        ],
-        "notation": "郵便(ゆうびん)"
+        ]
     },
     {
         "name": "yozora",
         "trans": [
+            "夜空(よぞら)",
             "① 名  夜空"
-        ],
-        "notation": "夜空(よぞら)"
+        ]
     },
     {
         "name": "reigi",
         "trans": [
+            "礼儀(れいぎ)",
             "③ 名  礼仪，礼节"
-        ],
-        "notation": "礼儀(れいぎ)"
+        ]
     },
     {
         "name": "waishatsu",
         "trans": [
+            "ワイシャツ",
             "⓪ 名  男士衬衫"
-        ],
-        "notation": "ワイシャツ"
+        ]
     },
     {
         "name": "wagamama",
         "trans": [
+            "わがまま",
             "③ 名·ナ形  任性，放肆"
-        ],
-        "notation": "わがまま"
+        ]
     },
     {
         "name": "eigyou",
         "trans": [
+            "営業(えいぎょう)",
             "⓪ 名·自动3  营业，经商"
-        ],
-        "notation": "営業(えいぎょう)"
+        ]
     },
     {
         "name": "yopparau",
         "trans": [
+            "酔(よ)っ払(ぱら)う",
             "⓪ 自动1  喝醉；晕车，晕船"
-        ],
-        "notation": "酔(よ)っ払(ぱら)う"
+        ]
     },
     {
         "name": "yarinaosu",
         "trans": [
+            "やり直(なお)す",
             "④ 他动1  重做"
-        ],
-        "notation": "やり直(なお)す"
+        ]
     },
     {
         "name": "zaisan",
         "trans": [
+            "財産(ざいさん)",
             "① 名  财产"
-        ],
-        "notation": "財産(ざいさん)"
+        ]
     },
     {
         "name": "saishin",
         "trans": [
+            "最新(さいしん)",
             "⓪ 名  最新"
-        ],
-        "notation": "最新(さいしん)"
+        ]
     },
     {
         "name": "koumoku",
         "trans": [
+            "項目(こうもく)",
             "⓪ 名  项目；条目"
-        ],
-        "notation": "項目(こうもく)"
+        ]
     },
     {
         "name": "keito",
         "trans": [
+            "毛糸(けいと)",
             "⓪ 名  毛线，绒线"
-        ],
-        "notation": "毛糸(けいと)"
+        ]
     },
     {
         "name": "kudaranai",
         "trans": [
+            "くだらない",
             "⓪ 连语  无用，无益，无聊"
-        ],
-        "notation": "くだらない"
+        ]
     },
     {
         "name": "bebi-ka-",
         "trans": [
+            "ベビーカー",
             "② 名  婴儿车"
-        ],
-        "notation": "ベビーカー"
+        ]
     },
     {
         "name": "kiduku",
         "trans": [
+            "気(き)づく",
             "② 自动1  注意到，发觉；苏醒过来"
-        ],
-        "notation": "気(き)づく"
+        ]
     },
     {
         "name": "shimai",
         "trans": [
+            "姉妹(しまい)",
             "① 名  姐妹"
-        ],
-        "notation": "姉妹(しまい)"
+        ]
     },
     {
         "name": "nettou",
         "trans": [
+            "熱湯(ねっとう)",
             "⓪ 名  热水，开水"
-        ],
-        "notation": "熱湯(ねっとう)"
+        ]
     },
     {
         "name": "enkei",
         "trans": [
+            "円形(えんけい)",
             "⓪ 名  圆形"
-        ],
-        "notation": "円形(えんけい)"
+        ]
     },
     {
         "name": "nashi",
         "trans": [
+            "無(な)し",
             "① 名  无，没有"
-        ],
-        "notation": "無(な)し"
+        ]
     },
     {
         "name": "~dukai",
         "trans": [
+            "～遣(づか)い/～使(づか)い",
             " 接尾  ⋯⋯用；⋯⋯用法；用⋯⋯的人"
-        ],
-        "notation": "～遣(づか)い/～使(づか)い"
+        ]
     },
     {
         "name": "senzai",
         "trans": [
+            "洗剤(せんざい)",
             "⓪ 名  洗涤剂，洗衣剂"
-        ],
-        "notation": "洗剤(せんざい)"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "無効(むこう)",
             "⓪ 名·ナ形  无效，失效"
-        ],
-        "notation": "無効(むこう)"
+        ]
     },
     {
         "name": "ho-musutei",
         "trans": [
+            "ホームステイ",
             "⑤ 名  （留学）寄宿家庭"
-        ],
-        "notation": "ホームステイ"
+        ]
     },
     {
         "name": "kigyou",
         "trans": [
+            "企業(きぎょう)",
             "① 名  企业"
-        ],
-        "notation": "企業(きぎょう)"
+        ]
     },
     {
         "name": "kantou",
         "trans": [
+            "関東(かんとう)",
             "① 名  日本关东，通常指以东京、横滨为中心的地区"
-        ],
-        "notation": "関東(かんとう)"
+        ]
     },
     {
         "name": "kawairashii",
         "trans": [
+            "可愛(かわい)らしい",
             "⑤ イ形  可爱的；小巧玲珑的"
-        ],
-        "notation": "可愛(かわい)らしい"
+        ]
     },
     {
         "name": "tashou",
         "trans": [
+            "多少(たしょう)",
             "⓪ 名·副  多少；稍微"
-        ],
-        "notation": "多少(たしょう)"
+        ]
     },
     {
         "name": "nori",
         "trans": [
+            "海苔(のり)",
             "② 名  海苔，海藻；紫菜"
-        ],
-        "notation": "海苔(のり)"
+        ]
     },
     {
         "name": "hanayome",
         "trans": [
+            "花嫁(はなよめ)",
             "② 名  新娘"
-        ],
-        "notation": "花嫁(はなよめ)"
+        ]
     },
     {
         "name": "manaita",
         "trans": [
+            "まな板(いた)",
             "⓪ 名  切菜板"
-        ],
-        "notation": "まな板(いた)"
+        ]
     },
     {
         "name": "yuge",
         "trans": [
+            "湯気(ゆげ)",
             "① 名  蒸汽，热气"
-        ],
-        "notation": "湯気(ゆげ)"
+        ]
     },
     {
         "name": "yuuhi",
         "trans": [
+            "夕日(ゆうひ)",
             "⓪ 名  夕阳"
-        ],
-        "notation": "夕日(ゆうひ)"
+        ]
     },
     {
         "name": "tobiagaru",
         "trans": [
+            "飛(と)び上(あ)がる",
             "④ 自动1  跳起来；飞起"
-        ],
-        "notation": "飛(と)び上(あ)がる"
+        ]
     },
     {
         "name": "deiri",
         "trans": [
+            "出入(でい)り",
             "⓪ 名·自动3  出入，进出；收支"
-        ],
-        "notation": "出入(でい)り"
+        ]
     },
     {
         "name": "sakebigoe",
         "trans": [
+            "叫(さけ)び声(ごえ)",
             "④ 名  呼喊声"
-        ],
-        "notation": "叫(さけ)び声(ごえ)"
+        ]
     },
     {
         "name": "kousei",
         "trans": [
+            "構成(こうせい)",
             "⓪ 名·他动3  构成，组成"
-        ],
-        "notation": "構成(こうせい)"
+        ]
     },
     {
         "name": "keijiban",
         "trans": [
+            "掲示板(けいじばん)",
             "⓪ 名  告示牌，告示栏"
-        ],
-        "notation": "掲示板(けいじばん)"
+        ]
     },
     {
         "name": "kurushimu",
         "trans": [
+            "苦(くる)しむ",
             "③ 自动1  感到痛苦；烦恼；苦于，难以"
-        ],
-        "notation": "苦(くる)しむ"
+        ]
     },
     {
         "name": "o-kushon",
         "trans": [
+            "オークション",
             "① 名  拍卖"
-        ],
-        "notation": "オークション"
+        ]
     },
     {
         "name": "choukyori",
         "trans": [
+            "長距離(ちょうきょり)",
             "③ 名  长途；远程"
-        ],
-        "notation": "長距離(ちょうきょり)"
+        ]
     },
     {
         "name": "gyouji",
         "trans": [
+            "行事(ぎょうじ)",
             "① 名  仪式，活动"
-        ],
-        "notation": "行事(ぎょうじ)"
+        ]
     },
     {
         "name": "gisshiri",
         "trans": [
+            "ぎっしり",
             "③ 副  满满地"
-        ],
-        "notation": "ぎっしり"
+        ]
     },
     {
         "name": "furumau",
         "trans": [
+            "振(ふ)る舞(ま)う",
             "③ 自他动1  行动，动作；请客"
-        ],
-        "notation": "振(ふ)る舞(ま)う"
+        ]
     },
     {
         "name": "moden",
         "trans": [
+            "モダン",
             "⓪ ナ形  现代的；流行的"
-        ],
-        "notation": "モダン"
+        ]
     },
     {
         "name": "yukai",
         "trans": [
+            "愉快(ゆかい)",
             "① ナ形  愉快的，高兴的"
-        ],
-        "notation": "愉快(ゆかい)"
+        ]
     },
     {
         "name": "wazawaza",
         "trans": [
+            "わざわざ",
             "① 副  特地，特意；故意地"
-        ],
-        "notation": "わざわざ"
+        ]
     },
     {
         "name": "reburu",
         "trans": [
+            "レベル",
             "① 名  水平，水准"
-        ],
-        "notation": "レベル"
+        ]
     },
     {
         "name": "monooki",
         "trans": [
+            "物置(ものおき)",
             "③ 名  库房"
-        ],
-        "notation": "物置(ものおき)"
+        ]
     },
     {
         "name": "majime",
         "trans": [
+            "真面目(まじめ)",
             "⓪ 名·ナ形  认真，严肃；诚实"
-        ],
-        "notation": "真面目(まじめ)"
+        ]
     },
     {
         "name": "henshin",
         "trans": [
+            "返信(へんしん)",
             "⓪ 名·自动3  回信，回电话"
-        ],
-        "notation": "返信(へんしん)"
+        ]
     },
     {
         "name": "~houdai",
         "trans": [
+            "～放題(ほうだい)",
             " 接尾  自由地⋯⋯，随便地⋯⋯"
-        ],
-        "notation": "～放題(ほうだい)"
+        ]
     },
     {
         "name": "furi",
         "trans": [
+            "振(ふ)り",
             "② 名  外表，样子；装作，假装"
-        ],
-        "notation": "振(ふ)り"
+        ]
     },
     {
         "name": "hanashigoe",
         "trans": [
+            "話(はな)し声(ごえ)",
             "④ 名  说话声"
-        ],
-        "notation": "話(はな)し声(ごえ)"
+        ]
     },
     {
         "name": "hadaka",
         "trans": [
+            "裸(はだか)",
             "⓪ 名  裸体；裸露在外；身无一物"
-        ],
-        "notation": "裸(はだか)"
+        ]
     },
     {
         "name": "raito",
         "trans": [
+            "ライト",
             "① 名  灯光；轻的"
-        ],
-        "notation": "ライト"
+        ]
     },
     {
         "name": "toreru",
         "trans": [
+            "取(と)れる",
             "② 自动2  脱落，掉下来；需要（时间）；解除，消除"
-        ],
-        "notation": "取(と)れる"
+        ]
     },
     {
         "name": "tenpura",
         "trans": [
+            "天麩羅(てんぷら)",
             "⓪ 名  天妇罗，油炸食物"
-        ],
-        "notation": "天麩羅(てんぷら)"
+        ]
     },
     {
         "name": "kakudo",
         "trans": [
+            "角度(かくど)",
             "① 名  角度"
-        ],
-        "notation": "角度(かくど)"
+        ]
     },
     {
         "name": "katagata",
         "trans": [
+            "方々(かたがた)",
             "② 名·副  各位，诸位；这个那个，种种"
-        ],
-        "notation": "方々(かたがた)"
+        ]
     },
     {
         "name": "yotto",
         "trans": [
+            "ヨット",
             "① 名  游艇；帆船"
-        ],
-        "notation": "ヨット"
+        ]
     },
     {
         "name": "kachou",
         "trans": [
+            "課長(かちょう)",
             "⓪ 名  课长，科长"
-        ],
-        "notation": "課長(かちょう)"
+        ]
     },
     {
         "name": "raifu",
         "trans": [
+            "ライフ",
             "① 名  生活，生命，人生"
-        ],
-        "notation": "ライフ"
+        ]
     },
     {
         "name": "kokuseki",
         "trans": [
+            "国籍(こくせき)",
             "⓪ 名  国籍"
-        ],
-        "notation": "国籍(こくせき)"
+        ]
     },
     {
         "name": "kokumin",
         "trans": [
+            "国民(こくみん)",
             "⓪ 名  国民"
-        ],
-        "notation": "国民(こくみん)"
+        ]
     },
     {
         "name": "kokuritsu",
         "trans": [
+            "国立(こくりつ)",
             "⓪ 名  国立"
-        ],
-        "notation": "国立(こくりつ)"
+        ]
     },
     {
         "name": "kokka",
         "trans": [
+            "国家(こっか)",
             "① 名  国家"
-        ],
-        "notation": "国家(こっか)"
+        ]
     },
     {
         "name": "kokkai",
         "trans": [
+            "国会(こっかい)",
             "⓪ 名  国会，议会"
-        ],
-        "notation": "国会(こっかい)"
+        ]
     },
     {
         "name": "hairikomu",
         "trans": [
+            "入(はい)り込(こ)む",
             "④ 自动1  进入；混入；深入"
-        ],
-        "notation": "入(はい)り込(こ)む"
+        ]
     },
     {
         "name": "herikoputa-",
         "trans": [
+            "ヘリコプター",
             "③ 名  直升机"
-        ],
-        "notation": "ヘリコプター"
+        ]
     },
     {
         "name": "mattaku",
         "trans": [
+            "まったく",
             "④ 副  完全，全然；简直，实在"
-        ],
-        "notation": "まったく"
+        ]
     },
     {
         "name": "misu",
         "trans": [
+            "ミス",
             "① 名  （对未婚女性的称呼）小姐"
-        ],
-        "notation": "ミス"
+        ]
     },
     {
         "name": "minari",
         "trans": [
+            "身(み)なり",
             "① 名  服饰，装束，打扮"
-        ],
-        "notation": "身(み)なり"
+        ]
     },
     {
         "name": "yaritori",
         "trans": [
+            "やりとり",
             "② 名·他动3  交换；对话；敬酒"
-        ],
-        "notation": "やりとり"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "酔(よ)う",
             "① 自动1  醉酒；晕车，晕船；陶醉"
-        ],
-        "notation": "酔(よ)う"
+        ]
     },
     {
         "name": "yotsukado",
         "trans": [
+            "四(よ)つ角(かど)",
             "⓪ 名  四个角；十字路口"
-        ],
-        "notation": "四(よ)つ角(かど)"
+        ]
     },
     {
         "name": "rentaka-",
         "trans": [
+            "レンタカー",
             "③ 名  租赁汽车"
-        ],
-        "notation": "レンタカー"
+        ]
     },
     {
         "name": "waribiku",
         "trans": [
+            "割(わ)り引(び)く",
             "③ 他动1  折扣，打折"
-        ],
-        "notation": "割(わ)り引(び)く"
+        ]
     },
     {
         "name": "moushikomisho",
         "trans": [
+            "申込書(もうしこみしょ)",
             "⑥ 名  申请书"
-        ],
-        "notation": "申込書(もうしこみしょ)"
+        ]
     },
     {
         "name": "honjitsu",
         "trans": [
+            "本日(ほんじつ)",
             "① 名  今天"
-        ],
-        "notation": "本日(ほんじつ)"
+        ]
     },
     {
         "name": "henkan",
         "trans": [
+            "変換(へんかん)",
             "⓪ 名·自他动3  改变，变换"
-        ],
-        "notation": "変換(へんかん)"
+        ]
     },
     {
         "name": "risuto",
         "trans": [
+            "リスト",
             "① 名  目录；名单；一览表"
-        ],
-        "notation": "リスト"
+        ]
     },
     {
         "name": "nao",
         "trans": [
+            "尚(なお)",
             "① 副·接续  还，仍然；尚且，而且"
-        ],
-        "notation": "尚(なお)"
+        ]
     },
     {
         "name": "toorikakaru",
         "trans": [
+            "通(とお)りかかる",
             "⑤ 自动1  恰巧路过"
-        ],
-        "notation": "通(とお)りかかる"
+        ]
     },
     {
         "name": "chishiki",
         "trans": [
+            "知識(ちしき)",
             "① 名  知识，见识"
-        ],
-        "notation": "知識(ちしき)"
+        ]
     },
     {
         "name": "tatta",
         "trans": [
+            "たった",
             "⓪ 副  只，仅仅"
-        ],
-        "notation": "たった"
+        ]
     },
     {
         "name": "yome",
         "trans": [
+            "嫁(よめ)",
             "⓪ 名  新娘；儿媳；妻子"
-        ],
-        "notation": "嫁(よめ)"
+        ]
     },
     {
         "name": "konsento",
         "trans": [
+            "コンセント",
             "① 名  插座"
-        ],
-        "notation": "コンセント"
+        ]
     },
     {
         "name": "gendai",
         "trans": [
+            "現代(げんだい)",
             "① 名  现代，当代"
-        ],
-        "notation": "現代(げんだい)"
+        ]
     },
     {
         "name": "kurejittoka-do",
         "trans": [
+            "クレジットカード",
             "⑥ 名  信用卡"
-        ],
-        "notation": "クレジットカード"
+        ]
     },
     {
         "name": "kuu",
         "trans": [
+            "食(く)う",
             "① 他动1  吃；生活"
-        ],
-        "notation": "食(く)う"
+        ]
     },
     {
         "name": "hari",
         "trans": [
+            "針(はり)",
             "① 名  针；刺"
-        ],
-        "notation": "針(はり)"
+        ]
     },
     {
         "name": "ribon",
         "trans": [
+            "リボン",
             "① 名  丝带，缎带"
-        ],
-        "notation": "リボン"
+        ]
     },
     {
         "name": "robotto",
         "trans": [
+            "ロボット",
             "① 名  机器人"
-        ],
-        "notation": "ロボット"
+        ]
     },
     {
         "name": "ru-ru",
         "trans": [
+            "ルール",
             "① 名  规则，章程"
-        ],
-        "notation": "ルール"
+        ]
     },
     {
         "name": "yokogiru",
         "trans": [
+            "横切(よこぎ)る",
             "③ 自动1  横过，横穿"
-        ],
-        "notation": "横切(よこぎ)る"
+        ]
     },
     {
         "name": "~muke",
         "trans": [
+            "～向(む)け",
             " 接尾  面向，以⋯⋯为对象"
-        ],
-        "notation": "～向(む)け"
+        ]
     },
     {
         "name": "mamonaku",
         "trans": [
+            "まもなく",
             "② 副  不久，一会儿"
-        ],
-        "notation": "まもなく"
+        ]
     },
     {
         "name": "hokou",
         "trans": [
+            "補講(ほこう)",
             "⓪ 名·自动3  补课，补习"
-        ],
-        "notation": "補講(ほこう)"
+        ]
     },
     {
         "name": "repo-ta-",
         "trans": [
+            "レポーター",
             "⓪ 名  报告人；记者"
-        ],
-        "notation": "レポーター"
+        ]
     },
     {
         "name": "kyori",
         "trans": [
+            "距離(きょり)",
             "① 名  距离，间隔"
-        ],
-        "notation": "距離(きょり)"
+        ]
     },
     {
         "name": "remon",
         "trans": [
+            "レモン",
             "① 名  柠檬"
-        ],
-        "notation": "レモン"
+        ]
     },
     {
         "name": "kankou",
         "trans": [
+            "観光(かんこう)",
             "⓪ 名·他动3  观光，旅游"
-        ],
-        "notation": "観光(かんこう)"
+        ]
     },
     {
         "name": "tobira",
         "trans": [
+            "扉(とびら)",
             "⓪ 名  门，门扉"
-        ],
-        "notation": "扉(とびら)"
+        ]
     },
     {
         "name": "hisshi",
         "trans": [
+            "必死(ひっし)",
             "⓪ 名·ナ形  拼命"
-        ],
-        "notation": "必死(ひっし)"
+        ]
     },
     {
         "name": "karappo",
         "trans": [
+            "空(から)っぽ",
             "⓪ 名·ナ形  空着；空虚"
-        ],
-        "notation": "空(から)っぽ"
+        ]
     },
     {
         "name": "ganjitsu",
         "trans": [
+            "元日(がんじつ)",
             "⓪ 名  元旦"
-        ],
-        "notation": "元日(がんじつ)"
+        ]
     },
     {
         "name": "kyuukou",
         "trans": [
+            "急行(きゅうこう)",
             "⓪ 名·自动3  快车；急往，奔赴"
-        ],
-        "notation": "急行(きゅうこう)"
+        ]
     },
     {
         "name": "shudan",
         "trans": [
+            "手段(しゅだん)",
             "① 名  手段，办法"
-        ],
-        "notation": "手段(しゅだん)"
+        ]
     },
     {
         "name": "akubi",
         "trans": [
+            "欠伸(あくび)",
             "⓪ 名·自动3  哈欠"
-        ],
-        "notation": "欠伸(あくび)"
+        ]
     },
     {
         "name": "ku-pon",
         "trans": [
+            "クーポン",
             "① 名  优惠券；联票"
-        ],
-        "notation": "クーポン"
+        ]
     },
     {
         "name": "hon'ne",
         "trans": [
+            "本音(ほんね)",
             "⓪ 名  真心话"
-        ],
-        "notation": "本音(ほんね)"
+        ]
     },
     {
         "name": "yunomi",
         "trans": [
+            "湯呑(ゆの)み",
             "③ 名  茶碗，茶杯"
-        ],
-        "notation": "湯呑(ゆの)み"
+        ]
     },
     {
         "name": "yawaraka",
         "trans": [
+            "柔(やわ)らか",
             "③ ナ形  柔软的，柔和的"
-        ],
-        "notation": "柔(やわ)らか"
+        ]
     },
     {
         "name": "yatto",
         "trans": [
+            "やっと",
             "⓪ 副  好不容易，终于；勉勉强强"
-        ],
-        "notation": "やっと"
+        ]
     },
     {
         "name": "mitame",
         "trans": [
+            "見(み)た目(め)",
             "① 名  看起来，外表"
-        ],
-        "notation": "見(み)た目(め)"
+        ]
     },
     {
         "name": "tsuuchou",
         "trans": [
+            "通帳(つうちょう)",
             "⓪ 名  存折"
-        ],
-        "notation": "通帳(つうちょう)"
+        ]
     },
     {
         "name": "jitsuyou",
         "trans": [
+            "実用(じつよう)",
             "⓪ 名·他动3  实用"
-        ],
-        "notation": "実用(じつよう)"
+        ]
     },
     {
         "name": "jitsuyouteki",
         "trans": [
+            "実用的(じつようてき)",
             "⓪ ナ形  实用的，有实用性的"
-        ],
-        "notation": "実用的(じつようてき)"
+        ]
     },
     {
         "name": "kuroppoi",
         "trans": [
+            "黒(くろ)っぽい",
             "④ イ形  发黑的"
-        ],
-        "notation": "黒(くろ)っぽい"
+        ]
     },
     {
         "name": "guai",
         "trans": [
+            "具合(ぐあい)",
             "⓪ 名  情况，状态；方便，合适"
-        ],
-        "notation": "具合(ぐあい)"
+        ]
     },
     {
         "name": "kikinaosu",
         "trans": [
+            "聞(き)き直(なお)す",
             "④ 他动1  再问一次"
-        ],
-        "notation": "聞(き)き直(なお)す"
+        ]
     },
     {
         "name": "kioku",
         "trans": [
+            "記憶(きおく)",
             "⓪ 名·他动3  记忆，记住"
-        ],
-        "notation": "記憶(きおく)"
+        ]
     },
     {
         "name": "kangaenaosu",
         "trans": [
+            "考(かんが)え直(なお)す",
             "⑥ 他动1  重新考虑"
-        ],
-        "notation": "考(かんが)え直(なお)す"
+        ]
     },
     {
         "name": "kanjou",
         "trans": [
+            "勘定(かんじょう)",
             "③ 名·他动3  计算；结账"
-        ],
-        "notation": "勘定(かんじょう)"
+        ]
     },
     {
         "name": "raketto",
         "trans": [
+            "ラケット",
             "② 名  球拍"
-        ],
-        "notation": "ラケット"
+        ]
     },
     {
         "name": "te-buru",
         "trans": [
+            "テーブル",
             "⓪ 名  饭桌，桌子"
-        ],
-        "notation": "テーブル"
+        ]
     },
     {
         "name": "tomonau",
         "trans": [
+            "伴(ともな)う",
             "③ 自他动1  伴随；随着；带领"
-        ],
-        "notation": "伴(ともな)う"
+        ]
     },
     {
         "name": "hodoku",
         "trans": [
+            "解(ほど)く",
             "② 他动1  解开；拆开"
-        ],
-        "notation": "解(ほど)く"
+        ]
     },
     {
         "name": "yakkyoku",
         "trans": [
+            "薬局(やっきょく)",
             "⓪ 名  药房，药店"
-        ],
-        "notation": "薬局(やっきょく)"
+        ]
     },
     {
         "name": "yureru",
         "trans": [
+            "揺(ゆ)れる",
             "⓪ 自动2  摇晃，动摇"
-        ],
-        "notation": "揺(ゆ)れる"
+        ]
     },
     {
         "name": "rirekisho",
         "trans": [
+            "履歴書(りれきしょ)",
             "⓪ 名  履历"
-        ],
-        "notation": "履歴書(りれきしょ)"
+        ]
     },
     {
         "name": "rusuban",
         "trans": [
+            "留守番(るすばん)",
             "⓪ 名  看家，看家的人"
-        ],
-        "notation": "留守番(るすばん)"
+        ]
     },
     {
         "name": "yumemiru",
         "trans": [
+            "夢見(ゆめみ)る",
             "③ 自他动2  做梦；梦想，幻想"
-        ],
-        "notation": "夢見(ゆめみ)る"
+        ]
     },
     {
         "name": "monosashi",
         "trans": [
+            "物差(ものさ)し",
             "③ 名  尺子；标准，尺度"
-        ],
-        "notation": "物差(ものさ)し"
+        ]
     },
     {
         "name": "heikin",
         "trans": [
+            "平均(へいきん)",
             "⓪ 名·自他动3  平均；平衡"
-        ],
-        "notation": "平均(へいきん)"
+        ]
     },
     {
         "name": "koukyou",
         "trans": [
+            "公共(こうきょう)",
             "⓪ 名  公共"
-        ],
-        "notation": "公共(こうきょう)"
+        ]
     },
     {
         "name": "kyuusoku",
         "trans": [
+            "急速(きゅうそく)",
             "⓪ 名·ナ形  迅速，快速"
-        ],
-        "notation": "急速(きゅうそく)"
+        ]
     },
     {
         "name": "ussuri",
         "trans": [
+            "うっすり",
             "③ 副  （颜色）淡淡地；（厚度）薄薄地"
-        ],
-        "notation": "うっすり"
+        ]
     },
     {
         "name": "tsuushin",
         "trans": [
+            "通信(つうしん)",
             "⓪ 名·自动3  通信，通讯"
-        ],
-        "notation": "通信(つうしん)"
+        ]
     },
     {
         "name": "nemutai",
         "trans": [
+            "眠(ねむ)たい",
             "③ イ形  困倦的，昏昏欲睡的"
-        ],
-        "notation": "眠(ねむ)たい"
+        ]
     },
     {
         "name": "fumikiri",
         "trans": [
+            "踏(ふ)み切(き)り",
             "⓪ 名  （铁路）道口"
-        ],
-        "notation": "踏(ふ)み切(き)り"
+        ]
     },
     {
         "name": "maamaa",
         "trans": [
+            "まあまあ",
             "③ 叹·副  （催促或安慰）好了好了，行了；大致，还算"
-        ],
-        "notation": "まあまあ"
+        ]
     },
     {
         "name": "riku",
         "trans": [
+            "陸(りく)",
             "⓪ 名  陆地"
-        ],
-        "notation": "陸(りく)"
+        ]
     },
     {
         "name": "yokubou",
         "trans": [
+            "欲望(よくぼう)",
             "⓪ 名  欲望"
-        ],
-        "notation": "欲望(よくぼう)"
+        ]
     },
     {
         "name": "matsuge",
         "trans": [
+            "まつげ",
             "① 名  睫毛"
-        ],
-        "notation": "まつげ"
+        ]
     },
     {
         "name": "haeru",
         "trans": [
+            "生(は)える",
             "② 自动2  生，长"
-        ],
-        "notation": "生(は)える"
+        ]
     },
     {
         "name": "toridasu",
         "trans": [
+            "取(と)り出(だ)す",
             "③ 他动1  拿出，取出，选出"
-        ],
-        "notation": "取(と)り出(だ)す"
+        ]
     },
     {
         "name": "gabugabu",
         "trans": [
+            "がぶがぶ",
             "① 副·自动3  咕咚咕咚地喝水；胃里液体多（咕噜咕噜响）"
-        ],
-        "notation": "がぶがぶ"
+        ]
     },
     {
         "name": "rieki",
         "trans": [
+            "利益(りえき)",
             "① 名  利益；盈利"
-        ],
-        "notation": "利益(りえき)"
+        ]
     },
     {
         "name": "gosogoso",
         "trans": [
+            "ごそごそ",
             "① 副·自动3  嘎吱嘎吱作响"
-        ],
-        "notation": "ごそごそ"
+        ]
     },
     {
         "name": "ranchi",
         "trans": [
+            "ランチ",
             "① 名  午餐"
-        ],
-        "notation": "ランチ"
+        ]
     },
     {
         "name": "yosan",
         "trans": [
+            "予算(よさん)",
             "⓪ 名  预算"
-        ],
-        "notation": "予算(よさん)"
+        ]
     },
     {
         "name": "roketto",
         "trans": [
+            "ロケット",
             "② 名  火箭"
-        ],
-        "notation": "ロケット"
+        ]
     },
     {
         "name": "mokuhyou",
         "trans": [
+            "目標(もくひょう)",
             "⓪ 名  目标，指标"
-        ],
-        "notation": "目標(もくひょう)"
+        ]
     },
     {
         "name": "makka",
         "trans": [
+            "真(ま)っ赤(か)",
             "③ 名·ナ形  通红，鲜红；纯粹，完全"
-        ],
-        "notation": "真(ま)っ赤(か)"
+        ]
     },
     {
         "name": "makkura",
         "trans": [
+            "真(ま)っ暗(くら)",
             "③ 名·ナ形  黑暗，漆黑；（前景）暗淡"
-        ],
-        "notation": "真(ま)っ暗(くら)"
+        ]
     },
     {
         "name": "~busoku",
         "trans": [
+            "～不足(ふそく)",
             " 接尾  ⋯⋯不足，⋯⋯不够"
-        ],
-        "notation": "～不足(ふそく)"
+        ]
     },
     {
         "name": "toku",
         "trans": [
+            "溶(と)く",
             "① 他动1  溶解，化开"
-        ],
-        "notation": "溶(と)く"
+        ]
     },
     {
         "name": "shina",
         "trans": [
+            "品(しな)",
             "⓪ 名  物品，商品；质量，品质"
-        ],
-        "notation": "品(しな)"
+        ]
     },
     {
         "name": "hozon",
         "trans": [
+            "保存(ほぞん)",
             "⓪ 名·他动3  保存"
-        ],
-        "notation": "保存(ほぞん)"
+        ]
     },
     {
         "name": "sa-bu",
         "trans": [
+            "セーブ",
             "① 名·他动3  救，搭救；保留（力量）；储蓄，节约"
-        ],
-        "notation": "セーブ"
+        ]
     },
     {
         "name": "shitsu",
         "trans": [
+            "質(しつ)",
             "⓪ 名  质量，品质"
-        ],
-        "notation": "質(しつ)"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "揚(あ)げる",
             "⓪ 他动2  举起；油炸"
-        ],
-        "notation": "揚(あ)げる"
+        ]
     },
     {
         "name": "hikiwake",
         "trans": [
+            "引(ひ)き分(わ)け",
             "⓪ 名  （比赛）平局"
-        ],
-        "notation": "引(ひ)き分(わ)け"
+        ]
     },
     {
         "name": "~naosu",
         "trans": [
+            "～直(なお)す",
             " 接尾  重新⋯⋯"
-        ],
-        "notation": "～直(なお)す"
+        ]
     },
     {
         "name": "tsuini",
         "trans": [
+            "ついに",
             "① 副  终于，最终；直到最后"
-        ],
-        "notation": "ついに"
+        ]
     },
     {
         "name": "dansui",
         "trans": [
+            "断水(だんすい)",
             "⓪ 名·自他动3  断水，停水"
-        ],
-        "notation": "断水(だんすい)"
+        ]
     },
     {
         "name": "ichigo",
         "trans": [
+            "苺(いちご)",
             "⓪ 名  草莓"
-        ],
-        "notation": "苺(いちご)"
+        ]
     },
     {
         "name": "zento",
         "trans": [
+            "前途(ぜんと)",
             "① 名  前途，将来"
-        ],
-        "notation": "前途(ぜんと)"
+        ]
     },
     {
         "name": "kona",
         "trans": [
+            "粉(こな)",
             "② 名  粉，粉末"
-        ],
-        "notation": "粉(こな)"
+        ]
     },
     {
         "name": "shihei",
         "trans": [
+            "紙幣(しへい)",
             "① 名  纸币，钞票"
-        ],
-        "notation": "紙幣(しへい)"
+        ]
     },
     {
         "name": "renjitsu",
         "trans": [
+            "連日(れんじつ)",
             "⓪ 名  连日，连续几天"
-        ],
-        "notation": "連日(れんじつ)"
+        ]
     },
     {
         "name": "yori",
         "trans": [
+            "より",
             "⓪ 副  更，更加"
-        ],
-        "notation": "より"
+        ]
     },
     {
         "name": "yuushoku",
         "trans": [
+            "夕食(ゆうしょく)",
             "⓪ 名  晚饭"
-        ],
-        "notation": "夕食(ゆうしょく)"
+        ]
     },
     {
         "name": "maku",
         "trans": [
+            "巻(ま)く",
             "⓪ 自他动1  卷；缠绕；拧，上发条"
-        ],
-        "notation": "巻(ま)く"
+        ]
     },
     {
         "name": "kuse",
         "trans": [
+            "癖(くせ)",
             "② 名  习惯，癖好；特点"
-        ],
-        "notation": "癖(くせ)"
+        ]
     },
     {
         "name": "kudoi",
         "trans": [
+            "くどい",
             "② イ形  冗长的，啰嗦的；油腻的"
-        ],
-        "notation": "くどい"
+        ]
     },
     {
         "name": "hokousha",
         "trans": [
+            "歩行者(ほこうしゃ)",
             "② 名  行人，步行者"
-        ],
-        "notation": "歩行者(ほこうしゃ)"
+        ]
     },
     {
         "name": "hakushu",
         "trans": [
+            "拍手(はくしゅ)",
             "① 名·自动3  拍手，鼓掌"
-        ],
-        "notation": "拍手(はくしゅ)"
+        ]
     },
     {
         "name": "gyaku",
         "trans": [
+            "逆(ぎゃく)",
             "⓪ 名·ナ形  逆，颠倒，反向"
-        ],
-        "notation": "逆(ぎゃく)"
+        ]
     },
     {
         "name": "iseki",
         "trans": [
+            "遺跡(いせき)",
             "⓪ 名  遗址，遗迹"
-        ],
-        "notation": "遺跡(いせき)"
+        ]
     },
     {
         "name": "aikou",
         "trans": [
+            "愛好(あいこう)",
             "⓪ 名·他动3  爱好"
-        ],
-        "notation": "愛好(あいこう)"
+        ]
     },
     {
         "name": "futa",
         "trans": [
+            "蓋(ふた)",
             "⓪ 名  盖子"
-        ],
-        "notation": "蓋(ふた)"
+        ]
     },
     {
         "name": "kitsuenseki",
         "trans": [
+            "喫煙席(きつえんせき)",
             "③ 名  吸烟区，可以吸烟的座位"
-        ],
-        "notation": "喫煙席(きつえんせき)"
+        ]
     },
     {
         "name": "taira",
         "trans": [
+            "平(たい)ら",
             "⓪ 名·ナ形  平地；平坦；平静"
-        ],
-        "notation": "平(たい)ら"
+        ]
     },
     {
         "name": "yokunen/yokutoshi",
         "trans": [
+            "翌年(よくねん/よくとし)",
             "⓪ 名  次年，下一年"
-        ],
-        "notation": "翌年(よくねん/よくとし)"
+        ]
     },
     {
         "name": "oyatsu",
         "trans": [
+            "おやつ",
             "② 名  点心，茶点"
-        ],
-        "notation": "おやつ"
+        ]
     },
     {
         "name": "eiyoubun",
         "trans": [
+            "栄養分(えいようぶん)",
             "③ 名  营养成分"
-        ],
-        "notation": "栄養分(えいようぶん)"
+        ]
     },
     {
         "name": "jinan",
         "trans": [
+            "次男(じなん)",
             "① 名  次子，二儿子"
-        ],
-        "notation": "次男(じなん)"
+        ]
     },
     {
         "name": "zaigaku",
         "trans": [
+            "在学(ざいがく)",
             "⓪ 名·自动3  在校，上学"
-        ],
-        "notation": "在学(ざいがく)"
+        ]
     },
     {
         "name": "kotowaza",
         "trans": [
+            "諺(ことわざ)",
             "⓪ 名  谚语，俗语"
-        ],
-        "notation": "諺(ことわざ)"
+        ]
     },
     {
         "name": "kikite",
         "trans": [
+            "聞(き)き手(て)",
             "⓪ 名  听者，听众"
-        ],
-        "notation": "聞(き)き手(て)"
+        ]
     },
     {
         "name": "kiso",
         "trans": [
+            "基礎(きそ)",
             "① 名  基础，根基"
-        ],
-        "notation": "基礎(きそ)"
+        ]
     },
     {
         "name": "kobetsu",
         "trans": [
+            "個別(こべつ)",
             "⓪ 名  个别"
-        ],
-        "notation": "個別(こべつ)"
+        ]
     },
     {
         "name": "keiko",
         "trans": [
+            "稽古(けいこ)",
             "① 名·他动3  练习；排演，排练"
-        ],
-        "notation": "稽古(けいこ)"
+        ]
     },
     {
         "name": "dandan",
         "trans": [
+            "だんだん",
             "⓪ 副  渐渐，逐渐地"
-        ],
-        "notation": "だんだん"
+        ]
     },
     {
         "name": "magarikado",
         "trans": [
+            "曲(ま)がり角(かど)",
             "⓪ 名  街角，拐角；转折点"
-        ],
-        "notation": "曲(ま)がり角(かど)"
+        ]
     },
     {
         "name": "mensetsu",
         "trans": [
+            "面接(めんせつ)",
             "⓪ 名·自动3  面试"
-        ],
-        "notation": "面接(めんせつ)"
+        ]
     },
     {
         "name": "kan'youku",
         "trans": [
+            "慣用句(かんようく)",
             "③ 名  惯用句，熟语"
-        ],
-        "notation": "慣用句(かんようく)"
+        ]
     },
     {
         "name": "motomeru",
         "trans": [
+            "求(もと)める",
             "③ 他动2  追求，寻求；要求，征求"
-        ],
-        "notation": "求(もと)める"
+        ]
     },
     {
         "name": "yowane",
         "trans": [
+            "弱音(よわね)",
             "⓪ 名  泄气话，不争气的话"
-        ],
-        "notation": "弱音(よわね)"
+        ]
     },
     {
         "name": "hataraki",
         "trans": [
+            "働(はたら)き",
             "⓪ 名  工作，劳动；功能，作用"
-        ],
-        "notation": "働(はたら)き"
+        ]
     },
     {
         "name": "tomari",
         "trans": [
+            "泊(と)まり",
             "⓪ 名  住宿，过夜"
-        ],
-        "notation": "泊(と)まり"
+        ]
     },
     {
         "name": "kodukai",
         "trans": [
+            "小遣(こづか)い",
             "① 名  零花钱，零用钱"
-        ],
-        "notation": "小遣(こづか)い"
+        ]
     }
 ]

--- a/assets/dicts/Jap_High-Frequency_N4N5.json
+++ b/assets/dicts/Jap_High-Frequency_N4N5.json
@@ -2,14001 +2,14001 @@
     {
         "name": "aisukuri-mu",
         "trans": [
+            "アイスクリーム",
             "⑤ 名  冰激凌"
-        ],
-        "notation": "アイスクリーム"
+        ]
     },
     {
         "name": "igai",
         "trans": [
+            "意外(いがい)",
             "⓪ 名·ナ形  意外；意想不到的"
-        ],
-        "notation": "意外(いがい)"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "紙(かみ)",
             "② 名  纸"
-        ],
-        "notation": "紙(かみ)"
+        ]
     },
     {
         "name": "nagai",
         "trans": [
+            "長(なが)い",
             "② イ形  长的；久远的"
-        ],
-        "notation": "長(なが)い"
+        ]
     },
     {
         "name": "himawari",
         "trans": [
+            "ひまわり",
             "② 名  向日葵"
-        ],
-        "notation": "ひまわり"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "会(あ)う",
             "① 自动1  见面；遇上"
-        ],
-        "notation": "会(あ)う"
+        ]
     },
     {
         "name": "tokubetsu",
         "trans": [
+            "特別(とくべつ)",
             "⓪ 副·ナ形  特别，格外"
-        ],
-        "notation": "特別(とくべつ)"
+        ]
     },
     {
         "name": "byouki",
         "trans": [
+            "病気(びょうき)",
             "⓪ 名  疾病；毛病，缺点"
-        ],
-        "notation": "病気(びょうき)"
+        ]
     },
     {
         "name": "me-ru",
         "trans": [
+            "メール",
             "① 名  邮件"
-        ],
-        "notation": "メール"
+        ]
     },
     {
         "name": "aoi",
         "trans": [
+            "青(あお)い",
             "② イ形  蓝色的；绿色的"
-        ],
-        "notation": "青(あお)い"
+        ]
     },
     {
         "name": "migi",
         "trans": [
+            "右(みぎ)",
             "⓪ 名  右边，右侧"
-        ],
-        "notation": "右(みぎ)"
+        ]
     },
     {
         "name": "tanoshii",
         "trans": [
+            "楽(たの)しい",
             "③ イ形  高兴的，快乐的"
-        ],
-        "notation": "楽(たの)しい"
+        ]
     },
     {
         "name": "amari",
         "trans": [
+            "あまり",
             "⓪ 副·ナ形  （不）太，（不）怎么样；过分"
-        ],
-        "notation": "あまり"
+        ]
     },
     {
         "name": "repo-to",
         "trans": [
+            "レポート",
             "② 名·他动3  报告；报道"
-        ],
-        "notation": "レポート"
+        ]
     },
     {
         "name": "migaku",
         "trans": [
+            "磨(みが)く",
             "⓪ 他动1  磨；刷"
-        ],
-        "notation": "磨(みが)く"
+        ]
     },
     {
         "name": "ashi",
         "trans": [
+            "足(あし)",
             "② 名  脚；腿；脚步"
-        ],
-        "notation": "足(あし)"
+        ]
     },
     {
         "name": "benkyou",
         "trans": [
+            "勉強(べんきょう)",
             "⓪ 名·自他动3  学习"
-        ],
-        "notation": "勉強(べんきょう)"
+        ]
     },
     {
         "name": "asobu",
         "trans": [
+            "遊(あそ)ぶ",
             "⓪ 自动1  玩耍"
-        ],
-        "notation": "遊(あそ)ぶ"
+        ]
     },
     {
         "name": "fun'iki",
         "trans": [
+            "雰囲気(ふんいき)",
             "③ 名  气氛，氛围"
-        ],
-        "notation": "雰囲気(ふんいき)"
+        ]
     },
     {
         "name": "aka",
         "trans": [
+            "赤(あか)",
             "① 名  红色"
-        ],
-        "notation": "赤(あか)"
+        ]
     },
     {
         "name": "akai",
         "trans": [
+            "赤(あか)い",
             "⓪ イ形  红色的"
-        ],
-        "notation": "赤(あか)い"
+        ]
     },
     {
         "name": "niru",
         "trans": [
+            "似(に)る",
             "⓪ 自动2  相似，像"
-        ],
-        "notation": "似(に)る"
+        ]
     },
     {
         "name": "suka-to",
         "trans": [
+            "スカート",
             "② 名  裙子"
-        ],
-        "notation": "スカート"
+        ]
     },
     {
         "name": "nenmatsu",
         "trans": [
+            "年末(ねんまつ)",
             "⓪ 名  年底"
-        ],
-        "notation": "年末(ねんまつ)"
+        ]
     },
     {
         "name": "akarui",
         "trans": [
+            "明(あか)るい",
             "⓪ イ形  明亮的；开朗的"
-        ],
-        "notation": "明(あか)るい"
+        ]
     },
     {
         "name": "pan",
         "trans": [
+            "パン",
             "① 名  面包"
-        ],
-        "notation": "パン"
+        ]
     },
     {
         "name": "jimi",
         "trans": [
+            "地味(じみ)",
             "② 名·ナ形  （生活）质朴；（外观）朴素；（想法）朴实"
-        ],
-        "notation": "地味(じみ)"
+        ]
     },
     {
         "name": "ryuugaku",
         "trans": [
+            "留学(りゅうがく)",
             "⓪ 名·自动3  留学"
-        ],
-        "notation": "留学(りゅうがく)"
+        ]
     },
     {
         "name": "akujon",
         "trans": [
+            "アクション",
             "① 名  动作"
-        ],
-        "notation": "アクション"
+        ]
     },
     {
         "name": "tobu",
         "trans": [
+            "飛(と)ぶ",
             "⓪ 自动1  飞；吹走，刮跑"
-        ],
-        "notation": "飛(と)ぶ"
+        ]
     },
     {
         "name": "isogashii",
         "trans": [
+            "忙(いそが)しい",
             "④ イ形  忙碌的"
-        ],
-        "notation": "忙(いそが)しい"
+        ]
     },
     {
         "name": "arau",
         "trans": [
+            "洗(あら)う",
             "⓪ 他动1  洗，清洗"
-        ],
-        "notation": "洗(あら)う"
+        ]
     },
     {
         "name": "butaniku",
         "trans": [
+            "豚肉(ぶたにく)",
             "⓪ 名  猪肉"
-        ],
-        "notation": "豚肉(ぶたにく)"
+        ]
     },
     {
         "name": "aruku",
         "trans": [
+            "歩(ある)く",
             "② 自动1  走路，步行"
-        ],
-        "notation": "歩(ある)く"
+        ]
     },
     {
         "name": "aki",
         "trans": [
+            "秋(あき)",
             "① 名  秋季"
-        ],
-        "notation": "秋(あき)"
+        ]
     },
     {
         "name": "tooru",
         "trans": [
+            "通(とお)る",
             "① 自动1  通过，经过"
-        ],
-        "notation": "通(とお)る"
+        ]
     },
     {
         "name": "bangohan",
         "trans": [
+            "晩(ばん)ご飯(はん)",
             "③ 名  晚饭"
-        ],
-        "notation": "晩(ばん)ご飯(はん)"
+        ]
     },
     {
         "name": "atarashii",
         "trans": [
+            "新(あたら)しい",
             "④ イ形  新的；新鲜的"
-        ],
-        "notation": "新(あたら)しい"
+        ]
     },
     {
         "name": "buji",
         "trans": [
+            "無事(ぶじ)",
             "⓪ 名·ナ形  安全；顺利"
-        ],
-        "notation": "無事(ぶじ)"
+        ]
     },
     {
         "name": "purojekuto",
         "trans": [
+            "プロジェクト",
             "② 名  课题，项目"
-        ],
-        "notation": "プロジェクト"
+        ]
     },
     {
         "name": "aku",
         "trans": [
+            "開(あ)く",
             "⓪ 自动1  开着；开始，（商店等）开门"
-        ],
-        "notation": "開(あ)く"
+        ]
     },
     {
         "name": "byouin",
         "trans": [
+            "病院(びょういん)",
             "⓪ 名  医院"
-        ],
-        "notation": "病院(びょういん)"
+        ]
     },
     {
         "name": "mata",
         "trans": [
+            "また",
             "⓪ 副  又，再"
-        ],
-        "notation": "また"
+        ]
     },
     {
         "name": "warui",
         "trans": [
+            "悪(わる)い",
             "② イ形  坏的"
-        ],
-        "notation": "悪(わる)い"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "上(あ)げる",
             "⓪ 他动2  举起；提高"
-        ],
-        "notation": "上(あ)げる"
+        ]
     },
     {
         "name": "tsukue",
         "trans": [
+            "机(つくえ)",
             "⓪ 名  桌子"
-        ],
-        "notation": "机(つくえ)"
+        ]
     },
     {
         "name": "iya",
         "trans": [
+            "嫌(いや)",
             "② ナ形  厌烦的，反感的；不愿意的"
-        ],
-        "notation": "嫌(いや)"
+        ]
     },
     {
         "name": "yachin",
         "trans": [
+            "家賃(やちん)",
             "① 名  房租"
-        ],
-        "notation": "家賃(やちん)"
+        ]
     },
     {
         "name": "iku",
         "trans": [
+            "行(い)く",
             "⓪ 自动1  去，到"
-        ],
-        "notation": "行(い)く"
+        ]
     },
     {
         "name": "imi",
         "trans": [
+            "意味(いみ)",
             "① 名  意思"
-        ],
-        "notation": "意味(いみ)"
+        ]
     },
     {
         "name": "usui",
         "trans": [
+            "薄(うす)い",
             "⓪ イ形  薄的；淡的"
-        ],
-        "notation": "薄(うす)い"
+        ]
     },
     {
         "name": "nugu",
         "trans": [
+            "脱(ぬ)ぐ",
             "① 他动1  脱掉，摘掉"
-        ],
-        "notation": "脱(ぬ)ぐ"
+        ]
     },
     {
         "name": "ushi",
         "trans": [
+            "牛(うし)",
             "⓪ 名  牛"
-        ],
-        "notation": "牛(うし)"
+        ]
     },
     {
         "name": "marui",
         "trans": [
+            "丸(まる)い",
             "⓪ イ形  圆的"
-        ],
-        "notation": "丸(まる)い"
+        ]
     },
     {
         "name": "hatachi",
         "trans": [
+            "二十歳(はたち)",
             "① 名  二十岁"
-        ],
-        "notation": "二十歳(はたち)"
+        ]
     },
     {
         "name": "totemo",
         "trans": [
+            "とても",
             "⓪ 副  非常，很"
-        ],
-        "notation": "とても"
+        ]
     },
     {
         "name": "iu",
         "trans": [
+            "言(い)う",
             "⓪ 他动1  说话；告诉；叫作"
-        ],
-        "notation": "言(い)う"
+        ]
     },
     {
         "name": "ryouri",
         "trans": [
+            "料理(りょうり)",
             "① 名·他动3  菜肴；做菜"
-        ],
-        "notation": "料理(りょうり)"
+        ]
     },
     {
         "name": "abiru",
         "trans": [
+            "浴(あ)びる",
             "⓪ 他动2  淋；沐浴"
-        ],
-        "notation": "浴(あ)びる"
+        ]
     },
     {
         "name": "yutaka",
         "trans": [
+            "豊(ゆた)か",
             "① ナ形  丰富的；富裕的"
-        ],
-        "notation": "豊(ゆた)か"
+        ]
     },
     {
         "name": "amai",
         "trans": [
+            "甘(あま)い",
             "⓪ イ形  （味道）甜的；（想法）乐观的"
-        ],
-        "notation": "甘(あま)い"
+        ]
     },
     {
         "name": "bi-ru",
         "trans": [
+            "ビール",
             "① 名  啤酒"
-        ],
-        "notation": "ビール"
+        ]
     },
     {
         "name": "umareru",
         "trans": [
+            "生(う)まれる",
             "⓪ 自动2  出生，诞生；产生"
-        ],
-        "notation": "生(う)まれる"
+        ]
     },
     {
         "name": "hatsumoude",
         "trans": [
+            "初詣(はつもうで)",
             "③ 名·自动3  新年首次去神社参拜"
-        ],
-        "notation": "初詣(はつもうで)"
+        ]
     },
     {
         "name": "depa-to",
         "trans": [
+            "デパート",
             "② 名  商场"
-        ],
-        "notation": "デパート"
+        ]
     },
     {
         "name": "yowai",
         "trans": [
+            "弱(よわ)い",
             "② イ形  弱的；脆弱的"
-        ],
-        "notation": "弱(よわ)い"
+        ]
     },
     {
         "name": "asa",
         "trans": [
+            "朝(あさ)",
             "① 名  早晨"
-        ],
-        "notation": "朝(あさ)"
+        ]
     },
     {
         "name": "watasu",
         "trans": [
+            "渡(わた)す",
             "⓪ 他动1  交给，转交"
-        ],
-        "notation": "渡(わた)す"
+        ]
     },
     {
         "name": "ureshii",
         "trans": [
+            "嬉(うれ)しい",
             "③ イ形  愉快的"
-        ],
-        "notation": "嬉(うれ)しい"
+        ]
     },
     {
         "name": "midori",
         "trans": [
+            "緑(みどり)",
             "① 名  绿色"
-        ],
-        "notation": "緑(みどり)"
+        ]
     },
     {
         "name": "itai",
         "trans": [
+            "痛(いた)い",
             "② イ形  疼的,痛的"
-        ],
-        "notation": "痛(いた)い"
+        ]
     },
     {
         "name": "reizouko",
         "trans": [
+            "冷蔵庫(れいぞうこ)",
             "③ 名  冰箱"
-        ],
-        "notation": "冷蔵庫(れいぞうこ)"
+        ]
     },
     {
         "name": "utsukushii",
         "trans": [
+            "美(うつく)しい",
             "④ イ形  美丽的，漂亮的；美好的"
-        ],
-        "notation": "美(うつく)しい"
+        ]
     },
     {
         "name": "hajimaru",
         "trans": [
+            "始(はじ)まる",
             "⓪ 自动1  开始"
-        ],
-        "notation": "始(はじ)まる"
+        ]
     },
     {
         "name": "asatte",
         "trans": [
+            "あさって",
             "② 名  后天"
-        ],
-        "notation": "あさって"
+        ]
     },
     {
         "name": "uriba",
         "trans": [
+            "売(う)り場(ば)",
             "⓪ 名  柜台，售货处"
-        ],
-        "notation": "売(う)り場(ば)"
+        ]
     },
     {
         "name": "chotto",
         "trans": [
+            "ちょっと",
             "① 副  稍微，一点（儿）"
-        ],
-        "notation": "ちょっと"
+        ]
     },
     {
         "name": "tonari",
         "trans": [
+            "隣(とな)り",
             "⓪ 名  旁边；邻居"
-        ],
-        "notation": "隣(とな)り"
+        ]
     },
     {
         "name": "uru",
         "trans": [
+            "売(う)る",
             "⓪ 他动1  卖，售卖"
-        ],
-        "notation": "売(う)る"
+        ]
     },
     {
         "name": "ryokou",
         "trans": [
+            "旅行(りょこう)",
             "⓪ 名·自动3  旅行"
-        ],
-        "notation": "旅行(りょこう)"
+        ]
     },
     {
         "name": "erebe-ta-",
         "trans": [
+            "エレベーター",
             "③ 名  升降电梯，直梯"
-        ],
-        "notation": "エレベーター"
+        ]
     },
     {
         "name": "unten",
         "trans": [
+            "運転(うんてん)",
             "⓪ 名·自他动3  驾驶；操纵，操控"
-        ],
-        "notation": "運転(うんてん)"
+        ]
     },
     {
         "name": "joubu",
         "trans": [
+            "丈夫(じょうぶ)",
             "⓪ ナ形  （身体等）健康的；（物品等）结实的，耐用的"
-        ],
-        "notation": "丈夫(じょうぶ)"
+        ]
     },
     {
         "name": "inta-netto",
         "trans": [
+            "インターネット",
             "⑤ 名  因特网"
-        ],
-        "notation": "インターネット"
+        ]
     },
     {
         "name": "tadashi",
         "trans": [
+            "ただし",
             "① 接续  但是"
-        ],
-        "notation": "ただし"
+        ]
     },
     {
         "name": "ue",
         "trans": [
+            "上(うえ)",
             "⓪ 名  （方位）上；（年龄）大"
-        ],
-        "notation": "上(うえ)"
+        ]
     },
     {
         "name": "hanayaka",
         "trans": [
+            "華(はな)やか",
             "② ナ形  华丽的"
-        ],
-        "notation": "華(はな)やか"
+        ]
     },
     {
         "name": "izakaya",
         "trans": [
+            "居酒屋(いざかや)",
             "⓪ 名  （日式）小酒馆"
-        ],
-        "notation": "居酒屋(いざかや)"
+        ]
     },
     {
         "name": "oishii",
         "trans": [
+            "おいしい",
             "③ イ形  好吃的，美味的"
-        ],
-        "notation": "おいしい"
+        ]
     },
     {
         "name": "fuyu",
         "trans": [
+            "冬(ふゆ)",
             "② 名  冬季"
-        ],
-        "notation": "冬(ふゆ)"
+        ]
     },
     {
         "name": "urikire",
         "trans": [
+            "売(う)り切(き)れ",
             "⓪ 名  售罄，销售一空"
-        ],
-        "notation": "売(う)り切(き)れ"
+        ]
     },
     {
         "name": "jisho",
         "trans": [
+            "辞書(じしょ)",
             "① 名  辞典，字典"
-        ],
-        "notation": "辞書(じしょ)"
+        ]
     },
     {
         "name": "iro",
         "trans": [
+            "色(いろ)",
             "② 名  颜色"
-        ],
-        "notation": "色(いろ)"
+        ]
     },
     {
         "name": "ookii",
         "trans": [
+            "大(おお)きい",
             "③ イ形  （规模、年龄等）大的"
-        ],
-        "notation": "大(おお)きい"
+        ]
     },
     {
         "name": "futon",
         "trans": [
+            "布団(ふとん)",
             "⓪ 名  被子，褥子"
-        ],
-        "notation": "布団(ふとん)"
+        ]
     },
     {
         "name": "noru",
         "trans": [
+            "乗(の)る",
             "⓪ 自动1  乘坐"
-        ],
-        "notation": "乗(の)る"
+        ]
     },
     {
         "name": "eakon",
         "trans": [
+            "エアコン",
             "⓪ 名  空调"
-        ],
-        "notation": "エアコン"
+        ]
     },
     {
         "name": "shinpuru",
         "trans": [
+            "シンプル",
             "① ナ形  简单的，单纯的；质朴的"
-        ],
-        "notation": "シンプル"
+        ]
     },
     {
         "name": "ike",
         "trans": [
+            "池(いけ)",
             "② 名  池塘，水池"
-        ],
-        "notation": "池(いけ)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "立(た)つ",
             "① 自动1  站立；出发，离开"
-        ],
-        "notation": "立(た)つ"
+        ]
     },
     {
         "name": "kirei",
         "trans": [
+            "きれい",
             "① ナ形  漂亮的，美丽的；干净的"
-        ],
-        "notation": "きれい"
+        ]
     },
     {
         "name": "imanouchi",
         "trans": [
+            "今(いま)のうち",
             "⓪ 名  现在；马上，立刻"
-        ],
-        "notation": "今(いま)のうち"
+        ]
     },
     {
         "name": "ushiro",
         "trans": [
+            "後(うし)ろ",
             "⓪ 名  （空间）后面"
-        ],
-        "notation": "後(うし)ろ"
+        ]
     },
     {
         "name": "doushite",
         "trans": [
+            "どうして",
             "① 副  为什么"
-        ],
-        "notation": "どうして"
+        ]
     },
     {
         "name": "uchiawase",
         "trans": [
+            "打(う)ち合(あ)わせ",
             "⓪ 名  事先商量，碰头商议"
-        ],
-        "notation": "打(う)ち合(あ)わせ"
+        ]
     },
     {
         "name": "koto",
         "trans": [
+            "事(こと)",
             "② 名  事情"
-        ],
-        "notation": "事(こと)"
+        ]
     },
     {
         "name": "eiga",
         "trans": [
+            "映画(えいが)",
             "① 名  电影"
-        ],
-        "notation": "映画(えいが)"
+        ]
     },
     {
         "name": "jouzu",
         "trans": [
+            "上手(じょうず)",
             "③ 名·ナ形  擅长，拿手"
-        ],
-        "notation": "上手(じょうず)"
+        ]
     },
     {
         "name": "urusai",
         "trans": [
+            "うるさい",
             "③ イ形  吵闹的；厌烦的；爱唠叨的"
-        ],
-        "notation": "うるさい"
+        ]
     },
     {
         "name": "suu",
         "trans": [
+            "吸(す)う",
             "⓪ 他动1  吸，吸入"
-        ],
-        "notation": "吸(す)う"
+        ]
     },
     {
         "name": "isha",
         "trans": [
+            "医者(いしゃ)",
             "⓪ 名  医生"
-        ],
-        "notation": "医者(いしゃ)"
+        ]
     },
     {
         "name": "chiisai",
         "trans": [
+            "小(ちい)さい",
             "③ イ形  （规模、年龄等）小的"
-        ],
-        "notation": "小(ちい)さい"
+        ]
     },
     {
         "name": "undou",
         "trans": [
+            "運動(うんどう)",
             "⓪ 名·自动3  运动"
-        ],
-        "notation": "運動(うんどう)"
+        ]
     },
     {
         "name": "sarani",
         "trans": [
+            "更(さら)に",
             "① 副  更加；并且"
-        ],
-        "notation": "更(さら)に"
+        ]
     },
     {
         "name": "imouto",
         "trans": [
+            "妹(いもうと)",
             "④ 名  妹妹"
-        ],
-        "notation": "妹(いもうと)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "止(と)まる",
             "⓪ 自动1  停止，停下来"
-        ],
-        "notation": "止(と)まる"
+        ]
     },
     {
         "name": "ke-ki",
         "trans": [
+            "ケーキ",
             "① 名  蛋糕"
-        ],
-        "notation": "ケーキ"
+        ]
     },
     {
         "name": "ensoku",
         "trans": [
+            "遠足(えんそく)",
             "⓪ 名·自动3  远足，徒步旅行；郊游"
-        ],
-        "notation": "遠足(えんそく)"
+        ]
     },
     {
         "name": "semai",
         "trans": [
+            "狭(せま)い",
             "② イ形  狭窄的；狭隘的"
-        ],
-        "notation": "狭(せま)い"
+        ]
     },
     {
         "name": "oomisoka",
         "trans": [
+            "大晦日(おおみそか)",
             "③ 名  除夕"
-        ],
-        "notation": "大晦日(おおみそか)"
+        ]
     },
     {
         "name": "taihen",
         "trans": [
+            "大変(たいへん)",
             "⓪ ナ形·副  重大的，不容易的；非常"
-        ],
-        "notation": "大変(たいへん)"
+        ]
     },
     {
         "name": "makura",
         "trans": [
+            "枕(まくら)",
             "① 名  枕头"
-        ],
-        "notation": "枕(まくら)"
+        ]
     },
     {
         "name": "dasu",
         "trans": [
+            "出(だ)す",
             "① 他动1  拿出；伸出；提出"
-        ],
-        "notation": "出(だ)す"
+        ]
     },
     {
         "name": "izen",
         "trans": [
+            "以前(いぜん)",
             "① 名  以前，之前"
-        ],
-        "notation": "以前(いぜん)"
+        ]
     },
     {
         "name": "oboeru",
         "trans": [
+            "覚(おぼ)える",
             "③ 他动2  记住；学会，掌握"
-        ],
-        "notation": "覚(おぼ)える"
+        ]
     },
     {
         "name": "takusan",
         "trans": [
+            "たくさん",
             "③ 名·副  很多"
-        ],
-        "notation": "たくさん"
+        ]
     },
     {
         "name": "enpitsu",
         "trans": [
+            "鉛筆(えんぴつ)",
             "⓪ 名  铅笔"
-        ],
-        "notation": "鉛筆(えんぴつ)"
+        ]
     },
     {
         "name": "koro",
         "trans": [
+            "頃(ころ)",
             "① 名  时候，时期"
-        ],
-        "notation": "頃(ころ)"
+        ]
     },
     {
         "name": "raigetsu",
         "trans": [
+            "来月(らいげつ)",
             "① 名  下个月"
-        ],
-        "notation": "来月(らいげつ)"
+        ]
     },
     {
         "name": "hogaraka",
         "trans": [
+            "朗(ほが)らか",
             "② ナ形  开朗的，爽快的"
-        ],
-        "notation": "朗(ほが)らか"
+        ]
     },
     {
         "name": "uchi",
         "trans": [
+            "内(うち)",
             "⓪ 名  里面"
-        ],
-        "notation": "内(うち)"
+        ]
     },
     {
         "name": "senshuu",
         "trans": [
+            "先週(せんしゅう)",
             "⓪ 名  上个星期"
-        ],
-        "notation": "先週(せんしゅう)"
+        ]
     },
     {
         "name": "tsukareru",
         "trans": [
+            "疲(つか)れる",
             "③ 自动2  疲倦，累"
-        ],
-        "notation": "疲(つか)れる"
+        ]
     },
     {
         "name": "oozei",
         "trans": [
+            "大勢(おおぜい)",
             "③ 名·副  众多（人）"
-        ],
-        "notation": "大勢(おおぜい)"
+        ]
     },
     {
         "name": "kaesu",
         "trans": [
+            "返(かえ)す",
             "① 他动1  归还；送回"
-        ],
-        "notation": "返(かえ)す"
+        ]
     },
     {
         "name": "ooi",
         "trans": [
+            "多(おお)い",
             "① イ形  多的"
-        ],
-        "notation": "多(おお)い"
+        ]
     },
     {
         "name": "te",
         "trans": [
+            "手(て)",
             "① 名  手；手腕"
-        ],
-        "notation": "手(て)"
+        ]
     },
     {
         "name": "nomu",
         "trans": [
+            "飲(の)む",
             "① 他动１  喝"
-        ],
-        "notation": "飲(の)む"
+        ]
     },
     {
         "name": "taisetsu",
         "trans": [
+            "大切(たいせつ)",
             "⓪ ナ形  重要的，贵重的；珍惜的"
-        ],
-        "notation": "大切(たいせつ)"
+        ]
     },
     {
         "name": "issho",
         "trans": [
+            "一緒(いっしょ)",
             "⓪ 名·ナ形  一起，一同"
-        ],
-        "notation": "一緒(いっしょ)"
+        ]
     },
     {
         "name": "osu",
         "trans": [
+            "押(お)す",
             "⓪ 他动1  压，按；推"
-        ],
-        "notation": "押(お)す"
+        ]
     },
     {
         "name": "taoru",
         "trans": [
+            "タオル",
             "① 名  毛巾"
-        ],
-        "notation": "タオル"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "帰(かえ)る",
             "① 自动1  回来,回去"
-        ],
-        "notation": "帰(かえ)る"
+        ]
     },
     {
         "name": "uwagi",
         "trans": [
+            "上着(うわぎ)",
             "⓪ 名  外套，上衣"
-        ],
-        "notation": "上着(うわぎ)"
+        ]
     },
     {
         "name": "shikashi",
         "trans": [
+            "しかし",
             "② 接续  可是，不过"
-        ],
-        "notation": "しかし"
+        ]
     },
     {
         "name": "kiiro",
         "trans": [
+            "黄色(きいろ)",
             "⓪ 名  黄色"
-        ],
-        "notation": "黄色(きいろ)"
+        ]
     },
     {
         "name": "okiru",
         "trans": [
+            "起(お)きる",
             "② 自动2  起床，起身"
-        ],
-        "notation": "起(お)きる"
+        ]
     },
     {
         "name": "chuugakkou",
         "trans": [
+            "中学校(ちゅうがっこう)",
             "③ 名  中学，初中"
-        ],
-        "notation": "中学校(ちゅうがっこう)"
+        ]
     },
     {
         "name": "suke-to",
         "trans": [
+            "スケート",
             "⓪ 名·自动3  滑冰"
-        ],
-        "notation": "スケート"
+        ]
     },
     {
         "name": "omoi",
         "trans": [
+            "重(おも)い",
             "⓪ イ形  （物品）重的；（心情）沉重的；（程度）严重的"
-        ],
-        "notation": "重(おも)い"
+        ]
     },
     {
         "name": "suni-ka-",
         "trans": [
+            "スニーカー",
             "⓪ 名  运动鞋"
-        ],
-        "notation": "スニーカー"
+        ]
     },
     {
         "name": "oshieru",
         "trans": [
+            "教(おし)える",
             "⓪ 他动2  教，教导；告诉"
-        ],
-        "notation": "教(おし)える"
+        ]
     },
     {
         "name": "machi",
         "trans": [
+            "町(まち)",
             "② 名  城镇；地区"
-        ],
-        "notation": "町(まち)"
+        ]
     },
     {
         "name": "kakaru",
         "trans": [
+            "掛(か)かる",
             "② 自动1  悬挂；花费"
-        ],
-        "notation": "掛(か)かる"
+        ]
     },
     {
         "name": "eigo",
         "trans": [
+            "英語(えいご)",
             "⓪ 名  英语"
-        ],
-        "notation": "英語(えいご)"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "差(さ)す",
             "① 自他动1  照射；撑着，打着"
-        ],
-        "notation": "差(さ)す"
+        ]
     },
     {
         "name": "otona",
         "trans": [
+            "大人(おとな)",
             "⓪ 名  成年人，大人"
-        ],
-        "notation": "大人(おとな)"
+        ]
     },
     {
         "name": "tenji",
         "trans": [
+            "展示(てんじ)",
             "⓪ 名·他动3  展示，展览"
-        ],
-        "notation": "展示(てんじ)"
+        ]
     },
     {
         "name": "osoi",
         "trans": [
+            "遅(おそ)い",
             "⓪ イ形  （速度）慢的；（时间）晚的"
-        ],
-        "notation": "遅(おそ)い"
+        ]
     },
     {
         "name": "kao",
         "trans": [
+            "顔(かお)",
             "⓪ 名  脸；表情；脸面"
-        ],
-        "notation": "顔(かお)"
+        ]
     },
     {
         "name": "dekakeru",
         "trans": [
+            "出(で)かける",
             "⓪ 自动2  出发，出门"
-        ],
-        "notation": "出(で)かける"
+        ]
     },
     {
         "name": "e",
         "trans": [
+            "絵(え)",
             "① 名  画，图画"
-        ],
-        "notation": "絵(え)"
+        ]
     },
     {
         "name": "sorekara",
         "trans": [
+            "それから",
             "⓪ 接续  然后；还有"
-        ],
-        "notation": "それから"
+        ]
     },
     {
         "name": "oyogu",
         "trans": [
+            "泳(およ)ぐ",
             "② 自动1  游泳"
-        ],
-        "notation": "泳(およ)ぐ"
+        ]
     },
     {
         "name": "niku",
         "trans": [
+            "肉(にく)",
             "② 名  肉，肉类"
-        ],
-        "notation": "肉(にく)"
+        ]
     },
     {
         "name": "omoshiroi",
         "trans": [
+            "面白(おもしろ)い",
             "④ イ形  有趣的；愉快的，高兴的"
-        ],
-        "notation": "面白(おもしろ)い"
+        ]
     },
     {
         "name": "se",
         "trans": [
+            "背(せ)",
             "① 名  后背；身高"
-        ],
-        "notation": "背(せ)"
+        ]
     },
     {
         "name": "kikan",
         "trans": [
+            "期間(きかん)",
             "① 名  期间，时间段"
-        ],
-        "notation": "期間(きかん)"
+        ]
     },
     {
         "name": "omou",
         "trans": [
+            "思(おも)う",
             "② 他动1  想，思考；觉得；思念"
-        ],
-        "notation": "思(おも)う"
+        ]
     },
     {
         "name": "shirase",
         "trans": [
+            "知(し)らせ",
             "⓪ 名  通知，告知"
-        ],
-        "notation": "知(し)らせ"
+        ]
     },
     {
         "name": "minasan",
         "trans": [
+            "皆(みな)さん",
             "② 名  大家"
-        ],
-        "notation": "皆(みな)さん"
+        ]
     },
     {
         "name": "suki",
         "trans": [
+            "好(す)き",
             "② ナ形  喜欢的"
-        ],
-        "notation": "好(す)き"
+        ]
     },
     {
         "name": "eki",
         "trans": [
+            "駅(えき)",
             "① 名  车站"
-        ],
-        "notation": "駅(えき)"
+        ]
     },
     {
         "name": "soredeha",
         "trans": [
+            "それでは",
             "③ 接续  那么"
-        ],
-        "notation": "それでは"
+        ]
     },
     {
         "name": "kaisha",
         "trans": [
+            "会社(かいしゃ)",
             "⓪ 名  公司"
-        ],
-        "notation": "会社(かいしゃ)"
+        ]
     },
     {
         "name": "kage",
         "trans": [
+            "影(かげ)",
             "① 名  影子"
-        ],
-        "notation": "影(かげ)"
+        ]
     },
     {
         "name": "tenki",
         "trans": [
+            "天気(てんき)",
             "① 名  天气"
-        ],
-        "notation": "天気(てんき)"
+        ]
     },
     {
         "name": "kaiwa",
         "trans": [
+            "会話(かいわ)",
             "⓪ 名·自动3  会话；交流"
-        ],
-        "notation": "会話(かいわ)"
+        ]
     },
     {
         "name": "takai",
         "trans": [
+            "高(たか)い",
             "② イ形  （高度、地位等）高的；（价格）贵的"
-        ],
-        "notation": "高(たか)い"
+        ]
     },
     {
         "name": "kakitome",
         "trans": [
+            "書留(かきとめ)",
             "⓪ 名  挂号（信）"
-        ],
-        "notation": "書留(かきとめ)"
+        ]
     },
     {
         "name": "owaru",
         "trans": [
+            "終(お)わる",
             "⓪ 自他动1  完毕，结束；做完，完结"
-        ],
-        "notation": "終(お)わる"
+        ]
     },
     {
         "name": "hinamatsuri",
         "trans": [
+            "雛祭(ひなまつ)り",
             "③ 名  女儿节"
-        ],
-        "notation": "雛祭(ひなまつ)り"
+        ]
     },
     {
         "name": "ongaku",
         "trans": [
+            "音楽(おんがく)",
             "① 名  音乐"
-        ],
-        "notation": "音楽(おんがく)"
+        ]
     },
     {
         "name": "otaku",
         "trans": [
+            "お宅(たく)",
             "⓪ 名  （您）府上；宅在家里"
-        ],
-        "notation": "お宅(たく)"
+        ]
     },
     {
         "name": "iriguchi",
         "trans": [
+            "入(い)り口(ぐち)",
             "⓪ 名  入口"
-        ],
-        "notation": "入(い)り口(ぐち)"
+        ]
     },
     {
         "name": "kansha",
         "trans": [
+            "感謝(かんしゃ)",
             "① 名·自他动3  感谢"
-        ],
-        "notation": "感謝(かんしゃ)"
+        ]
     },
     {
         "name": "tsumaranai",
         "trans": [
+            "つまらない",
             "③ イ形  无聊的，没意思的"
-        ],
-        "notation": "つまらない"
+        ]
     },
     {
         "name": "kouen",
         "trans": [
+            "公園(こうえん)",
             "⓪ 名  公园"
-        ],
-        "notation": "公園(こうえん)"
+        ]
     },
     {
         "name": "shiru",
         "trans": [
+            "知(し)る",
             "⓪ 他动1  知道，懂得；认识"
-        ],
-        "notation": "知(し)る"
+        ]
     },
     {
         "name": "kagi",
         "trans": [
+            "鍵(かぎ)",
             "② 名  钥匙"
-        ],
-        "notation": "鍵(かぎ)"
+        ]
     },
     {
         "name": "bukka",
         "trans": [
+            "物価(ぶっか)",
             "⓪ 名  物价"
-        ],
-        "notation": "物価(ぶっか)"
+        ]
     },
     {
         "name": "onaji",
         "trans": [
+            "同(おな)じ",
             "⓪ 连体  相同，同样"
-        ],
-        "notation": "同(おな)じ"
+        ]
     },
     {
         "name": "naifu",
         "trans": [
+            "ナイフ",
             "① 名  小刀，餐刀"
-        ],
-        "notation": "ナイフ"
+        ]
     },
     {
         "name": "oku",
         "trans": [
+            "置(お)く",
             "⓪ 自他动1  放置，放；留下"
-        ],
-        "notation": "置(お)く"
+        ]
     },
     {
         "name": "fuyuyasumi",
         "trans": [
+            "冬休(ふゆやす)み",
             "③ 名  寒假"
-        ],
-        "notation": "冬休(ふゆやす)み"
+        ]
     },
     {
         "name": "satsuei",
         "trans": [
+            "撮影(さつえい)",
             "⓪ 名·他动3  拍照，摄影"
-        ],
-        "notation": "撮影(さつえい)"
+        ]
     },
     {
         "name": "tame",
         "trans": [
+            "為(ため)",
             "② 名  为了；因为"
-        ],
-        "notation": "為(ため)"
+        ]
     },
     {
         "name": "matsu",
         "trans": [
+            "待(ま)つ",
             "① 他动1  等，等待"
-        ],
-        "notation": "待(ま)つ"
+        ]
     },
     {
         "name": "ko-ra",
         "trans": [
+            "コーラ",
             "① 名  可乐"
-        ],
-        "notation": "コーラ"
+        ]
     },
     {
         "name": "kissaten",
         "trans": [
+            "喫茶店(きっさてん)",
             "⓪ 名  咖啡馆，茶馆"
-        ],
-        "notation": "喫茶店(きっさてん)"
+        ]
     },
     {
         "name": "supo-tsu",
         "trans": [
+            "スポーツ",
             "② 名  运动"
-        ],
-        "notation": "スポーツ"
+        ]
     },
     {
         "name": "mawasu",
         "trans": [
+            "回(まわ)す",
             "⓪ 他动1  转动；传递"
-        ],
-        "notation": "回(まわ)す"
+        ]
     },
     {
         "name": "kaihi",
         "trans": [
+            "回避(かいひ)",
             "① 名·他动3  回避"
-        ],
-        "notation": "回避(かいひ)"
+        ]
     },
     {
         "name": "chikai",
         "trans": [
+            "近(ちか)い",
             "② イ形  （距离、时间等）近的；关系亲近的"
-        ],
-        "notation": "近(ちか)い"
+        ]
     },
     {
         "name": "ehagaki",
         "trans": [
+            "絵葉書(えはがき)",
             "② 名  美术明信片"
-        ],
-        "notation": "絵葉書(えはがき)"
+        ]
     },
     {
         "name": "ane",
         "trans": [
+            "姉(あね)",
             "⓪ 名  姐姐"
-        ],
-        "notation": "姉(あね)"
+        ]
     },
     {
         "name": "tokuchou",
         "trans": [
+            "特徴(とくちょう)",
             "⓪ 名  特征，特色"
-        ],
-        "notation": "特徴(とくちょう)"
+        ]
     },
     {
         "name": "muzukashii",
         "trans": [
+            "難(むずか)しい",
             "④ イ形  难的，困难的"
-        ],
-        "notation": "難(むずか)しい"
+        ]
     },
     {
         "name": "oriru",
         "trans": [
+            "降(お)りる",
             "② 自动2  下来；（从交通工具）下来"
-        ],
-        "notation": "降(お)りる"
+        ]
     },
     {
         "name": "hidarigawa",
         "trans": [
+            "左側(ひだりがわ)",
             "⓪ 名  左侧"
-        ],
-        "notation": "左側(ひだりがわ)"
+        ]
     },
     {
         "name": "mada",
         "trans": [
+            "まだ",
             "① 副  还，仍然"
-        ],
-        "notation": "まだ"
+        ]
     },
     {
         "name": "kasu",
         "trans": [
+            "貸(か)す",
             "⓪ 他动1  借出，借给"
-        ],
-        "notation": "貸(か)す"
+        ]
     },
     {
         "name": "hankachi",
         "trans": [
+            "ハンカチ",
             "③ 名  手帕，手绢"
-        ],
-        "notation": "ハンカチ"
+        ]
     },
     {
         "name": "ii/yoi",
         "trans": [
+            "良(いい/よ)い",
             "① イ形  好的"
-        ],
-        "notation": "良(いい/よ)い"
+        ]
     },
     {
         "name": "yakusoku",
         "trans": [
+            "約束(やくそく)",
             "⓪ 名·他动3  约定，商定"
-        ],
-        "notation": "約束(やくそく)"
+        ]
     },
     {
         "name": "rippa",
         "trans": [
+            "立派(りっぱ)",
             "⓪ ナ形  漂亮的；壮丽的；出色的"
-        ],
-        "notation": "立派(りっぱ)"
+        ]
     },
     {
         "name": "kaidan",
         "trans": [
+            "階段(かいだん)",
             "⓪ 名  台阶，楼梯"
-        ],
-        "notation": "階段(かいだん)"
+        ]
     },
     {
         "name": "sentakushi",
         "trans": [
+            "選択肢(せんたくし)",
             "③ 名  选项"
-        ],
-        "notation": "選択肢(せんたくし)"
+        ]
     },
     {
         "name": "kaban",
         "trans": [
+            "かばん",
             "⓪ 名  包"
-        ],
-        "notation": "かばん"
+        ]
     },
     {
         "name": "itsutsu",
         "trans": [
+            "五(いつ)つ",
             "② 名  五个；五岁"
-        ],
-        "notation": "五(いつ)つ"
+        ]
     },
     {
         "name": "daitai",
         "trans": [
+            "大体(だいたい)",
             "⓪ 副  大致，大体，差不多"
-        ],
-        "notation": "大体(だいたい)"
+        ]
     },
     {
         "name": "otearai",
         "trans": [
+            "お手洗(てあら)い",
             "③ 名  洗手间"
-        ],
-        "notation": "お手洗(てあら)い"
+        ]
     },
     {
         "name": "narau",
         "trans": [
+            "習(なら)う",
             "② 他动1  学习，练习（某种技能）"
-        ],
-        "notation": "習(なら)う"
+        ]
     },
     {
         "name": "se-ru",
         "trans": [
+            "セール",
             "① 名  促销，大减价"
-        ],
-        "notation": "セール"
+        ]
     },
     {
         "name": "riyou",
         "trans": [
+            "利用(りよう)",
             "⓪ 名·他动3  利用"
-        ],
-        "notation": "利用(りよう)"
+        ]
     },
     {
         "name": "tsumetai",
         "trans": [
+            "冷(つめ)たい",
             "③ イ形  冰冷的；冷淡的"
-        ],
-        "notation": "冷(つめ)たい"
+        ]
     },
     {
         "name": "karada",
         "trans": [
+            "体(からだ)",
             "⓪ 名  身体；体格，身材"
-        ],
-        "notation": "体(からだ)"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "取(と)る",
             "① 他动1  拿；取得"
-        ],
-        "notation": "取(と)る"
+        ]
     },
     {
         "name": "kasa",
         "trans": [
+            "傘(かさ)",
             "① 名  伞"
-        ],
-        "notation": "傘(かさ)"
+        ]
     },
     {
         "name": "shoppingu",
         "trans": [
+            "ショッピング",
             "① 名·自动3  购物，逛街"
-        ],
-        "notation": "ショッピング"
+        ]
     },
     {
         "name": "hana",
         "trans": [
+            "花(はな)",
             "② 名  花"
-        ],
-        "notation": "花(はな)"
+        ]
     },
     {
         "name": "kaburu",
         "trans": [
+            "被(かぶ)る",
             "② 他动1  戴；蒙，盖"
-        ],
-        "notation": "被(かぶ)る"
+        ]
     },
     {
         "name": "iesu",
         "trans": [
+            "イエス",
             "② 叹  是，对"
-        ],
-        "notation": "イエス"
+        ]
     },
     {
         "name": "ren'ai",
         "trans": [
+            "恋愛(れんあい)",
             "⓪ 名·自动3  恋爱"
-        ],
-        "notation": "恋愛(れんあい)"
+        ]
     },
     {
         "name": "haizara",
         "trans": [
+            "灰皿(はいざら)",
             "③ 名  烟灰缸"
-        ],
-        "notation": "灰皿(はいざら)"
+        ]
     },
     {
         "name": "kitanai",
         "trans": [
+            "汚(きたな)い",
             "③ イ形  脏的；卑鄙的"
-        ],
-        "notation": "汚(きたな)い"
+        ]
     },
     {
         "name": "gaikoku",
         "trans": [
+            "外国(がいこく)",
             "⓪ 名  外国"
-        ],
-        "notation": "外国(がいこく)"
+        ]
     },
     {
         "name": "memori-",
         "trans": [
+            "メモリー",
             "① 名  记忆；存储（卡）"
-        ],
-        "notation": "メモリー"
+        ]
     },
     {
         "name": "shichaku",
         "trans": [
+            "試着(しちゃく)",
             "⓪ 名·他动3  试穿"
-        ],
-        "notation": "試着(しちゃく)"
+        ]
     },
     {
         "name": "kado",
         "trans": [
+            "角(かど)",
             "① 名  角；拐弯，拐角"
-        ],
-        "notation": "角(かど)"
+        ]
     },
     {
         "name": "mochiron",
         "trans": [
+            "もちろん",
             "② 副  当然"
-        ],
-        "notation": "もちろん"
+        ]
     },
     {
         "name": "suibun",
         "trans": [
+            "水分(すいぶん)",
             "① 名  水分"
-        ],
-        "notation": "水分(すいぶん)"
+        ]
     },
     {
         "name": "ekimae",
         "trans": [
+            "駅前(えきまえ)",
             "③ 名  车站前，车站附近"
-        ],
-        "notation": "駅前(えきまえ)"
+        ]
     },
     {
         "name": "tekisuto",
         "trans": [
+            "テキスト",
             "① 名  课本，教科书"
-        ],
-        "notation": "テキスト"
+        ]
     },
     {
         "name": "shinu",
         "trans": [
+            "死(し)ぬ",
             "⓪ 自动1  死亡"
-        ],
-        "notation": "死(し)ぬ"
+        ]
     },
     {
         "name": "kaminari",
         "trans": [
+            "雷(かみなり)",
             "③ 名  雷"
-        ],
-        "notation": "雷(かみなり)"
+        ]
     },
     {
         "name": "hiroi",
         "trans": [
+            "広(ひろ)い",
             "② イ形  宽广的；广泛的"
-        ],
-        "notation": "広(ひろ)い"
+        ]
     },
     {
         "name": "gakusei",
         "trans": [
+            "学生(がくせい)",
             "⓪ 名  学生"
-        ],
-        "notation": "学生(がくせい)"
+        ]
     },
     {
         "name": "ninshin",
         "trans": [
+            "妊娠(にんしん)",
             "⓪ 名·自动3  怀孕"
-        ],
-        "notation": "妊娠(にんしん)"
+        ]
     },
     {
         "name": "suteki",
         "trans": [
+            "素敵(すてき)",
             "⓪ ナ形  极好的，绝佳的"
-        ],
-        "notation": "素敵(すてき)"
+        ]
     },
     {
         "name": "kazoku",
         "trans": [
+            "家族(かぞく)",
             "① 名  家人；家庭，家族"
-        ],
-        "notation": "家族(かぞく)"
+        ]
     },
     {
         "name": "torihiki",
         "trans": [
+            "取引(とりひき)",
             "② 名·自动3  交易，贸易"
-        ],
-        "notation": "取引(とりひき)"
+        ]
     },
     {
         "name": "kamera",
         "trans": [
+            "カメラ",
             "① 名  照相机"
-        ],
-        "notation": "カメラ"
+        ]
     },
     {
         "name": "yukkuri",
         "trans": [
+            "ゆっくり",
             "③ 副  缓慢地；悠闲地，舒服地"
-        ],
-        "notation": "ゆっくり"
+        ]
     },
     {
         "name": "tamanegi",
         "trans": [
+            "玉(たま)ねぎ",
             "③ 名  洋葱"
-        ],
-        "notation": "玉(たま)ねぎ"
+        ]
     },
     {
         "name": "chikoku",
         "trans": [
+            "遅刻(ちこく)",
             "⓪ 名·自动3  迟到"
-        ],
-        "notation": "遅刻(ちこく)"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "書(か)く",
             "① 他动1  写"
-        ],
-        "notation": "書(か)く"
+        ]
     },
     {
         "name": "himitsu",
         "trans": [
+            "秘密(ひみつ)",
             "⓪ 名·ナ形  秘密"
-        ],
-        "notation": "秘密(ひみつ)"
+        ]
     },
     {
         "name": "ba-bekyu-",
         "trans": [
+            "バーベキュー",
             "③ 名  烧烤"
-        ],
-        "notation": "バーベキュー"
+        ]
     },
     {
         "name": "kanojo",
         "trans": [
+            "彼女(かのじょ)",
             "① 名·代  她；女朋友"
-        ],
-        "notation": "彼女(かのじょ)"
+        ]
     },
     {
         "name": "massugu",
         "trans": [
+            "まっすぐ",
             "③ 名·ナ形·副  笔直；直接；正直"
-        ],
-        "notation": "まっすぐ"
+        ]
     },
     {
         "name": "katakana",
         "trans": [
+            "片仮名(かたかな)",
             "③ 名  片假名"
-        ],
-        "notation": "片仮名(かたかな)"
+        ]
     },
     {
         "name": "magaru",
         "trans": [
+            "曲(ま)がる",
             "⓪ 自动1  弯曲；拐弯"
-        ],
-        "notation": "曲(ま)がる"
+        ]
     },
     {
         "name": "sukoshi",
         "trans": [
+            "少(すこ)し",
             "② 副  少许，稍微"
-        ],
-        "notation": "少(すこ)し"
+        ]
     },
     {
         "name": "kikaku",
         "trans": [
+            "企画(きかく)",
             "⓪ 名·他动3  计划，策划"
-        ],
-        "notation": "企画(きかく)"
+        ]
     },
     {
         "name": "poketto",
         "trans": [
+            "ポケット",
             "② 名  口袋"
-        ],
-        "notation": "ポケット"
+        ]
     },
     {
         "name": "kieru",
         "trans": [
+            "消(き)える",
             "⓪ 自动2  消失；熄灭"
-        ],
-        "notation": "消(き)える"
+        ]
     },
     {
         "name": "tabemono",
         "trans": [
+            "食(た)べ物(もの)",
             "③ 名  食物"
-        ],
-        "notation": "食(た)べ物(もの)"
+        ]
     },
     {
         "name": "hade",
         "trans": [
+            "派手(はで)",
             "② 名·ナ形  华丽；高调"
-        ],
-        "notation": "派手(はで)"
+        ]
     },
     {
         "name": "kanban",
         "trans": [
+            "看板(かんばん)",
             "⓪ 名  招牌；牌子"
-        ],
-        "notation": "看板(かんばん)"
+        ]
     },
     {
         "name": "jugyou",
         "trans": [
+            "授業(じゅぎょう)",
             "① 名·自动3  授课，上课"
-        ],
-        "notation": "授業(じゅぎょう)"
+        ]
     },
     {
         "name": "dakara",
         "trans": [
+            "だから",
             "① 接续  所以，因此"
-        ],
-        "notation": "だから"
+        ]
     },
     {
         "name": "tesuto",
         "trans": [
+            "テスト",
             "① 名  测验，考试"
-        ],
-        "notation": "テスト"
+        ]
     },
     {
         "name": "kigen",
         "trans": [
+            "期限(きげん)",
             "① 名  期限"
-        ],
-        "notation": "期限(きげん)"
+        ]
     },
     {
         "name": "hansamu",
         "trans": [
+            "ハンサム",
             "① ナ形  英俊的，潇洒的"
-        ],
-        "notation": "ハンサム"
+        ]
     },
     {
         "name": "gakkou",
         "trans": [
+            "学校(がっこう)",
             "⓪ 名  学校"
-        ],
-        "notation": "学校(がっこう)"
+        ]
     },
     {
         "name": "hajimeru",
         "trans": [
+            "始(はじ)める",
             "⓪ 他动2  开始"
-        ],
-        "notation": "始(はじ)める"
+        ]
     },
     {
         "name": "shitsumon",
         "trans": [
+            "質問(しつもん)",
             "⓪ 名·自动3  问题；提问，询问"
-        ],
-        "notation": "質問(しつもん)"
+        ]
     },
     {
         "name": "kankyaku",
         "trans": [
+            "観客(かんきゃく)",
             "⓪ 名  观众"
-        ],
-        "notation": "観客(かんきゃく)"
+        ]
     },
     {
         "name": "~hiki",
         "trans": [
+            "～匹(ひき)",
             " 接尾  （鸟、鱼、虫等小动物）只，条"
-        ],
-        "notation": "～匹(ひき)"
+        ]
     },
     {
         "name": "genki",
         "trans": [
+            "元気(げんき)",
             "① 名·ナ形  精神，活力；健康"
-        ],
-        "notation": "元気(げんき)"
+        ]
     },
     {
         "name": "kurushii",
         "trans": [
+            "苦(くる)しい",
             "③ イ形  痛苦的；艰难的；苦恼的"
-        ],
-        "notation": "苦(くる)しい"
+        ]
     },
     {
         "name": "mokuteki",
         "trans": [
+            "目的(もくてき)",
             "⓪ 名  目的"
-        ],
-        "notation": "目的(もくてき)"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "聞(き)く",
             "⓪ 他动1  听；询问"
-        ],
-        "notation": "聞(き)く"
+        ]
     },
     {
         "name": "tenisu",
         "trans": [
+            "テニス",
             "① 名  网球"
-        ],
-        "notation": "テニス"
+        ]
     },
     {
         "name": "kitsuen",
         "trans": [
+            "喫煙(きつえん)",
             "⓪ 名·自动3  吸烟"
-        ],
-        "notation": "喫煙(きつえん)"
+        ]
     },
     {
         "name": "ongakuka",
         "trans": [
+            "音楽家(おんがくか)",
             "⓪ 名  音乐家"
-        ],
-        "notation": "音楽家(おんがくか)"
+        ]
     },
     {
         "name": "kekkou",
         "trans": [
+            "結構(けっこう)",
             "① 副·ナ形  相当；很好，优秀；足够"
-        ],
-        "notation": "結構(けっこう)"
+        ]
     },
     {
         "name": "katei",
         "trans": [
+            "家庭(かてい)",
             "⓪ 名  家庭"
-        ],
-        "notation": "家庭(かてい)"
+        ]
     },
     {
         "name": "narabu",
         "trans": [
+            "並(なら)ぶ",
             "⓪ 自动1  排列，排队"
-        ],
-        "notation": "並(なら)ぶ"
+        ]
     },
     {
         "name": "kippu",
         "trans": [
+            "切符(きっぷ)",
             "⓪ 名  票"
-        ],
-        "notation": "切符(きっぷ)"
+        ]
     },
     {
         "name": "~chuu",
         "trans": [
+            "～中(ちゅう)",
             " 接尾  正在……"
-        ],
-        "notation": "～中(ちゅう)"
+        ]
     },
     {
         "name": "bando",
         "trans": [
+            "バンド",
             "⓪ 名  乐队；腰带，皮带"
-        ],
-        "notation": "バンド"
+        ]
     },
     {
         "name": "kiru",
         "trans": [
+            "着(き)る",
             "⓪ 他动2  穿（衣服等）"
-        ],
-        "notation": "着(き)る"
+        ]
     },
     {
         "name": "ishiatama",
         "trans": [
+            "石頭(いしあたま)",
             "③ 名  死脑筋"
-        ],
-        "notation": "石頭(いしあたま)"
+        ]
     },
     {
         "name": "hayai",
         "trans": [
+            "早(はや)い",
             "② イ形  早的"
-        ],
-        "notation": "早(はや)い"
+        ]
     },
     {
         "name": "nama",
         "trans": [
+            "生(なま)",
             "① 名  生；直接"
-        ],
-        "notation": "生(なま)"
+        ]
     },
     {
         "name": "kinou",
         "trans": [
+            "機能(きのう)",
             "① 名·自动3  功能，机能；起作用"
-        ],
-        "notation": "機能(きのう)"
+        ]
     },
     {
         "name": "hima",
         "trans": [
+            "暇(ひま)",
             "⓪ 名·ナ形  空闲"
-        ],
-        "notation": "暇(ひま)"
+        ]
     },
     {
         "name": "wakaru",
         "trans": [
+            "分(わ)かる",
             "② 自动1  明白，懂得"
-        ],
-        "notation": "分(わ)かる"
+        ]
     },
     {
         "name": "onsen",
         "trans": [
+            "温泉(おんせん)",
             "⓪ 名  温泉"
-        ],
-        "notation": "温泉(おんせん)"
+        ]
     },
     {
         "name": "choukoku",
         "trans": [
+            "彫刻(ちょうこく)",
             "⓪ 名·他动3  雕刻"
-        ],
-        "notation": "彫刻(ちょうこく)"
+        ]
     },
     {
         "name": "sorosoro",
         "trans": [
+            "そろそろ",
             "① 副  就要，快要；逐渐，渐渐"
-        ],
-        "notation": "そろそろ"
+        ]
     },
     {
         "name": "kiji",
         "trans": [
+            "記事(きじ)",
             "① 名  新闻，报道"
-        ],
-        "notation": "記事(きじ)"
+        ]
     },
     {
         "name": "taberu",
         "trans": [
+            "食(た)べる",
             "② 他动2  吃"
-        ],
-        "notation": "食(た)べる"
+        ]
     },
     {
         "name": "kabe",
         "trans": [
+            "壁(かべ)",
             "⓪ 名  墙壁；障碍，隔阂"
-        ],
-        "notation": "壁(かべ)"
+        ]
     },
     {
         "name": "hairu",
         "trans": [
+            "入(はい)る",
             "① 自动1  进入"
-        ],
-        "notation": "入(はい)る"
+        ]
     },
     {
         "name": "kyonen",
         "trans": [
+            "去年(きょねん)",
             "① 名  去年"
-        ],
-        "notation": "去年(きょねん)"
+        ]
     },
     {
         "name": "shiken",
         "trans": [
+            "試験(しけん)",
             "② 名·他动3  考试，测验"
-        ],
-        "notation": "試験(しけん)"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "貼(は)る",
             "⓪ 他动1  粘，贴"
-        ],
-        "notation": "貼(は)る"
+        ]
     },
     {
         "name": "yaoya",
         "trans": [
+            "八百屋(やおや)",
             "⓪ 名  蔬菜店，水果店"
-        ],
-        "notation": "八百屋(やおや)"
+        ]
     },
     {
         "name": "nekutai",
         "trans": [
+            "ネクタイ",
             "① 名  领带"
-        ],
-        "notation": "ネクタイ"
+        ]
     },
     {
         "name": "kuroi",
         "trans": [
+            "黒(くろ)い",
             "② イ形  黑色的"
-        ],
-        "notation": "黒(くろ)い"
+        ]
     },
     {
         "name": "tomodachi",
         "trans": [
+            "友達(ともだち)",
             "⓪ 名  朋友"
-        ],
-        "notation": "友達(ともだち)"
+        ]
     },
     {
         "name": "shimeru",
         "trans": [
+            "締(し)める",
             "② 他动2  系，绑紧"
-        ],
-        "notation": "締(し)める"
+        ]
     },
     {
         "name": "on'na",
         "trans": [
+            "女(おんな)",
             "③ 名  女性，女子"
-        ],
-        "notation": "女(おんな)"
+        ]
     },
     {
         "name": "musuko",
         "trans": [
+            "息子(むすこ)",
             "⓪ 名  儿子"
-        ],
-        "notation": "息子(むすこ)"
+        ]
     },
     {
         "name": "choudo",
         "trans": [
+            "ちょうど",
             "⓪ 副  正好，恰好"
-        ],
-        "notation": "ちょうど"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "気(き)",
             "⓪ 名  性情；心情；气度，气量"
-        ],
-        "notation": "気(き)"
+        ]
     },
     {
         "name": "chigau",
         "trans": [
+            "違(ちが)う",
             "⓪ 自动1  不一致；错误"
-        ],
-        "notation": "違(ちが)う"
+        ]
     },
     {
         "name": "nanatsu",
         "trans": [
+            "七(なな)つ",
             "② 名  七个；七岁"
-        ],
-        "notation": "七(なな)つ"
+        ]
     },
     {
         "name": "kicchin",
         "trans": [
+            "キッチン",
             "① 名  厨房"
-        ],
-        "notation": "キッチン"
+        ]
     },
     {
         "name": "naru",
         "trans": [
+            "鳴(な)る",
             "⓪ 自动1  响，发出声音"
-        ],
-        "notation": "鳴(な)る"
+        ]
     },
     {
         "name": "kashidashi",
         "trans": [
+            "貸出(かしだ)し",
             "⓪ 名  出租"
-        ],
-        "notation": "貸出(かしだ)し"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "着(つ)く",
             "① 自动1  到达，抵达"
-        ],
-        "notation": "着(つ)く"
+        ]
     },
     {
         "name": "furo",
         "trans": [
+            "風呂(ふろ)",
             "② 名  浴室；洗澡"
-        ],
-        "notation": "風呂(ふろ)"
+        ]
     },
     {
         "name": "deru",
         "trans": [
+            "出(で)る",
             "① 自动2  出去，出来；显现"
-        ],
-        "notation": "出(で)る"
+        ]
     },
     {
         "name": "henkyaku",
         "trans": [
+            "返却(へんきゃく)",
             "⓪ 名·他动3  归还，退还"
-        ],
-        "notation": "返却(へんきゃく)"
+        ]
     },
     {
         "name": "kane",
         "trans": [
+            "鐘(かね)",
             "⓪ 名  钟，钟声"
-        ],
-        "notation": "鐘(かね)"
+        ]
     },
     {
         "name": "seiri",
         "trans": [
+            "整理(せいり)",
             "① 名·他动3  整理，收拾"
-        ],
-        "notation": "整理(せいり)"
+        ]
     },
     {
         "name": "hako",
         "trans": [
+            "箱(はこ)",
             "⓪ 名  箱子"
-        ],
-        "notation": "箱(はこ)"
+        ]
     },
     {
         "name": "hiragana",
         "trans": [
+            "平仮名(ひらがな)",
             "③ 名  平假名"
-        ],
-        "notation": "平仮名(ひらがな)"
+        ]
     },
     {
         "name": "kaze",
         "trans": [
+            "風(かぜ)",
             "⓪ 名  风"
-        ],
-        "notation": "風(かぜ)"
+        ]
     },
     {
         "name": "hiyasu",
         "trans": [
+            "冷(ひ)やす",
             "② 他动1  冰镇；使冷静"
-        ],
-        "notation": "冷(ひ)やす"
+        ]
     },
     {
         "name": "tenkou",
         "trans": [
+            "天候(てんこう)",
             "⓪ 名  天气，气候"
-        ],
-        "notation": "天候(てんこう)"
+        ]
     },
     {
         "name": "kumoru",
         "trans": [
+            "曇(くも)る",
             "② 自动1  阴天"
-        ],
-        "notation": "曇(くも)る"
+        ]
     },
     {
         "name": "gita-",
         "trans": [
+            "ギター",
             "① 名  吉他"
-        ],
-        "notation": "ギター"
+        ]
     },
     {
         "name": "yuusou",
         "trans": [
+            "郵送(ゆうそう)",
             "⓪ 名·他动3  邮寄"
-        ],
-        "notation": "郵送(ゆうそう)"
+        ]
     },
     {
         "name": "kotaeru",
         "trans": [
+            "答(こた)える",
             "③ 自动2  回答，应答；解答"
-        ],
-        "notation": "答(こた)える"
+        ]
     },
     {
         "name": "shiryou",
         "trans": [
+            "資料(しりょう)",
             "① 名  资料，材料"
-        ],
-        "notation": "資料(しりょう)"
+        ]
     },
     {
         "name": "tsuyoi",
         "trans": [
+            "強(つよ)い",
             "② イ形  强的；强壮的"
-        ],
-        "notation": "強(つよ)い"
+        ]
     },
     {
         "name": "kyoushi",
         "trans": [
+            "教師(きょうし)",
             "① 名  教师，老师"
-        ],
-        "notation": "教師(きょうし)"
+        ]
     },
     {
         "name": "bata-",
         "trans": [
+            "バター",
             "① 名  黄油"
-        ],
-        "notation": "バター"
+        ]
     },
     {
         "name": "komaru",
         "trans": [
+            "困(こま)る",
             "② 自动1  为难；难受；不行"
-        ],
-        "notation": "困(こま)る"
+        ]
     },
     {
         "name": "toshokan",
         "trans": [
+            "図書館(としょかん)",
             "② 名  图书馆"
-        ],
-        "notation": "図書館(としょかん)"
+        ]
     },
     {
         "name": "shizuka",
         "trans": [
+            "静(しず)か",
             "① ナ形  安静的；文静的"
-        ],
-        "notation": "静(しず)か"
+        ]
     },
     {
         "name": "saifu",
         "trans": [
+            "財布(さいふ)",
             "⓪ 名  钱包"
-        ],
-        "notation": "財布(さいふ)"
+        ]
     },
     {
         "name": "shussan",
         "trans": [
+            "出産(しゅっさん)",
             "⓪ 名·自他动3  分娩，生产"
-        ],
-        "notation": "出産(しゅっさん)"
+        ]
     },
     {
         "name": "yo-roppa",
         "trans": [
+            "ヨーロッパ",
             "③ 名  欧洲"
-        ],
-        "notation": "ヨーロッパ"
+        ]
     },
     {
         "name": "sakubun",
         "trans": [
+            "作文(さくぶん)",
             "⓪ 名  作文"
-        ],
-        "notation": "作文(さくぶん)"
+        ]
     },
     {
         "name": "demo",
         "trans": [
+            "でも",
             "① 接续  但是，可是"
-        ],
-        "notation": "でも"
+        ]
     },
     {
         "name": "migigawa",
         "trans": [
+            "右側(みぎがわ)",
             "⓪ 名  右侧"
-        ],
-        "notation": "右側(みぎがわ)"
+        ]
     },
     {
         "name": "jibun",
         "trans": [
+            "自分(じぶん)",
             "⓪ 名·代  自己，本身"
-        ],
-        "notation": "自分(じぶん)"
+        ]
     },
     {
         "name": "rikai",
         "trans": [
+            "理解(りかい)",
             "① 名·他动3  理解，了解"
-        ],
-        "notation": "理解(りかい)"
+        ]
     },
     {
         "name": "sagasu",
         "trans": [
+            "探(さが)す",
             "⓪ 他动1  寻找，搜索"
-        ],
-        "notation": "探(さが)す"
+        ]
     },
     {
         "name": "karaage",
         "trans": [
+            "唐揚(からあ)げ",
             "⓪ 名  油炸；油炸食品"
-        ],
-        "notation": "唐揚(からあ)げ"
+        ]
     },
     {
         "name": "saki",
         "trans": [
+            "先(さき)",
             "⓪ 名  之前；前面"
-        ],
-        "notation": "先(さき)"
+        ]
     },
     {
         "name": "futoi",
         "trans": [
+            "太(ふと)い",
             "② イ形  粗的；胖的"
-        ],
-        "notation": "太(ふと)い"
+        ]
     },
     {
         "name": "kyoushitsu",
         "trans": [
+            "教室(きょうしつ)",
             "⓪ 名  教室；课堂"
-        ],
-        "notation": "教室(きょうしつ)"
+        ]
     },
     {
         "name": "sekkei",
         "trans": [
+            "設計(せっけい)",
             "⓪ 名·他动3  设计"
-        ],
-        "notation": "設計(せっけい)"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "盾(たて)",
             "① 名  盾牌"
-        ],
-        "notation": "盾(たて)"
+        ]
     },
     {
         "name": "shinsei",
         "trans": [
+            "申請(しんせい)",
             "⓪ 名·他动3  申请"
-        ],
-        "notation": "申請(しんせい)"
+        ]
     },
     {
         "name": "dandan",
         "trans": [
+            "だんだん",
             "⓪ 副  逐渐，慢慢地"
-        ],
-        "notation": "だんだん"
+        ]
     },
     {
         "name": "maishuu",
         "trans": [
+            "毎週(まいしゅう)",
             "⓪ 名  每周"
-        ],
-        "notation": "毎週(まいしゅう)"
+        ]
     },
     {
         "name": "pairotto",
         "trans": [
+            "パイロット",
             "③ 名  飞行员"
-        ],
-        "notation": "パイロット"
+        ]
     },
     {
         "name": "tan'nin",
         "trans": [
+            "担任(たんにん)",
             "⓪ 名·他动3  担任，担当"
-        ],
-        "notation": "担任(たんにん)"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "話(はな)す",
             "② 他动1  说话，谈论"
-        ],
-        "notation": "話(はな)す"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "ある",
             "① 自动1  （植物、没有生命的物体）有；存在"
-        ],
-        "notation": "ある"
+        ]
     },
     {
         "name": "nankai",
         "trans": [
+            "難解(なんかい)",
             "⓪ 名·ナ形  难解，费解"
-        ],
-        "notation": "難解(なんかい)"
+        ]
     },
     {
         "name": "koukousei",
         "trans": [
+            "高校生(こうこうせい)",
             "③ 名  高中生"
-        ],
-        "notation": "高校生(こうこうせい)"
+        ]
     },
     {
         "name": "ko-na-",
         "trans": [
+            "コーナー",
             "① 名  角落；柜台"
-        ],
-        "notation": "コーナー"
+        ]
     },
     {
         "name": "houkoku",
         "trans": [
+            "報告(ほうこく)",
             "⓪ 名·他动3  报告"
-        ],
-        "notation": "報告(ほうこく)"
+        ]
     },
     {
         "name": "suwaru",
         "trans": [
+            "座(すわ)る",
             "⓪ 自动1  坐"
-        ],
-        "notation": "座(すわ)る"
+        ]
     },
     {
         "name": "kyoudai",
         "trans": [
+            "兄弟(きょうだい)",
             "① 名  兄弟姐妹"
-        ],
-        "notation": "兄弟(きょうだい)"
+        ]
     },
     {
         "name": "furu",
         "trans": [
+            "降(ふ)る",
             "① 自动1  下（雨、雪等）"
-        ],
-        "notation": "降(ふ)る"
+        ]
     },
     {
         "name": "kiri",
         "trans": [
+            "霧(きり)",
             "⓪ 名  雾"
-        ],
-        "notation": "霧(きり)"
+        ]
     },
     {
         "name": "gakuchou",
         "trans": [
+            "学長(がくちょう)",
             "⓪ 名  （大学）校长"
-        ],
-        "notation": "学長(がくちょう)"
+        ]
     },
     {
         "name": "hontou",
         "trans": [
+            "本当(ほんとう)",
             "⓪ 名·ナ形  真；真的；实在"
-        ],
-        "notation": "本当(ほんとう)"
+        ]
     },
     {
         "name": "kyuuyou",
         "trans": [
+            "急用(きゅうよう)",
             "⓪ 名  急事"
-        ],
-        "notation": "急用(きゅうよう)"
+        ]
     },
     {
         "name": "mura",
         "trans": [
+            "村(むら)",
             "② 名  村庄，村"
-        ],
-        "notation": "村(むら)"
+        ]
     },
     {
         "name": "kuchi",
         "trans": [
+            "口(くち)",
             "⓪ 名  嘴；说话；出入口"
-        ],
-        "notation": "口(くち)"
+        ]
     },
     {
         "name": "furui",
         "trans": [
+            "古(ふる)い",
             "② イ形  旧的；古老的"
-        ],
-        "notation": "古(ふる)い"
+        ]
     },
     {
         "name": "keisatsu",
         "trans": [
+            "警察(けいさつ)",
             "⓪ 名  警察"
-        ],
-        "notation": "警察(けいさつ)"
+        ]
     },
     {
         "name": "supe-chi",
         "trans": [
+            "スピーチ",
             "② 名  演讲，致辞"
-        ],
-        "notation": "スピーチ"
+        ]
     },
     {
         "name": "zu",
         "trans": [
+            "図(ず)",
             "⓪ 名  图"
-        ],
-        "notation": "図(ず)"
+        ]
     },
     {
         "name": "too",
         "trans": [
+            "十(とお)",
             "① 名  十个；十岁"
-        ],
-        "notation": "十(とお)"
+        ]
     },
     {
         "name": "mochidasu",
         "trans": [
+            "持(も)ち出(だ)す",
             "③ 他动1  拿出去；提出，谈及"
-        ],
-        "notation": "持(も)ち出(だ)す"
+        ]
     },
     {
         "name": "chizu",
         "trans": [
+            "地図(ちず)",
             "① 名  地图"
-        ],
-        "notation": "地図(ちず)"
+        ]
     },
     {
         "name": "jogingu",
         "trans": [
+            "ジョギング",
             "⓪ 名·自动3  慢跑"
-        ],
-        "notation": "ジョギング"
+        ]
     },
     {
         "name": "jikan",
         "trans": [
+            "時間(じかん)",
             "⓪ 名  时间，工夫"
-        ],
-        "notation": "時間(じかん)"
+        ]
     },
     {
         "name": "tanomu",
         "trans": [
+            "頼(たの)む",
             "② 他动1  请求，拜托；委托"
-        ],
-        "notation": "頼(たの)む"
+        ]
     },
     {
         "name": "ginkou",
         "trans": [
+            "銀行(ぎんこう)",
             "⓪ 名  银行"
-        ],
-        "notation": "銀行(ぎんこう)"
+        ]
     },
     {
         "name": "hitotsu",
         "trans": [
+            "一(ひと)つ",
             "② 名  一个；一岁"
-        ],
-        "notation": "一(ひと)つ"
+        ]
     },
     {
         "name": "kyuushoku",
         "trans": [
+            "給食(きゅうしょく)",
             "⓪ 名·自动3  提供伙食"
-        ],
-        "notation": "給食(きゅうしょく)"
+        ]
     },
     {
         "name": "nakama",
         "trans": [
+            "仲間(なかま)",
             "③ 名  伙伴，同志"
-        ],
-        "notation": "仲間(なかま)"
+        ]
     },
     {
         "name": "pasupo-to",
         "trans": [
+            "パスポート",
             "③ 名  护照"
-        ],
-        "notation": "パスポート"
+        ]
     },
     {
         "name": "maiasa",
         "trans": [
+            "毎朝(まいあさ)",
             "① 名  每天早晨"
-        ],
-        "notation": "毎朝(まいあさ)"
+        ]
     },
     {
         "name": "noboru",
         "trans": [
+            "登(のぼ)る",
             "⓪ 自动1  攀登；上升"
-        ],
-        "notation": "登(のぼ)る"
+        ]
     },
     {
         "name": "reji/rejisuta-",
         "trans": [
+            "レジ/レジスター",
             "① 名  收款台；收银员"
-        ],
-        "notation": "レジ/レジスター"
+        ]
     },
     {
         "name": "pe-ji",
         "trans": [
+            "ページ",
             "⓪ 名  页，页数"
-        ],
-        "notation": "ページ"
+        ]
     },
     {
         "name": "seito",
         "trans": [
+            "生徒(せいと)",
             "① 名  （初、高中）学生"
-        ],
-        "notation": "生徒(せいと)"
+        ]
     },
     {
         "name": "panfuretto",
         "trans": [
+            "パンフレット",
             "① 名  小册子"
-        ],
-        "notation": "パンフレット"
+        ]
     },
     {
         "name": "hare",
         "trans": [
+            "晴(は)れ",
             "② 名  晴天"
-        ],
-        "notation": "晴(は)れ"
+        ]
     },
     {
         "name": "yobu",
         "trans": [
+            "呼(よ)ぶ",
             "⓪ 他动1  叫；呼唤"
-        ],
-        "notation": "呼(よ)ぶ"
+        ]
     },
     {
         "name": "kousaten",
         "trans": [
+            "交差点(こうさてん)",
             "⓪ 名  十字路口"
-        ],
-        "notation": "交差点(こうさてん)"
+        ]
     },
     {
         "name": "mijikai",
         "trans": [
+            "短(みじか)い",
             "③ イ形  短的；短暂的"
-        ],
-        "notation": "短(みじか)い"
+        ]
     },
     {
         "name": "kudamono",
         "trans": [
+            "果物(くだもの)",
             "② 名  水果"
-        ],
-        "notation": "果物(くだもの)"
+        ]
     },
     {
         "name": "souji",
         "trans": [
+            "掃除(そうじ)",
             "⓪ 名·他动3  扫除，清扫"
-        ],
-        "notation": "掃除(そうじ)"
+        ]
     },
     {
         "name": "tsugi",
         "trans": [
+            "次(つぎ)",
             "② 名  下一个，下面"
-        ],
-        "notation": "次(つぎ)"
+        ]
     },
     {
         "name": "yasai",
         "trans": [
+            "野菜(やさい)",
             "⓪ 名  蔬菜"
-        ],
-        "notation": "野菜(やさい)"
+        ]
     },
     {
         "name": "kyouju",
         "trans": [
+            "教授(きょうじゅ)",
             "⓪ 名·他动3  教授；传授，教学"
-        ],
-        "notation": "教授(きょうじゅ)"
+        ]
     },
     {
         "name": "fuben",
         "trans": [
+            "不便(ふべん)",
             "① 名·ナ形  不方便，不便"
-        ],
-        "notation": "不便(ふべん)"
+        ]
     },
     {
         "name": "hanashi",
         "trans": [
+            "話(はなし)",
             "③ 名  话，说话，讲话"
-        ],
-        "notation": "話(はなし)"
+        ]
     },
     {
         "name": "gekijou",
         "trans": [
+            "劇場(げきじょう)",
             "⓪ 名  剧场，剧院"
-        ],
-        "notation": "劇場(げきじょう)"
+        ]
     },
     {
         "name": "hanbun",
         "trans": [
+            "半分(はんぶん)",
             "③ 名  一半"
-        ],
-        "notation": "半分(はんぶん)"
+        ]
     },
     {
         "name": "shi-zun",
         "trans": [
+            "シーズン",
             "① 名  季节；旺季"
-        ],
-        "notation": "シーズン"
+        ]
     },
     {
         "name": "konshuu",
         "trans": [
+            "今週(こんしゅう)",
             "⓪ 名  这周，本周"
-        ],
-        "notation": "今週(こんしゅう)"
+        ]
     },
     {
         "name": "renshuu",
         "trans": [
+            "練習(れんしゅう)",
             "⓪ 名·他动3  练习，训练"
-        ],
-        "notation": "練習(れんしゅう)"
+        ]
     },
     {
         "name": "kin",
         "trans": [
+            "金(きん)",
             "① 名  黄金；金属；金钱"
-        ],
-        "notation": "金(きん)"
+        ]
     },
     {
         "name": "ko-su",
         "trans": [
+            "コース",
             "① 名  路线；课程"
-        ],
-        "notation": "コース"
+        ]
     },
     {
         "name": "yasumu",
         "trans": [
+            "休(やす)む",
             "② 自动1  休息；请假"
-        ],
-        "notation": "休(やす)む"
+        ]
     },
     {
         "name": "hana",
         "trans": [
+            "鼻(はな)",
             "⓪ 名  鼻子"
-        ],
-        "notation": "鼻(はな)"
+        ]
     },
     {
         "name": "bengoshi",
         "trans": [
+            "弁護士(べんごし)",
             "③ 名  律师"
-        ],
-        "notation": "弁護士(べんごし)"
+        ]
     },
     {
         "name": "tatami",
         "trans": [
+            "畳(たたみ)",
             "⓪ 名  草席"
-        ],
-        "notation": "畳(たたみ)"
+        ]
     },
     {
         "name": "posuta-",
         "trans": [
+            "ポスター",
             "① 名  海报，宣传画"
-        ],
-        "notation": "ポスター"
+        ]
     },
     {
         "name": "kokonoka",
         "trans": [
+            "九日(ここのか)",
             "④ 名  九号；九天"
-        ],
-        "notation": "九日(ここのか)"
+        ]
     },
     {
         "name": "miseru",
         "trans": [
+            "見(み)せる",
             "② 他动2  让（别人）看，展示"
-        ],
-        "notation": "見(み)せる"
+        ]
     },
     {
         "name": "kuni",
         "trans": [
+            "国(くに)",
             "⓪ 名  国家；故乡"
-        ],
-        "notation": "国(くに)"
+        ]
     },
     {
         "name": "bo-nasu",
         "trans": [
+            "ボーナス",
             "① 名  奖金，额外津贴"
-        ],
-        "notation": "ボーナス"
+        ]
     },
     {
         "name": "ochiru",
         "trans": [
+            "落(お)ちる",
             "② 自动2  掉，落"
-        ],
-        "notation": "落(お)ちる"
+        ]
     },
     {
         "name": "boku",
         "trans": [
+            "僕(ぼく)",
             "① 代  （男性自称）我"
-        ],
-        "notation": "僕(ぼく)"
+        ]
     },
     {
         "name": "yakyuu",
         "trans": [
+            "野球(やきゅう)",
             "⓪ 名  棒球"
-        ],
-        "notation": "野球(やきゅう)"
+        ]
     },
     {
         "name": "hito",
         "trans": [
+            "人(ひと)",
             "⓪ 名  人；别人；人手"
-        ],
-        "notation": "人(ひと)"
+        ]
     },
     {
         "name": "kekkon",
         "trans": [
+            "結婚(けっこん)",
             "⓪ 名·自动3  结婚"
-        ],
-        "notation": "結婚(けっこん)"
+        ]
     },
     {
         "name": "badominton",
         "trans": [
+            "バドミントン",
             "③ 名  羽毛球"
-        ],
-        "notation": "バドミントン"
+        ]
     },
     {
         "name": "asu",
         "trans": [
+            "明日(あす)",
             "⓪ 名  明天；将来"
-        ],
-        "notation": "明日(あす)"
+        ]
     },
     {
         "name": "bukatsu",
         "trans": [
+            "部活(ぶかつ)",
             "⓪ 名  社团活动"
-        ],
-        "notation": "部活(ぶかつ)"
+        ]
     },
     {
         "name": "umi",
         "trans": [
+            "海(うみ)",
             "① 名  海洋"
-        ],
-        "notation": "海(うみ)"
+        ]
     },
     {
         "name": "kuruma",
         "trans": [
+            "車(くるま)",
             "⓪ 名  车，汽车"
-        ],
-        "notation": "車(くるま)"
+        ]
     },
     {
         "name": "sandoicchi",
         "trans": [
+            "サンドイッチ",
             "④ 名  三明治"
-        ],
-        "notation": "サンドイッチ"
+        ]
     },
     {
         "name": "tsuku",
         "trans": [
+            "付(つ)く",
             "① 自动1  附着，粘上；跟着"
-        ],
-        "notation": "付(つ)く"
+        ]
     },
     {
         "name": "kita",
         "trans": [
+            "北(きた)",
             "⓪ 名  北，北边"
-        ],
-        "notation": "北(きた)"
+        ]
     },
     {
         "name": "miai",
         "trans": [
+            "見合(みあ)い",
             "⓪ 名·自动3  相亲"
-        ],
-        "notation": "見合(みあ)い"
+        ]
     },
     {
         "name": "koukuubin",
         "trans": [
+            "航空便(こうくうびん)",
             "⓪ 名  空运"
-        ],
-        "notation": "航空便(こうくうびん)"
+        ]
     },
     {
         "name": "fakkusu",
         "trans": [
+            "ファックス",
             "① 名  传真"
-        ],
-        "notation": "ファックス"
+        ]
     },
     {
         "name": "hakkiri",
         "trans": [
+            "はっきり",
             "③ 副  清楚地，明确地"
-        ],
-        "notation": "はっきり"
+        ]
     },
     {
         "name": "kondo",
         "trans": [
+            "今度(こんど)",
             "① 名  这次；下次"
-        ],
-        "notation": "今度(こんど)"
+        ]
     },
     {
         "name": "te-pu",
         "trans": [
+            "テープ",
             "① 名  磁带，录音带"
-        ],
-        "notation": "テープ"
+        ]
     },
     {
         "name": "keibi",
         "trans": [
+            "警備(けいび)",
             "① 名·他动3  警戒，警备"
-        ],
-        "notation": "警備(けいび)"
+        ]
     },
     {
         "name": "bessou",
         "trans": [
+            "別荘(べっそう)",
             "③ 名  别墅"
-        ],
-        "notation": "別荘(べっそう)"
+        ]
     },
     {
         "name": "konbini",
         "trans": [
+            "コンビニ",
             "⓪ 名  便利店"
-        ],
-        "notation": "コンビニ"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "勤(つと)める",
             "③ 自动2  工作，任职"
-        ],
-        "notation": "勤(つと)める"
+        ]
     },
     {
         "name": "moyou",
         "trans": [
+            "模様(もよう)",
             "⓪ 名  花纹，花样；样子"
-        ],
-        "notation": "模様(もよう)"
+        ]
     },
     {
         "name": "kenchiku",
         "trans": [
+            "建築(けんちく)",
             "⓪ 名·他动3  建筑，建造"
-        ],
-        "notation": "建築(けんちく)"
+        ]
     },
     {
         "name": "tokoro",
         "trans": [
+            "所(ところ)",
             "⓪ 名  场所，地方"
-        ],
-        "notation": "所(ところ)"
+        ]
     },
     {
         "name": "sugu",
         "trans": [
+            "すぐ",
             "① 副  立刻，马上"
-        ],
-        "notation": "すぐ"
+        ]
     },
     {
         "name": "kinenhin",
         "trans": [
+            "記念品(きねんひん)",
             "⓪ 名  纪念品"
-        ],
-        "notation": "記念品(きねんひん)"
+        ]
     },
     {
         "name": "nichijou",
         "trans": [
+            "日常(にちじょう)",
             "⓪ 名  日常，平时"
-        ],
-        "notation": "日常(にちじょう)"
+        ]
     },
     {
         "name": "hareru",
         "trans": [
+            "晴(は)れる",
             "② 自动2  （天气）放晴；（疑惑）消散"
-        ],
-        "notation": "晴(は)れる"
+        ]
     },
     {
         "name": "~satsu",
         "trans": [
+            "～冊(さつ)",
             " 接尾  （书、本等）册，本"
-        ],
-        "notation": "～冊(さつ)"
+        ]
     },
     {
         "name": "shio",
         "trans": [
+            "塩(しお)",
             "② 名  食盐"
-        ],
-        "notation": "塩(しお)"
+        ]
     },
     {
         "name": "kurasu",
         "trans": [
+            "クラス",
             "① 名  班级；等级"
-        ],
-        "notation": "クラス"
+        ]
     },
     {
         "name": "macchi",
         "trans": [
+            "マッチ",
             "① 名·自动3  火柴；相称"
-        ],
-        "notation": "マッチ"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "三(さん)",
             "⓪ 数  三"
-        ],
-        "notation": "三(さん)"
+        ]
     },
     {
         "name": "zenbu",
         "trans": [
+            "全部(ぜんぶ)",
             "① 名·副  全部"
-        ],
-        "notation": "全部(ぜんぶ)"
+        ]
     },
     {
         "name": "hoteru",
         "trans": [
+            "ホテル",
             "① 名  （西式）宾馆，酒店"
-        ],
-        "notation": "ホテル"
+        ]
     },
     {
         "name": "sanpo",
         "trans": [
+            "散歩(さんぽ)",
             "⓪ 名·自动3  散步"
-        ],
-        "notation": "散歩(さんぽ)"
+        ]
     },
     {
         "name": "jinja",
         "trans": [
+            "神社(じんじゃ)",
             "① 名  神社"
-        ],
-        "notation": "神社(じんじゃ)"
+        ]
     },
     {
         "name": "burando",
         "trans": [
+            "ブランド",
             "⓪ 名  商标，品牌"
-        ],
-        "notation": "ブランド"
+        ]
     },
     {
         "name": "kiru",
         "trans": [
+            "切(き)る",
             "① 他动1  切，切开；断绝"
-        ],
-        "notation": "切(き)る"
+        ]
     },
     {
         "name": "mae",
         "trans": [
+            "前(まえ)",
             "① 名  （空间）前面；（时间）之前"
-        ],
-        "notation": "前(まえ)"
+        ]
     },
     {
         "name": "ko-to",
         "trans": [
+            "コート",
             "① 名  大衣，外套"
-        ],
-        "notation": "コート"
+        ]
     },
     {
         "name": "toshi",
         "trans": [
+            "年(とし)",
             "② 名  年；年龄，岁数"
-        ],
-        "notation": "年(とし)"
+        ]
     },
     {
         "name": "yasashii",
         "trans": [
+            "優(やさ)しい",
             "③ イ形  温柔的；柔和的"
-        ],
-        "notation": "優(やさ)しい"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "寮(りょう)",
             "① 名  宿舍"
-        ],
-        "notation": "寮(りょう)"
+        ]
     },
     {
         "name": "shiyou",
         "trans": [
+            "使用(しよう)",
             "⓪ 名·他动3  使用，利用"
-        ],
-        "notation": "使用(しよう)"
+        ]
     },
     {
         "name": "youfuku",
         "trans": [
+            "洋服(ようふく)",
             "⓪ 名  西服，西装"
-        ],
-        "notation": "洋服(ようふく)"
+        ]
     },
     {
         "name": "koubutsu",
         "trans": [
+            "好物(こうぶつ)",
             "① 名  爱吃的东西；喜欢的东西"
-        ],
-        "notation": "好物(こうぶつ)"
+        ]
     },
     {
         "name": "momiji",
         "trans": [
+            "紅葉(もみじ)",
             "① 名  枫叶"
-        ],
-        "notation": "紅葉(もみじ)"
+        ]
     },
     {
         "name": "kopi-",
         "trans": [
+            "コピー",
             "① 名·他动3  复印"
-        ],
-        "notation": "コピー"
+        ]
     },
     {
         "name": "chikatetsu",
         "trans": [
+            "地下鉄(ちかてつ)",
             "⓪ 名  地铁"
-        ],
-        "notation": "地下鉄(ちかてつ)"
+        ]
     },
     {
         "name": "fukai",
         "trans": [
+            "深(ふか)い",
             "② イ形  深的；（颜色、程度等）深的，浓的"
-        ],
-        "notation": "深(ふか)い"
+        ]
     },
     {
         "name": "futari",
         "trans": [
+            "二人(ふたり)",
             "③ 名  两个人"
-        ],
-        "notation": "二人(ふたり)"
+        ]
     },
     {
         "name": "mana-",
         "trans": [
+            "マナー",
             "① 名  礼节，规矩；礼貌"
-        ],
-        "notation": "マナー"
+        ]
     },
     {
         "name": "tsukau",
         "trans": [
+            "使(つか)う",
             "⓪ 他动1  使用"
-        ],
-        "notation": "使(つか)う"
+        ]
     },
     {
         "name": "nimotsu",
         "trans": [
+            "荷物(にもつ)",
             "① 名  行李"
-        ],
-        "notation": "荷物(にもつ)"
+        ]
     },
     {
         "name": "go-ru",
         "trans": [
+            "ゴール",
             "① 名  终点；目标"
-        ],
-        "notation": "ゴール"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "吹(ふ)く",
             "① 自他动1  吹；吹奏"
-        ],
-        "notation": "吹(ふ)く"
+        ]
     },
     {
         "name": "kouban",
         "trans": [
+            "交番(こうばん)",
             "⓪ 名  派出所"
-        ],
-        "notation": "交番(こうばん)"
+        ]
     },
     {
         "name": "petto",
         "trans": [
+            "ペット",
             "① 名  宠物"
-        ],
-        "notation": "ペット"
+        ]
     },
     {
         "name": "shokuji",
         "trans": [
+            "食事(しょくじ)",
             "⓪ 名·自动3  吃饭，进餐"
-        ],
-        "notation": "食事(しょくじ)"
+        ]
     },
     {
         "name": "ki",
         "trans": [
+            "木(き)",
             "① 名  树；木头"
-        ],
-        "notation": "木(き)"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "引(ひ)く",
             "⓪ 他动1  拉，拽；引起；吸引"
-        ],
-        "notation": "引(ひ)く"
+        ]
     },
     {
         "name": "yobikou",
         "trans": [
+            "予備校(よびこう)",
             "⓪ 名  补习学校"
-        ],
-        "notation": "予備校(よびこう)"
+        ]
     },
     {
         "name": "genkou",
         "trans": [
+            "原稿(げんこう)",
             "⓪ 名  原稿，草稿"
-        ],
-        "notation": "原稿(げんこう)"
+        ]
     },
     {
         "name": "bo-to",
         "trans": [
+            "ボート",
             "① 名  小船，船"
-        ],
-        "notation": "ボート"
+        ]
     },
     {
         "name": "kotoba",
         "trans": [
+            "言葉(ことば)",
             "③ 名  话，语言；说法，措辞"
-        ],
-        "notation": "言葉(ことば)"
+        ]
     },
     {
         "name": "morau",
         "trans": [
+            "もらう",
             "⓪ 他动1  得到，接受"
-        ],
-        "notation": "もらう"
+        ]
     },
     {
         "name": "kayoubi",
         "trans": [
+            "火曜日(かようび)",
             "② 名  星期二"
-        ],
-        "notation": "火曜日(かようび)"
+        ]
     },
     {
         "name": "rajio",
         "trans": [
+            "ラジオ",
             "① 名  收音机，广播"
-        ],
-        "notation": "ラジオ"
+        ]
     },
     {
         "name": "kitte",
         "trans": [
+            "切手(きって)",
             "⓪ 名  邮票"
-        ],
-        "notation": "切手(きって)"
+        ]
     },
     {
         "name": "reberu",
         "trans": [
+            "レベル",
             "① 名  水准，水平"
-        ],
-        "notation": "レベル"
+        ]
     },
     {
         "name": "satou",
         "trans": [
+            "砂糖(さとう)",
             "② 名  糖，砂糖"
-        ],
-        "notation": "砂糖(さとう)"
+        ]
     },
     {
         "name": "tsukuru",
         "trans": [
+            "作(つく)る",
             "② 他动1  做，制作；创作"
-        ],
-        "notation": "作(つく)る"
+        ]
     },
     {
         "name": "kutsu",
         "trans": [
+            "靴(くつ)",
             "② 名  鞋子"
-        ],
-        "notation": "靴(くつ)"
+        ]
     },
     {
         "name": "denwa",
         "trans": [
+            "電話(でんわ)",
             "⓪ 名·自动3  电话；打电话"
-        ],
-        "notation": "電話(でんわ)"
+        ]
     },
     {
         "name": "konpyu-ta-",
         "trans": [
+            "コンピューター",
             "③ 名  电脑，计算机"
-        ],
-        "notation": "コンピューター"
+        ]
     },
     {
         "name": "ronbun",
         "trans": [
+            "論文(ろんぶん)",
             "⓪ 名  论文"
-        ],
-        "notation": "論文(ろんぶん)"
+        ]
     },
     {
         "name": "~toshi",
         "trans": [
+            "～歳(とし)",
             " 接尾  ……岁"
-        ],
-        "notation": "～歳(とし)"
+        ]
     },
     {
         "name": "me",
         "trans": [
+            "目(め)",
             "① 名  眼睛；眼神"
-        ],
-        "notation": "目(め)"
+        ]
     },
     {
         "name": "posuto",
         "trans": [
+            "ポスト",
             "① 名  邮筒，信箱"
-        ],
-        "notation": "ポスト"
+        ]
     },
     {
         "name": "kikoku",
         "trans": [
+            "帰国(きこく)",
             "⓪ 名·自动3  回国"
-        ],
-        "notation": "帰国(きこく)"
+        ]
     },
     {
         "name": "yuumei",
         "trans": [
+            "有名(ゆうめい)",
             "⓪ 名·ナ形  有名"
-        ],
-        "notation": "有名(ゆうめい)"
+        ]
     },
     {
         "name": "koe",
         "trans": [
+            "声(こえ)",
             "① 名  （人或动物发出的）声音"
-        ],
-        "notation": "声(こえ)"
+        ]
     },
     {
         "name": "menba-",
         "trans": [
+            "メンバー",
             "① 名  成员"
-        ],
-        "notation": "メンバー"
+        ]
     },
     {
         "name": "hakubutsukan",
         "trans": [
+            "博物館(はくぶつかん)",
             "④ 名  博物馆"
-        ],
-        "notation": "博物館(はくぶつかん)"
+        ]
     },
     {
         "name": "kesa",
         "trans": [
+            "今朝(けさ)",
             "① 名  今天早晨"
-        ],
-        "notation": "今朝(けさ)"
+        ]
     },
     {
         "name": "genkan",
         "trans": [
+            "玄関(げんかん)",
             "① 名  玄关，门口"
-        ],
-        "notation": "玄関(げんかん)"
+        ]
     },
     {
         "name": "daibingu",
         "trans": [
+            "ダイビング",
             "① 名·自动3  潜水"
-        ],
-        "notation": "ダイビング"
+        ]
     },
     {
         "name": "youji",
         "trans": [
+            "幼児(ようじ)",
             "① 名  幼儿"
-        ],
-        "notation": "幼児(ようじ)"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "橋(はし)",
             "② 名  桥"
-        ],
-        "notation": "橋(はし)"
+        ]
     },
     {
         "name": "biyouin",
         "trans": [
+            "美容院(びよういん)",
             "② 名  美容院，理发馆"
-        ],
-        "notation": "美容院(びよういん)"
+        ]
     },
     {
         "name": "botan",
         "trans": [
+            "ボタン",
             "⓪ 名  纽扣；按钮"
-        ],
-        "notation": "ボタン"
+        ]
     },
     {
         "name": "kousui",
         "trans": [
+            "香水(こうすい)",
             "⓪ 名  香水"
-        ],
-        "notation": "香水(こうすい)"
+        ]
     },
     {
         "name": "wasureru",
         "trans": [
+            "忘(わす)れる",
             "⓪ 他动2  忘记，遗忘"
-        ],
-        "notation": "忘(わす)れる"
+        ]
     },
     {
         "name": "saigo",
         "trans": [
+            "最後(さいご)",
             "① 名  最后，最终"
-        ],
-        "notation": "最後(さいご)"
+        ]
     },
     {
         "name": "ma-ku",
         "trans": [
+            "マーク",
             "① 名·他动3  标记；做标记"
-        ],
-        "notation": "マーク"
+        ]
     },
     {
         "name": "kusuri",
         "trans": [
+            "薬(くすり)",
             "⓪ 名  药，药物"
-        ],
-        "notation": "薬(くすり)"
+        ]
     },
     {
         "name": "waribiki",
         "trans": [
+            "割引(わりびき)",
             "⓪ 名·他动3  折扣，打折"
-        ],
-        "notation": "割引(わりびき)"
+        ]
     },
     {
         "name": "hoka",
         "trans": [
+            "他(ほか)",
             "⓪ 名  其他"
-        ],
-        "notation": "他(ほか)"
+        ]
     },
     {
         "name": "pointo",
         "trans": [
+            "ポイント",
             "⓪ 名  积分；要点"
-        ],
-        "notation": "ポイント"
+        ]
     },
     {
         "name": "shitsudo",
         "trans": [
+            "湿度(しつど)",
             "② 名  湿度"
-        ],
-        "notation": "湿度(しつど)"
+        ]
     },
     {
         "name": "hangaku",
         "trans": [
+            "半額(はんがく)",
             "⓪ 名  半价"
-        ],
-        "notation": "半額(はんがく)"
+        ]
     },
     {
         "name": "wakai",
         "trans": [
+            "若(わか)い",
             "② イ形  年轻的"
-        ],
-        "notation": "若(わか)い"
+        ]
     },
     {
         "name": "kongetsu",
         "trans": [
+            "今月(こんげつ)",
             "⓪ 名  本月，这个月"
-        ],
-        "notation": "今月(こんげつ)"
+        ]
     },
     {
         "name": "beddo",
         "trans": [
+            "ベッド",
             "① 名  床"
-        ],
-        "notation": "ベッド"
+        ]
     },
     {
         "name": "suteru",
         "trans": [
+            "捨(す)てる",
             "⓪ 他动2  扔掉，丢弃"
-        ],
-        "notation": "捨(す)てる"
+        ]
     },
     {
         "name": "zasshi",
         "trans": [
+            "雑誌(ざっし)",
             "⓪ 名  杂志"
-        ],
-        "notation": "雑誌(ざっし)"
+        ]
     },
     {
         "name": "chansu",
         "trans": [
+            "チャンス",
             "① 名  机会"
-        ],
-        "notation": "チャンス"
+        ]
     },
     {
         "name": "shumi",
         "trans": [
+            "趣味(しゅみ)",
             "① 名  爱好，喜好"
-        ],
-        "notation": "趣味(しゅみ)"
+        ]
     },
     {
         "name": "sentaku",
         "trans": [
+            "洗濯(せんたく)",
             "⓪ 名·他动3  洗，洗衣服"
-        ],
-        "notation": "洗濯(せんたく)"
+        ]
     },
     {
         "name": "shiruku",
         "trans": [
+            "シルク",
             "① 名  丝绸"
-        ],
-        "notation": "シルク"
+        ]
     },
     {
         "name": "hon",
         "trans": [
+            "本(ほん)",
             "① 名  书"
-        ],
-        "notation": "本(ほん)"
+        ]
     },
     {
         "name": "shouhin",
         "trans": [
+            "商品(しょうひん)",
             "① 名  商品"
-        ],
-        "notation": "商品(しょうひん)"
+        ]
     },
     {
         "name": "miokuri",
         "trans": [
+            "見送(みおく)り",
             "⓪ 名  送行"
-        ],
-        "notation": "見送(みおく)り"
+        ]
     },
     {
         "name": "setto",
         "trans": [
+            "セット",
             "① 名  一套，一组"
-        ],
-        "notation": "セット"
+        ]
     },
     {
         "name": "joushi",
         "trans": [
+            "上司(じょうし)",
             "① 名  上司，上级"
-        ],
-        "notation": "上司(じょうし)"
+        ]
     },
     {
         "name": "tori",
         "trans": [
+            "鳥(とり)",
             "⓪ 名  鸟，鸟类"
-        ],
-        "notation": "鳥(とり)"
+        ]
     },
     {
         "name": "~ya",
         "trans": [
+            "～屋(や)",
             " 接尾  ……店；容易……的人"
-        ],
-        "notation": "～屋(や)"
+        ]
     },
     {
         "name": "taishi",
         "trans": [
+            "大使(たいし)",
             "① 名  大使"
-        ],
-        "notation": "大使(たいし)"
+        ]
     },
     {
         "name": "ho-mushikku",
         "trans": [
+            "ホームシック",
             "④ 名  思乡"
-        ],
-        "notation": "ホームシック"
+        ]
     },
     {
         "name": "shukudai",
         "trans": [
+            "宿題(しゅくだい)",
             "⓪ 名  作业"
-        ],
-        "notation": "宿題(しゅくだい)"
+        ]
     },
     {
         "name": "mado",
         "trans": [
+            "窓(まど)",
             "① 名  窗户，窗子"
-        ],
-        "notation": "窓(まど)"
+        ]
     },
     {
         "name": "supu-n",
         "trans": [
+            "スプーン",
             "② 名  汤匙，勺子"
-        ],
-        "notation": "スプーン"
+        ]
     },
     {
         "name": "nihon",
         "trans": [
+            "日本(にほん)",
             "② 名  日本"
-        ],
-        "notation": "日本(にほん)"
+        ]
     },
     {
         "name": "saku",
         "trans": [
+            "咲(さ)く",
             "⓪ 自动1  开（花）"
-        ],
-        "notation": "咲(さ)く"
+        ]
     },
     {
         "name": "shuumatsu",
         "trans": [
+            "週末(しゅうまつ)",
             "⓪ 名  周末"
-        ],
-        "notation": "週末(しゅうまつ)"
+        ]
     },
     {
         "name": "shinkansen",
         "trans": [
+            "新幹線(しんかんせん)",
             "③ 名  新干线"
-        ],
-        "notation": "新幹線(しんかんせん)"
+        ]
     },
     {
         "name": "hora-",
         "trans": [
+            "ホラー",
             "① 名  恐怖"
-        ],
-        "notation": "ホラー"
+        ]
     },
     {
         "name": "shujin",
         "trans": [
+            "主人(しゅじん)",
             "① 名  主人；丈夫"
-        ],
-        "notation": "主人(しゅじん)"
+        ]
     },
     {
         "name": "memo",
         "trans": [
+            "メモ",
             "① 名·他动3  笔记；做笔记"
-        ],
-        "notation": "メモ"
+        ]
     },
     {
         "name": "shokudou",
         "trans": [
+            "食堂(しょくどう)",
             "⓪ 名  食堂"
-        ],
-        "notation": "食堂(しょくどう)"
+        ]
     },
     {
         "name": "megane",
         "trans": [
+            "眼鏡(めがね)",
             "① 名  眼镜"
-        ],
-        "notation": "眼鏡(めがね)"
+        ]
     },
     {
         "name": "sekken",
         "trans": [
+            "石(せっ)けん",
             "⓪ 名  肥皂"
-        ],
-        "notation": "石(せっ)けん"
+        ]
     },
     {
         "name": "~mai",
         "trans": [
+            "～枚(まい)",
             " 接尾  （薄片状物体）片，枚，张"
-        ],
-        "notation": "～枚(まい)"
+        ]
     },
     {
         "name": "igirisu",
         "trans": [
+            "イギリス",
             "⓪ 名  英国"
-        ],
-        "notation": "イギリス"
+        ]
     },
     {
         "name": "niwa",
         "trans": [
+            "庭(にわ)",
             "⓪ 名  院子，庭园"
-        ],
-        "notation": "庭(にわ)"
+        ]
     },
     {
         "name": "bunshou",
         "trans": [
+            "文章(ぶんしょう)",
             "① 名  文章"
-        ],
-        "notation": "文章(ぶんしょう)"
+        ]
     },
     {
         "name": "saiko",
         "trans": [
+            "最古(さいこ)",
             "① 名  最早，最古老"
-        ],
-        "notation": "最古(さいこ)"
+        ]
     },
     {
         "name": "hataraku",
         "trans": [
+            "働(はたら)く",
             "⓪ 自动1  工作；起作用"
-        ],
-        "notation": "働(はたら)く"
+        ]
     },
     {
         "name": "koukou",
         "trans": [
+            "高校(こうこう)",
             "⓪ 名  高中"
-        ],
-        "notation": "高校(こうこう)"
+        ]
     },
     {
         "name": "ryoushin",
         "trans": [
+            "両親(りょうしん)",
             "① 名  父母，双亲"
-        ],
-        "notation": "両親(りょうしん)"
+        ]
     },
     {
         "name": "setsubun",
         "trans": [
+            "節分(せつぶん)",
             "⓪ 名  立春、立夏、立秋、立冬的前一天；（特指）立春的前一天"
-        ],
-        "notation": "節分(せつぶん)"
+        ]
     },
     {
         "name": "rouka",
         "trans": [
+            "廊下(ろうか)",
             "⓪ 名  走廊，过道"
-        ],
-        "notation": "廊下(ろうか)"
+        ]
     },
     {
         "name": "shimekiri",
         "trans": [
+            "締(し)め切(き)り",
             "⓪ 名  截止日期"
-        ],
-        "notation": "締(し)め切(き)り"
+        ]
     },
     {
         "name": "toho",
         "trans": [
+            "徒歩(とほ)",
             "① 名  徒步"
-        ],
-        "notation": "徒歩(とほ)"
+        ]
     },
     {
         "name": "gogo",
         "trans": [
+            "午後(ごご)",
             "① 名  下午，午后"
-        ],
-        "notation": "午後(ごご)"
+        ]
     },
     {
         "name": "nyuugakushiki",
         "trans": [
+            "入学式(にゅうがくしき)",
             "④ 名  开学典礼"
-        ],
-        "notation": "入学式(にゅうがくしき)"
+        ]
     },
     {
         "name": "soba",
         "trans": [
+            "傍(そば)",
             "① 名  旁边，附近"
-        ],
-        "notation": "傍(そば)"
+        ]
     },
     {
         "name": "sumu",
         "trans": [
+            "住(す)む",
             "① 自动1  住，居住"
-        ],
-        "notation": "住(す)む"
+        ]
     },
     {
         "name": "chuuka",
         "trans": [
+            "中華(ちゅうか)",
             "① 名  中华，中国"
-        ],
-        "notation": "中華(ちゅうか)"
+        ]
     },
     {
         "name": "bounenkai",
         "trans": [
+            "忘年会(ぼうねんかい)",
             "③ 名  忘年会，年末聚会"
-        ],
-        "notation": "忘年会(ぼうねんかい)"
+        ]
     },
     {
         "name": "shigoto",
         "trans": [
+            "仕事(しごと)",
             "⓪ 名  工作，职业"
-        ],
-        "notation": "仕事(しごと)"
+        ]
     },
     {
         "name": "yuugata",
         "trans": [
+            "夕方(ゆうがた)",
             "⓪ 名  黄昏，傍晚"
-        ],
-        "notation": "夕方(ゆうがた)"
+        ]
     },
     {
         "name": "jikou",
         "trans": [
+            "事項(じこう)",
             "① 名  事项，项目"
-        ],
-        "notation": "事項(じこう)"
+        ]
     },
     {
         "name": "neko",
         "trans": [
+            "猫(ねこ)",
             "① 名  猫"
-        ],
-        "notation": "猫(ねこ)"
+        ]
     },
     {
         "name": "tokei",
         "trans": [
+            "時計(とけい)",
             "⓪ 名  时钟，钟表"
-        ],
-        "notation": "時計(とけい)"
+        ]
     },
     {
         "name": "genkin",
         "trans": [
+            "現金(げんきん)",
             "③ 名  现金"
-        ],
-        "notation": "現金(げんきん)"
+        ]
     },
     {
         "name": "shinbun",
         "trans": [
+            "新聞(しんぶん)",
             "⓪ 名  报纸"
-        ],
-        "notation": "新聞(しんぶん)"
+        ]
     },
     {
         "name": "hikouki",
         "trans": [
+            "飛行機(ひこうき)",
             "② 名  飞机"
-        ],
-        "notation": "飛行機(ひこうき)"
+        ]
     },
     {
         "name": "mizu",
         "trans": [
+            "水(みず)",
             "⓪ 名  水，凉水"
-        ],
-        "notation": "水(みず)"
+        ]
     },
     {
         "name": "rekishi",
         "trans": [
+            "歴史(れきし)",
             "⓪ 名  历史"
-        ],
-        "notation": "歴史(れきし)"
+        ]
     },
     {
         "name": "chichi",
         "trans": [
+            "父(ちち)",
             "① 名  爸爸"
-        ],
-        "notation": "父(ちち)"
+        ]
     },
     {
         "name": "mayou",
         "trans": [
+            "迷(まよ)う",
             "② 自动1  迷路，迷失；犹豫"
-        ],
-        "notation": "迷(まよ)う"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "件(けん)",
             "① 名  事情，事件"
-        ],
-        "notation": "件(けん)"
+        ]
     },
     {
         "name": "denki",
         "trans": [
+            "電気(でんき)",
             "① 名  电流，电气；电灯"
-        ],
-        "notation": "電気(でんき)"
+        ]
     },
     {
         "name": "yukata",
         "trans": [
+            "浴衣(ゆかた)",
             "⓪ 名  夏季穿的简易和服"
-        ],
-        "notation": "浴衣(ゆかた)"
+        ]
     },
     {
         "name": "sakana",
         "trans": [
+            "魚(さかな)",
             "⓪ 名  鱼"
-        ],
-        "notation": "魚(さかな)"
+        ]
     },
     {
         "name": "namae",
         "trans": [
+            "名前(なまえ)",
             "⓪ 名  名字"
-        ],
-        "notation": "名前(なまえ)"
+        ]
     },
     {
         "name": "mayu",
         "trans": [
+            "眉(まゆ)",
             "① 名  眉毛"
-        ],
-        "notation": "眉(まゆ)"
+        ]
     },
     {
         "name": "higashi",
         "trans": [
+            "東(ひがし)",
             "⓪ 名  东，东方"
-        ],
-        "notation": "東(ひがし)"
+        ]
     },
     {
         "name": "niji",
         "trans": [
+            "虹(にじ)",
             "⓪ 名  彩虹"
-        ],
-        "notation": "虹(にじ)"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "合(あ)う",
             "① 自动1  合适，一致；协调，相称"
-        ],
-        "notation": "合(あ)う"
+        ]
     },
     {
         "name": "mukou",
         "trans": [
+            "向(む)こう",
             "② 名  对面；对方"
-        ],
-        "notation": "向(む)こう"
+        ]
     },
     {
         "name": "abunai",
         "trans": [
+            "危(あぶ)ない",
             "⓪ イ形  危险的"
-        ],
-        "notation": "危(あぶ)ない"
+        ]
     },
     {
         "name": "sora",
         "trans": [
+            "空(そら)",
             "① 名  天空；天气"
-        ],
-        "notation": "空(そら)"
+        ]
     },
     {
         "name": "kawaisou",
         "trans": [
+            "かわいそう",
             "④ ナ形  可怜的"
-        ],
-        "notation": "かわいそう"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "歯(は)",
             "① 名  牙齿"
-        ],
-        "notation": "歯(は)"
+        ]
     },
     {
         "name": "ureru",
         "trans": [
+            "売(う)れる",
             "⓪ 自动2  畅销；出名，知名"
-        ],
-        "notation": "売(う)れる"
+        ]
     },
     {
         "name": "gomi",
         "trans": [
+            "ごみ",
             "② 名  垃圾"
-        ],
-        "notation": "ごみ"
+        ]
     },
     {
         "name": "~ka",
         "trans": [
+            "～家(か)",
             " 接尾  （某种职业）……家"
-        ],
-        "notation": "～家(か)"
+        ]
     },
     {
         "name": "teika",
         "trans": [
+            "定価(ていか)",
             "⓪ 名  定价"
-        ],
-        "notation": "定価(ていか)"
+        ]
     },
     {
         "name": "hinshitsu",
         "trans": [
+            "品質(ひんしつ)",
             "⓪ 名  品质，质量"
-        ],
-        "notation": "品質(ひんしつ)"
+        ]
     },
     {
         "name": "wain",
         "trans": [
+            "ワイン",
             "① 名  葡萄酒"
-        ],
-        "notation": "ワイン"
+        ]
     },
     {
         "name": "kodomo",
         "trans": [
+            "子供(こども)",
             "⓪ 名  孩子，儿童"
-        ],
-        "notation": "子供(こども)"
+        ]
     },
     {
         "name": "okashii",
         "trans": [
+            "おかしい",
             "③ イ形  可笑的；反常的，奇怪的"
-        ],
-        "notation": "おかしい"
+        ]
     },
     {
         "name": "tate",
         "trans": [
+            "縦(たて)",
             "① 名  竖，纵向"
-        ],
-        "notation": "縦(たて)"
+        ]
     },
     {
         "name": "kawaru",
         "trans": [
+            "変(か)わる",
             "⓪ 自动1  改变，变化"
-        ],
-        "notation": "変(か)わる"
+        ]
     },
     {
         "name": "shikin",
         "trans": [
+            "資金(しきん)",
             "② 名  资金"
-        ],
-        "notation": "資金(しきん)"
+        ]
     },
     {
         "name": "denpou",
         "trans": [
+            "電報(でんぽう)",
             "⓪ 名  电报"
-        ],
-        "notation": "電報(でんぽう)"
+        ]
     },
     {
         "name": "tsuki",
         "trans": [
+            "月(つき)",
             "② 名  月亮"
-        ],
-        "notation": "月(つき)"
+        ]
     },
     {
         "name": "hidari",
         "trans": [
+            "左(ひだり)",
             "⓪ 名  左边，左侧"
-        ],
-        "notation": "左(ひだり)"
+        ]
     },
     {
         "name": "akeru",
         "trans": [
+            "明(あ)ける",
             "⓪ 自动2  变得明亮；结束"
-        ],
-        "notation": "明(あ)ける"
+        ]
     },
     {
         "name": "seihin",
         "trans": [
+            "製品(せいひん)",
             "⓪ 名  产品"
-        ],
-        "notation": "製品(せいひん)"
+        ]
     },
     {
         "name": "boushi",
         "trans": [
+            "帽子(ぼうし)",
             "⓪ 名  帽子"
-        ],
-        "notation": "帽子(ぼうし)"
+        ]
     },
     {
         "name": "ka-ten",
         "trans": [
+            "カーテン",
             "① 名  窗帘"
-        ],
-        "notation": "カーテン"
+        ]
     },
     {
         "name": "shufu",
         "trans": [
+            "主婦(しゅふ)",
             "① 名  主妇"
-        ],
-        "notation": "主婦(しゅふ)"
+        ]
     },
     {
         "name": "mukashi",
         "trans": [
+            "昔(むかし)",
             "⓪ 名  过去，从前"
-        ],
-        "notation": "昔(むかし)"
+        ]
     },
     {
         "name": "shinsen",
         "trans": [
+            "新鮮(しんせん)",
             "⓪ 名·ナ形  新鲜，鲜活"
-        ],
-        "notation": "新鮮(しんせん)"
+        ]
     },
     {
         "name": "tanjoubi",
         "trans": [
+            "誕生日(たんじょうび)",
             "③ 名  生日"
-        ],
-        "notation": "誕生日(たんじょうび)"
+        ]
     },
     {
         "name": "seido",
         "trans": [
+            "制度(せいど)",
             "① 名  制度"
-        ],
-        "notation": "制度(せいど)"
+        ]
     },
     {
         "name": "doubutsu",
         "trans": [
+            "動物(どうぶつ)",
             "⓪ 名  动物"
-        ],
-        "notation": "動物(どうぶつ)"
+        ]
     },
     {
         "name": "bangou",
         "trans": [
+            "番号(ばんごう)",
             "③ 名  号码"
-        ],
-        "notation": "番号(ばんごう)"
+        ]
     },
     {
         "name": "raishuu",
         "trans": [
+            "来週(らいしゅう)",
             "⓪ 名  下周"
-        ],
-        "notation": "来週(らいしゅう)"
+        ]
     },
     {
         "name": "kotoshi",
         "trans": [
+            "今年(ことし)",
             "⓪ 名  今年"
-        ],
-        "notation": "今年(ことし)"
+        ]
     },
     {
         "name": "hashi",
         "trans": [
+            "箸(はし)",
             "① 名  筷子"
-        ],
-        "notation": "箸(はし)"
+        ]
     },
     {
         "name": "tamago",
         "trans": [
+            "卵(たまご)",
             "② 名  鸡蛋"
-        ],
-        "notation": "卵(たまご)"
+        ]
     },
     {
         "name": "mame",
         "trans": [
+            "豆(まめ)",
             "② 名·接头  豆子，豆类；小的"
-        ],
-        "notation": "豆(まめ)"
+        ]
     },
     {
         "name": "man",
         "trans": [
+            "万(まん)",
             "① 数  万"
-        ],
-        "notation": "万(まん)"
+        ]
     },
     {
         "name": "kedo",
         "trans": [
+            "けど",
             "① 接续  可是，然而"
-        ],
-        "notation": "けど"
+        ]
     },
     {
         "name": "nabe",
         "trans": [
+            "鍋(なべ)",
             "① 名  锅；火锅"
-        ],
-        "notation": "鍋(なべ)"
+        ]
     },
     {
         "name": "atsui",
         "trans": [
+            "厚(あつ)い",
             "⓪ イ形  厚的"
-        ],
-        "notation": "厚(あつ)い"
+        ]
     },
     {
         "name": "koucha",
         "trans": [
+            "紅茶(こうちゃ)",
             "⓪ 名  红茶"
-        ],
-        "notation": "紅茶(こうちゃ)"
+        ]
     },
     {
         "name": "mendan",
         "trans": [
+            "面談(めんだん)",
             "⓪ 名·自动3  面谈"
-        ],
-        "notation": "面談(めんだん)"
+        ]
     },
     {
         "name": "tatemono",
         "trans": [
+            "建物(たてもの)",
             "② 名  建筑物"
-        ],
-        "notation": "建物(たてもの)"
+        ]
     },
     {
         "name": "mondai",
         "trans": [
+            "問題(もんだい)",
             "⓪ 名  问题；麻烦事"
-        ],
-        "notation": "問題(もんだい)"
+        ]
     },
     {
         "name": "daibubun",
         "trans": [
+            "大部分(だいぶぶん)",
             "③ 名·副  大部分，多半"
-        ],
-        "notation": "大部分(だいぶぶん)"
+        ]
     },
     {
         "name": "tsuuro",
         "trans": [
+            "通路(つうろ)",
             "① 名  通道，过道"
-        ],
-        "notation": "通路(つうろ)"
+        ]
     },
     {
         "name": "tabako",
         "trans": [
+            "タバコ",
             "⓪ 名  香烟，烟草"
-        ],
-        "notation": "タバコ"
+        ]
     },
     {
         "name": "muryou",
         "trans": [
+            "無料(むりょう)",
             "⓪ 名  免费"
-        ],
-        "notation": "無料(むりょう)"
+        ]
     },
     {
         "name": "kaji",
         "trans": [
+            "火事(かじ)",
             "① 名  火灾"
-        ],
-        "notation": "火事(かじ)"
+        ]
     },
     {
         "name": "yane",
         "trans": [
+            "屋根(やね)",
             "① 名  屋顶"
-        ],
-        "notation": "屋根(やね)"
+        ]
     },
     {
         "name": "ninki",
         "trans": [
+            "人気(にんき)",
             "⓪ 名  有人气，受欢迎"
-        ],
-        "notation": "人気(にんき)"
+        ]
     },
     {
         "name": "kurasu",
         "trans": [
+            "暮(く)らす",
             "⓪ 自他动1  生活；度日"
-        ],
-        "notation": "暮(く)らす"
+        ]
     },
     {
         "name": "toki",
         "trans": [
+            "時(とき)",
             "② 名  时候，时间；时光"
-        ],
-        "notation": "時(とき)"
+        ]
     },
     {
         "name": "tegami",
         "trans": [
+            "手紙(てがみ)",
             "⓪ 名  书信"
-        ],
-        "notation": "手紙(てがみ)"
+        ]
     },
     {
         "name": "tokugi",
         "trans": [
+            "特技(とくぎ)",
             "① 名  特长，特别技能"
-        ],
-        "notation": "特技(とくぎ)"
+        ]
     },
     {
         "name": "dame",
         "trans": [
+            "駄目(だめ)",
             "② ナ形  没用的，徒劳的；不行，不可以"
-        ],
-        "notation": "駄目(だめ)"
+        ]
     },
     {
         "name": "suiyoubi",
         "trans": [
+            "水曜日(すいようび)",
             "③ 名  星期三"
-        ],
-        "notation": "水曜日(すいようび)"
+        ]
     },
     {
         "name": "kurabu",
         "trans": [
+            "クラブ",
             "① 名  俱乐部"
-        ],
-        "notation": "クラブ"
+        ]
     },
     {
         "name": "komu",
         "trans": [
+            "込(こ)む",
             "① 自动1  混杂，拥挤"
-        ],
-        "notation": "込(こ)む"
+        ]
     },
     {
         "name": "saikin",
         "trans": [
+            "最近(さいきん)",
             "⓪ 名  最近"
-        ],
-        "notation": "最近(さいきん)"
+        ]
     },
     {
         "name": "taisou",
         "trans": [
+            "体操(たいそう)",
             "⓪ 名  体操"
-        ],
-        "notation": "体操(たいそう)"
+        ]
     },
     {
         "name": "oru",
         "trans": [
+            "折(お)る",
             "① 他动1  折，折断；折叠"
-        ],
-        "notation": "折(お)る"
+        ]
     },
     {
         "name": "sansuu",
         "trans": [
+            "算数(さんすう)",
             "③ 名  计算，算术"
-        ],
-        "notation": "算数(さんすう)"
+        ]
     },
     {
         "name": "taiyou",
         "trans": [
+            "太陽(たいよう)",
             "① 名  太阳"
-        ],
-        "notation": "太陽(たいよう)"
+        ]
     },
     {
         "name": "fukushuu",
         "trans": [
+            "復習(ふくしゅう)",
             "⓪ 名·他动3  复习"
-        ],
-        "notation": "復習(ふくしゅう)"
+        ]
     },
     {
         "name": "kuri-mu",
         "trans": [
+            "クリーム",
             "② 名  奶油；乳，霜"
-        ],
-        "notation": "クリーム"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "市(し)",
             "① 名  （行政区划）市"
-        ],
-        "notation": "市(し)"
+        ]
     },
     {
         "name": "kamu",
         "trans": [
+            "噛(か)む",
             "① 他动1  咬，嚼"
-        ],
-        "notation": "噛(か)む"
+        ]
     },
     {
         "name": "mokuyoubi",
         "trans": [
+            "木曜日(もくようび)",
             "③ 名  星期四"
-        ],
-        "notation": "木曜日(もくようび)"
+        ]
     },
     {
         "name": "keigo",
         "trans": [
+            "敬語(けいご)",
             "⓪ 名  敬语"
-        ],
-        "notation": "敬語(けいご)"
+        ]
     },
     {
         "name": "kuwashii",
         "trans": [
+            "詳(くわ)しい",
             "③ イ形  详细的；精通的"
-        ],
-        "notation": "詳(くわ)しい"
+        ]
     },
     {
         "name": "anime",
         "trans": [
+            "アニメ",
             "① 名  动画片"
-        ],
-        "notation": "アニメ"
+        ]
     },
     {
         "name": "kon'ya",
         "trans": [
+            "今夜(こんや)",
             "① 名  今晚"
-        ],
-        "notation": "今夜(こんや)"
+        ]
     },
     {
         "name": "kangaeru",
         "trans": [
+            "考(かんが)える",
             "④ 他动2  思考，思索；想办法"
-        ],
-        "notation": "考(かんが)える"
+        ]
     },
     {
         "name": "shiki",
         "trans": [
+            "四季(しき)",
             "② 名  四季"
-        ],
-        "notation": "四季(しき)"
+        ]
     },
     {
         "name": "tatoeba",
         "trans": [
+            "例(たと)えば",
             "② 副  例如；假设"
-        ],
-        "notation": "例(たと)えば"
+        ]
     },
     {
         "name": "arubaito",
         "trans": [
+            "アルバイト",
             "③ 名·自动3  打工，兼职"
-        ],
-        "notation": "アルバイト"
+        ]
     },
     {
         "name": "nichiyoubi",
         "trans": [
+            "日曜日(にちようび)",
             "③ 名  星期天"
-        ],
-        "notation": "日曜日(にちようび)"
+        ]
     },
     {
         "name": "utsuru",
         "trans": [
+            "移(うつ)る",
             "② 自动1  转移，移动"
-        ],
-        "notation": "移(うつ)る"
+        ]
     },
     {
         "name": "kyabetsu",
         "trans": [
+            "キャベツ",
             "① 名  圆白菜，卷心菜"
-        ],
-        "notation": "キャベツ"
+        ]
     },
     {
         "name": "koujou",
         "trans": [
+            "工場(こうじょう)",
             "③ 名  工厂"
-        ],
-        "notation": "工場(こうじょう)"
+        ]
     },
     {
         "name": "sugiru",
         "trans": [
+            "過(す)ぎる",
             "② 自动2  经过；（时间）流逝；超过"
-        ],
-        "notation": "過(す)ぎる"
+        ]
     },
     {
         "name": "uma",
         "trans": [
+            "馬(うま)",
             "② 名  马"
-        ],
-        "notation": "馬(うま)"
+        ]
     },
     {
         "name": "josei",
         "trans": [
+            "女性(じょせい)",
             "⓪ 名  女性"
-        ],
-        "notation": "女性(じょせい)"
+        ]
     },
     {
         "name": "koeru",
         "trans": [
+            "超(こ)える",
             "⓪ 自动2  超出，超过"
-        ],
-        "notation": "超(こ)える"
+        ]
     },
     {
         "name": "kare-",
         "trans": [
+            "カレー",
             "⓪ 名  咖喱"
-        ],
-        "notation": "カレー"
+        ]
     },
     {
         "name": "nami",
         "trans": [
+            "波(なみ)",
             "② 名  波浪"
-        ],
-        "notation": "波(なみ)"
+        ]
     },
     {
         "name": "douyatte",
         "trans": [
+            "どうやって",
             "① 副  怎么做，怎么办"
-        ],
-        "notation": "どうやって"
+        ]
     },
     {
         "name": "gasu",
         "trans": [
+            "ガス",
             "① 名  气体；煤气"
-        ],
-        "notation": "ガス"
+        ]
     },
     {
         "name": "ime-ji",
         "trans": [
+            "イメージ",
             "② 名  印象，形象"
-        ],
-        "notation": "イメージ"
+        ]
     },
     {
         "name": "aku",
         "trans": [
+            "空(あ)く",
             "⓪ 自动1  （时间或空间）空闲，空缺"
-        ],
-        "notation": "空(あ)く"
+        ]
     },
     {
         "name": "shin'nen",
         "trans": [
+            "新年(しんねん)",
             "① 名  新年"
-        ],
-        "notation": "新年(しんねん)"
+        ]
     },
     {
         "name": "tokai",
         "trans": [
+            "都会(とかい)",
             "⓪ 名  都市，城市"
-        ],
-        "notation": "都会(とかい)"
+        ]
     },
     {
         "name": "tamani",
         "trans": [
+            "たまに",
             "⓪ 副  偶尔"
-        ],
-        "notation": "たまに"
+        ]
     },
     {
         "name": "~go",
         "trans": [
+            "～後(ご)",
             " 接尾  ……之后"
-        ],
-        "notation": "～後(ご)"
+        ]
     },
     {
         "name": "adoresu",
         "trans": [
+            "アドレス",
             "① 名  地址，住址"
-        ],
-        "notation": "アドレス"
+        ]
     },
     {
         "name": "rainen",
         "trans": [
+            "来年(らいねん)",
             "⓪ 名  明年"
-        ],
-        "notation": "来年(らいねん)"
+        ]
     },
     {
         "name": "hitsuyou",
         "trans": [
+            "必要(ひつよう)",
             "⓪ 名·ナ形  必要，必需"
-        ],
-        "notation": "必要(ひつよう)"
+        ]
     },
     {
         "name": "ai",
         "trans": [
+            "愛(あい)",
             "① 名  爱"
-        ],
-        "notation": "愛(あい)"
+        ]
     },
     {
         "name": "getsuyoubi",
         "trans": [
+            "月曜日(げつようび)",
             "③ 名  星期一"
-        ],
-        "notation": "月曜日(げつようび)"
+        ]
     },
     {
         "name": "kanjiru",
         "trans": [
+            "感(かん)じる",
             "⓪ 自他动2  感觉，感到"
-        ],
-        "notation": "感(かん)じる"
+        ]
     },
     {
         "name": "orinpikku",
         "trans": [
+            "オリンピック",
             "④ 名  奥运会，奥林匹克"
-        ],
-        "notation": "オリンピック"
+        ]
     },
     {
         "name": "naiyou",
         "trans": [
+            "内容(ないよう)",
             "⓪ 名  内容"
-        ],
-        "notation": "内容(ないよう)"
+        ]
     },
     {
         "name": "tokuni",
         "trans": [
+            "特(とく)に",
             "① 副  特别"
-        ],
-        "notation": "特(とく)に"
+        ]
     },
     {
         "name": "shourai",
         "trans": [
+            "将来(しょうらい)",
             "① 名  将来，未来"
-        ],
-        "notation": "将来(しょうらい)"
+        ]
     },
     {
         "name": "daijoubu",
         "trans": [
+            "大丈夫(だいじょうぶ)",
             "③ ナ形  没关系的；可靠的，牢固的"
-        ],
-        "notation": "大丈夫(だいじょうぶ)"
+        ]
     },
     {
         "name": "taifuu",
         "trans": [
+            "台風(たいふう)",
             "③ 名  台风"
-        ],
-        "notation": "台風(たいふう)"
+        ]
     },
     {
         "name": "bo-ru",
         "trans": [
+            "ボール",
             "⓪ 名  球"
-        ],
-        "notation": "ボール"
+        ]
     },
     {
         "name": "kaze",
         "trans": [
+            "風邪(かぜ)",
             "⓪ 名  感冒"
-        ],
-        "notation": "風邪(かぜ)"
+        ]
     },
     {
         "name": "umare",
         "trans": [
+            "生(う)まれ",
             "⓪ 名  出生，诞生"
-        ],
-        "notation": "生(う)まれ"
+        ]
     },
     {
         "name": "ikutsuka",
         "trans": [
+            "いくつか",
             "① 名·副  若干，几个"
-        ],
-        "notation": "いくつか"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "硬(かた)い",
             "⓪ イ形  坚硬的；死板的"
-        ],
-        "notation": "硬(かた)い"
+        ]
     },
     {
         "name": "ken",
         "trans": [
+            "県(けん)",
             "① 名  （日本行政区划）县"
-        ],
-        "notation": "県(けん)"
+        ]
     },
     {
         "name": "hatsuon",
         "trans": [
+            "発音(はつおん)",
             "⓪ 名·他动3  发音"
-        ],
-        "notation": "発音(はつおん)"
+        ]
     },
     {
         "name": "chuushin",
         "trans": [
+            "中心(ちゅうしん)",
             "⓪ 名  中心；核心"
-        ],
-        "notation": "中心(ちゅうしん)"
+        ]
     },
     {
         "name": "sokode",
         "trans": [
+            "そこで",
             "⓪ 接续  因此，所以"
-        ],
-        "notation": "そこで"
+        ]
     },
     {
         "name": "katarogu",
         "trans": [
+            "カタログ",
             "⓪ 名  商品目录"
-        ],
-        "notation": "カタログ"
+        ]
     },
     {
         "name": "aru",
         "trans": [
+            "或(あ)る",
             "① 连体  某……，某个……"
-        ],
-        "notation": "或(あ)る"
+        ]
     },
     {
         "name": "kappu",
         "trans": [
+            "カップ",
             "① 名  杯子"
-        ],
-        "notation": "カップ"
+        ]
     },
     {
         "name": "nashi",
         "trans": [
+            "梨(なし)",
             "② 名  梨"
-        ],
-        "notation": "梨(なし)"
+        ]
     },
     {
         "name": "de-to",
         "trans": [
+            "デート",
             "① 名·自动3  约会"
-        ],
-        "notation": "デート"
+        ]
     },
     {
         "name": "takkyuu",
         "trans": [
+            "卓球(たっきゅう)",
             "⓪ 名  乒乓球"
-        ],
-        "notation": "卓球(たっきゅう)"
+        ]
     },
     {
         "name": "kanashii",
         "trans": [
+            "悲(かな)しい",
             "③ イ形  悲伤的"
-        ],
-        "notation": "悲(かな)しい"
+        ]
     },
     {
         "name": "kin'youbi",
         "trans": [
+            "金曜日(きんようび)",
             "③ 名  星期五"
-        ],
-        "notation": "金曜日(きんようび)"
+        ]
     },
     {
         "name": "ara-mu",
         "trans": [
+            "アラーム",
             "② 名  闹钟；警报"
-        ],
-        "notation": "アラーム"
+        ]
     },
     {
         "name": "noseru",
         "trans": [
+            "載(の)せる",
             "⓪ 他动2  登载，刊登"
-        ],
-        "notation": "載(の)せる"
+        ]
     },
     {
         "name": "tsuinru-mu",
         "trans": [
+            "ツインルーム",
             "④ 名  双人间"
-        ],
-        "notation": "ツインルーム"
+        ]
     },
     {
         "name": "shokuhin",
         "trans": [
+            "食品(しょくひん)",
             "⓪ 名  食品"
-        ],
-        "notation": "食品(しょくひん)"
+        ]
     },
     {
         "name": "katsu",
         "trans": [
+            "勝(か)つ",
             "① 自动1  赢，胜利"
-        ],
-        "notation": "勝(か)つ"
+        ]
     },
     {
         "name": "kokoro",
         "trans": [
+            "心(こころ)",
             "② 名  心；内心；心情"
-        ],
-        "notation": "心(こころ)"
+        ]
     },
     {
         "name": "ha",
         "trans": [
+            "葉(は)",
             "⓪ 名  叶，叶子"
-        ],
-        "notation": "葉(は)"
+        ]
     },
     {
         "name": "sabishii",
         "trans": [
+            "寂(さび)しい",
             "③ イ形  寂寞的，孤单的"
-        ],
-        "notation": "寂(さび)しい"
+        ]
     },
     {
         "name": "sake",
         "trans": [
+            "酒(さけ)",
             "⓪ 名  酒"
-        ],
-        "notation": "酒(さけ)"
+        ]
     },
     {
         "name": "usagi",
         "trans": [
+            "ウサギ",
             "⓪ 名  兔子"
-        ],
-        "notation": "ウサギ"
+        ]
     },
     {
         "name": "miru",
         "trans": [
+            "見(み)る",
             "① 他动2  看，观看"
-        ],
-        "notation": "見(み)る"
+        ]
     },
     {
         "name": "kantan",
         "trans": [
+            "簡単(かんたん)",
             "⓪ 名·ナ形  简单"
-        ],
-        "notation": "簡単(かんたん)"
+        ]
     },
     {
         "name": "senmon",
         "trans": [
+            "専門(せんもん)",
             "⓪ 名  专业"
-        ],
-        "notation": "専門(せんもん)"
+        ]
     },
     {
         "name": "ba-gen",
         "trans": [
+            "バーゲン",
             "① 名  特价品；大减价"
-        ],
-        "notation": "バーゲン"
+        ]
     },
     {
         "name": "iru",
         "trans": [
+            "要(い)る",
             "⓪ 自动1  需要"
-        ],
-        "notation": "要(い)る"
+        ]
     },
     {
         "name": "kuukou",
         "trans": [
+            "空港(くうこう)",
             "⓪ 名  机场"
-        ],
-        "notation": "空港(くうこう)"
+        ]
     },
     {
         "name": "zou",
         "trans": [
+            "象(ぞう)",
             "① 名  大象"
-        ],
-        "notation": "象(ぞう)"
+        ]
     },
     {
         "name": "hazukashii",
         "trans": [
+            "恥(は)ずかしい",
             "④ イ形  惭愧的；害羞的"
-        ],
-        "notation": "恥(は)ずかしい"
+        ]
     },
     {
         "name": "gasorin",
         "trans": [
+            "ガソリン",
             "⓪ 名  汽油"
-        ],
-        "notation": "ガソリン"
+        ]
     },
     {
         "name": "igaku",
         "trans": [
+            "医学(いがく)",
             "① 名  医学"
-        ],
-        "notation": "医学(いがく)"
+        ]
     },
     {
         "name": "~sei",
         "trans": [
+            "～製(せい)",
             "⓪ 接尾  （表示产地）……制造"
-        ],
-        "notation": "～製(せい)"
+        ]
     },
     {
         "name": "sumou",
         "trans": [
+            "相撲(すもう)",
             "⓪ 名  相扑"
-        ],
-        "notation": "相撲(すもう)"
+        ]
     },
     {
         "name": "sasu",
         "trans": [
+            "指(さ)す",
             "① 他动1  指，指着；指向"
-        ],
-        "notation": "指(さ)す"
+        ]
     },
     {
         "name": "kukki-",
         "trans": [
+            "クッキー",
             "① 名  曲奇饼干"
-        ],
-        "notation": "クッキー"
+        ]
     },
     {
         "name": "oya",
         "trans": [
+            "親(おや)",
             "② 名  父母，双亲"
-        ],
-        "notation": "親(おや)"
+        ]
     },
     {
         "name": "ageru",
         "trans": [
+            "挙(あ)げる",
             "⓪ 他动2  列举；举行（仪式）"
-        ],
-        "notation": "挙(あ)げる"
+        ]
     },
     {
         "name": "take",
         "trans": [
+            "竹(たけ)",
             "⓪ 名  竹子"
-        ],
-        "notation": "竹(たけ)"
+        ]
     },
     {
         "name": "beru",
         "trans": [
+            "ベル",
             "① 名  铃，电铃"
-        ],
-        "notation": "ベル"
+        ]
     },
     {
         "name": "makotoni",
         "trans": [
+            "誠(まこと)に",
             "⓪ 副  非常，十分"
-        ],
-        "notation": "誠(まこと)に"
+        ]
     },
     {
         "name": "toshiue",
         "trans": [
+            "年上(としうえ)",
             "⓪ 名  年长"
-        ],
-        "notation": "年上(としうえ)"
+        ]
     },
     {
         "name": "senpuuki",
         "trans": [
+            "扇風機(せんぷうき)",
             "③ 名  电风扇"
-        ],
-        "notation": "扇風機(せんぷうき)"
+        ]
     },
     {
         "name": "shuppatsu",
         "trans": [
+            "出発(しゅっぱつ)",
             "⓪ 名·自动3  出发；开始"
-        ],
-        "notation": "出発(しゅっぱつ)"
+        ]
     },
     {
         "name": "okuru",
         "trans": [
+            "贈(おく)る",
             "⓪ 他动1  赠送"
-        ],
-        "notation": "贈(おく)る"
+        ]
     },
     {
         "name": "baiorin",
         "trans": [
+            "バイオリン",
             "⓪ 名  小提琴"
-        ],
-        "notation": "バイオリン"
+        ]
     },
     {
         "name": "mise",
         "trans": [
+            "店(みせ)",
             "② 名  店，商店"
-        ],
-        "notation": "店(みせ)"
+        ]
     },
     {
         "name": "igi",
         "trans": [
+            "異議(いぎ)",
             "① 名  异议，反对意见"
-        ],
-        "notation": "異議(いぎ)"
+        ]
     },
     {
         "name": "seiji",
         "trans": [
+            "政治(せいじ)",
             "⓪ 名  政治"
-        ],
-        "notation": "政治(せいじ)"
+        ]
     },
     {
         "name": "saragu",
         "trans": [
+            "サラダ",
             "① 名  沙拉"
-        ],
-        "notation": "サラダ"
+        ]
     },
     {
         "name": "isshou",
         "trans": [
+            "一生(いっしょう)",
             "⓪ 名  一生，一辈子"
-        ],
-        "notation": "一生(いっしょう)"
+        ]
     },
     {
         "name": "sorezore",
         "trans": [
+            "それぞれ",
             "② 名·副  各自，分别"
-        ],
-        "notation": "それぞれ"
+        ]
     },
     {
         "name": "shakai",
         "trans": [
+            "社会(しゃかい)",
             "① 名  社会"
-        ],
-        "notation": "社会(しゃかい)"
+        ]
     },
     {
         "name": "kabocha",
         "trans": [
+            "カボチャ",
             "⓪ 名  南瓜"
-        ],
-        "notation": "カボチャ"
+        ]
     },
     {
         "name": "kokonotsu",
         "trans": [
+            "九(ここの)つ",
             "② 名  九个；九岁"
-        ],
-        "notation": "九(ここの)つ"
+        ]
     },
     {
         "name": "hirumeshi",
         "trans": [
+            "昼飯(ひるめし)",
             "⓪ 名  午饭"
-        ],
-        "notation": "昼飯(ひるめし)"
+        ]
     },
     {
         "name": "bangumi",
         "trans": [
+            "番組(ばんぐみ)",
             "⓪ 名  （电视或广播）节目"
-        ],
-        "notation": "番組(ばんぐみ)"
+        ]
     },
     {
         "name": "tsumari",
         "trans": [
+            "つまり",
             "① 副  也就是说，总之"
-        ],
-        "notation": "つまり"
+        ]
     },
     {
         "name": "shunin",
         "trans": [
+            "主任(しゅにん)",
             "⓪ 名  主任"
-        ],
-        "notation": "主任(しゅにん)"
+        ]
     },
     {
         "name": "sakka-",
         "trans": [
+            "サッカー",
             "① 名  足球"
-        ],
-        "notation": "サッカー"
+        ]
     },
     {
         "name": "keiken",
         "trans": [
+            "経験(けいけん)",
             "⓪ 名·他动3  经验；体验"
-        ],
-        "notation": "経験(けいけん)"
+        ]
     },
     {
         "name": "otto",
         "trans": [
+            "夫(おっと)",
             "⓪ 名  丈夫"
-        ],
-        "notation": "夫(おっと)"
+        ]
     },
     {
         "name": "chousa",
         "trans": [
+            "調査(ちょうさ)",
             "① 名·他动3  调查"
-        ],
-        "notation": "調査(ちょうさ)"
+        ]
     },
     {
         "name": "dougu",
         "trans": [
+            "道具(どうぐ)",
             "③ 名  道具"
-        ],
-        "notation": "道具(どうぐ)"
+        ]
     },
     {
         "name": "fueru",
         "trans": [
+            "増(ふ)える",
             "② 自动2  增加"
-        ],
-        "notation": "増(ふ)える"
+        ]
     },
     {
         "name": "taiya",
         "trans": [
+            "タイヤ",
             "⓪ 名  轮胎"
-        ],
-        "notation": "タイヤ"
+        ]
     },
     {
         "name": "en",
         "trans": [
+            "円(えん)",
             "① 名  圆形；日元"
-        ],
-        "notation": "円(えん)"
+        ]
     },
     {
         "name": "kanemochi",
         "trans": [
+            "金持(かねも)ち",
             "③ 名  有钱人"
-        ],
-        "notation": "金持(かねも)ち"
+        ]
     },
     {
         "name": "wasabi",
         "trans": [
+            "わさび",
             "① 名  芥末"
-        ],
-        "notation": "わさび"
+        ]
     },
     {
         "name": "mottomo",
         "trans": [
+            "最(もっと)も",
             "③ 副  最"
-        ],
-        "notation": "最(もっと)も"
+        ]
     },
     {
         "name": "keshigomu",
         "trans": [
+            "消(け)しゴム",
             "⓪ 名  橡皮"
-        ],
-        "notation": "消(け)しゴム"
+        ]
     },
     {
         "name": "kataduku",
         "trans": [
+            "片付(かたづ)く",
             "③ 自动1  收拾整齐；处理得当"
-        ],
-        "notation": "片付(かたづ)く"
+        ]
     },
     {
         "name": "anzen",
         "trans": [
+            "安全(あんぜん)",
             "⓪ 名·ナ形  安全"
-        ],
-        "notation": "安全(あんぜん)"
+        ]
     },
     {
         "name": "tokorode",
         "trans": [
+            "ところで",
             "③ 接续  （转换话题）话说，不过"
-        ],
-        "notation": "ところで"
+        ]
     },
     {
         "name": "kanji",
         "trans": [
+            "漢字(かんじ)",
             "⓪ 名  汉字"
-        ],
-        "notation": "漢字(かんじ)"
+        ]
     },
     {
         "name": "tan'i",
         "trans": [
+            "単位(たんい)",
             "① 名  （数量）单位；学分"
-        ],
-        "notation": "単位(たんい)"
+        ]
     },
     {
         "name": "~shiki",
         "trans": [
+            "～式(しき)",
             " 接尾  ……仪式；……类型"
-        ],
-        "notation": "～式(しき)"
+        ]
     },
     {
         "name": "okosu",
         "trans": [
+            "起(お)こす",
             "② 他动1  叫醒，唤醒；引起"
-        ],
-        "notation": "起(お)こす"
+        ]
     },
     {
         "name": "koudou",
         "trans": [
+            "講堂(こうどう)",
             "⓪ 名  礼堂，讲堂"
-        ],
-        "notation": "講堂(こうどう)"
+        ]
     },
     {
         "name": "doresshingu",
         "trans": [
+            "ドレッシング",
             "② 名  调味汁，调味酱"
-        ],
-        "notation": "ドレッシング"
+        ]
     },
     {
         "name": "hikage",
         "trans": [
+            "日陰(ひかげ)",
             "⓪ 名  阴凉处；见不得人"
-        ],
-        "notation": "日陰(ひかげ)"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "菊(きく)",
             "② 名  菊花"
-        ],
-        "notation": "菊(きく)"
+        ]
     },
     {
         "name": "oiru",
         "trans": [
+            "オイル",
             "① 名  油；石油"
-        ],
-        "notation": "オイル"
+        ]
     },
     {
         "name": "ayamaru",
         "trans": [
+            "謝(あやま)る",
             "③ 自他动1  道歉，谢罪"
-        ],
-        "notation": "謝(あやま)る"
+        ]
     },
     {
         "name": "seki",
         "trans": [
+            "席(せき)",
             "① 名  座位"
-        ],
-        "notation": "席(せき)"
+        ]
     },
     {
         "name": "gyouretsu",
         "trans": [
+            "行列(ぎょうれつ)",
             "⓪ 名  队伍，行列"
-        ],
-        "notation": "行列(ぎょうれつ)"
+        ]
     },
     {
         "name": "aida",
         "trans": [
+            "間(あいだ)",
             "⓪ 名  中间；期间；间隔"
-        ],
-        "notation": "間(あいだ)"
+        ]
     },
     {
         "name": "zaseki",
         "trans": [
+            "座席(ざせき)",
             "⓪ 名  座位"
-        ],
-        "notation": "座席(ざせき)"
+        ]
     },
     {
         "name": "kimaru",
         "trans": [
+            "決(き)まる",
             "⓪ 自动1  决定，规定"
-        ],
-        "notation": "決(き)まる"
+        ]
     },
     {
         "name": "chokore-to",
         "trans": [
+            "チョコレート",
             "③ 名  巧克力"
-        ],
-        "notation": "チョコレート"
+        ]
     },
     {
         "name": "koibito",
         "trans": [
+            "恋人(こいびと)",
             "⓪ 名  恋人"
-        ],
-        "notation": "恋人(こいびと)"
+        ]
     },
     {
         "name": "mezurashii",
         "trans": [
+            "珍(めずら)しい",
             "④ イ形  新奇的，新颖的；罕见的"
-        ],
-        "notation": "珍(めずら)しい"
+        ]
     },
     {
         "name": "hayashi",
         "trans": [
+            "林(はやし)",
             "⓪ 名  树林，树丛"
-        ],
-        "notation": "林(はやし)"
+        ]
     },
     {
         "name": "suidou",
         "trans": [
+            "水道(すいどう)",
             "⓪ 名  自来水管道"
-        ],
-        "notation": "水道(すいどう)"
+        ]
     },
     {
         "name": "sa-kuru",
         "trans": [
+            "サークル",
             "① 名  圆；小组，社团"
-        ],
-        "notation": "サークル"
+        ]
     },
     {
         "name": "kyuuni",
         "trans": [
+            "急(きゅう)に",
             "⓪ 副  突然"
-        ],
-        "notation": "急(きゅう)に"
+        ]
     },
     {
         "name": "genzai",
         "trans": [
+            "現在(げんざい)",
             "① 名  现在"
-        ],
-        "notation": "現在(げんざい)"
+        ]
     },
     {
         "name": "asai",
         "trans": [
+            "浅(あさ)い",
             "⓪ イ形  浅的；（颜色、程度等）浅的，淡的"
-        ],
-        "notation": "浅(あさ)い"
+        ]
     },
     {
         "name": "kaminoke",
         "trans": [
+            "髪(かみ)の毛(け)",
             "③ 名  头发"
-        ],
-        "notation": "髪(かみ)の毛(け)"
+        ]
     },
     {
         "name": "resutoran",
         "trans": [
+            "レストラン",
             "① 名  饭店"
-        ],
-        "notation": "レストラン"
+        ]
     },
     {
         "name": "ko-hi-",
         "trans": [
+            "コーヒー",
             "③ 名  咖啡"
-        ],
-        "notation": "コーヒー"
+        ]
     },
     {
         "name": "guraundo",
         "trans": [
+            "グラウンド",
             "⓪ 名  运动场，操场"
-        ],
-        "notation": "グラウンド"
+        ]
     },
     {
         "name": "itsudemo",
         "trans": [
+            "いつでも",
             "① 副  无论什么时候，随时"
-        ],
-        "notation": "いつでも"
+        ]
     },
     {
         "name": "kin'iro",
         "trans": [
+            "金色(きんいろ)",
             "⓪ 名  金色"
-        ],
-        "notation": "金色(きんいろ)"
+        ]
     },
     {
         "name": "futsuu",
         "trans": [
+            "普通(ふつう)",
             "⓪ 名·ナ形  一般，普遍"
-        ],
-        "notation": "普通(ふつう)"
+        ]
     },
     {
         "name": "tetsudau",
         "trans": [
+            "手伝(てつだ)う",
             "③ 自他动1  帮忙，帮助"
-        ],
-        "notation": "手伝(てつだ)う"
+        ]
     },
     {
         "name": "shinai",
         "trans": [
+            "市内(しない)",
             "① 名  市内"
-        ],
-        "notation": "市内(しない)"
+        ]
     },
     {
         "name": "gouka",
         "trans": [
+            "豪華(ごうか)",
             "① 名·ナ形  豪华，奢华"
-        ],
-        "notation": "豪華(ごうか)"
+        ]
     },
     {
         "name": "aisatsu",
         "trans": [
+            "挨拶(あいさつ)",
             "① 名·自动3  寒暄；致辞"
-        ],
-        "notation": "挨拶(あいさつ)"
+        ]
     },
     {
         "name": "mikan",
         "trans": [
+            "みかん",
             "① 名  桔子"
-        ],
-        "notation": "みかん"
+        ]
     },
     {
         "name": "naoru",
         "trans": [
+            "直(なお)る",
             "② 自动1  修好；复原；改正过来"
-        ],
-        "notation": "直(なお)る"
+        ]
     },
     {
         "name": "tooku",
         "trans": [
+            "遠(とお)く",
             "③ 名  远处，远方"
-        ],
-        "notation": "遠(とお)く"
+        ]
     },
     {
         "name": "shorui",
         "trans": [
+            "書類(しょるい)",
             "⓪ 名  文件，资料"
-        ],
-        "notation": "書類(しょるい)"
+        ]
     },
     {
         "name": "kibishii",
         "trans": [
+            "厳(きび)しい",
             "③ イ形  严格的，严厉的；严峻的"
-        ],
-        "notation": "厳(きび)しい"
+        ]
     },
     {
         "name": "o-tobai",
         "trans": [
+            "オートバイ",
             "③ 名  摩托车"
-        ],
-        "notation": "オートバイ"
+        ]
     },
     {
         "name": "sensou",
         "trans": [
+            "戦争(せんそう)",
             "⓪ 名  战争"
-        ],
-        "notation": "戦争(せんそう)"
+        ]
     },
     {
         "name": "jiyuu",
         "trans": [
+            "自由(じゆう)",
             "② 名·ナ形  自由，随意"
-        ],
-        "notation": "自由(じゆう)"
+        ]
     },
     {
         "name": "kouji",
         "trans": [
+            "工事(こうじ)",
             "① 名  施工，工程"
-        ],
-        "notation": "工事(こうじ)"
+        ]
     },
     {
         "name": "kappuru",
         "trans": [
+            "カップル",
             "① 名  情侣，恋人"
-        ],
-        "notation": "カップル"
+        ]
     },
     {
         "name": "esa",
         "trans": [
+            "餌(えさ)",
             "② 名  饵；诱饵"
-        ],
-        "notation": "餌(えさ)"
+        ]
     },
     {
         "name": "nedan",
         "trans": [
+            "値段(ねだん)",
             "⓪ 名  价格，价钱"
-        ],
-        "notation": "値段(ねだん)"
+        ]
     },
     {
         "name": "kansei",
         "trans": [
+            "完成(かんせい)",
             "⓪ 名·自他动3  完成"
-        ],
-        "notation": "完成(かんせい)"
+        ]
     },
     {
         "name": "touieba",
         "trans": [
+            "そういえば",
             "④ 接续  （提起话题）说起来，对了"
-        ],
-        "notation": "そういえば"
+        ]
     },
     {
         "name": "taosu",
         "trans": [
+            "倒(たお)す",
             "② 他动1  推倒；推翻，打倒"
-        ],
-        "notation": "倒(たお)す"
+        ]
     },
     {
         "name": "shigen",
         "trans": [
+            "資源(しげん)",
             "① 名  资源"
-        ],
-        "notation": "資源(しげん)"
+        ]
     },
     {
         "name": "keihi",
         "trans": [
+            "経費(けいひ)",
             "① 名  经费，开销"
-        ],
-        "notation": "経費(けいひ)"
+        ]
     },
     {
         "name": "shuushoku",
         "trans": [
+            "就職(しゅうしょく)",
             "⓪ 名·自动3  就业，找到工作"
-        ],
-        "notation": "就職(しゅうしょく)"
+        ]
     },
     {
         "name": "sakihodo",
         "trans": [
+            "先(さき)ほど",
             "⓪ 名·副  刚才"
-        ],
-        "notation": "先(さき)ほど"
+        ]
     },
     {
         "name": "ninzuu",
         "trans": [
+            "人数(にんずう)",
             "① 名  人数"
-        ],
-        "notation": "人数(にんずう)"
+        ]
     },
     {
         "name": "tsuduku",
         "trans": [
+            "続(つづ)く",
             "⓪ 自动1  继续，持续"
-        ],
-        "notation": "続(つづ)く"
+        ]
     },
     {
         "name": "satsu",
         "trans": [
+            "札(さつ)",
             "⓪ 名  纸币"
-        ],
-        "notation": "札(さつ)"
+        ]
     },
     {
         "name": "goi",
         "trans": [
+            "語彙(ごい)",
             "① 名  词汇"
-        ],
-        "notation": "語彙(ごい)"
+        ]
     },
     {
         "name": "su-tsu",
         "trans": [
+            "スーツ",
             "① 名  西装"
-        ],
-        "notation": "スーツ"
+        ]
     },
     {
         "name": "yawarakai",
         "trans": [
+            "柔(やわ)らかい",
             "④ イ形  柔和的，柔软的"
-        ],
-        "notation": "柔(やわ)らかい"
+        ]
     },
     {
         "name": "gin'iro",
         "trans": [
+            "銀色(ぎんいろ)",
             "⓪ 名  银色，银白色"
-        ],
-        "notation": "銀色(ぎんいろ)"
+        ]
     },
     {
         "name": "akaji",
         "trans": [
+            "赤字(あかじ)",
             "⓪ 名  赤字，亏空"
-        ],
-        "notation": "赤字(あかじ)"
+        ]
     },
     {
         "name": "kitai",
         "trans": [
+            "期待(きたい)",
             "⓪ 名·他动3  期待，希望"
-        ],
-        "notation": "期待(きたい)"
+        ]
     },
     {
         "name": "tsuyu",
         "trans": [
+            "梅雨(つゆ)",
             "⓪ 名  梅雨；梅雨季节"
-        ],
-        "notation": "梅雨(つゆ)"
+        ]
     },
     {
         "name": "oogoe",
         "trans": [
+            "大声(おおごえ)",
             "③ 名  大声"
-        ],
-        "notation": "大声(おおごえ)"
+        ]
     },
     {
         "name": "inoru",
         "trans": [
+            "祈(いの)る",
             "② 他动1  祈祷，祷告"
-        ],
-        "notation": "祈(いの)る"
+        ]
     },
     {
         "name": "ringo",
         "trans": [
+            "リンゴ",
             "⓪ 名  苹果"
-        ],
-        "notation": "リンゴ"
+        ]
     },
     {
         "name": "shutsujou",
         "trans": [
+            "出場(しゅつじょう)",
             "⓪ 名·自动3  出场，登场"
-        ],
-        "notation": "出場(しゅつじょう)"
+        ]
     },
     {
         "name": "setsumei",
         "trans": [
+            "説明(せつめい)",
             "⓪ 名·他动3  说明，解释"
-        ],
-        "notation": "説明(せつめい)"
+        ]
     },
     {
         "name": "kyousou",
         "trans": [
+            "競争(きょうそう)",
             "⓪ 名·自他动3  竞争"
-        ],
-        "notation": "競争(きょうそう)"
+        ]
     },
     {
         "name": "ude",
         "trans": [
+            "腕(うで)",
             "② 名  手臂；本领，技能"
-        ],
-        "notation": "腕(うで)"
+        ]
     },
     {
         "name": "anaunsa-",
         "trans": [
+            "アナウンサー",
             "③ 名  播音员"
-        ],
-        "notation": "アナウンサー"
+        ]
     },
     {
         "name": "settai",
         "trans": [
+            "接待(せったい)",
             "① 名·他动3  接待，招待"
-        ],
-        "notation": "接待(せったい)"
+        ]
     },
     {
         "name": "hamigaki",
         "trans": [
+            "歯磨(はみが)き",
             "② 名  牙膏"
-        ],
-        "notation": "歯磨(はみが)き"
+        ]
     },
     {
         "name": "hitori",
         "trans": [
+            "一人(ひとり)",
             "② 名  一个人"
-        ],
-        "notation": "一人(ひとり)"
+        ]
     },
     {
         "name": "tsuri",
         "trans": [
+            "釣(つ)り",
             "⓪ 名  钓鱼；零钱，零头"
-        ],
-        "notation": "釣(つ)り"
+        ]
     },
     {
         "name": "shokubutsu",
         "trans": [
+            "植物(しょくぶつ)",
             "② 名  植物"
-        ],
-        "notation": "植物(しょくぶつ)"
+        ]
     },
     {
         "name": "oiwai",
         "trans": [
+            "お祝(いわ)い",
             "⓪ 名·他动3  贺礼；祝贺，庆祝"
-        ],
-        "notation": "お祝(いわ)い"
+        ]
     },
     {
         "name": "uwasa",
         "trans": [
+            "噂(うわさ)",
             "⓪ 名  传言，风言风语；议论"
-        ],
-        "notation": "噂(うわさ)"
+        ]
     },
     {
         "name": "hen",
         "trans": [
+            "変(へん)",
             "① ナ形  奇怪的，反常的"
-        ],
-        "notation": "変(へん)"
+        ]
     },
     {
         "name": "suicchi",
         "trans": [
+            "スイッチ",
             "② 名  电源开关"
-        ],
-        "notation": "スイッチ"
+        ]
     },
     {
         "name": "sashimi",
         "trans": [
+            "刺身(さしみ)",
             "③ 名  生鱼片"
-        ],
-        "notation": "刺身(さしみ)"
+        ]
     },
     {
         "name": "i",
         "trans": [
+            "胃(い)",
             "⓪ 名  胃"
-        ],
-        "notation": "胃(い)"
+        ]
     },
     {
         "name": "kougyou",
         "trans": [
+            "工業(こうぎょう)",
             "① 名  工业"
-        ],
-        "notation": "工業(こうぎょう)"
+        ]
     },
     {
         "name": "minami",
         "trans": [
+            "南(みなみ)",
             "⓪ 名  南，南边"
-        ],
-        "notation": "南(みなみ)"
+        ]
     },
     {
         "name": "ataeru",
         "trans": [
+            "与(あた)える",
             "⓪ 他动2  给予；使蒙受，使遭遇"
-        ],
-        "notation": "与(あた)える"
+        ]
     },
     {
         "name": "tachiba",
         "trans": [
+            "立場(たちば)",
             "③ 名  立场"
-        ],
-        "notation": "立場(たちば)"
+        ]
     },
     {
         "name": "sutaffu",
         "trans": [
+            "スタッフ",
             "② 名  职员，工作人员"
-        ],
-        "notation": "スタッフ"
+        ]
     },
     {
         "name": "kossori",
         "trans": [
+            "こっそり",
             "③ 副  悄悄地，蹑手蹑脚地"
-        ],
-        "notation": "こっそり"
+        ]
     },
     {
         "name": "gijutsu",
         "trans": [
+            "技術(ぎじゅつ)",
             "① 名  技术，工艺"
-        ],
-        "notation": "技術(ぎじゅつ)"
+        ]
     },
     {
         "name": "aite",
         "trans": [
+            "相手(あいて)",
             "③ 名  对象；对手，竞争者"
-        ],
-        "notation": "相手(あいて)"
+        ]
     },
     {
         "name": "masumasu",
         "trans": [
+            "ますます",
             "② 副  越来越，更加"
-        ],
-        "notation": "ますます"
+        ]
     },
     {
         "name": "nesshin",
         "trans": [
+            "熱心(ねっしん)",
             "① 名·ナ形  热心，热情"
-        ],
-        "notation": "熱心(ねっしん)"
+        ]
     },
     {
         "name": "tsuukin",
         "trans": [
+            "通勤(つうきん)",
             "⓪ 名·自动3  上下班，通勤"
-        ],
-        "notation": "通勤(つうきん)"
+        ]
     },
     {
         "name": "shinjiru",
         "trans": [
+            "信(しん)じる",
             "③ 他动2  相信；确信"
-        ],
-        "notation": "信(しん)じる"
+        ]
     },
     {
         "name": "chiisana",
         "trans": [
+            "小(ちい)さな",
             "① 连体  小的"
-        ],
-        "notation": "小(ちい)さな"
+        ]
     },
     {
         "name": "ofisu",
         "trans": [
+            "オフィス",
             "① 名  办公室"
-        ],
-        "notation": "オフィス"
+        ]
     },
     {
         "name": "aikawarazu",
         "trans": [
+            "相変(あいか)わらず",
             "⓪ 副  照旧，仍旧"
-        ],
-        "notation": "相変(あいか)わらず"
+        ]
     },
     {
         "name": "gara",
         "trans": [
+            "柄(がら)",
             "⓪ 名  花纹；人品；身材"
-        ],
-        "notation": "柄(がら)"
+        ]
     },
     {
         "name": "kuru",
         "trans": [
+            "来(く)る",
             "① 自动3  来，到来"
-        ],
-        "notation": "来(く)る"
+        ]
     },
     {
         "name": "butsuri",
         "trans": [
+            "物理(ぶつり)",
             "① 名  物理"
-        ],
-        "notation": "物理(ぶつり)"
+        ]
     },
     {
         "name": "nasu",
         "trans": [
+            "茄子(なす)",
             "① 名  茄子"
-        ],
-        "notation": "茄子(なす)"
+        ]
     },
     {
         "name": "darui",
         "trans": [
+            "だるい",
             "② イ形  慵懒的，疲乏的"
-        ],
-        "notation": "だるい"
+        ]
     },
     {
         "name": "sara",
         "trans": [
+            "皿(さら)",
             "⓪ 名  盘子，碟子"
-        ],
-        "notation": "皿(さら)"
+        ]
     },
     {
         "name": "au",
         "trans": [
+            "遭(あ)う",
             "① 自动1  遭遇，遭到"
-        ],
-        "notation": "遭(あ)う"
+        ]
     },
     {
         "name": "~kai",
         "trans": [
+            "～会(かい)",
             " 接尾  （组织或活动）……会"
-        ],
-        "notation": "～会(かい)"
+        ]
     },
     {
         "name": "samazama",
         "trans": [
+            "さまざま",
             "② ナ形  形形色色的，各种各样的"
-        ],
-        "notation": "さまざま"
+        ]
     },
     {
         "name": "tabi",
         "trans": [
+            "旅(たび)",
             "② 名  旅行，旅途"
-        ],
-        "notation": "旅(たび)"
+        ]
     },
     {
         "name": "namida",
         "trans": [
+            "涙(なみだ)",
             "① 名  眼泪"
-        ],
-        "notation": "涙(なみだ)"
+        ]
     },
     {
         "name": "sasou",
         "trans": [
+            "誘(さそ)う",
             "⓪ 他动1  邀请；引诱，诱发"
-        ],
-        "notation": "誘(さそ)う"
+        ]
     },
     {
         "name": "an'nai",
         "trans": [
+            "案内(あんない)",
             "③ 名·他动3  指南；陪同游览，向导"
-        ],
-        "notation": "案内(あんない)"
+        ]
     },
     {
         "name": "zairyou",
         "trans": [
+            "材料(ざいりょう)",
             "③ 名  （制造）材料；（调查研究）素材"
-        ],
-        "notation": "材料(ざいりょう)"
+        ]
     },
     {
         "name": "amu",
         "trans": [
+            "編(あ)む",
             "① 他动1  编，织"
-        ],
-        "notation": "編(あ)む"
+        ]
     },
     {
         "name": "oubo",
         "trans": [
+            "応募(おうぼ)",
             "⓪ 名·自动3  报名，应征"
-        ],
-        "notation": "応募(おうぼ)"
+        ]
     },
     {
         "name": "juudou",
         "trans": [
+            "柔道(じゅうどう)",
             "① 名  柔道"
-        ],
-        "notation": "柔道(じゅうどう)"
+        ]
     },
     {
         "name": "awai",
         "trans": [
+            "淡(あわ)い",
             "② イ形  （颜色）浅的；（味道）淡的"
-        ],
-        "notation": "淡(あわ)い"
+        ]
     },
     {
         "name": "kaishi",
         "trans": [
+            "開始(かいし)",
             "⓪ 名·自他动3  开始"
-        ],
-        "notation": "開始(かいし)"
+        ]
     },
     {
         "name": "o-ke-",
         "trans": [
+            "オーケー",
             "① 叹  好"
-        ],
-        "notation": "オーケー"
+        ]
     },
     {
         "name": "sugata",
         "trans": [
+            "姿(すがた)",
             "① 名  姿态；打扮；面貌"
-        ],
-        "notation": "姿(すがた)"
+        ]
     },
     {
         "name": "omocha",
         "trans": [
+            "おもちゃ",
             "② 名  玩具"
-        ],
-        "notation": "おもちゃ"
+        ]
     },
     {
         "name": "tokkyuu",
         "trans": [
+            "特急(とっきゅう)",
             "⓪ 名  特快列车；加急，火速"
-        ],
-        "notation": "特急(とっきゅう)"
+        ]
     },
     {
         "name": "mori",
         "trans": [
+            "森(もり)",
             "⓪ 名  森林"
-        ],
-        "notation": "森(もり)"
+        ]
     },
     {
         "name": "juujitsu",
         "trans": [
+            "充実(じゅうじつ)",
             "⓪ 名·自动3  充实，丰富"
-        ],
-        "notation": "充実(じゅうじつ)"
+        ]
     },
     {
         "name": "satsumaimo",
         "trans": [
+            "サツマイモ",
             "⓪ 名  红薯"
-        ],
-        "notation": "サツマイモ"
+        ]
     },
     {
         "name": "erai",
         "trans": [
+            "偉(えら)い",
             "② イ形  伟大的；厉害的"
-        ],
-        "notation": "偉(えら)い"
+        ]
     },
     {
         "name": "shurui",
         "trans": [
+            "種類(しゅるい)",
             "① 名  种类"
-        ],
-        "notation": "種類(しゅるい)"
+        ]
     },
     {
         "name": "dekirudake",
         "trans": [
+            "できるだけ",
             "⓪ 副  尽量，尽可能"
-        ],
-        "notation": "できるだけ"
+        ]
     },
     {
         "name": "keikaku",
         "trans": [
+            "計画(けいかく)",
             "⓪ 名·他动3  计划，规划"
-        ],
-        "notation": "計画(けいかく)"
+        ]
     },
     {
         "name": "akusesari-",
         "trans": [
+            "アクセサリー",
             "① 名  饰品；零件"
-        ],
-        "notation": "アクセサリー"
+        ]
     },
     {
         "name": "kyoumi",
         "trans": [
+            "興味(きょうみ)",
             "① 名  兴趣"
-        ],
-        "notation": "興味(きょうみ)"
+        ]
     },
     {
         "name": "shichi/nana",
         "trans": [
+            "七（しち/なな）②/",
             "① 数  七"
-        ],
-        "notation": "七（しち/なな）②/"
+        ]
     },
     {
         "name": "tasu",
         "trans": [
+            "足(た)す",
             "⓪ 他动1  添加；（数学运算）加"
-        ],
-        "notation": "足(た)す"
+        ]
     },
     {
         "name": "hajime",
         "trans": [
+            "始(はじ)め",
             "⓪ 名  最初；开始"
-        ],
-        "notation": "始(はじ)め"
+        ]
     },
     {
         "name": "youshi",
         "trans": [
+            "用紙(ようし)",
             "① 名  用纸，纸张"
-        ],
-        "notation": "用紙(ようし)"
+        ]
     },
     {
         "name": "no-",
         "trans": [
+            "ノー",
             "① 叹  不"
-        ],
-        "notation": "ノー"
+        ]
     },
     {
         "name": "tokoya",
         "trans": [
+            "床屋(とこや)",
             "⓪ 名  理发店"
-        ],
-        "notation": "床屋(とこや)"
+        ]
     },
     {
         "name": "jishin",
         "trans": [
+            "自信(じしん)",
             "⓪ 名  自信"
-        ],
-        "notation": "自信(じしん)"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "利(き)く",
             "⓪ 自动1  有效；好用，灵敏"
-        ],
-        "notation": "利(き)く"
+        ]
     },
     {
         "name": "eda",
         "trans": [
+            "枝(えだ)",
             "⓪ 名  树枝"
-        ],
-        "notation": "枝(えだ)"
+        ]
     },
     {
         "name": "sangyou",
         "trans": [
+            "産業(さんぎょう)",
             "⓪ 名  产业，实业"
-        ],
-        "notation": "産業(さんぎょう)"
+        ]
     },
     {
         "name": "sensei",
         "trans": [
+            "先生(せんせい)",
             "③ 名  老师；医生；律师"
-        ],
-        "notation": "先生(せんせい)"
+        ]
     },
     {
         "name": "hakobu",
         "trans": [
+            "運(はこ)ぶ",
             "⓪ 他动1  搬运；推进"
-        ],
-        "notation": "運(はこ)ぶ"
+        ]
     },
     {
         "name": "sofu",
         "trans": [
+            "祖父(そふ)",
             "① 名  祖父；外祖父"
-        ],
-        "notation": "祖父(そふ)"
+        ]
     },
     {
         "name": "shima",
         "trans": [
+            "島(しま)",
             "② 名  岛，岛屿"
-        ],
-        "notation": "島(しま)"
+        ]
     },
     {
         "name": "kandou",
         "trans": [
+            "感動(かんどう)",
             "⓪ 名·自动3  感动"
-        ],
-        "notation": "感動(かんどう)"
+        ]
     },
     {
         "name": "aruko-ru",
         "trans": [
+            "アルコール",
             "⓪ 名  酒；酒精"
-        ],
-        "notation": "アルコール"
+        ]
     },
     {
         "name": "hachi",
         "trans": [
+            "八(はち)",
             "② 数  八"
-        ],
-        "notation": "八(はち)"
+        ]
     },
     {
         "name": "hijou",
         "trans": [
+            "非常(ひじょう)",
             "⓪ 名·ナ形  非常，特别；紧急"
-        ],
-        "notation": "非常(ひじょう)"
+        ]
     },
     {
         "name": "mittsu",
         "trans": [
+            "三(みっ)つ",
             "⓪ 名  三个；三岁"
-        ],
-        "notation": "三(みっ)つ"
+        ]
     },
     {
         "name": "nandaka",
         "trans": [
+            "なんだか",
             "① 副  不知为何，总觉得"
-        ],
-        "notation": "なんだか"
+        ]
     },
     {
         "name": "haha",
         "trans": [
+            "母(はは)",
             "① 名  妈妈"
-        ],
-        "notation": "母(はは)"
+        ]
     },
     {
         "name": "seikou",
         "trans": [
+            "成功(せいこう)",
             "⓪ 名·自动3  成功"
-        ],
-        "notation": "成功(せいこう)"
+        ]
     },
     {
         "name": "jihyou",
         "trans": [
+            "辞表(じひょう)",
             "⓪ 名  辞呈，辞职报告"
-        ],
-        "notation": "辞表(じひょう)"
+        ]
     },
     {
         "name": "butsukaru",
         "trans": [
+            "ぶつかる",
             "⓪ 自动1  碰，撞"
-        ],
-        "notation": "ぶつかる"
+        ]
     },
     {
         "name": "choujou",
         "trans": [
+            "長城(ちょうじょう)",
             "⓪ 名  长城"
-        ],
-        "notation": "長城(ちょうじょう)"
+        ]
     },
     {
         "name": "papa",
         "trans": [
+            "パパ",
             "① 名  爸爸"
-        ],
-        "notation": "パパ"
+        ]
     },
     {
         "name": "keitai",
         "trans": [
+            "携帯(けいたい)",
             "⓪ 名·他动3  携带，便携"
-        ],
-        "notation": "携帯(けいたい)"
+        ]
     },
     {
         "name": "enerugi-",
         "trans": [
+            "エネルギー",
             "② 名  能源"
-        ],
-        "notation": "エネルギー"
+        ]
     },
     {
         "name": "itaru",
         "trans": [
+            "至(いた)る",
             "② 自动1  至，到达"
-        ],
-        "notation": "至(いた)る"
+        ]
     },
     {
         "name": "kaji",
         "trans": [
+            "家事(かじ)",
             "① 名  家务活"
-        ],
-        "notation": "家事(かじ)"
+        ]
     },
     {
         "name": "zaiko",
         "trans": [
+            "在庫(ざいこ)",
             "⓪ 名  库存，存货"
-        ],
-        "notation": "在庫(ざいこ)"
+        ]
     },
     {
         "name": "dokoka",
         "trans": [
+            "どこか",
             "① 连语·副  （不确定的）某处；总觉得"
-        ],
-        "notation": "どこか"
+        ]
     },
     {
         "name": "jouhou",
         "trans": [
+            "情報(じょうほう)",
             "⓪ 名  信息，情报"
-        ],
-        "notation": "情報(じょうほう)"
+        ]
     },
     {
         "name": "mawari",
         "trans": [
+            "周(まわ)り",
             "⓪ 名  周围，附近"
-        ],
-        "notation": "周(まわ)り"
+        ]
     },
     {
         "name": "hikaru",
         "trans": [
+            "光(ひか)る",
             "② 自动1  发光"
-        ],
-        "notation": "光(ひか)る"
+        ]
     },
     {
         "name": "ningyou",
         "trans": [
+            "人形(にんぎょう)",
             "⓪ 名  玩偶，人偶"
-        ],
-        "notation": "人形(にんぎょう)"
+        ]
     },
     {
         "name": "tsuugaku",
         "trans": [
+            "通学(つうがく)",
             "⓪ 名·自动3  上下学"
-        ],
-        "notation": "通学(つうがく)"
+        ]
     },
     {
         "name": "hikui",
         "trans": [
+            "低(ひく)い",
             "② イ形  （高度、地位等）低的"
-        ],
-        "notation": "低(ひく)い"
+        ]
     },
     {
         "name": "shuto",
         "trans": [
+            "首都(しゅと)",
             "① 名  首都"
-        ],
-        "notation": "首都(しゅと)"
+        ]
     },
     {
         "name": "ura",
         "trans": [
+            "裏(うら)",
             "② 名  背面，反面；内幕"
-        ],
-        "notation": "裏(うら)"
+        ]
     },
     {
         "name": "hoshii",
         "trans": [
+            "欲(ほ)しい",
             "② イ形  想要的；希望的"
-        ],
-        "notation": "欲(ほ)しい"
+        ]
     },
     {
         "name": "kaiketsu",
         "trans": [
+            "解決(かいけつ)",
             "⓪ 名·自他动3  解决"
-        ],
-        "notation": "解決(かいけつ)"
+        ]
     },
     {
         "name": "atari",
         "trans": [
+            "辺(あた)り",
             "① 名  附近，周围"
-        ],
-        "notation": "辺(あた)り"
+        ]
     },
     {
         "name": "sukeju-ru",
         "trans": [
+            "スケジュール",
             "② 名  日程；日程表"
-        ],
-        "notation": "スケジュール"
+        ]
     },
     {
         "name": "tsukamaeru",
         "trans": [
+            "捕(つか)まえる",
             "⓪ 他动2  抓住；逮捕"
-        ],
-        "notation": "捕(つか)まえる"
+        ]
     },
     {
         "name": "nyuugaku",
         "trans": [
+            "入学(にゅうがく)",
             "⓪ 名·自动3  入学，上学"
-        ],
-        "notation": "入学(にゅうがく)"
+        ]
     },
     {
         "name": "kawa",
         "trans": [
+            "川(かわ)",
             "② 名  河流"
-        ],
-        "notation": "川(かわ)"
+        ]
     },
     {
         "name": "taoreru",
         "trans": [
+            "倒(たお)れる",
             "③ 自动2  倒下，跌倒；垮台，倒闭"
-        ],
-        "notation": "倒(たお)れる"
+        ]
     },
     {
         "name": "supi-do",
         "trans": [
+            "スピード",
             "⓪ 名  速度"
-        ],
-        "notation": "スピード"
+        ]
     },
     {
         "name": "guai",
         "trans": [
+            "具合(ぐあい)",
             "⓪ 名  情况，状态；方便，合适"
-        ],
-        "notation": "具合(ぐあい)"
+        ]
     },
     {
         "name": "otoko",
         "trans": [
+            "男(おとこ)",
             "③ 名  男性，男子"
-        ],
-        "notation": "男(おとこ)"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "機会(きかい)",
             "② 名  机会"
-        ],
-        "notation": "機会(きかい)"
+        ]
     },
     {
         "name": "shikata",
         "trans": [
+            "仕方(しかた)",
             "⓪ 名  做法，方法"
-        ],
-        "notation": "仕方(しかた)"
+        ]
     },
     {
         "name": "kenka",
         "trans": [
+            "喧嘩(けんか)",
             "⓪ 名·自动3  吵架，打架"
-        ],
-        "notation": "喧嘩(けんか)"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "変(か)える",
             "⓪ 他动2  改变，变更"
-        ],
-        "notation": "変(か)える"
+        ]
     },
     {
         "name": "irai",
         "trans": [
+            "依頼(いらい)",
             "⓪ 名·他动3  请求，委托；依赖"
-        ],
-        "notation": "依頼(いらい)"
+        ]
     },
     {
         "name": "migite",
         "trans": [
+            "右手(みぎて)",
             "⓪ 名  右手"
-        ],
-        "notation": "右手(みぎて)"
+        ]
     },
     {
         "name": "sakiototoi",
         "trans": [
+            "さきおととい",
             "⑤ 名  大前天"
-        ],
-        "notation": "さきおととい"
+        ]
     },
     {
         "name": "kesshite",
         "trans": [
+            "決(けっ)して",
             "⓪ 副  （后接否定）决（不）"
-        ],
-        "notation": "決(けっ)して"
+        ]
     },
     {
         "name": "sakura",
         "trans": [
+            "桜(さくら)",
             "⓪ 名  樱花"
-        ],
-        "notation": "桜(さくら)"
+        ]
     },
     {
         "name": "tango",
         "trans": [
+            "単語(たんご)",
             "⓪ 名  单词"
-        ],
-        "notation": "単語(たんご)"
+        ]
     },
     {
         "name": "tousan",
         "trans": [
+            "倒産(とうさん)",
             "⓪ 名·自动3  倒闭，破产"
-        ],
-        "notation": "倒産(とうさん)"
+        ]
     },
     {
         "name": "sakan",
         "trans": [
+            "盛(さか)ん",
             "⓪ ナ形  兴盛的，繁荣的；盛大的"
-        ],
-        "notation": "盛(さか)ん"
+        ]
     },
     {
         "name": "oogata",
         "trans": [
+            "大型(おおがた)",
             "⓪ 名·ナ形  大型"
-        ],
-        "notation": "大型(おおがた)"
+        ]
     },
     {
         "name": "isogu",
         "trans": [
+            "急(いそ)ぐ",
             "② 自他动1  着急；加快"
-        ],
-        "notation": "急(いそ)ぐ"
+        ]
     },
     {
         "name": "kome",
         "trans": [
+            "米(こめ)",
             "② 名  大米"
-        ],
-        "notation": "米(こめ)"
+        ]
     },
     {
         "name": "kashikiri",
         "trans": [
+            "貸切(かしきり)",
             "⓪ 名  （船、房间等）包租"
-        ],
-        "notation": "貸切(かしきり)"
+        ]
     },
     {
         "name": "okoru",
         "trans": [
+            "怒(おこ)る",
             "② 自动1  生气，发怒，发火"
-        ],
-        "notation": "怒(おこ)る"
+        ]
     },
     {
         "name": "shoutai",
         "trans": [
+            "招待(しょうたい)",
             "① 名·他动3  招待，邀请"
-        ],
-        "notation": "招待(しょうたい)"
+        ]
     },
     {
         "name": "senaka",
         "trans": [
+            "背中(せなか)",
             "⓪ 名  背，后背"
-        ],
-        "notation": "背中(せなか)"
+        ]
     },
     {
         "name": "kibou",
         "trans": [
+            "希望(きぼう)",
             "⓪ 名·他动3  希望，愿望"
-        ],
-        "notation": "希望(きぼう)"
+        ]
     },
     {
         "name": "odoru",
         "trans": [
+            "踊(おど)る",
             "⓪ 自动1  跳舞"
-        ],
-        "notation": "踊(おど)る"
+        ]
     },
     {
         "name": "shinbunsha",
         "trans": [
+            "新聞社(しんぶんしゃ)",
             "③ 名  报社"
-        ],
-        "notation": "新聞社(しんぶんしゃ)"
+        ]
     },
     {
         "name": "shisetsu",
         "trans": [
+            "施設(しせつ)",
             "① 名  设施"
-        ],
-        "notation": "施設(しせつ)"
+        ]
     },
     {
         "name": "tsuuka",
         "trans": [
+            "通過(つうか)",
             "⓪ 名·自动3  通过，经过"
-        ],
-        "notation": "通過(つうか)"
+        ]
     },
     {
         "name": "zan'nen",
         "trans": [
+            "残念(ざんねん)",
             "③ ナ形  遗憾的，可惜的；懊悔的"
-        ],
-        "notation": "残念(ざんねん)"
+        ]
     },
     {
         "name": "arawasu",
         "trans": [
+            "表(あらわ)す",
             "③ 他动1  表达，表现"
-        ],
-        "notation": "表(あらわ)す"
+        ]
     },
     {
         "name": "uso",
         "trans": [
+            "嘘(うそ)",
             "① 名  谎言，假话"
-        ],
-        "notation": "嘘(うそ)"
+        ]
     },
     {
         "name": "kanri",
         "trans": [
+            "管理(かんり)",
             "① 名·他动3  管理；保管"
-        ],
-        "notation": "管理(かんり)"
+        ]
     },
     {
         "name": "zensen",
         "trans": [
+            "前線(ぜんせん)",
             "⓪ 名  前线"
-        ],
-        "notation": "前線(ぜんせん)"
+        ]
     },
     {
         "name": "seijin",
         "trans": [
+            "成人(せいじん)",
             "⓪ 名·自动3  成年人；长大成人"
-        ],
-        "notation": "成人(せいじん)"
+        ]
     },
     {
         "name": "ninjin",
         "trans": [
+            "人参(にんじん)",
             "⓪ 名  胡萝卜"
-        ],
-        "notation": "人参(にんじん)"
+        ]
     },
     {
         "name": "kinjo",
         "trans": [
+            "近所(きんじょ)",
             "① 名  附近；邻居"
-        ],
-        "notation": "近所(きんじょ)"
+        ]
     },
     {
         "name": "shussha",
         "trans": [
+            "出社(しゅっしゃ)",
             "⓪ 名·自动3  上班"
-        ],
-        "notation": "出社(しゅっしゃ)"
+        ]
     },
     {
         "name": "tsukeru",
         "trans": [
+            "漬(つ)ける",
             "⓪ 他动2  腌，泡"
-        ],
-        "notation": "漬(つ)ける"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "位置(いち)",
             "① 名  位置"
-        ],
-        "notation": "位置(いち)"
+        ]
     },
     {
         "name": "pen",
         "trans": [
+            "ペン",
             "① 名  钢笔"
-        ],
-        "notation": "ペン"
+        ]
     },
     {
         "name": "sassoku",
         "trans": [
+            "早速(さっそく)",
             "⓪ 副  立刻，马上"
-        ],
-        "notation": "早速(さっそく)"
+        ]
     },
     {
         "name": "kangae",
         "trans": [
+            "考(かんが)え",
             "③ 名  想法，意见"
-        ],
-        "notation": "考(かんが)え"
+        ]
     },
     {
         "name": "ou",
         "trans": [
+            "追(お)う",
             "⓪ 他动1  追赶；追求"
-        ],
-        "notation": "追(お)う"
+        ]
     },
     {
         "name": "shippai",
         "trans": [
+            "失敗(しっぱい)",
             "⓪ 名·自动3  失败"
-        ],
-        "notation": "失敗(しっぱい)"
+        ]
     },
     {
         "name": "nyuuin",
         "trans": [
+            "入院(にゅういん)",
             "⓪ 名·自动3  住院"
-        ],
-        "notation": "入院(にゅういん)"
+        ]
     },
     {
         "name": "tanjun",
         "trans": [
+            "単純(たんじゅん)",
             "⓪ 名·ナ形  单纯，简单"
-        ],
-        "notation": "単純(たんじゅん)"
+        ]
     },
     {
         "name": "azukaru",
         "trans": [
+            "預(あず)かる",
             "③ 他动1  （代为）保管"
-        ],
-        "notation": "預(あず)かる"
+        ]
     },
     {
         "name": "mazui",
         "trans": [
+            "まずい",
             "② イ形  难吃的"
-        ],
-        "notation": "まずい"
+        ]
     },
     {
         "name": "enjin",
         "trans": [
+            "エンジン",
             "① 名  引擎，发动机"
-        ],
-        "notation": "エンジン"
+        ]
     },
     {
         "name": "chuushi",
         "trans": [
+            "中止(ちゅうし)",
             "⓪ 名·他动3  中止"
-        ],
-        "notation": "中止(ちゅうし)"
+        ]
     },
     {
         "name": "nikoniko",
         "trans": [
+            "にこにこ",
             "① 副·自动3  笑眯眯"
-        ],
-        "notation": "にこにこ"
+        ]
     },
     {
         "name": "bunka",
         "trans": [
+            "文化(ぶんか)",
             "① 名  文化"
-        ],
-        "notation": "文化(ぶんか)"
+        ]
     },
     {
         "name": "moeru",
         "trans": [
+            "燃(も)える",
             "⓪ 自动2  燃烧，着火"
-        ],
-        "notation": "燃(も)える"
+        ]
     },
     {
         "name": "narubeku",
         "trans": [
+            "なるべく",
             "⓪ 副  尽量，尽可能"
-        ],
-        "notation": "なるべく"
+        ]
     },
     {
         "name": "shouganai",
         "trans": [
+            "しょうがない",
             "④ イ形  没办法的，不得已的"
-        ],
-        "notation": "しょうがない"
+        ]
     },
     {
         "name": "okujou",
         "trans": [
+            "屋上(おくじょう)",
             "⓪ 名  屋顶"
-        ],
-        "notation": "屋上(おくじょう)"
+        ]
     },
     {
         "name": "soudan",
         "trans": [
+            "相談(そうだん)",
             "⓪ 名·他动3  商量，商议"
-        ],
-        "notation": "相談(そうだん)"
+        ]
     },
     {
         "name": "menyu-",
         "trans": [
+            "メニュー",
             "① 名  菜单"
-        ],
-        "notation": "メニュー"
+        ]
     },
     {
         "name": "hanareru",
         "trans": [
+            "離(はな)れる",
             "③ 自动2  分离，离开；相隔"
-        ],
-        "notation": "離(はな)れる"
+        ]
     },
     {
         "name": "kusuriya",
         "trans": [
+            "薬屋(くすりや)",
             "⓪ 名  药店"
-        ],
-        "notation": "薬屋(くすりや)"
+        ]
     },
     {
         "name": "senpai",
         "trans": [
+            "先輩(せんぱい)",
             "⓪ 名  前辈；学长，学姐"
-        ],
-        "notation": "先輩(せんぱい)"
+        ]
     },
     {
         "name": "uttori",
         "trans": [
+            "うっとり",
             "③ 副·自动3  发呆，出神；入迷，陶醉"
-        ],
-        "notation": "うっとり"
+        ]
     },
     {
         "name": "ita",
         "trans": [
+            "板(いた)",
             "① 名  板，木板"
-        ],
-        "notation": "板(いた)"
+        ]
     },
     {
         "name": "ten",
         "trans": [
+            "点(てん)",
             "⓪ 名  点；得分"
-        ],
-        "notation": "点(てん)"
+        ]
     },
     {
         "name": "agaru",
         "trans": [
+            "上(あ)がる",
             "⓪ 自动1  上，登；提高"
-        ],
-        "notation": "上(あ)がる"
+        ]
     },
     {
         "name": "shuunyuu",
         "trans": [
+            "収入(しゅうにゅう)",
             "⓪ 名  收入"
-        ],
-        "notation": "収入(しゅうにゅう)"
+        ]
     },
     {
         "name": "tochuu",
         "trans": [
+            "途中(とちゅう)",
             "⓪ 名  途中，中途"
-        ],
-        "notation": "途中(とちゅう)"
+        ]
     },
     {
         "name": "betsu",
         "trans": [
+            "別(べつ)",
             "⓪ 名·ナ形  区别；别的，另外"
-        ],
-        "notation": "別(べつ)"
+        ]
     },
     {
         "name": "kenkyuu",
         "trans": [
+            "研究(けんきゅう)",
             "⓪ 名·他动3  研究"
-        ],
-        "notation": "研究(けんきゅう)"
+        ]
     },
     {
         "name": "o-ba-",
         "trans": [
+            "オーバー",
             "① 名·自动3  超出，超过"
-        ],
-        "notation": "オーバー"
+        ]
     },
     {
         "name": "takarakuji",
         "trans": [
+            "宝(たから)くじ",
             "③ 名  彩票"
-        ],
-        "notation": "宝(たから)くじ"
+        ]
     },
     {
         "name": "suberu",
         "trans": [
+            "滑(すべ)る",
             "② 自动1  滑，打滑；滑行"
-        ],
-        "notation": "滑(すべ)る"
+        ]
     },
     {
         "name": "zangyou",
         "trans": [
+            "残業(ざんぎょう)",
             "⓪ 名·自动3  加班"
-        ],
-        "notation": "残業(ざんぎょう)"
+        ]
     },
     {
         "name": "gantan",
         "trans": [
+            "元旦(がんたん)",
             "⓪ 名  元旦"
-        ],
-        "notation": "元旦(がんたん)"
+        ]
     },
     {
         "name": "okuru",
         "trans": [
+            "送(おく)る",
             "⓪ 他动1  送，寄送；送行"
-        ],
-        "notation": "送(おく)る"
+        ]
     },
     {
         "name": "kimono",
         "trans": [
+            "着物(きもの)",
             "⓪ 名  和服"
-        ],
-        "notation": "着物(きもの)"
+        ]
     },
     {
         "name": "kuma",
         "trans": [
+            "熊(くま)",
             "② 名  熊"
-        ],
-        "notation": "熊(くま)"
+        ]
     },
     {
         "name": "atsumaru",
         "trans": [
+            "集(あつ)まる",
             "③ 自动1  集合；汇集"
-        ],
-        "notation": "集(あつ)まる"
+        ]
     },
     {
         "name": "saizu",
         "trans": [
+            "サイズ",
             "① 名  尺寸"
-        ],
-        "notation": "サイズ"
+        ]
     },
     {
         "name": "suiei",
         "trans": [
+            "水泳(すいえい)",
             "⓪ 名·自动3  游泳"
-        ],
-        "notation": "水泳(すいえい)"
+        ]
     },
     {
         "name": "kawarini",
         "trans": [
+            "代(か)わりに",
             "⓪ 接续  代替，取代；作为补偿"
-        ],
-        "notation": "代(か)わりに"
+        ]
     },
     {
         "name": "shikaku",
         "trans": [
+            "四角(しかく)",
             "③ 名  四角形，方形"
-        ],
-        "notation": "四角(しかく)"
+        ]
     },
     {
         "name": "kokuban",
         "trans": [
+            "黒板(こくばん)",
             "⓪ 名  黑板"
-        ],
-        "notation": "黒板(こくばん)"
+        ]
     },
     {
         "name": "ukabu",
         "trans": [
+            "浮(う)かぶ",
             "⓪ 自动1  漂，浮；想起；浮现"
-        ],
-        "notation": "浮(う)かぶ"
+        ]
     },
     {
         "name": "tera",
         "trans": [
+            "寺(てら)",
             "② 名  （佛教）寺庙"
-        ],
-        "notation": "寺(てら)"
+        ]
     },
     {
         "name": "danjo",
         "trans": [
+            "男女(だんじょ)",
             "① 名  男女"
-        ],
-        "notation": "男女(だんじょ)"
+        ]
     },
     {
         "name": "sorenara",
         "trans": [
+            "それなら",
             "③ 接续  如果那样"
-        ],
-        "notation": "それなら"
+        ]
     },
     {
         "name": "kinshi",
         "trans": [
+            "禁止(きんし)",
             "⓪ 名·他动3  禁止"
-        ],
-        "notation": "禁止(きんし)"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "下(した)",
             "⓪ 名  （方位）下；（年龄）小"
-        ],
-        "notation": "下(した)"
+        ]
     },
     {
         "name": "awateru",
         "trans": [
+            "慌(あわ)てる",
             "⓪ 自动2  慌张；急忙"
-        ],
-        "notation": "慌(あわ)てる"
+        ]
     },
     {
         "name": "benri",
         "trans": [
+            "便利(べんり)",
             "① 名·ナ形  方便，便利"
-        ],
-        "notation": "便利(べんり)"
+        ]
     },
     {
         "name": "bunkei",
         "trans": [
+            "文型(ぶんけい)",
             "⓪ 名  句型"
-        ],
-        "notation": "文型(ぶんけい)"
+        ]
     },
     {
         "name": "juubun",
         "trans": [
+            "十分(じゅうぶん)",
             "③ ナ形·副  足够，充分"
-        ],
-        "notation": "十分(じゅうぶん)"
+        ]
     },
     {
         "name": "ganbaru",
         "trans": [
+            "頑張(がんば)る",
             "③ 自动1  加油，努力"
-        ],
-        "notation": "頑張(がんば)る"
+        ]
     },
     {
         "name": "uketsuke",
         "trans": [
+            "受付(うけつけ)",
             "⓪ 名  受理；问讯处"
-        ],
-        "notation": "受付(うけつけ)"
+        ]
     },
     {
         "name": "jagaimo",
         "trans": [
+            "ジャガイモ",
             "⓪ 名  土豆"
-        ],
-        "notation": "ジャガイモ"
+        ]
     },
     {
         "name": "kuchimoto",
         "trans": [
+            "口元(くちもと)",
             "⓪ 名  嘴边"
-        ],
-        "notation": "口元(くちもと)"
+        ]
     },
     {
         "name": "miryoku",
         "trans": [
+            "魅力(みりょく)",
             "⓪ 名  魅力"
-        ],
-        "notation": "魅力(みりょく)"
+        ]
     },
     {
         "name": "damaru",
         "trans": [
+            "黙(だま)る",
             "② 自动1  沉默"
-        ],
-        "notation": "黙(だま)る"
+        ]
     },
     {
         "name": "jiken",
         "trans": [
+            "事件(じけん)",
             "① 名  事件；案件"
-        ],
-        "notation": "事件(じけん)"
+        ]
     },
     {
         "name": "kaisai",
         "trans": [
+            "開催(かいさい)",
             "⓪ 名·他动3  举行，召开"
-        ],
-        "notation": "開催(かいさい)"
+        ]
     },
     {
         "name": "azukeru",
         "trans": [
+            "預(あず)ける",
             "③ 他动2  寄存，存放"
-        ],
-        "notation": "預(あず)ける"
+        ]
     },
     {
         "name": "kenbutsu",
         "trans": [
+            "見物(けんぶつ)",
             "⓪ 名·他动3  参观，游览"
-        ],
-        "notation": "見物(けんぶつ)"
+        ]
     },
     {
         "name": "fudousan",
         "trans": [
+            "不動産(ふどうさん)",
             "② 名  房地产"
-        ],
-        "notation": "不動産(ふどうさん)"
+        ]
     },
     {
         "name": "chanto",
         "trans": [
+            "ちゃんと",
             "⓪ 副·自动3  准确无误地；好好地"
-        ],
-        "notation": "ちゃんと"
+        ]
     },
     {
         "name": "emoji",
         "trans": [
+            "絵文字(えもじ)",
             "⓪ 名  表情符号"
-        ],
-        "notation": "絵文字(えもじ)"
+        ]
     },
     {
         "name": "kokuhaku",
         "trans": [
+            "告白(こくはく)",
             "⓪ 名·他动3  表白；坦白"
-        ],
-        "notation": "告白(こくはく)"
+        ]
     },
     {
         "name": "kangaedasu",
         "trans": [
+            "考(かんが)え出(だ)す",
             "⑤ 他动1  想出来；开始思考"
-        ],
-        "notation": "考(かんが)え出(だ)す"
+        ]
     },
     {
         "name": "otokonoko",
         "trans": [
+            "男(おとこ)の子(こ)",
             "③ 名  男孩子"
-        ],
-        "notation": "男(おとこ)の子(こ)"
+        ]
     },
     {
         "name": "gakunen",
         "trans": [
+            "学年(がくねん)",
             "⓪ 名  学年"
-        ],
-        "notation": "学年(がくねん)"
+        ]
     },
     {
         "name": "fuufu",
         "trans": [
+            "夫婦(ふうふ)",
             "① 名  夫妻"
-        ],
-        "notation": "夫婦(ふうふ)"
+        ]
     },
     {
         "name": "zurarito",
         "trans": [
+            "ずらりと",
             "② 副  一长排，成排地"
-        ],
-        "notation": "ずらりと"
+        ]
     },
     {
         "name": "sandaru",
         "trans": [
+            "サンダル",
             "⓪ 名  凉鞋"
-        ],
-        "notation": "サンダル"
+        ]
     },
     {
         "name": "kankei",
         "trans": [
+            "関係(かんけい)",
             "⓪ 名  关系"
-        ],
-        "notation": "関係(かんけい)"
+        ]
     },
     {
         "name": "toru",
         "trans": [
+            "撮(と)る",
             "① 他动1  拍照，摄像"
-        ],
-        "notation": "撮(と)る"
+        ]
     },
     {
         "name": "kouzui",
         "trans": [
+            "洪水(こうずい)",
             "⓪ 名  洪水"
-        ],
-        "notation": "洪水(こうずい)"
+        ]
     },
     {
         "name": "kimochi",
         "trans": [
+            "気持(きも)ち",
             "⓪ 名  心情，感受"
-        ],
-        "notation": "気持(きも)ち"
+        ]
     },
     {
         "name": "chokusetsu",
         "trans": [
+            "直接(ちょくせつ)",
             "⓪ 名·副  直接"
-        ],
-        "notation": "直接(ちょくせつ)"
+        ]
     },
     {
         "name": "habahiroi",
         "trans": [
+            "幅広(はばひろ)い",
             "④ イ形  广泛的"
-        ],
-        "notation": "幅広(はばひろ)い"
+        ]
     },
     {
         "name": "takushi-",
         "trans": [
+            "タクシー",
             "① 名  出租车"
-        ],
-        "notation": "タクシー"
+        ]
     },
     {
         "name": "taikai",
         "trans": [
+            "大会(たいかい)",
             "⓪ 名  大会"
-        ],
-        "notation": "大会(たいかい)"
+        ]
     },
     {
         "name": "nekkuresu",
         "trans": [
+            "ネックレス",
             "① 名  项链"
-        ],
-        "notation": "ネックレス"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "固(かた)い",
             "⓪ イ形  坚硬的；顽固的"
-        ],
-        "notation": "固(かた)い"
+        ]
     },
     {
         "name": "inaka",
         "trans": [
+            "田舎(いなか)",
             "⓪ 名  乡下，农村"
-        ],
-        "notation": "田舎(いなか)"
+        ]
     },
     {
         "name": "tsukaikata",
         "trans": [
+            "使(つか)い方(かた)",
             "⓪ 名  用法"
-        ],
-        "notation": "使(つか)い方(かた)"
+        ]
     },
     {
         "name": "naruhodo",
         "trans": [
+            "なるほど",
             "⓪ 副·叹  果然，的确，怪不得"
-        ],
-        "notation": "なるほど"
+        ]
     },
     {
         "name": "jiten",
         "trans": [
+            "辞典(じてん)",
             "⓪ 名  词典"
-        ],
-        "notation": "辞典(じてん)"
+        ]
     },
     {
         "name": "gakushuu",
         "trans": [
+            "学習(がくしゅう)",
             "⓪ 名·他动3  学习"
-        ],
-        "notation": "学習(がくしゅう)"
+        ]
     },
     {
         "name": "akogareru",
         "trans": [
+            "憧(あこが)れる",
             "⓪ 自动2  憧憬，向往"
-        ],
-        "notation": "憧(あこが)れる"
+        ]
     },
     {
         "name": "tochi",
         "trans": [
+            "土地(とち)",
             "⓪ 名  土地，土壤；当地"
-        ],
-        "notation": "土地(とち)"
+        ]
     },
     {
         "name": "telisshu",
         "trans": [
+            "ティッシュ",
             "① 名  餐巾纸，面巾纸"
-        ],
-        "notation": "ティッシュ"
+        ]
     },
     {
         "name": "subete",
         "trans": [
+            "全(すべ)て",
             "① 名·副  全部"
-        ],
-        "notation": "全(すべ)て"
+        ]
     },
     {
         "name": "tokuchou",
         "trans": [
+            "特長(とくちょう)",
             "⓪ 名  特长"
-        ],
-        "notation": "特長(とくちょう)"
+        ]
     },
     {
         "name": "shawa-",
         "trans": [
+            "シャワー",
             "① 名  淋浴"
-        ],
-        "notation": "シャワー"
+        ]
     },
     {
         "name": "jitensha",
         "trans": [
+            "自転車(じてんしゃ)",
             "② 名  自行车"
-        ],
-        "notation": "自転車(じてんしゃ)"
+        ]
     },
     {
         "name": "ondo",
         "trans": [
+            "温度(おんど)",
             "① 名  温度"
-        ],
-        "notation": "温度(おんど)"
+        ]
     },
     {
         "name": "sotsugyou",
         "trans": [
+            "卒業(そつぎょう)",
             "⓪ 名·自动3  毕业"
-        ],
-        "notation": "卒業(そつぎょう)"
+        ]
     },
     {
         "name": "koi",
         "trans": [
+            "濃(こ)い",
             "① イ形  （颜色）浓的；（味道）重的"
-        ],
-        "notation": "濃(こ)い"
+        ]
     },
     {
         "name": "toire",
         "trans": [
+            "トイレ",
             "① 名  洗手间"
-        ],
-        "notation": "トイレ"
+        ]
     },
     {
         "name": "go",
         "trans": [
+            "五(ご)",
             "① 数  五"
-        ],
-        "notation": "五(ご)"
+        ]
     },
     {
         "name": "guramu",
         "trans": [
+            "グラム",
             "① 量  （重量单位）克"
-        ],
-        "notation": "グラム"
+        ]
     },
     {
         "name": "keizai",
         "trans": [
+            "経済(けいざい)",
             "① 名  经济"
-        ],
-        "notation": "経済(けいざい)"
+        ]
     },
     {
         "name": "manshon",
         "trans": [
+            "マンション",
             "① 名  高级公寓"
-        ],
-        "notation": "マンション"
+        ]
     },
     {
         "name": "atatameru",
         "trans": [
+            "温(あたた)める",
             "④ 他动2  加热"
-        ],
-        "notation": "温(あたた)める"
+        ]
     },
     {
         "name": "gaishutsu",
         "trans": [
+            "外出(がいしゅつ)",
             "⓪ 名·自动3  外出，出门"
-        ],
-        "notation": "外出(がいしゅつ)"
+        ]
     },
     {
         "name": "musume",
         "trans": [
+            "娘(むすめ)",
             "③ 名  女儿"
-        ],
-        "notation": "娘(むすめ)"
+        ]
     },
     {
         "name": "kenkyuuin",
         "trans": [
+            "研究員(けんきゅういん)",
             "③ 名  研究员"
-        ],
-        "notation": "研究員(けんきゅういん)"
+        ]
     },
     {
         "name": "seikatsu",
         "trans": [
+            "生活(せいかつ)",
             "⓪ 名·自动3  生活；生计，谋生"
-        ],
-        "notation": "生活(せいかつ)"
+        ]
     },
     {
         "name": "jimu",
         "trans": [
+            "事務(じむ)",
             "① 名  事务，办公"
-        ],
-        "notation": "事務(じむ)"
+        ]
     },
     {
         "name": "kureru",
         "trans": [
+            "くれる",
             "⓪ 他动2  （别人）给我或我方的人……"
-        ],
-        "notation": "くれる"
+        ]
     },
     {
         "name": "gaidobukku",
         "trans": [
+            "ガイドブック",
             "④ 名  导游手册，旅行指南"
-        ],
-        "notation": "ガイドブック"
+        ]
     },
     {
         "name": "ooame",
         "trans": [
+            "大雨(おおあめ)",
             "③ 名  大雨"
-        ],
-        "notation": "大雨(おおあめ)"
+        ]
     },
     {
         "name": "ijimeru",
         "trans": [
+            "いじめる",
             "⓪ 他动2  虐待，欺凌"
-        ],
-        "notation": "いじめる"
+        ]
     },
     {
         "name": "kyoukai",
         "trans": [
+            "教会(きょうかい)",
             "⓪ 名  教会；教堂"
-        ],
-        "notation": "教会(きょうかい)"
+        ]
     },
     {
         "name": "momo",
         "trans": [
+            "桃(もも)",
             "⓪ 名  桃树；桃子"
-        ],
-        "notation": "桃(もも)"
+        ]
     },
     {
         "name": "atama",
         "trans": [
+            "頭(あたま)",
             "③ 名  头；头脑；首领"
-        ],
-        "notation": "頭(あたま)"
+        ]
     },
     {
         "name": "shinsetsu",
         "trans": [
+            "親切(しんせつ)",
             "① 名·ナ形  亲切，热情"
-        ],
-        "notation": "親切(しんせつ)"
+        ]
     },
     {
         "name": "kougi",
         "trans": [
+            "講義(こうぎ)",
             "① 名·他动3  讲义；（大学里）授课"
-        ],
-        "notation": "講義(こうぎ)"
+        ]
     },
     {
         "name": "gakki",
         "trans": [
+            "楽器(がっき)",
             "⓪ 名  乐器"
-        ],
-        "notation": "楽器(がっき)"
+        ]
     },
     {
         "name": "imadoki",
         "trans": [
+            "今時(いまどき)",
             "⓪ 名  当代，现在"
-        ],
-        "notation": "今時(いまどき)"
+        ]
     },
     {
         "name": "aji",
         "trans": [
+            "味(あじ)",
             "⓪ 名  味道"
-        ],
-        "notation": "味(あじ)"
+        ]
     },
     {
         "name": "shijou",
         "trans": [
+            "市場(しじょう)",
             "⓪ 名  市场"
-        ],
-        "notation": "市場(しじょう)"
+        ]
     },
     {
         "name": "kireru",
         "trans": [
+            "切(き)れる",
             "② 自动2  切断，中断；用尽"
-        ],
-        "notation": "切(き)れる"
+        ]
     },
     {
         "name": "zenkoku",
         "trans": [
+            "全国(ぜんこく)",
             "① 名  全国"
-        ],
-        "notation": "全国(ぜんこく)"
+        ]
     },
     {
         "name": "hatsugen",
         "trans": [
+            "発言(はつげん)",
             "⓪ 名·自动3  发言"
-        ],
-        "notation": "発言(はつげん)"
+        ]
     },
     {
         "name": "juuyou",
         "trans": [
+            "重要(じゅうよう)",
             "⓪ 名·ナ形  重要"
-        ],
-        "notation": "重要(じゅうよう)"
+        ]
     },
     {
         "name": "kikoeru",
         "trans": [
+            "聞(き)こえる",
             "⓪ 自动2  听得见，听到"
-        ],
-        "notation": "聞(き)こえる"
+        ]
     },
     {
         "name": "hanataba",
         "trans": [
+            "花束(はなたば)",
             "② 名  花束"
-        ],
-        "notation": "花束(はなたば)"
+        ]
     },
     {
         "name": "ryoute",
         "trans": [
+            "両手(りょうて)",
             "⓪ 名  双手"
-        ],
-        "notation": "両手(りょうて)"
+        ]
     },
     {
         "name": "purezento",
         "trans": [
+            "プレゼント",
             "② 名  礼物"
-        ],
-        "notation": "プレゼント"
+        ]
     },
     {
         "name": "gin",
         "trans": [
+            "銀(ぎん)",
             "① 名  银；银色"
-        ],
-        "notation": "銀(ぎん)"
+        ]
     },
     {
         "name": "shuukan",
         "trans": [
+            "習慣(しゅうかん)",
             "⓪ 名  习惯；风俗"
-        ],
-        "notation": "習慣(しゅうかん)"
+        ]
     },
     {
         "name": "omote",
         "trans": [
+            "表(おもて)",
             "③ 名  表面，正面；外表，外观"
-        ],
-        "notation": "表(おもて)"
+        ]
     },
     {
         "name": "sorou",
         "trans": [
+            "揃(そろ)う",
             "② 自动1  集齐，到齐；一致"
-        ],
-        "notation": "揃(そろ)う"
+        ]
     },
     {
         "name": "shuuhen",
         "trans": [
+            "周辺(しゅうへん)",
             "⓪ 名  周围"
-        ],
-        "notation": "周辺(しゅうへん)"
+        ]
     },
     {
         "name": "hada",
         "trans": [
+            "肌(はだ)",
             "① 名  皮肤；（物体）表面"
-        ],
-        "notation": "肌(はだ)"
+        ]
     },
     {
         "name": "yottsu",
         "trans": [
+            "四(よっ)つ",
             "③ 名  四个；四岁"
-        ],
-        "notation": "四(よっ)つ"
+        ]
     },
     {
         "name": "chuuko",
         "trans": [
+            "中古(ちゅうこ)",
             "⓪ 名  二手，半新"
-        ],
-        "notation": "中古(ちゅうこ)"
+        ]
     },
     {
         "name": "shizen",
         "trans": [
+            "自然(しぜん)",
             "⓪ 名·ナ形  大自然；自然，不做作"
-        ],
-        "notation": "自然(しぜん)"
+        ]
     },
     {
         "name": "kyuuryou",
         "trans": [
+            "給料(きゅうりょう)",
             "① 名  工资"
-        ],
-        "notation": "給料(きゅうりょう)"
+        ]
     },
     {
         "name": "ataru",
         "trans": [
+            "当(あ)たる",
             "⓪ 自动1  撞上；命中；相当于"
-        ],
-        "notation": "当(あ)たる"
+        ]
     },
     {
         "name": "kikou",
         "trans": [
+            "気候(きこう)",
             "⓪ 名  气候"
-        ],
-        "notation": "気候(きこう)"
+        ]
     },
     {
         "name": "sofuto",
         "trans": [
+            "ソフト",
             "① 名·ナ形  计算机软件；柔软的"
-        ],
-        "notation": "ソフト"
+        ]
     },
     {
         "name": "amerika",
         "trans": [
+            "アメリカ",
             "⓪ 名  美国"
-        ],
-        "notation": "アメリカ"
+        ]
     },
     {
         "name": "nezumi",
         "trans": [
+            "鼠(ねずみ)",
             "⓪ 名  老鼠"
-        ],
-        "notation": "鼠(ねずみ)"
+        ]
     },
     {
         "name": "yogosu",
         "trans": [
+            "汚(よご)す",
             "⓪ 他动1  弄脏"
-        ],
-        "notation": "汚(よご)す"
+        ]
     },
     {
         "name": "nittei",
         "trans": [
+            "日程(にってい)",
             "⓪ 名  日程"
-        ],
-        "notation": "日程(にってい)"
+        ]
     },
     {
         "name": "suna",
         "trans": [
+            "砂(すな)",
             "⓪ 名  沙子"
-        ],
-        "notation": "砂(すな)"
+        ]
     },
     {
         "name": "iraira",
         "trans": [
+            "いらいら",
             "① 副·自动3  焦躁，焦急"
-        ],
-        "notation": "いらいら"
+        ]
     },
     {
         "name": "settoku",
         "trans": [
+            "説得(せっとく)",
             "⓪ 名·他动3  说服"
-        ],
-        "notation": "説得(せっとく)"
+        ]
     },
     {
         "name": "kin'en",
         "trans": [
+            "禁煙(きんえん)",
             "⓪ 名·自动3  禁烟"
-        ],
-        "notation": "禁煙(きんえん)"
+        ]
     },
     {
         "name": "nokoru",
         "trans": [
+            "残(のこ)る",
             "② 自动1  留下，剩下"
-        ],
-        "notation": "残(のこ)る"
+        ]
     },
     {
         "name": "bijutsu",
         "trans": [
+            "美術(びじゅつ)",
             "① 名  美术"
-        ],
-        "notation": "美術(びじゅつ)"
+        ]
     },
     {
         "name": "hyoushiki",
         "trans": [
+            "標識(ひょうしき)",
             "⓪ 名  标识，标记"
-        ],
-        "notation": "標識(ひょうしき)"
+        ]
     },
     {
         "name": "mimi",
         "trans": [
+            "耳(みみ)",
             "② 名  耳朵"
-        ],
-        "notation": "耳(みみ)"
+        ]
     },
     {
         "name": "kyakuma",
         "trans": [
+            "客間(きゃくま)",
             "⓪ 名  客厅"
-        ],
-        "notation": "客間(きゃくま)"
+        ]
     },
     {
         "name": "ito",
         "trans": [
+            "糸(いと)",
             "① 名  线"
-        ],
-        "notation": "糸(いと)"
+        ]
     },
     {
         "name": "tsudukeru",
         "trans": [
+            "続(つづ)ける",
             "⓪ 他动2  继续，持续"
-        ],
-        "notation": "続(つづ)ける"
+        ]
     },
     {
         "name": "senta-",
         "trans": [
+            "センター",
             "① 名  中心，中央"
-        ],
-        "notation": "センター"
+        ]
     },
     {
         "name": "gekkyuu",
         "trans": [
+            "月給(げっきゅう)",
             "⓪ 名  月薪"
-        ],
-        "notation": "月給(げっきゅう)"
+        ]
     },
     {
         "name": "gomibako",
         "trans": [
+            "ゴミ箱(ばこ)",
             "③ 名  垃圾箱"
-        ],
-        "notation": "ゴミ箱(ばこ)"
+        ]
     },
     {
         "name": "biyou",
         "trans": [
+            "美容(びよう)",
             "⓪ 名  美容"
-        ],
-        "notation": "美容(びよう)"
+        ]
     },
     {
         "name": "kega",
         "trans": [
+            "怪我(けが)",
             "② 名  （身体）伤，受伤"
-        ],
-        "notation": "怪我(けが)"
+        ]
     },
     {
         "name": "okureru",
         "trans": [
+            "遅(おく)れる",
             "⓪ 自动2  迟到；进展慢"
-        ],
-        "notation": "遅(おく)れる"
+        ]
     },
     {
         "name": "bungaku",
         "trans": [
+            "文学(ぶんがく)",
             "① 名  文学"
-        ],
-        "notation": "文学(ぶんがく)"
+        ]
     },
     {
         "name": "baai",
         "trans": [
+            "場合(ばあい)",
             "⓪ 名  场合，情形"
-        ],
-        "notation": "場合(ばあい)"
+        ]
     },
     {
         "name": "tomaru",
         "trans": [
+            "泊(と)まる",
             "⓪ 自动1  住宿；（船）停泊"
-        ],
-        "notation": "泊(と)まる"
+        ]
     },
     {
         "name": "shuyaku",
         "trans": [
+            "主役(しゅやく)",
             "⓪ 名  主角，主要人物"
-        ],
-        "notation": "主役(しゅやく)"
+        ]
     },
     {
         "name": "kurou",
         "trans": [
+            "苦労(くろう)",
             "① 名·ナ形·自动3  辛苦，操劳"
-        ],
-        "notation": "苦労(くろう)"
+        ]
     },
     {
         "name": "youyaku",
         "trans": [
+            "ようやく",
             "⓪ 副  渐渐；终于，好不容易"
-        ],
-        "notation": "ようやく"
+        ]
     },
     {
         "name": "furu-tsu",
         "trans": [
+            "フルーツ",
             "② 名  水果"
-        ],
-        "notation": "フルーツ"
+        ]
     },
     {
         "name": "nikki",
         "trans": [
+            "日記(にっき)",
             "⓪ 名  日记"
-        ],
-        "notation": "日記(にっき)"
+        ]
     },
     {
         "name": "shiraberu",
         "trans": [
+            "調(しら)べる",
             "③ 他动2  查，调查"
-        ],
-        "notation": "調(しら)べる"
+        ]
     },
     {
         "name": "goukaku",
         "trans": [
+            "合格(ごうかく)",
             "⓪ 名·自动3  合格，及格"
-        ],
-        "notation": "合格(ごうかく)"
+        ]
     },
     {
         "name": "maitsuki",
         "trans": [
+            "毎月(まいつき)",
             "⓪ 名  每个月"
-        ],
-        "notation": "毎月(まいつき)"
+        ]
     },
     {
         "name": "shokutaku",
         "trans": [
+            "食卓(しょくたく)",
             "⓪ 名  餐桌"
-        ],
-        "notation": "食卓(しょくたく)"
+        ]
     },
     {
         "name": "tomeru",
         "trans": [
+            "止(と)める",
             "⓪ 他动2  使停止，使停下"
-        ],
-        "notation": "止(と)める"
+        ]
     },
     {
         "name": "hidarite",
         "trans": [
+            "左手(ひだりて)",
             "⓪ 名  左手"
-        ],
-        "notation": "左手(ひだりて)"
+        ]
     },
     {
         "name": "basho",
         "trans": [
+            "場所(ばしょ)",
             "⓪ 名  位置，场所"
-        ],
-        "notation": "場所(ばしょ)"
+        ]
     },
     {
         "name": "sawayaka",
         "trans": [
+            "爽(さわ)やか",
             "② ナ形  清爽的，爽朗的"
-        ],
-        "notation": "爽(さわ)やか"
+        ]
     },
     {
         "name": "ge-mu",
         "trans": [
+            "ゲーム",
             "① 名  游戏；竞技，比赛"
-        ],
-        "notation": "ゲーム"
+        ]
     },
     {
         "name": "dekigoto",
         "trans": [
+            "出来事(できごと)",
             "② 名  事情，事件"
-        ],
-        "notation": "出来事(できごと)"
+        ]
     },
     {
         "name": "umai",
         "trans": [
+            "うまい",
             "② イ形  好吃的；高明的；擅长的"
-        ],
-        "notation": "うまい"
+        ]
     },
     {
         "name": "manga",
         "trans": [
+            "漫画(まんが)",
             "⓪ 名  漫画"
-        ],
-        "notation": "漫画(まんが)"
+        ]
     },
     {
         "name": "fukusou",
         "trans": [
+            "服装(ふくそう)",
             "⓪ 名  服装"
-        ],
-        "notation": "服装(ふくそう)"
+        ]
     },
     {
         "name": "nayamu",
         "trans": [
+            "悩(なや)む",
             "② 自动1  烦恼"
-        ],
-        "notation": "悩(なや)む"
+        ]
     },
     {
         "name": "su-tsuke-su",
         "trans": [
+            "スーツケース",
             "④ 名  行李箱"
-        ],
-        "notation": "スーツケース"
+        ]
     },
     {
         "name": "shain",
         "trans": [
+            "社員(しゃいん)",
             "① 名  公司职员"
-        ],
-        "notation": "社員(しゃいん)"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "移(うつ)す",
             "② 他动1  移动；转移"
-        ],
-        "notation": "移(うつ)す"
+        ]
     },
     {
         "name": "mikata",
         "trans": [
+            "見方(みかた)",
             "③ 名  看法，见解"
-        ],
-        "notation": "見方(みかた)"
+        ]
     },
     {
         "name": "shika",
         "trans": [
+            "鹿(しか)",
             "⓪ 名  鹿"
-        ],
-        "notation": "鹿(しか)"
+        ]
     },
     {
         "name": "kawaku",
         "trans": [
+            "乾(かわ)く",
             "② 自动1  干燥"
-        ],
-        "notation": "乾(かわ)く"
+        ]
     },
     {
         "name": "inshokuten",
         "trans": [
+            "飲食店(いんしょくてん)",
             "④ 名  餐饮店"
-        ],
-        "notation": "飲食店(いんしょくてん)"
+        ]
     },
     {
         "name": "hikidashi",
         "trans": [
+            "引(ひ)き出(だ)し",
             "⓪ 名  抽屉"
-        ],
-        "notation": "引(ひ)き出(だ)し"
+        ]
     },
     {
         "name": "mono",
         "trans": [
+            "者(もの)",
             "② 名  人"
-        ],
-        "notation": "者(もの)"
+        ]
     },
     {
         "name": "sousa",
         "trans": [
+            "操作(そうさ)",
             "① 名·他动3  操作"
-        ],
-        "notation": "操作(そうさ)"
+        ]
     },
     {
         "name": "kuroji",
         "trans": [
+            "黒字(くろじ)",
             "⓪ 名  盈余，赚钱"
-        ],
-        "notation": "黒字(くろじ)"
+        ]
     },
     {
         "name": "nusumu",
         "trans": [
+            "盗(ぬす)む",
             "② 他动1  偷，偷盗"
-        ],
-        "notation": "盗(ぬす)む"
+        ]
     },
     {
         "name": "takuhaibin",
         "trans": [
+            "宅配便(たくはいびん)",
             "⓪ 名  快递"
-        ],
-        "notation": "宅配便(たくはいびん)"
+        ]
     },
     {
         "name": "ebi",
         "trans": [
+            "蝦(えび)",
             "⓪ 名  虾"
-        ],
-        "notation": "蝦(えび)"
+        ]
     },
     {
         "name": "surudoi",
         "trans": [
+            "鋭(するど)い",
             "③ イ形  锋利的；敏锐的"
-        ],
-        "notation": "鋭(するど)い"
+        ]
     },
     {
         "name": "nyuukoku",
         "trans": [
+            "入国(にゅうこく)",
             "⓪ 名·自动3  入境"
-        ],
-        "notation": "入国(にゅうこく)"
+        ]
     },
     {
         "name": "misuteri-",
         "trans": [
+            "ミステリー",
             "① 名  神秘；推理小说"
-        ],
-        "notation": "ミステリー"
+        ]
     },
     {
         "name": "risou",
         "trans": [
+            "理想(りそう)",
             "⓪ 名  理想"
-        ],
-        "notation": "理想(りそう)"
+        ]
     },
     {
         "name": "mainichi",
         "trans": [
+            "毎日(まいにち)",
             "① 名  每天"
-        ],
-        "notation": "毎日(まいにち)"
+        ]
     },
     {
         "name": "settei",
         "trans": [
+            "設定(せってい)",
             "⓪ 名·他动3  设立，制定"
-        ],
-        "notation": "設定(せってい)"
+        ]
     },
     {
         "name": "karasu",
         "trans": [
+            "カラス",
             "① 名  乌鸦"
-        ],
-        "notation": "カラス"
+        ]
     },
     {
         "name": "ikaga",
         "trans": [
+            "いかが",
             "② 副  怎么样，怎么办"
-        ],
-        "notation": "いかが"
+        ]
     },
     {
         "name": "jikanwari",
         "trans": [
+            "時間割(じかんわり)",
             "⓪ 名  时间表；课程表"
-        ],
-        "notation": "時間割(じかんわり)"
+        ]
     },
     {
         "name": "netsu",
         "trans": [
+            "熱(ねつ)",
             "② 名  发烧"
-        ],
-        "notation": "熱(ねつ)"
+        ]
     },
     {
         "name": "atsumeru",
         "trans": [
+            "集(あつ)める",
             "③ 他动2  集中，召集"
-        ],
-        "notation": "集(あつ)める"
+        ]
     },
     {
         "name": "ryouhou",
         "trans": [
+            "両方(りょうほう)",
             "③ 名  双方"
-        ],
-        "notation": "両方(りょうほう)"
+        ]
     },
     {
         "name": "manyuaru",
         "trans": [
+            "マニュアル",
             "⓪ 名  说明书，操作指南"
-        ],
-        "notation": "マニュアル"
+        ]
     },
     {
         "name": "tateru",
         "trans": [
+            "建(た)てる",
             "② 他动2  建，盖"
-        ],
-        "notation": "建(た)てる"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "例(れい)",
             "① 名  例子"
-        ],
-        "notation": "例(れい)"
+        ]
     },
     {
         "name": "fuutou",
         "trans": [
+            "封筒(ふうとう)",
             "⓪ 名  信封"
-        ],
-        "notation": "封筒(ふうとう)"
+        ]
     },
     {
         "name": "suruto",
         "trans": [
+            "すると",
             "⓪ 接续  于是；那么，那样的话"
-        ],
-        "notation": "すると"
+        ]
     },
     {
         "name": "rikon",
         "trans": [
+            "離婚(りこん)",
             "⓪ 名·自动3  离婚"
-        ],
-        "notation": "離婚(りこん)"
+        ]
     },
     {
         "name": "wake",
         "trans": [
+            "訳(わけ)",
             "① 名  意思；原因"
-        ],
-        "notation": "訳(わけ)"
+        ]
     },
     {
         "name": "sushi",
         "trans": [
+            "寿司(すし)",
             "② 名  寿司"
-        ],
-        "notation": "寿司(すし)"
+        ]
     },
     {
         "name": "shachou",
         "trans": [
+            "社長(しゃちょう)",
             "⓪ 名  社长，总经理"
-        ],
-        "notation": "社長(しゃちょう)"
+        ]
     },
     {
         "name": "kan",
         "trans": [
+            "缶(かん)",
             "① 名  （金属制的）罐子"
-        ],
-        "notation": "缶(かん)"
+        ]
     },
     {
         "name": "iwau",
         "trans": [
+            "祝(いわ)う",
             "② 他动1  庆祝"
-        ],
-        "notation": "祝(いわ)う"
+        ]
     },
     {
         "name": "sansei",
         "trans": [
+            "賛成(さんせい)",
             "⓪ 名·自动3  赞成"
-        ],
-        "notation": "賛成(さんせい)"
+        ]
     },
     {
         "name": "bai",
         "trans": [
+            "倍(ばい)",
             "⓪ 名  倍；两倍"
-        ],
-        "notation": "倍(ばい)"
+        ]
     },
     {
         "name": "rirakkusu",
         "trans": [
+            "リラックス",
             "② 名·自动3  放松"
-        ],
-        "notation": "リラックス"
+        ]
     },
     {
         "name": "mataha",
         "trans": [
+            "または",
             "② 接续  或者"
-        ],
-        "notation": "または"
+        ]
     },
     {
         "name": "tenkiyohou",
         "trans": [
+            "天気予報(てんきよほう)",
             "④ 名  天气预报"
-        ],
-        "notation": "天気予報(てんきよほう)"
+        ]
     },
     {
         "name": "sawaru",
         "trans": [
+            "触(さわ)る",
             "⓪ 自动1  触，碰"
-        ],
-        "notation": "触(さわ)る"
+        ]
     },
     {
         "name": "kyouiku",
         "trans": [
+            "教育(きょういく)",
             "⓪ 名·他动3  教育"
-        ],
-        "notation": "教育(きょういく)"
+        ]
     },
     {
         "name": "kyou",
         "trans": [
+            "今日(きょう)",
             "① 名  今天"
-        ],
-        "notation": "今日(きょう)"
+        ]
     },
     {
         "name": "sakki",
         "trans": [
+            "さっき",
             "① 名·副  刚才"
-        ],
-        "notation": "さっき"
+        ]
     },
     {
         "name": "teika",
         "trans": [
+            "低下(ていか)",
             "⓪ 名·自动3  降低，下降"
-        ],
-        "notation": "低下(ていか)"
+        ]
     },
     {
         "name": "hiraku",
         "trans": [
+            "開(ひら)く",
             "② 自他动1  开；打开；开张；召开"
-        ],
-        "notation": "開(ひら)く"
+        ]
     },
     {
         "name": "ri-da-",
         "trans": [
+            "リーダー",
             "① 名  领导，领袖"
-        ],
-        "notation": "リーダー"
+        ]
     },
     {
         "name": "juutaku",
         "trans": [
+            "住宅(じゅうたく)",
             "⓪ 名  住宅"
-        ],
-        "notation": "住宅(じゅうたく)"
+        ]
     },
     {
         "name": "otozureru",
         "trans": [
+            "訪(おとず)れる",
             "④ 自动2  访问，拜访；到来"
-        ],
-        "notation": "訪(おとず)れる"
+        ]
     },
     {
         "name": "kizu",
         "trans": [
+            "傷(きず)",
             "⓪ 名  创伤；瑕疵"
-        ],
-        "notation": "傷(きず)"
+        ]
     },
     {
         "name": "teita-",
         "trans": [
+            "ライター",
             "① 名  打火机"
-        ],
-        "notation": "ライター"
+        ]
     },
     {
         "name": "koishii",
         "trans": [
+            "恋(こい)しい",
             "③ イ形  爱慕的；怀念的，眷恋的"
-        ],
-        "notation": "恋(こい)しい"
+        ]
     },
     {
         "name": "iken",
         "trans": [
+            "意見(いけん)",
             "① 名·自他动3  意见；提建议，劝告"
-        ],
-        "notation": "意見(いけん)"
+        ]
     },
     {
         "name": "yonaka",
         "trans": [
+            "夜中(よなか)",
             "③ 名  夜间"
-        ],
-        "notation": "夜中(よなか)"
+        ]
     },
     {
         "name": "on'nanoko",
         "trans": [
+            "女(おんな)の子(こ)",
             "③ 名  女孩子"
-        ],
-        "notation": "女(おんな)の子(こ)"
+        ]
     },
     {
         "name": "jamu",
         "trans": [
+            "ジャム",
             "① 名  果酱"
-        ],
-        "notation": "ジャム"
+        ]
     },
     {
         "name": "kyuujitsu",
         "trans": [
+            "休日(きゅうじつ)",
             "⓪ 名  休息日"
-        ],
-        "notation": "休日(きゅうじつ)"
+        ]
     },
     {
         "name": "riyuu",
         "trans": [
+            "理由(りゆう)",
             "⓪ 名  理由"
-        ],
-        "notation": "理由(りゆう)"
+        ]
     },
     {
         "name": "itasu",
         "trans": [
+            "致(いた)す",
             "② 他动1  (する的自谦语）做"
-        ],
-        "notation": "致(いた)す"
+        ]
     },
     {
         "name": "yu",
         "trans": [
+            "湯(ゆ)",
             "① 名  热水；洗澡水"
-        ],
-        "notation": "湯(ゆ)"
+        ]
     },
     {
         "name": "junbi",
         "trans": [
+            "準備(じゅんび)",
             "① 名·他动3  准备"
-        ],
-        "notation": "準備(じゅんび)"
+        ]
     },
     {
         "name": "chichioya",
         "trans": [
+            "父親(ちちおや)",
             "⓪ 名  父亲"
-        ],
-        "notation": "父親(ちちおや)"
+        ]
     },
     {
         "name": "ueru",
         "trans": [
+            "植(う)える",
             "⓪ 他动2  种植"
-        ],
-        "notation": "植(う)える"
+        ]
     },
     {
         "name": "iroenpitsu",
         "trans": [
+            "色鉛筆(いろえんぴつ)",
             "③ 名  彩色铅笔"
-        ],
-        "notation": "色鉛筆(いろえんぴつ)"
+        ]
     },
     {
         "name": "sakuhin",
         "trans": [
+            "作品(さくひん)",
             "⓪ 名  作品"
-        ],
-        "notation": "作品(さくひん)"
+        ]
     },
     {
         "name": "uisuki-",
         "trans": [
+            "ウイスキー",
             "③ 名  威士忌"
-        ],
-        "notation": "ウイスキー"
+        ]
     },
     {
         "name": "kotowaru",
         "trans": [
+            "断(ことわ)る",
             "③ 他动1  拒绝"
-        ],
-        "notation": "断(ことわ)る"
+        ]
     },
     {
         "name": "teien",
         "trans": [
+            "庭園(ていえん)",
             "⓪ 名  庭园"
-        ],
-        "notation": "庭園(ていえん)"
+        ]
     },
     {
         "name": "futago",
         "trans": [
+            "双子(ふたご)",
             "⓪ 名  双胞胎"
-        ],
-        "notation": "双子(ふたご)"
+        ]
     },
     {
         "name": "daiji",
         "trans": [
+            "大事(だいじ)",
             "③ 名·ナ形  重要，宝贵；珍视"
-        ],
-        "notation": "大事(だいじ)"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "一(いち)",
             "② 数  一"
-        ],
-        "notation": "一(いち)"
+        ]
     },
     {
         "name": "hitode",
         "trans": [
+            "人出(ひとで)",
             "⓪ 名  外出的人群"
-        ],
-        "notation": "人出(ひとで)"
+        ]
     },
     {
         "name": "ryuukou",
         "trans": [
+            "流行(りゅうこう)",
             "⓪ 名·自动3  流行，时髦；（疾病）蔓延"
-        ],
-        "notation": "流行(りゅうこう)"
+        ]
     },
     {
         "name": "shi/yon",
         "trans": [
+            "四(し/よん)",
             "① 数  四"
-        ],
-        "notation": "四(し/よん)"
+        ]
     },
     {
         "name": "ji",
         "trans": [
+            "字(じ)",
             "① 名  文字；笔迹"
-        ],
-        "notation": "字(じ)"
+        ]
     },
     {
         "name": "gamu",
         "trans": [
+            "ガム",
             "① 名  口香糖"
-        ],
-        "notation": "ガム"
+        ]
     },
     {
         "name": "ateru",
         "trans": [
+            "当(あ)てる",
             "⓪ 他动2  碰，撞；贴上；猜"
-        ],
-        "notation": "当(あ)てる"
+        ]
     },
     {
         "name": "kaigan",
         "trans": [
+            "海岸(かいがん)",
             "⓪ 名  海岸"
-        ],
-        "notation": "海岸(かいがん)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "十(じゅう)",
             "① 数  十"
-        ],
-        "notation": "十(じゅう)"
+        ]
     },
     {
         "name": "tegaru",
         "trans": [
+            "手軽(てがる)",
             "⓪ 名·ナ形  简便，轻易"
-        ],
-        "notation": "手軽(てがる)"
+        ]
     },
     {
         "name": "burausu",
         "trans": [
+            "ブラウス",
             "② 名  女士衬衫"
-        ],
-        "notation": "ブラウス"
+        ]
     },
     {
         "name": "sakebu",
         "trans": [
+            "叫(さけ)ぶ",
             "② 自动1  喊叫；呼吁"
-        ],
-        "notation": "叫(さけ)ぶ"
+        ]
     },
     {
         "name": "ougon",
         "trans": [
+            "黄金(おうごん)",
             "⓪ 名  黄金"
-        ],
-        "notation": "黄金(おうごん)"
+        ]
     },
     {
         "name": "ryouashi",
         "trans": [
+            "両足(りょうあし)",
             "⓪ 名  双脚；双腿"
-        ],
-        "notation": "両足(りょうあし)"
+        ]
     },
     {
         "name": "shiraseru",
         "trans": [
+            "知(し)らせる",
             "⓪ 他动2  通知，告知"
-        ],
-        "notation": "知(し)らせる"
+        ]
     },
     {
         "name": "kaishain",
         "trans": [
+            "会社員(かいしゃいん)",
             "③ 名  公司职员"
-        ],
-        "notation": "会社員(かいしゃいん)"
+        ]
     },
     {
         "name": "budou",
         "trans": [
+            "葡萄(ぶどう)",
             "⓪ 名  葡萄"
-        ],
-        "notation": "葡萄(ぶどう)"
+        ]
     },
     {
         "name": "zuibun",
         "trans": [
+            "随分(ずいぶん)",
             "① 副  相当，非常"
-        ],
-        "notation": "随分(ずいぶん)"
+        ]
     },
     {
         "name": "ojousan",
         "trans": [
+            "お嬢(じょう)さん",
             "② 名  令爱；小姐"
-        ],
-        "notation": "お嬢(じょう)さん"
+        ]
     },
     {
         "name": "uchiageru",
         "trans": [
+            "打(う)ち上(あ)げる",
             "④ 他动2  发射"
-        ],
-        "notation": "打(う)ち上(あ)げる"
+        ]
     },
     {
         "name": "denshijisho",
         "trans": [
+            "電子辞書(でんしじしょ)",
             "④ 名  电子词典"
-        ],
-        "notation": "電子辞書(でんしじしょ)"
+        ]
     },
     {
         "name": "so-su",
         "trans": [
+            "ソース",
             "① 名  调味汁"
-        ],
-        "notation": "ソース"
+        ]
     },
     {
         "name": "chawan",
         "trans": [
+            "茶碗(ちゃわん)",
             "⓪ 名  茶杯；饭碗"
-        ],
-        "notation": "茶碗(ちゃわん)"
+        ]
     },
     {
         "name": "taiin",
         "trans": [
+            "退院(たいいん)",
             "⓪ 名·自动3  出院"
-        ],
-        "notation": "退院(たいいん)"
+        ]
     },
     {
         "name": "shiai",
         "trans": [
+            "試合(しあい)",
             "⓪ 名·自动3  比赛"
-        ],
-        "notation": "試合(しあい)"
+        ]
     },
     {
         "name": "oodoori",
         "trans": [
+            "大通(おおどお)り",
             "③ 名  大街，主路"
-        ],
-        "notation": "大通(おおどお)り"
+        ]
     },
     {
         "name": "katai",
         "trans": [
+            "堅(かた)い",
             "⓪ イ形  坚硬的"
-        ],
-        "notation": "堅(かた)い"
+        ]
     },
     {
         "name": "shinamono",
         "trans": [
+            "品物(しなもの)",
             "⓪ 名  物品，商品"
-        ],
-        "notation": "品物(しなもの)"
+        ]
     },
     {
         "name": "yuube",
         "trans": [
+            "夕(ゆう)べ",
             "③ 名  昨天晚上"
-        ],
-        "notation": "夕(ゆう)べ"
+        ]
     },
     {
         "name": "tsuujiru",
         "trans": [
+            "通(つう)じる",
             "⓪ 自他动2  通；精通；通过；通晓"
-        ],
-        "notation": "通(つう)じる"
+        ]
     },
     {
         "name": "seiseki",
         "trans": [
+            "成績(せいせき)",
             "⓪ 名  成绩"
-        ],
-        "notation": "成績(せいせき)"
+        ]
     },
     {
         "name": "kangoshi",
         "trans": [
+            "看護師(かんごし)",
             "③ 名  护士"
-        ],
-        "notation": "看護師(かんごし)"
+        ]
     },
     {
         "name": "utsusu",
         "trans": [
+            "写(うつ)す",
             "② 他动1  誊，抄；拍照"
-        ],
-        "notation": "写(うつ)す"
+        ]
     },
     {
         "name": "youki",
         "trans": [
+            "容器(ようき)",
             "① 名  容器"
-        ],
-        "notation": "容器(ようき)"
+        ]
     },
     {
         "name": "roujin",
         "trans": [
+            "老人(ろうじん)",
             "⓪ 名  老年人"
-        ],
-        "notation": "老人(ろうじん)"
+        ]
     },
     {
         "name": "roku",
         "trans": [
+            "六(ろく)",
             "② 数  六"
-        ],
-        "notation": "六(ろく)"
+        ]
     },
     {
         "name": "isan",
         "trans": [
+            "遺産(いさん)",
             "⓪ 名  遗产"
-        ],
-        "notation": "遺産(いさん)"
+        ]
     },
     {
         "name": "akushu",
         "trans": [
+            "握手(あくしゅ)",
             "① 名·自动3  握手；和好；妥协"
-        ],
-        "notation": "握手(あくしゅ)"
+        ]
     },
     {
         "name": "katachi",
         "trans": [
+            "形(かたち)",
             "⓪ 名  形状，形式"
-        ],
-        "notation": "形(かたち)"
+        ]
     },
     {
         "name": "suku",
         "trans": [
+            "空(す)く",
             "⓪ 自动1  有空隙，空旷"
-        ],
-        "notation": "空(す)く"
+        ]
     },
     {
         "name": "mizuumi",
         "trans": [
+            "湖(みずうみ)",
             "③ 名  湖泊"
-        ],
-        "notation": "湖(みずうみ)"
+        ]
     },
     {
         "name": "hyouka",
         "trans": [
+            "評価(ひょうか)",
             "① 名·他动3  评价"
-        ],
-        "notation": "評価(ひょうか)"
+        ]
     },
     {
         "name": "tokiniha",
         "trans": [
+            "時(とき)には",
             "② 副  有时"
-        ],
-        "notation": "時(とき)には"
+        ]
     },
     {
         "name": "haru",
         "trans": [
+            "春(はる)",
             "① 名  春季"
-        ],
-        "notation": "春(はる)"
+        ]
     },
     {
         "name": "ima",
         "trans": [
+            "居間(いま)",
             "② 名  起居室"
-        ],
-        "notation": "居間(いま)"
+        ]
     },
     {
         "name": "kagu",
         "trans": [
+            "嗅(か)ぐ",
             "⓪ 他动1  闻，嗅"
-        ],
-        "notation": "嗅(か)ぐ"
+        ]
     },
     {
         "name": "nuno",
         "trans": [
+            "布(ぬの)",
             "⓪ 名  布"
-        ],
-        "notation": "布(ぬの)"
+        ]
     },
     {
         "name": "sumi",
         "trans": [
+            "隅(すみ)",
             "① 名  角落"
-        ],
-        "notation": "隅(すみ)"
+        ]
     },
     {
         "name": "kemui",
         "trans": [
+            "煙(けむ)い",
             "⓪ イ形  呛人的，熏人的"
-        ],
-        "notation": "煙(けむ)い"
+        ]
     },
     {
         "name": "oshiire",
         "trans": [
+            "押(お)し入(い)れ",
             "⓪ 名  壁橱"
-        ],
-        "notation": "押(お)し入(い)れ"
+        ]
     },
     {
         "name": "ryokan",
         "trans": [
+            "旅館(りょかん)",
             "⓪ 名  （日式）旅馆"
-        ],
-        "notation": "旅館(りょかん)"
+        ]
     },
     {
         "name": "mochikaeru",
         "trans": [
+            "持(も)ち帰(かえ)る",
             "⓪ 他动1  拿回，打包"
-        ],
-        "notation": "持(も)ち帰(かえ)る"
+        ]
     },
     {
         "name": "tenkou",
         "trans": [
+            "転校(てんこう)",
             "⓪ 名·自动3  转校"
-        ],
-        "notation": "転校(てんこう)"
+        ]
     },
     {
         "name": "suugaku",
         "trans": [
+            "数学(すうがく)",
             "⓪ 名  数学"
-        ],
-        "notation": "数学(すうがく)"
+        ]
     },
     {
         "name": "odoroku",
         "trans": [
+            "驚(おどろ)く",
             "③ 自动1  惊讶；惊恐"
-        ],
-        "notation": "驚(おどろ)く"
+        ]
     },
     {
         "name": "hakusai",
         "trans": [
+            "白菜(はくさい)",
             "③ 名  白菜"
-        ],
-        "notation": "白菜(はくさい)"
+        ]
     },
     {
         "name": "miruku",
         "trans": [
+            "ミルク",
             "① 名  牛奶"
-        ],
-        "notation": "ミルク"
+        ]
     },
     {
         "name": "hirogaru",
         "trans": [
+            "広(ひろ)がる",
             "⓪ 自动1  扩展，蔓延"
-        ],
-        "notation": "広(ひろ)がる"
+        ]
     },
     {
         "name": "~senchi",
         "trans": [
+            "～センチ",
             " 接尾  ……厘米"
-        ],
-        "notation": "～センチ"
+        ]
     },
     {
         "name": "ishi",
         "trans": [
+            "石(いし)",
             "② 名  石头"
-        ],
-        "notation": "石(いし)"
+        ]
     },
     {
         "name": "kowasu",
         "trans": [
+            "壊(こわ)す",
             "② 他动1  弄坏；破坏"
-        ],
-        "notation": "壊(こわ)す"
+        ]
     },
     {
         "name": "soutai",
         "trans": [
+            "早退(そうたい)",
             "⓪ 名·自动3  早退"
-        ],
-        "notation": "早退(そうたい)"
+        ]
     },
     {
         "name": "buhin",
         "trans": [
+            "部品(ぶひん)",
             "⓪ 名  零件"
-        ],
-        "notation": "部品(ぶひん)"
+        ]
     },
     {
         "name": "monogatari",
         "trans": [
+            "物語(ものがたり)",
             "③ 名  故事"
-        ],
-        "notation": "物語(ものがたり)"
+        ]
     },
     {
         "name": "ukeru",
         "trans": [
+            "受(う)ける",
             "② 他动2  接住；受到，接受"
-        ],
-        "notation": "受(う)ける"
+        ]
     },
     {
         "name": "ningen",
         "trans": [
+            "人間(にんげん)",
             "⓪ 名  人，人类"
-        ],
-        "notation": "人間(にんげん)"
+        ]
     },
     {
         "name": "seisan",
         "trans": [
+            "生産(せいさん)",
             "⓪ 名·他动3  生产"
-        ],
-        "notation": "生産(せいさん)"
+        ]
     },
     {
         "name": "burashi",
         "trans": [
+            "ブラシ",
             "① 名  刷子"
-        ],
-        "notation": "ブラシ"
+        ]
     },
     {
         "name": "koeru",
         "trans": [
+            "越(こ)える",
             "⓪ 自动2  越过(山峰等)；超越"
-        ],
-        "notation": "越(こ)える"
+        ]
     },
     {
         "name": "ippai",
         "trans": [
+            "いっぱい",
             "⓪ 名·副  充满；全部"
-        ],
-        "notation": "いっぱい"
+        ]
     },
     {
         "name": "shiroi",
         "trans": [
+            "白(しろ)い",
             "② イ形  白色的"
-        ],
-        "notation": "白(しろ)い"
+        ]
     },
     {
         "name": "bo-ringu",
         "trans": [
+            "ボーリング",
             "⓪ 名  保龄球"
-        ],
-        "notation": "ボーリング"
+        ]
     },
     {
         "name": "shikaru",
         "trans": [
+            "叱(しか)る",
             "⓪ 他动1  责备，训斥"
-        ],
-        "notation": "叱(しか)る"
+        ]
     },
     {
         "name": "kodutsumi",
         "trans": [
+            "小包(こづつみ)",
             "② 名  包裹"
-        ],
-        "notation": "小包(こづつみ)"
+        ]
     },
     {
         "name": "kariru",
         "trans": [
+            "借(か)りる",
             "⓪ 他动2  借入；借助"
-        ],
-        "notation": "借(か)りる"
+        ]
     },
     {
         "name": "pittari",
         "trans": [
+            "ぴったり",
             "③ 副·自动3  紧密，严实；正合适"
-        ],
-        "notation": "ぴったり"
+        ]
     },
     {
         "name": "sekinin",
         "trans": [
+            "責任(せきにん)",
             "⓪ 名  责任"
-        ],
-        "notation": "責任(せきにん)"
+        ]
     },
     {
         "name": "shinshutsu",
         "trans": [
+            "進出(しんしゅつ)",
             "⓪ 名·自动3  进入"
-        ],
-        "notation": "進出(しんしゅつ)"
+        ]
     },
     {
         "name": "ukagau",
         "trans": [
+            "伺(うかが)う",
             "⓪ 他动1  拜访；请教"
-        ],
-        "notation": "伺(うかが)う"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "履(は)く",
             "⓪ 他动1  穿（鞋）"
-        ],
-        "notation": "履(は)く"
+        ]
     },
     {
         "name": "saisho",
         "trans": [
+            "最初(さいしょ)",
             "⓪ 名  最初，最开始"
-        ],
-        "notation": "最初(さいしょ)"
+        ]
     },
     {
         "name": "hikkosu",
         "trans": [
+            "引(ひ)っ越(こ)す",
             "③ 他动1  搬家，搬迁"
-        ],
-        "notation": "引(ひ)っ越(こ)す"
+        ]
     },
     {
         "name": "rei",
         "trans": [
+            "礼(れい)",
             "① 名  行礼；礼貌；礼物；道谢"
-        ],
-        "notation": "礼(れい)"
+        ]
     },
     {
         "name": "yakei",
         "trans": [
+            "夜景(やけい)",
             "⓪ 名  夜景"
-        ],
-        "notation": "夜景(やけい)"
+        ]
     },
     {
         "name": "maitoshi",
         "trans": [
+            "毎年(まいとし)",
             "⓪ 名  每年"
-        ],
-        "notation": "毎年(まいとし)"
+        ]
     },
     {
         "name": "shiya",
         "trans": [
+            "視野(しや)",
             "① 名  视野；眼界"
-        ],
-        "notation": "視野(しや)"
+        ]
     },
     {
         "name": "kekka",
         "trans": [
+            "結果(けっか)",
             "⓪ 名  结果"
-        ],
-        "notation": "結果(けっか)"
+        ]
     },
     {
         "name": "oreru",
         "trans": [
+            "折(お)れる",
             "② 自动2  折，折断"
-        ],
-        "notation": "折(お)れる"
+        ]
     },
     {
         "name": "risaikuru",
         "trans": [
+            "リサイクル",
             "② 名  再利用"
-        ],
-        "notation": "リサイクル"
+        ]
     },
     {
         "name": "moji",
         "trans": [
+            "文字(もじ)",
             "① 名  文字"
-        ],
-        "notation": "文字(もじ)"
+        ]
     },
     {
         "name": "shi",
         "trans": [
+            "詩(し)",
             "⓪ 名  诗"
-        ],
-        "notation": "詩(し)"
+        ]
     },
     {
         "name": "daichi",
         "trans": [
+            "大地(だいち)",
             "① 名  大地"
-        ],
-        "notation": "大地(だいち)"
+        ]
     },
     {
         "name": "ikou",
         "trans": [
+            "以降(いこう)",
             "① 名  以后"
-        ],
-        "notation": "以降(いこう)"
+        ]
     },
     {
         "name": "nigate",
         "trans": [
+            "苦手(にがて)",
             "⓪ 名·ナ形  不擅长"
-        ],
-        "notation": "苦手(にがて)"
+        ]
     },
     {
         "name": "bideokamera",
         "trans": [
+            "ビデオカメラ",
             "④ 名  摄像机"
-        ],
-        "notation": "ビデオカメラ"
+        ]
     },
     {
         "name": "reidanbou",
         "trans": [
+            "冷暖房(れいだんぼう)",
             "③ 名  冷暖气设备"
-        ],
-        "notation": "冷暖房(れいだんぼう)"
+        ]
     },
     {
         "name": "tsumoru",
         "trans": [
+            "積(つ)もる",
             "② 自他动1  堆积；积累"
-        ],
-        "notation": "積(つ)もる"
+        ]
     },
     {
         "name": "juusho",
         "trans": [
+            "住所(じゅうしょ)",
             "① 名  住址"
-        ],
-        "notation": "住所(じゅうしょ)"
+        ]
     },
     {
         "name": "keshiki",
         "trans": [
+            "景色(けしき)",
             "① 名  景色"
-        ],
-        "notation": "景色(けしき)"
+        ]
     },
     {
         "name": "kagu",
         "trans": [
+            "家具(かぐ)",
             "① 名  家具"
-        ],
-        "notation": "家具(かぐ)"
+        ]
     },
     {
         "name": "retsu",
         "trans": [
+            "列(れつ)",
             "① 名  列；队伍"
-        ],
-        "notation": "列(れつ)"
+        ]
     },
     {
         "name": "hige",
         "trans": [
+            "髭(ひげ)",
             "⓪ 名  胡子"
-        ],
-        "notation": "髭(ひげ)"
+        ]
     },
     {
         "name": "su-pu",
         "trans": [
+            "スープ",
             "① 名  （西餐）汤"
-        ],
-        "notation": "スープ"
+        ]
     },
     {
         "name": "satsujin",
         "trans": [
+            "殺人(さつじん)",
             "⓪ 名  杀人"
-        ],
-        "notation": "殺人(さつじん)"
+        ]
     },
     {
         "name": "kaijou",
         "trans": [
+            "会場(かいじょう)",
             "⓪ 名  会场"
-        ],
-        "notation": "会場(かいじょう)"
+        ]
     },
     {
         "name": "ukkari",
         "trans": [
+            "うっかり",
             "③ 副·自动3  不留神，不小心"
-        ],
-        "notation": "うっかり"
+        ]
     },
     {
         "name": "gurafu",
         "trans": [
+            "グラフ",
             "① 名  图表"
-        ],
-        "notation": "グラフ"
+        ]
     },
     {
         "name": "kuuki",
         "trans": [
+            "空気(くうき)",
             "① 名  空气；气氛"
-        ],
-        "notation": "空気(くうき)"
+        ]
     },
     {
         "name": "naosu",
         "trans": [
+            "直(なお)す",
             "② 他动1  改正；修改；修理"
-        ],
-        "notation": "直(なお)す"
+        ]
     },
     {
         "name": "buka",
         "trans": [
+            "部下(ぶか)",
             "① 名  部下，下属"
-        ],
-        "notation": "部下(ぶか)"
+        ]
     },
     {
         "name": "yanagi",
         "trans": [
+            "柳(やなぎ)",
             "⓪ 名  柳树"
-        ],
-        "notation": "柳(やなぎ)"
+        ]
     },
     {
         "name": "tameru",
         "trans": [
+            "溜(た)める",
             "⓪ 他动2  积，积攒；停滞"
-        ],
-        "notation": "溜(た)める"
+        ]
     },
     {
         "name": "jiko",
         "trans": [
+            "事故(じこ)",
             "① 名  事故"
-        ],
-        "notation": "事故(じこ)"
+        ]
     },
     {
         "name": "ibento",
         "trans": [
+            "イベント",
             "⓪ 名  事件；集会，活动"
-        ],
-        "notation": "イベント"
+        ]
     },
     {
         "name": "sugoi",
         "trans": [
+            "すごい",
             "② イ形  了不起的；厉害的"
-        ],
-        "notation": "すごい"
+        ]
     },
     {
         "name": "keikan",
         "trans": [
+            "警官(けいかん)",
             "⓪ 名  警察，警官"
-        ],
-        "notation": "警官(けいかん)"
+        ]
     },
     {
         "name": "youji",
         "trans": [
+            "用事(ようじ)",
             "⓪ 名  事情"
-        ],
-        "notation": "用事(ようじ)"
+        ]
     },
     {
         "name": "tsutaeru",
         "trans": [
+            "伝(つた)える",
             "⓪ 他动2  传达，转告；传授"
-        ],
-        "notation": "伝(つた)える"
+        ]
     },
     {
         "name": "shokki",
         "trans": [
+            "食器(しょっき)",
             "⓪ 名  餐具"
-        ],
-        "notation": "食器(しょっき)"
+        ]
     },
     {
         "name": "kyoukasho",
         "trans": [
+            "教科書(きょうかしょ)",
             "③ 名  课本，教科书"
-        ],
-        "notation": "教科書(きょうかしょ)"
+        ]
     },
     {
         "name": "kau",
         "trans": [
+            "飼(か)う",
             "① 他动1  饲养"
-        ],
-        "notation": "飼(か)う"
+        ]
     },
     {
         "name": "mama",
         "trans": [
+            "ママ",
             "① 名  妈妈"
-        ],
-        "notation": "ママ"
+        ]
     },
     {
         "name": "tensuu",
         "trans": [
+            "点数(てんすう)",
             "③ 名  分数；件数"
-        ],
-        "notation": "点数(てんすう)"
+        ]
     },
     {
         "name": "mazu",
         "trans": [
+            "まず",
             "① 副  首先，最初"
-        ],
-        "notation": "まず"
+        ]
     },
     {
         "name": "yuuenchi",
         "trans": [
+            "遊園地(ゆうえんち)",
             "③ 名  游乐场"
-        ],
-        "notation": "遊園地(ゆうえんち)"
+        ]
     },
     {
         "name": "eki",
         "trans": [
+            "液(えき)",
             "① 名  液体"
-        ],
-        "notation": "液(えき)"
+        ]
     },
     {
         "name": "yuubinkyoku",
         "trans": [
+            "郵便局(ゆうびんきょく)",
             "③ 名  邮局"
-        ],
-        "notation": "郵便局(ゆうびんきょく)"
+        ]
     },
     {
         "name": "senjitsu",
         "trans": [
+            "先日(せんじつ)",
             "⓪ 名  前几天"
-        ],
-        "notation": "先日(せんじつ)"
+        ]
     },
     {
         "name": "hiruma",
         "trans": [
+            "昼間(ひるま)",
             "③ 名  白天"
-        ],
-        "notation": "昼間(ひるま)"
+        ]
     },
     {
         "name": "wakareru",
         "trans": [
+            "分(わ)かれる",
             "③ 自动2  分开；区分"
-        ],
-        "notation": "分(わ)かれる"
+        ]
     },
     {
         "name": "boueki",
         "trans": [
+            "貿易(ぼうえき)",
             "⓪ 名·自动3  贸易"
-        ],
-        "notation": "貿易(ぼうえき)"
+        ]
     },
     {
         "name": "barentainde-",
         "trans": [
+            "バレンタインデー",
             "⑤ 名  情人节"
-        ],
-        "notation": "バレンタインデー"
+        ]
     },
     {
         "name": "suru",
         "trans": [
+            "掏(す)る",
             "① 他动1  偷窃"
-        ],
-        "notation": "掏(す)る"
+        ]
     },
     {
         "name": "shimin",
         "trans": [
+            "市民(しみん)",
             "① 名  市民；公民"
-        ],
-        "notation": "市民(しみん)"
+        ]
     },
     {
         "name": "kagaku",
         "trans": [
+            "化学(かがく)",
             "① 名  化学"
-        ],
-        "notation": "化学(かがく)"
+        ]
     },
     {
         "name": "uwaru",
         "trans": [
+            "植(う)わる",
             "⓪ 自动1  种植"
-        ],
-        "notation": "植(う)わる"
+        ]
     },
     {
         "name": "tsuma",
         "trans": [
+            "妻(つま)",
             "① 名  妻子"
-        ],
-        "notation": "妻(つま)"
+        ]
     },
     {
         "name": "nishiguchi",
         "trans": [
+            "西口(にしぐち)",
             "⓪ 名  西侧出入口"
-        ],
-        "notation": "西口(にしぐち)"
+        ]
     },
     {
         "name": "basukettobo-ru",
         "trans": [
+            "バスケットボール",
             "⑥ 名  篮球"
-        ],
-        "notation": "バスケットボール"
+        ]
     },
     {
         "name": "kowagaru",
         "trans": [
+            "怖(こわ)がる",
             "③ 自动1  害怕"
-        ],
-        "notation": "怖(こわ)がる"
+        ]
     },
     {
         "name": "buchou",
         "trans": [
+            "部長(ぶちょう)",
             "⓪ 名  部长"
-        ],
-        "notation": "部長(ぶちょう)"
+        ]
     },
     {
         "name": "~rittoru",
         "trans": [
+            "～リットル",
             " 接尾  ……升"
-        ],
-        "notation": "～リットル"
+        ]
     },
     {
         "name": "fuku",
         "trans": [
+            "服(ふく)",
             "② 名  衣服"
-        ],
-        "notation": "服(ふく)"
+        ]
     },
     {
         "name": "seizou",
         "trans": [
+            "製造(せいぞう)",
             "⓪ 名·他动3  制造"
-        ],
-        "notation": "製造(せいぞう)"
+        ]
     },
     {
         "name": "shisutemu",
         "trans": [
+            "システム",
             "① 名  系统"
-        ],
-        "notation": "システム"
+        ]
     },
     {
         "name": "okonau",
         "trans": [
+            "行(おこな)う",
             "⓪ 他动1  实行；举行"
-        ],
-        "notation": "行(おこな)う"
+        ]
     },
     {
         "name": "juumin",
         "trans": [
+            "住民(じゅうみん)",
             "⓪ 名  居民"
-        ],
-        "notation": "住民(じゅうみん)"
+        ]
     },
     {
         "name": "hantsuki",
         "trans": [
+            "半月(はんつき)",
             "⓪ 名  半个月"
-        ],
-        "notation": "半月(はんつき)"
+        ]
     },
     {
         "name": "ugokasu",
         "trans": [
+            "動(うご)かす",
             "③ 他动1  动；移动；启动（机器等）"
-        ],
-        "notation": "動(うご)かす"
+        ]
     },
     {
         "name": "sakaya",
         "trans": [
+            "酒屋(さかや)",
             "⓪ 名  酒馆"
-        ],
-        "notation": "酒屋(さかや)"
+        ]
     },
     {
         "name": "honsha",
         "trans": [
+            "本社(ほんしゃ)",
             "① 名  总公司"
-        ],
-        "notation": "本社(ほんしゃ)"
+        ]
     },
     {
         "name": "soto",
         "trans": [
+            "外(そと)",
             "① 名  外面"
-        ],
-        "notation": "外(そと)"
+        ]
     },
     {
         "name": "su-pa-ma-ketto",
         "trans": [
+            "スーパーマーケット",
             "⑤ 名  超市"
-        ],
-        "notation": "スーパーマーケット"
+        ]
     },
     {
         "name": "konkai",
         "trans": [
+            "今回(こんかい)",
             "① 名  这次"
-        ],
-        "notation": "今回(こんかい)"
+        ]
     },
     {
         "name": "sugosu",
         "trans": [
+            "過(す)ごす",
             "② 他动1  度过；生活"
-        ],
-        "notation": "過(す)ごす"
+        ]
     },
     {
         "name": "bentou",
         "trans": [
+            "弁当(べんとう)",
             "③ 名  盒饭"
-        ],
-        "notation": "弁当(べんとう)"
+        ]
     },
     {
         "name": "ryougawa",
         "trans": [
+            "両側(りょうがわ)",
             "⓪ 名  两侧"
-        ],
-        "notation": "両側(りょうがわ)"
+        ]
     },
     {
         "name": "suyasuya",
         "trans": [
+            "すやすや",
             "① 副  睡得很香甜"
-        ],
-        "notation": "すやすや"
+        ]
     },
     {
         "name": "machiaishitsu",
         "trans": [
+            "待合室(まちあいしつ)",
             "③ 名  等候室"
-        ],
-        "notation": "待合室(まちあいしつ)"
+        ]
     },
     {
         "name": "~noki",
         "trans": [
+            "～軒(のき)",
             " 接尾  （房屋）……栋"
-        ],
-        "notation": "～軒(のき)"
+        ]
     },
     {
         "name": "warau",
         "trans": [
+            "笑(わら)う",
             "⓪ 自他动1  笑；嘲笑"
-        ],
-        "notation": "笑(わら)う"
+        ]
     },
     {
         "name": "meishi",
         "trans": [
+            "名刺(めいし)",
             "⓪ 名  名片"
-        ],
-        "notation": "名刺(めいし)"
+        ]
     },
     {
         "name": "jidousha",
         "trans": [
+            "自動車(じどうしゃ)",
             "② 名  汽车"
-        ],
-        "notation": "自動車(じどうしゃ)"
+        ]
     },
     {
         "name": "isshoukenmei",
         "trans": [
+            "一生懸命(いっしょうけんめい)",
             "⑤ 副·ナ形  努力，拼命"
-        ],
-        "notation": "一生懸命(いっしょうけんめい)"
+        ]
     },
     {
         "name": "sukuri-n",
         "trans": [
+            "スクリーン",
             "③ 名  屏幕"
-        ],
-        "notation": "スクリーン"
+        ]
     },
     {
         "name": "tenkin",
         "trans": [
+            "転勤(てんきん)",
             "⓪ 名·自动3  工作调动"
-        ],
-        "notation": "転勤(てんきん)"
+        ]
     },
     {
         "name": "nigeru",
         "trans": [
+            "逃(に)げる",
             "② 自动2  逃跑；逃避，推卸"
-        ],
-        "notation": "逃(に)げる"
+        ]
     },
     {
         "name": "miso",
         "trans": [
+            "味噌(みそ)",
             "① 名  大酱"
-        ],
-        "notation": "味噌(みそ)"
+        ]
     },
     {
         "name": "kau",
         "trans": [
+            "買(か)う",
             "⓪ 他动1  买，购买"
-        ],
-        "notation": "買(か)う"
+        ]
     },
     {
         "name": "komakai",
         "trans": [
+            "細(こま)かい",
             "③ イ形  细小的，零碎的；详细的"
-        ],
-        "notation": "細(こま)かい"
+        ]
     },
     {
         "name": "kumo",
         "trans": [
+            "雲(くも)",
             "① 名  云彩"
-        ],
-        "notation": "雲(くも)"
+        ]
     },
     {
         "name": "orenji",
         "trans": [
+            "オレンジ",
             "② 名  橙子；橙色"
-        ],
-        "notation": "オレンジ"
+        ]
     },
     {
         "name": "issou",
         "trans": [
+            "いっそう",
             "⓪ 副  更加，越发"
-        ],
-        "notation": "いっそう"
+        ]
     },
     {
         "name": "kanja",
         "trans": [
+            "患者(かんじゃ)",
             "⓪ 名  患者"
-        ],
-        "notation": "患者(かんじゃ)"
+        ]
     },
     {
         "name": "yasumi",
         "trans": [
+            "休(やす)み",
             "③ 名  休息；请假"
-        ],
-        "notation": "休(やす)み"
+        ]
     },
     {
         "name": "heisha",
         "trans": [
+            "弊社(へいしゃ)",
             "① 名  （称自己公司）敝公司"
-        ],
-        "notation": "弊社(へいしゃ)"
+        ]
     },
     {
         "name": "soko",
         "trans": [
+            "底(そこ)",
             "⓪ 名  底部"
-        ],
-        "notation": "底(そこ)"
+        ]
     },
     {
         "name": "erabu",
         "trans": [
+            "選(えら)ぶ",
             "② 他动1  选择"
-        ],
-        "notation": "選(えら)ぶ"
+        ]
     },
     {
         "name": "ni",
         "trans": [
+            "二(に)",
             "① 数  二"
-        ],
-        "notation": "二(に)"
+        ]
     },
     {
         "name": "daikon",
         "trans": [
+            "大根(だいこん)",
             "⓪ 名  白萝卜"
-        ],
-        "notation": "大根(だいこん)"
+        ]
     },
     {
         "name": "ka-do",
         "trans": [
+            "カード",
             "① 名  银行卡；卡片"
-        ],
-        "notation": "カード"
+        ]
     },
     {
         "name": "dansei",
         "trans": [
+            "男性(だんせい)",
             "⓪ 名  男性"
-        ],
-        "notation": "男性(だんせい)"
+        ]
     },
     {
         "name": "juku",
         "trans": [
+            "塾(じゅく)",
             "① 名  补习班"
-        ],
-        "notation": "塾(じゅく)"
+        ]
     },
     {
         "name": "kunekune",
         "trans": [
+            "くねくね",
             "① 副·自动3  弯曲，蜿蜒"
-        ],
-        "notation": "くねくね"
+        ]
     },
     {
         "name": "you",
         "trans": [
+            "用(よう)",
             "① 名  事情"
-        ],
-        "notation": "用(よう)"
+        ]
     },
     {
         "name": "wakamono",
         "trans": [
+            "若者(わかもの)",
             "⓪ 名  年轻人"
-        ],
-        "notation": "若者(わかもの)"
+        ]
     },
     {
         "name": "makikomu",
         "trans": [
+            "巻(ま)き込(こ)む",
             "③ 他动1  卷进；牵连"
-        ],
-        "notation": "巻(ま)き込(こ)む"
+        ]
     },
     {
         "name": "nodo",
         "trans": [
+            "喉(のど)",
             "① 名  喉咙"
-        ],
-        "notation": "喉(のど)"
+        ]
     },
     {
         "name": "sankaku",
         "trans": [
+            "三角(さんかく)",
             "① 名  三角，三角形"
-        ],
-        "notation": "三角(さんかく)"
+        ]
     },
     {
         "name": "haku",
         "trans": [
+            "吐(は)く",
             "① 他动1  吐出，呕吐；吐露，说出"
-        ],
-        "notation": "吐(は)く"
+        ]
     },
     {
         "name": "tenisuko-to",
         "trans": [
+            "テニスコート",
             "④ 名  网球场"
-        ],
-        "notation": "テニスコート"
+        ]
     },
     {
         "name": "serifu",
         "trans": [
+            "台詞(せりふ)",
             "⓪ 名  台词"
-        ],
-        "notation": "台詞(せりふ)"
+        ]
     },
     {
         "name": "esukare-ta-",
         "trans": [
+            "エスカレーター",
             "④ 名  自动扶梯"
-        ],
-        "notation": "エスカレーター"
+        ]
     },
     {
         "name": "hitoban",
         "trans": [
+            "一晩(ひとばん)",
             "② 名  一晚上"
-        ],
-        "notation": "一晩(ひとばん)"
+        ]
     },
     {
         "name": "kikai",
         "trans": [
+            "機械(きかい)",
             "② 名  机器，机械"
-        ],
-        "notation": "機械(きかい)"
+        ]
     },
     {
         "name": "hotondo",
         "trans": [
+            "ほとんど",
             "② 名·副  大部分；几乎"
-        ],
-        "notation": "ほとんど"
+        ]
     },
     {
         "name": "seikai",
         "trans": [
+            "正解(せいかい)",
             "⓪ 名  正确答案"
-        ],
-        "notation": "正解(せいかい)"
+        ]
     },
     {
         "name": "kaigi",
         "trans": [
+            "会議(かいぎ)",
             "① 名  会议"
-        ],
-        "notation": "会議(かいぎ)"
+        ]
     },
     {
         "name": "utsu",
         "trans": [
+            "打(う)つ",
             "① 他动1  打，揍；碰撞"
-        ],
-        "notation": "打(う)つ"
+        ]
     },
     {
         "name": "minato",
         "trans": [
+            "港(みなと)",
             "⓪ 名  港口"
-        ],
-        "notation": "港(みなと)"
+        ]
     },
     {
         "name": "bin",
         "trans": [
+            "瓶(びん)",
             "① 名  瓶子"
-        ],
-        "notation": "瓶(びん)"
+        ]
     },
     {
         "name": "nemui",
         "trans": [
+            "眠(ねむ)い",
             "⓪ イ形  困的，发困的"
-        ],
-        "notation": "眠(ねむ)い"
+        ]
     },
     {
         "name": "doro",
         "trans": [
+            "泥(どろ)",
             "② 名  泥，泥巴"
-        ],
-        "notation": "泥(どろ)"
+        ]
     },
     {
         "name": "sobo",
         "trans": [
+            "祖母(そぼ)",
             "① 名  祖母；外祖母"
-        ],
-        "notation": "祖母(そぼ)"
+        ]
     },
     {
         "name": "shibaraku",
         "trans": [
+            "しばらく",
             "② 副  暂时，暂且"
-        ],
-        "notation": "しばらく"
+        ]
     },
     {
         "name": "kishi",
         "trans": [
+            "岸(きし)",
             "② 名  岸，岸边"
-        ],
-        "notation": "岸(きし)"
+        ]
     },
     {
         "name": "inochi",
         "trans": [
+            "命(いのち)",
             "① 名  生命；最关键的东西"
-        ],
-        "notation": "命(いのち)"
+        ]
     },
     {
         "name": "hiku",
         "trans": [
+            "弾(ひ)く",
             "⓪ 他动1  弹奏（乐器等）"
-        ],
-        "notation": "弾(ひ)く"
+        ]
     },
     {
         "name": "~han",
         "trans": [
+            "～半(はん)",
             " 接尾  （时间）……半"
-        ],
-        "notation": "～半(はん)"
+        ]
     },
     {
         "name": "yuukou",
         "trans": [
+            "友好(ゆうこう)",
             "⓪ 名  友好"
-        ],
-        "notation": "友好(ゆうこう)"
+        ]
     },
     {
         "name": "mousugu",
         "trans": [
+            "もうすぐ",
             "③ 副  马上就要，快要"
-        ],
-        "notation": "もうすぐ"
+        ]
     },
     {
         "name": "terebi",
         "trans": [
+            "テレビ",
             "① 名  电视机"
-        ],
-        "notation": "テレビ"
+        ]
     },
     {
         "name": "pi-man",
         "trans": [
+            "ピーマン",
             "① 名  青椒"
-        ],
-        "notation": "ピーマン"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "夜(よる)",
             "① 名  晚上"
-        ],
-        "notation": "夜(よる)"
+        ]
     },
     {
         "name": "hanami",
         "trans": [
+            "花見(はなみ)",
             "③ 名  赏花；赏樱花"
-        ],
-        "notation": "花見(はなみ)"
+        ]
     },
     {
         "name": "douro",
         "trans": [
+            "道路(どうろ)",
             "① 名  道路"
-        ],
-        "notation": "道路(どうろ)"
+        ]
     },
     {
         "name": "taishite",
         "trans": [
+            "たいして",
             "① 副  （后接否定）并不太……"
-        ],
-        "notation": "たいして"
+        ]
     },
     {
         "name": "shikikin",
         "trans": [
+            "敷金(しききん)",
             "② 名  （租房等的）押金"
-        ],
-        "notation": "敷金(しききん)"
+        ]
     },
     {
         "name": "iru",
         "trans": [
+            "いる",
             "⓪ 自动2  （人、动物）有；存在"
-        ],
-        "notation": "いる"
+        ]
     },
     {
         "name": "itadaku",
         "trans": [
+            "いただく",
             "⓪ 他动1  领受，得到；吃喝"
-        ],
-        "notation": "いただく"
+        ]
     },
     {
         "name": "kongo",
         "trans": [
+            "今後(こんご)",
             "⓪ 名  今后"
-        ],
-        "notation": "今後(こんご)"
+        ]
     },
     {
         "name": "bun",
         "trans": [
+            "文(ぶん)",
             "① 名  文章，作文；句子，语句"
-        ],
-        "notation": "文(ぶん)"
+        ]
     },
     {
         "name": "nande",
         "trans": [
+            "なんで",
             "① 副  为什么"
-        ],
-        "notation": "なんで"
+        ]
     },
     {
         "name": "shokuryouhin",
         "trans": [
+            "食料品(しょくりょうひん)",
             "⓪ 名  食品"
-        ],
-        "notation": "食料品(しょくりょうひん)"
+        ]
     },
     {
         "name": "kengaku",
         "trans": [
+            "見学(けんがく)",
             "⓪ 名·他动3  参观学习"
-        ],
-        "notation": "見学(けんがく)"
+        ]
     },
     {
         "name": "kayou",
         "trans": [
+            "通(かよ)う",
             "⓪ 自动1  往返；上学，上班"
-        ],
-        "notation": "通(かよ)う"
+        ]
     },
     {
         "name": "ijou",
         "trans": [
+            "以上(いじょう)",
             "① 名  以上；上述"
-        ],
-        "notation": "以上(いじょう)"
+        ]
     },
     {
         "name": "sutereo",
         "trans": [
+            "ステレオ",
             "⓪ 名  立体声，立体声设备"
-        ],
-        "notation": "ステレオ"
+        ]
     },
     {
         "name": "tsume",
         "trans": [
+            "爪(つめ)",
             "⓪ 名  指甲"
-        ],
-        "notation": "爪(つめ)"
+        ]
     },
     {
         "name": "tsutomeru",
         "trans": [
+            "努(つと)める",
             "③ 自动2  努力，尽力"
-        ],
-        "notation": "努(つと)める"
+        ]
     },
     {
         "name": "murasaki",
         "trans": [
+            "紫(むらさき)",
             "② 名  紫色"
-        ],
-        "notation": "紫(むらさき)"
+        ]
     },
     {
         "name": "shiriai",
         "trans": [
+            "知(し)り合(あ)い",
             "⓪ 名  熟人"
-        ],
-        "notation": "知(し)り合(あ)い"
+        ]
     },
     {
         "name": "kowai",
         "trans": [
+            "怖(こわ)い",
             "② イ形  可怕的，令人害怕的"
-        ],
-        "notation": "怖(こわ)い"
+        ]
     },
     {
         "name": "kisetsu",
         "trans": [
+            "季節(きせつ)",
             "① 名  季节"
-        ],
-        "notation": "季節(きせつ)"
+        ]
     },
     {
         "name": "okage",
         "trans": [
+            "おかげ",
             "⓪ 名  幸亏，托……的福"
-        ],
-        "notation": "おかげ"
+        ]
     },
     {
         "name": "yakusu",
         "trans": [
+            "訳(やく)す",
             "② 他动1  翻译"
-        ],
-        "notation": "訳(やく)す"
+        ]
     },
     {
         "name": "rouka",
         "trans": [
+            "老化(ろうか)",
             "⓪ 名·自动3  老化"
-        ],
-        "notation": "老化(ろうか)"
+        ]
     },
     {
         "name": "pikunikku",
         "trans": [
+            "ピクニック",
             "① 名·自动3  郊游"
-        ],
-        "notation": "ピクニック"
+        ]
     },
     {
         "name": "tora",
         "trans": [
+            "虎(とら)",
             "⓪ 名  老虎"
-        ],
-        "notation": "虎(とら)"
+        ]
     },
     {
         "name": "mukau",
         "trans": [
+            "向(む)かう",
             "⓪ 自动1  朝，向；前往"
-        ],
-        "notation": "向(む)かう"
+        ]
     },
     {
         "name": "nokori",
         "trans": [
+            "残(のこ)り",
             "③ 名  剩余"
-        ],
-        "notation": "残(のこ)り"
+        ]
     },
     {
         "name": "konsa-to",
         "trans": [
+            "コンサート",
             "① 名  音乐会"
-        ],
-        "notation": "コンサート"
+        ]
     },
     {
         "name": "naosu",
         "trans": [
+            "治(なお)す",
             "② 他动1  医治，治疗"
-        ],
-        "notation": "治(なお)す"
+        ]
     },
     {
         "name": "bunpou",
         "trans": [
+            "文法(ぶんぽう)",
             "⓪ 名  语法"
-        ],
-        "notation": "文法(ぶんぽう)"
+        ]
     },
     {
         "name": "wakareru",
         "trans": [
+            "別(わか)れる",
             "③ 自动2  分别，分离；分手"
-        ],
-        "notation": "別(わか)れる"
+        ]
     },
     {
         "name": "touchaku",
         "trans": [
+            "到着(とうちゃく)",
             "⓪ 名·自动3  到达"
-        ],
-        "notation": "到着(とうちゃく)"
+        ]
     },
     {
         "name": "shin~",
         "trans": [
+            "新(しん)～",
             " 接头  新……"
-        ],
-        "notation": "新(しん)～"
+        ]
     },
     {
         "name": "kureru",
         "trans": [
+            "暮(く)れる",
             "⓪ 自动2  日暮，天黑"
-        ],
-        "notation": "暮(く)れる"
+        ]
     },
     {
         "name": "chi",
         "trans": [
+            "血(ち)",
             "⓪ 名  血，血液；血缘"
-        ],
-        "notation": "血(ち)"
+        ]
     },
     {
         "name": "houhou",
         "trans": [
+            "方法(ほうほう)",
             "⓪ 名  方法"
-        ],
-        "notation": "方法(ほうほう)"
+        ]
     },
     {
         "name": "nakunaru",
         "trans": [
+            "亡(な)くなる",
             "⓪ 自动1  死亡，去世"
-        ],
-        "notation": "亡(な)くなる"
+        ]
     },
     {
         "name": "hitobito",
         "trans": [
+            "人々(ひとびと)",
             "② 名  人们，众人"
-        ],
-        "notation": "人々(ひとびと)"
+        ]
     },
     {
         "name": "yume",
         "trans": [
+            "夢(ゆめ)",
             "② 名  梦；梦想"
-        ],
-        "notation": "夢(ゆめ)"
+        ]
     },
     {
         "name": "tsurai",
         "trans": [
+            "辛(つら)い",
             "⓪ イ形  痛苦的，难过的"
-        ],
-        "notation": "辛(つら)い"
+        ]
     },
     {
         "name": "yuki",
         "trans": [
+            "雪(ゆき)",
             "② 名  雪"
-        ],
-        "notation": "雪(ゆき)"
+        ]
     },
     {
         "name": "sukiyaki",
         "trans": [
+            "すきやき",
             "⓪ 名  日式牛肉火锅"
-        ],
-        "notation": "すきやき"
+        ]
     },
     {
         "name": "itsumademo",
         "trans": [
+            "いつまでも",
             "① 副  永远，始终"
-        ],
-        "notation": "いつまでも"
+        ]
     },
     {
         "name": "shougatsu",
         "trans": [
+            "正月(しょうがつ)",
             "④ 名  正月；新年"
-        ],
-        "notation": "正月(しょうがつ)"
+        ]
     },
     {
         "name": "ryou",
         "trans": [
+            "量(りょう)",
             "① 名  量，数量"
-        ],
-        "notation": "量(りょう)"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "日(ひ)",
             "① 名  太阳；日子，日期"
-        ],
-        "notation": "日(ひ)"
+        ]
     },
     {
         "name": "dansu",
         "trans": [
+            "ダンス",
             "① 名  跳舞，舞蹈"
-        ],
-        "notation": "ダンス"
+        ]
     },
     {
         "name": "kotori",
         "trans": [
+            "小鳥(ことり)",
             "⓪ 名  小鸟"
-        ],
-        "notation": "小鳥(ことり)"
+        ]
     },
     {
         "name": "okoru",
         "trans": [
+            "起(お)こる",
             "② 自动1  发生（事件）"
-        ],
-        "notation": "起(お)こる"
+        ]
     },
     {
         "name": "watashi",
         "trans": [
+            "私(わたし)",
             "⓪ 代  我"
-        ],
-        "notation": "私(わたし)"
+        ]
     },
     {
         "name": "nyuusha",
         "trans": [
+            "入社(にゅうしゃ)",
             "⓪ 名·自动3  进入公司"
-        ],
-        "notation": "入社(にゅうしゃ)"
+        ]
     },
     {
         "name": "shiawase",
         "trans": [
+            "幸(しあわ)せ",
             "⓪ 名·ナ形  幸福"
-        ],
-        "notation": "幸(しあわ)せ"
+        ]
     },
     {
         "name": "kurashi",
         "trans": [
+            "暮(く)らし",
             "⓪ 名  生活，生计"
-        ],
-        "notation": "暮(く)らし"
+        ]
     },
     {
         "name": "imademo",
         "trans": [
+            "今(いま)でも",
             "① 副  至今，仍然"
-        ],
-        "notation": "今(いま)でも"
+        ]
     },
     {
         "name": "tebukuro",
         "trans": [
+            "手袋(てぶくろ)",
             "② 名  手套"
-        ],
-        "notation": "手袋(てぶくろ)"
+        ]
     },
     {
         "name": "hon'ya",
         "trans": [
+            "本屋(ほんや)",
             "① 名  书店"
-        ],
-        "notation": "本屋(ほんや)"
+        ]
     },
     {
         "name": "homeru",
         "trans": [
+            "褒(ほ)める",
             "② 他动2  称赞，夸奖"
-        ],
-        "notation": "褒(ほ)める"
+        ]
     },
     {
         "name": "sekai",
         "trans": [
+            "世界(せかい)",
             "① 名  世界"
-        ],
-        "notation": "世界(せかい)"
+        ]
     },
     {
         "name": "koukuuken",
         "trans": [
+            "航空券(こうくうけん)",
             "③ 名  机票"
-        ],
-        "notation": "航空券(こうくうけん)"
+        ]
     },
     {
         "name": "michi",
         "trans": [
+            "道(みち)",
             "⓪ 名  道路"
-        ],
-        "notation": "道(みち)"
+        ]
     },
     {
         "name": "ika",
         "trans": [
+            "以下(いか)",
             "① 名  以下；下述"
-        ],
-        "notation": "以下(いか)"
+        ]
     },
     {
         "name": "to",
         "trans": [
+            "都(と)",
             "① 名  都，首都"
-        ],
-        "notation": "都(と)"
+        ]
     },
     {
         "name": "kitto",
         "trans": [
+            "きっと",
             "⓪ 副  一定，必定"
-        ],
-        "notation": "きっと"
+        ]
     },
     {
         "name": "reshi-to",
         "trans": [
+            "レシート",
             "② 名  收据，小票"
-        ],
-        "notation": "レシート"
+        ]
     },
     {
         "name": "machigai",
         "trans": [
+            "間違(まちが)い",
             "③ 名  错误，差错"
-        ],
-        "notation": "間違(まちが)い"
+        ]
     },
     {
         "name": "gozen",
         "trans": [
+            "午前(ごぜん)",
             "① 名  上午"
-        ],
-        "notation": "午前(ごぜん)"
+        ]
     },
     {
         "name": "jidai",
         "trans": [
+            "時代(じだい)",
             "⓪ 名  时代"
-        ],
-        "notation": "時代(じだい)"
+        ]
     },
     {
         "name": "dorobou",
         "trans": [
+            "泥棒(どろぼう)",
             "⓪ 名  小偷，盗贼"
-        ],
-        "notation": "泥棒(どろぼう)"
+        ]
     },
     {
         "name": "minikui",
         "trans": [
+            "醜(みにく)い",
             "③ イ形  丑陋的；丑恶的"
-        ],
-        "notation": "醜(みにく)い"
+        ]
     },
     {
         "name": "norimono",
         "trans": [
+            "乗(の)り物(もの)",
             "⓪ 名  交通工具"
-        ],
-        "notation": "乗(の)り物(もの)"
+        ]
     },
     {
         "name": "boryu-mu",
         "trans": [
+            "ボリューム",
             "⓪ 名  体积，容量；音量"
-        ],
-        "notation": "ボリューム"
+        ]
     },
     {
         "name": "mageru",
         "trans": [
+            "曲(ま)げる",
             "② 他动2  弯，曲；倾斜"
-        ],
-        "notation": "曲(ま)げる"
+        ]
     },
     {
         "name": "denchi",
         "trans": [
+            "電池(でんち)",
             "① 名  电池"
-        ],
-        "notation": "電池(でんち)"
+        ]
     },
     {
         "name": "nioi",
         "trans": [
+            "匂(にお)い",
             "② 名  气味，气息"
-        ],
-        "notation": "匂(にお)い"
+        ]
     },
     {
         "name": "yurusu",
         "trans": [
+            "許(ゆる)す",
             "② 他动1  允许，准许；原谅"
-        ],
-        "notation": "許(ゆる)す"
+        ]
     },
     {
         "name": "seinengappi",
         "trans": [
+            "生年月日(せいねんがっぴ)",
             "⑤ 名  出生年月日"
-        ],
-        "notation": "生年月日(せいねんがっぴ)"
+        ]
     },
     {
         "name": "kousokubasu",
         "trans": [
+            "高速(こうそく)バス",
             "⑤ 名  高速大巴，长途大巴"
-        ],
-        "notation": "高速(こうそく)バス"
+        ]
     },
     {
         "name": "omo",
         "trans": [
+            "主(おも)",
             "① ナ形  主要的，重要的"
-        ],
-        "notation": "主(おも)"
+        ]
     },
     {
         "name": "chi-zu",
         "trans": [
+            "チーズ",
             "① 名  芝士，奶酪"
-        ],
-        "notation": "チーズ"
+        ]
     },
     {
         "name": "omawarisan",
         "trans": [
+            "お巡(まわ)りさん",
             "② 名  巡警"
-        ],
-        "notation": "お巡(まわ)りさん"
+        ]
     },
     {
         "name": "yaburu",
         "trans": [
+            "破(やぶ)る",
             "② 他动1  破坏，弄破；打破"
-        ],
-        "notation": "破(やぶ)る"
+        ]
     },
     {
         "name": "jikai",
         "trans": [
+            "次回(じかい)",
             "① 名  下次"
-        ],
-        "notation": "次回(じかい)"
+        ]
     },
     {
         "name": "enkatsu",
         "trans": [
+            "円滑(えんかつ)",
             "⓪ 名·ナ形  圆滑，顺利"
-        ],
-        "notation": "円滑(えんかつ)"
+        ]
     },
     {
         "name": "nozoku",
         "trans": [
+            "除(のぞ)く",
             "⓪ 他动1  消除，去掉；除了……之外"
-        ],
-        "notation": "除(のぞ)く"
+        ]
     },
     {
         "name": "momen",
         "trans": [
+            "木綿(もめん)",
             "⓪ 名  棉花；棉织品"
-        ],
-        "notation": "木綿(もめん)"
+        ]
     },
     {
         "name": "jikka",
         "trans": [
+            "実家(じっか)",
             "⓪ 名  老家；娘家"
-        ],
-        "notation": "実家(じっか)"
+        ]
     },
     {
         "name": "sorenanoni",
         "trans": [
+            "それなのに",
             "③ 接续  尽管那样，即使那样"
-        ],
-        "notation": "それなのに"
+        ]
     },
     {
         "name": "konoha",
         "trans": [
+            "木(こ)の葉(は)",
             "① 名  树叶"
-        ],
-        "notation": "木(こ)の葉(は)"
+        ]
     },
     {
         "name": "kagami",
         "trans": [
+            "鏡(かがみ)",
             "③ 名  镜子"
-        ],
-        "notation": "鏡(かがみ)"
+        ]
     },
     {
         "name": "ikeru",
         "trans": [
+            "行(い)ける",
             "⓪ 自动2  能去；会，可以"
-        ],
-        "notation": "行(い)ける"
+        ]
     },
     {
         "name": "chuugoku",
         "trans": [
+            "中国(ちゅうごく)",
             "① 名  中国"
-        ],
-        "notation": "中国(ちゅうごく)"
+        ]
     },
     {
         "name": "sute-ki",
         "trans": [
+            "ステーキ",
             "② 名  牛排"
-        ],
-        "notation": "ステーキ"
+        ]
     },
     {
         "name": "nonbiri",
         "trans": [
+            "のんびり",
             "③ 副·自动3  悠闲自在，无拘无束"
-        ],
-        "notation": "のんびり"
+        ]
     },
     {
         "name": "ressha",
         "trans": [
+            "列車(れっしゃ)",
             "⓪ 名  列车，火车"
-        ],
-        "notation": "列車(れっしゃ)"
+        ]
     },
     {
         "name": "meisho",
         "trans": [
+            "名所(めいしょ)",
             "③ 名  名胜"
-        ],
-        "notation": "名所(めいしょ)"
+        ]
     },
     {
         "name": "hiru",
         "trans": [
+            "昼(ひる)",
             "② 名  中午；白天"
-        ],
-        "notation": "昼(ひる)"
+        ]
     },
     {
         "name": "yama",
         "trans": [
+            "山(やま)",
             "② 名  山"
-        ],
-        "notation": "山(やま)"
+        ]
     },
     {
         "name": "kaihi",
         "trans": [
+            "会費(かいひ)",
             "⓪ 名  会费"
-        ],
-        "notation": "会費(かいひ)"
+        ]
     },
     {
         "name": "futoru",
         "trans": [
+            "太(ふと)る",
             "② 自动1  变胖"
-        ],
-        "notation": "太(ふと)る"
+        ]
     },
     {
         "name": "suri",
         "trans": [
+            "すり",
             "① 名  小偷"
-        ],
-        "notation": "すり"
+        ]
     },
     {
         "name": "kosuto",
         "trans": [
+            "コスト",
             "① 名  成本"
-        ],
-        "notation": "コスト"
+        ]
     },
     {
         "name": "kazaru",
         "trans": [
+            "飾(かざ)る",
             "⓪ 他动1  装饰"
-        ],
-        "notation": "飾(かざ)る"
+        ]
     },
     {
         "name": "ichido",
         "trans": [
+            "一度(いちど)",
             "③ 名  一回，一次"
-        ],
-        "notation": "一度(いちど)"
+        ]
     },
     {
         "name": "seki",
         "trans": [
+            "咳(せき)",
             "② 名  咳嗽"
-        ],
-        "notation": "咳(せき)"
+        ]
     },
     {
         "name": "jibiki",
         "trans": [
+            "字引(じびき)",
             "③ 名  字典"
-        ],
-        "notation": "字引(じびき)"
+        ]
     },
     {
         "name": "kyoudou",
         "trans": [
+            "共同(きょうどう)",
             "⓪ 名·自动3  共同"
-        ],
-        "notation": "共同(きょうどう)"
+        ]
     },
     {
         "name": "mata",
         "trans": [
+            "股(また)",
             "① 名  大腿"
-        ],
-        "notation": "股(また)"
+        ]
     },
     {
         "name": "wakuwaku",
         "trans": [
+            "わくわく",
             "① 副·自动3  （欢欣雀跃）心扑通扑通地跳"
-        ],
-        "notation": "わくわく"
+        ]
     },
     {
         "name": "houritsu",
         "trans": [
+            "法律(ほうりつ)",
             "⓪ 名  法律"
-        ],
-        "notation": "法律(ほうりつ)"
+        ]
     },
     {
         "name": "tsuri-",
         "trans": [
+            "ツリー",
             "② 名  树"
-        ],
-        "notation": "ツリー"
+        ]
     },
     {
         "name": "kowareru",
         "trans": [
+            "壊(こわ)れる",
             "③ 自动2  坏，出故障"
-        ],
-        "notation": "壊(こわ)れる"
+        ]
     },
     {
         "name": "kaoku",
         "trans": [
+            "家屋(かおく)",
             "① 名  房屋，住房"
-        ],
-        "notation": "家屋(かおく)"
+        ]
     },
     {
         "name": "bijutsukan",
         "trans": [
+            "美術館(びじゅつかん)",
             "③ 名  美术馆"
-        ],
-        "notation": "美術館(びじゅつかん)"
+        ]
     },
     {
         "name": "utau",
         "trans": [
+            "歌(うた)う",
             "⓪ 他动1  唱"
-        ],
-        "notation": "歌(うた)う"
+        ]
     },
     {
         "name": "kumori",
         "trans": [
+            "曇(くも)り",
             "③ 名  阴天"
-        ],
-        "notation": "曇(くも)り"
+        ]
     },
     {
         "name": "hoshi",
         "trans": [
+            "星(ほし)",
             "⓪ 名  星星"
-        ],
-        "notation": "星(ほし)"
+        ]
     },
     {
         "name": "nakidasu",
         "trans": [
+            "泣(な)き出(だ)す",
             "③ 自动1  哭出来，哭起来"
-        ],
-        "notation": "泣(な)き出(だ)す"
+        ]
     },
     {
         "name": "shukka",
         "trans": [
+            "出荷(しゅっか)",
             "⓪ 名·他动3  发货"
-        ],
-        "notation": "出荷(しゅっか)"
+        ]
     },
     {
         "name": "ikisaki/yukisaki",
         "trans": [
+            "行先(いきさき/ゆきさき)",
             "⓪ 名  目的地"
-        ],
-        "notation": "行先(いきさき/ゆきさき)"
+        ]
     },
     {
         "name": "soretomo",
         "trans": [
+            "それとも",
             "③ 接续  或者，还是"
-        ],
-        "notation": "それとも"
+        ]
     },
     {
         "name": "jinsei",
         "trans": [
+            "人生(じんせい)",
             "① 名  人生"
-        ],
-        "notation": "人生(じんせい)"
+        ]
     },
     {
         "name": "tetsuya",
         "trans": [
+            "徹夜(てつや)",
             "⓪ 名·自动3  通宵，熬夜"
-        ],
-        "notation": "徹夜(てつや)"
+        ]
     },
     {
         "name": "kougai",
         "trans": [
+            "郊外(こうがい)",
             "① 名  郊外"
-        ],
-        "notation": "郊外(こうがい)"
+        ]
     },
     {
         "name": "kinen",
         "trans": [
+            "記念(きねん)",
             "⓪ 名·他动3  纪念"
-        ],
-        "notation": "記念(きねん)"
+        ]
     },
     {
         "name": "shukkin",
         "trans": [
+            "出勤(しゅっきん)",
             "⓪ 名·自动3  出勤，上班"
-        ],
-        "notation": "出勤(しゅっきん)"
+        ]
     },
     {
         "name": "negau",
         "trans": [
+            "願(ねが)う",
             "② 他动1  请求；希望"
-        ],
-        "notation": "願(ねが)う"
+        ]
     },
     {
         "name": "yakiniku",
         "trans": [
+            "焼肉(やきにく)",
             "⓪ 名  烤肉"
-        ],
-        "notation": "焼肉(やきにく)"
+        ]
     },
     {
         "name": "doyoubi",
         "trans": [
+            "土曜日(どようび)",
             "③ 名  星期六"
-        ],
-        "notation": "土曜日(どようび)"
+        ]
     },
     {
         "name": "kaeru",
         "trans": [
+            "換(か)える",
             "⓪ 他动2  更换，交换"
-        ],
-        "notation": "換(か)える"
+        ]
     },
     {
         "name": "hanba-gu",
         "trans": [
+            "ハンバーグ",
             "③ 名  汉堡牛肉饼"
-        ],
-        "notation": "ハンバーグ"
+        ]
     },
     {
         "name": "unkou",
         "trans": [
+            "運行(うんこう)",
             "⓪ 名·自动3  行驶"
-        ],
-        "notation": "運行(うんこう)"
+        ]
     },
     {
         "name": "ugoku",
         "trans": [
+            "動(うご)く",
             "② 自动1  动；转动；动摇"
-        ],
-        "notation": "動(うご)く"
+        ]
     },
     {
         "name": "shougakusei",
         "trans": [
+            "小学生(しょうがくせい)",
             "③ 名  小学生"
-        ],
-        "notation": "小学生(しょうがくせい)"
+        ]
     },
     {
         "name": "~bansen",
         "trans": [
+            "～番線(ばんせん)",
             " 接尾  ……号线"
-        ],
-        "notation": "～番線(ばんせん)"
+        ]
     },
     {
         "name": "tsutawaru",
         "trans": [
+            "伝(つた)わる",
             "⓪ 自动1  流传；传播"
-        ],
-        "notation": "伝(つた)わる"
+        ]
     },
     {
         "name": "shisatsu",
         "trans": [
+            "視察(しさつ)",
             "⓪ 名·他动3  视察"
-        ],
-        "notation": "視察(しさつ)"
+        ]
     },
     {
         "name": "kouchou",
         "trans": [
+            "校長(こうちょう)",
             "⓪ 名  （中小学）校长"
-        ],
-        "notation": "校長(こうちょう)"
+        ]
     },
     {
         "name": "yoko",
         "trans": [
+            "横(よこ)",
             "⓪ 名  横，横向；旁边"
-        ],
-        "notation": "横(よこ)"
+        ]
     },
     {
         "name": "yarikata",
         "trans": [
+            "やり方(かた)",
             "⓪ 名  做法"
-        ],
-        "notation": "やり方(かた)"
+        ]
     },
     {
         "name": "fuan",
         "trans": [
+            "不安(ふあん)",
             "⓪ 名·ナ形  担心，不安；不稳定"
-        ],
-        "notation": "不安(ふあん)"
+        ]
     },
     {
         "name": "kimeru",
         "trans": [
+            "決(き)める",
             "⓪ 他动2  决定"
-        ],
-        "notation": "決(き)める"
+        ]
     },
     {
         "name": "tougarashi",
         "trans": [
+            "唐辛子(とうがらし)",
             "③ 名  辣椒"
-        ],
-        "notation": "唐辛子(とうがらし)"
+        ]
     },
     {
         "name": "kotae",
         "trans": [
+            "答(こた)え",
             "② 名  答复，回答；答案"
-        ],
-        "notation": "答(こた)え"
+        ]
     },
     {
         "name": "fumu",
         "trans": [
+            "踏(ふ)む",
             "⓪ 他动1  踏，踩"
-        ],
-        "notation": "踏(ふ)む"
+        ]
     },
     {
         "name": "mufura-",
         "trans": [
+            "マフラー",
             "① 名  围巾"
-        ],
-        "notation": "マフラー"
+        ]
     },
     {
         "name": "muttsu",
         "trans": [
+            "六(むっ)つ",
             "③ 名  六个；六岁"
-        ],
-        "notation": "六(むっ)つ"
+        ]
     },
     {
         "name": "todokeru",
         "trans": [
+            "届(とど)ける",
             "③ 他动2  送到，送给；转达，报告"
-        ],
-        "notation": "届(とど)ける"
+        ]
     },
     {
         "name": "kyaria",
         "trans": [
+            "キャリア",
             "① 名  履历；职业生涯"
-        ],
-        "notation": "キャリア"
+        ]
     },
     {
         "name": "kesu",
         "trans": [
+            "消(け)す",
             "⓪ 他动1  消除；关（电源、灯等）"
-        ],
-        "notation": "消(け)す"
+        ]
     },
     {
         "name": "sawagu",
         "trans": [
+            "騒(さわ)ぐ",
             "② 自动1  吵闹；骚动"
-        ],
-        "notation": "騒(さわ)ぐ"
+        ]
     },
     {
         "name": "enryo",
         "trans": [
+            "遠慮(えんりょ)",
             "⓪ 名·自他动3  客气；谢绝"
-        ],
-        "notation": "遠慮(えんりょ)"
+        ]
     },
     {
         "name": "gengo",
         "trans": [
+            "言語(げんご)",
             "① 名  语言，言语"
-        ],
-        "notation": "言語(げんご)"
+        ]
     },
     {
         "name": "koudou",
         "trans": [
+            "行動(こうどう)",
             "⓪ 名·自动3  行动"
-        ],
-        "notation": "行動(こうどう)"
+        ]
     },
     {
         "name": "megusuri",
         "trans": [
+            "目薬(めぐすり)",
             "② 名  眼药水"
-        ],
-        "notation": "目薬(めぐすり)"
+        ]
     },
     {
         "name": "kenkou",
         "trans": [
+            "健康(けんこう)",
             "⓪ 名·ナ形  健康，健全"
-        ],
-        "notation": "健康(けんこう)"
+        ]
     },
     {
         "name": "ajia",
         "trans": [
+            "アジア",
             "① 名  亚洲"
-        ],
-        "notation": "アジア"
+        ]
     },
     {
         "name": "sen",
         "trans": [
+            "線(せん)",
             "① 名  线；路线"
-        ],
-        "notation": "線(せん)"
+        ]
     },
     {
         "name": "merodeli-",
         "trans": [
+            "メロディー",
             "① 名  旋律"
-        ],
-        "notation": "メロディー"
+        ]
     },
     {
         "name": "imanimo",
         "trans": [
+            "今(いま)にも",
             "① 副  眼看，就要"
-        ],
-        "notation": "今(いま)にも"
+        ]
     },
     {
         "name": "tenrankai",
         "trans": [
+            "展覧会(てんらんかい)",
             "③ 名  展览会"
-        ],
-        "notation": "展覧会(てんらんかい)"
+        ]
     },
     {
         "name": "suki-",
         "trans": [
+            "スキー",
             "② 名·自动3  滑雪"
-        ],
-        "notation": "スキー"
+        ]
     },
     {
         "name": "nigai",
         "trans": [
+            "苦(にが)い",
             "② イ形  （味道）苦的；痛苦的"
-        ],
-        "notation": "苦(にが)い"
+        ]
     },
     {
         "name": "kousokudouro",
         "trans": [
+            "高速道路(こうそくどうろ)",
             "⑤ 名  高速公路"
-        ],
-        "notation": "高速道路(こうそくどうろ)"
+        ]
     },
     {
         "name": "nomimono",
         "trans": [
+            "飲(の)み物(もの)",
             "② 名  饮料"
-        ],
-        "notation": "飲(の)み物(もの)"
+        ]
     },
     {
         "name": "katadukeru",
         "trans": [
+            "片付(かたづ)ける",
             "④ 他动2  收拾；解决，处理"
-        ],
-        "notation": "片付(かたづ)ける"
+        ]
     },
     {
         "name": "su",
         "trans": [
+            "酢(す)",
             "① 名  醋"
-        ],
-        "notation": "酢(す)"
+        ]
     },
     {
         "name": "deiriguchi",
         "trans": [
+            "出入(でい)り口(ぐち)",
             "③ 名  出入口"
-        ],
-        "notation": "出入(でい)り口(ぐち)"
+        ]
     },
     {
         "name": "susumu",
         "trans": [
+            "進(すす)む",
             "⓪ 自动1  前进；进展；进步，先进"
-        ],
-        "notation": "進(すす)む"
+        ]
     },
     {
         "name": "on",
         "trans": [
+            "恩(おん)",
             "① 名  恩情"
-        ],
-        "notation": "恩(おん)"
+        ]
     },
     {
         "name": "chuushajou",
         "trans": [
+            "駐車場(ちゅうしゃじょう)",
             "⓪ 名  停车场"
-        ],
-        "notation": "駐車場(ちゅうしゃじょう)"
+        ]
     },
     {
         "name": "mieru",
         "trans": [
+            "見(み)える",
             "② 自动2  看得见"
-        ],
-        "notation": "見(み)える"
+        ]
     },
     {
         "name": "wafuku",
         "trans": [
+            "和服(わふく)",
             "⓪ 名  和服"
-        ],
-        "notation": "和服(わふく)"
+        ]
     },
     {
         "name": "seiyou",
         "trans": [
+            "西洋(せいよう)",
             "① 名  西洋，西方"
-        ],
-        "notation": "西洋(せいよう)"
+        ]
     },
     {
         "name": "manabu",
         "trans": [
+            "学(まな)ぶ",
             "⓪ 他动1  学习"
-        ],
-        "notation": "学(まな)ぶ"
+        ]
     },
     {
         "name": "toori",
         "trans": [
+            "通(とお)り",
             "③ 名  道路；来往，通行"
-        ],
-        "notation": "通(とお)り"
+        ]
     },
     {
         "name": "jama",
         "trans": [
+            "邪魔(じゃま)",
             "⓪ 名·ナ形·他动3  打扰；妨碍，阻碍"
-        ],
-        "notation": "邪魔(じゃま)"
+        ]
     },
     {
         "name": "kuraberu",
         "trans": [
+            "比(くら)べる",
             "⓪ 他动2  比较，对比；较量"
-        ],
-        "notation": "比(くら)べる"
+        ]
     },
     {
         "name": "kane",
         "trans": [
+            "金(かね)",
             "⓪ 名  金钱"
-        ],
-        "notation": "金(かね)"
+        ]
     },
     {
         "name": "sakini",
         "trans": [
+            "先(さき)に",
             "⓪ 副  以前"
-        ],
-        "notation": "先(さき)に"
+        ]
     },
     {
         "name": "tsutsumu",
         "trans": [
+            "包(つつ)む",
             "② 他动1  包，裹；笼罩，覆盖"
-        ],
-        "notation": "包(つつ)む"
+        ]
     },
     {
         "name": "mango-",
         "trans": [
+            "マンゴー",
             "① 名  芒果"
-        ],
-        "notation": "マンゴー"
+        ]
     },
     {
         "name": "yousu",
         "trans": [
+            "様子(ようす)",
             "⓪ 名  样子，神情；情况，动向"
-        ],
-        "notation": "様子(ようす)"
+        ]
     },
     {
         "name": "sorede",
         "trans": [
+            "それで",
             "⓪ 接续  因此，因而"
-        ],
-        "notation": "それで"
+        ]
     },
     {
         "name": "koutsuu",
         "trans": [
+            "交通(こうつう)",
             "⓪ 名  交通"
-        ],
-        "notation": "交通(こうつう)"
+        ]
     },
     {
         "name": "bishonure",
         "trans": [
+            "びしょ濡(ぬ)れ",
             "⓪ 名  全身淋湿，湿透"
-        ],
-        "notation": "びしょ濡(ぬ)れ"
+        ]
     },
     {
         "name": "kazoeru",
         "trans": [
+            "数(かぞ)える",
             "③ 他动2  数，计算；列举"
-        ],
-        "notation": "数(かぞ)える"
+        ]
     },
     {
         "name": "senshu",
         "trans": [
+            "選手(せんしゅ)",
             "① 名  选手，运动员"
-        ],
-        "notation": "選手(せんしゅ)"
+        ]
     },
     {
         "name": "mono",
         "trans": [
+            "物(もの)",
             "⓪ 名  物品"
-        ],
-        "notation": "物(もの)"
+        ]
     },
     {
         "name": "iyoiyo",
         "trans": [
+            "いよいよ",
             "② 副  终于；越来越"
-        ],
-        "notation": "いよいよ"
+        ]
     },
     {
         "name": "oku",
         "trans": [
+            "奥(おく)",
             "① 名  最里面；内部，深处"
-        ],
-        "notation": "奥(おく)"
+        ]
     },
     {
         "name": "dokusho",
         "trans": [
+            "読書(どくしょ)",
             "① 名·自动3  读书"
-        ],
-        "notation": "読書(どくしょ)"
+        ]
     },
     {
         "name": "nemuru",
         "trans": [
+            "眠(ねむ)る",
             "⓪ 自动1  睡觉"
-        ],
-        "notation": "眠(ねむ)る"
+        ]
     },
     {
         "name": "biru",
         "trans": [
+            "ビル",
             "① 名  大楼"
-        ],
-        "notation": "ビル"
+        ]
     },
     {
         "name": "wariai",
         "trans": [
+            "割合(わりあい)",
             "⓪ 名  比例"
-        ],
-        "notation": "割合(わりあい)"
+        ]
     },
     {
         "name": "sorehodo",
         "trans": [
+            "それほど",
             "⓪ 副  那么，那样；（后接否定）没那么"
-        ],
-        "notation": "それほど"
+        ]
     },
     {
         "name": "kouhai",
         "trans": [
+            "後輩(こうはい)",
             "⓪ 名  晚辈；学弟，学妹"
-        ],
-        "notation": "後輩(こうはい)"
+        ]
     },
     {
         "name": "owari",
         "trans": [
+            "終(お)わり",
             "⓪ 名  结尾"
-        ],
-        "notation": "終(お)わり"
+        ]
     },
     {
         "name": "nareru",
         "trans": [
+            "慣(な)れる",
             "② 自动2  习惯，适应"
-        ],
-        "notation": "慣(な)れる"
+        ]
     },
     {
         "name": "~byou",
         "trans": [
+            "～秒(びょう)",
             " 名  ……秒"
-        ],
-        "notation": "～秒(びょう)"
+        ]
     },
     {
         "name": "kokugai",
         "trans": [
+            "国外(こくがい)",
             "② 名  国外"
-        ],
-        "notation": "国外(こくがい)"
+        ]
     },
     {
         "name": "yasui",
         "trans": [
+            "安(やす)い",
             "② イ形  便宜的"
-        ],
-        "notation": "安(やす)い"
+        ]
     },
     {
         "name": "man'naka",
         "trans": [
+            "真(ま)ん中(なか)",
             "⓪ 名  正中间，正中央"
-        ],
-        "notation": "真(ま)ん中(なか)"
+        ]
     },
     {
         "name": "renraku",
         "trans": [
+            "連絡(れんらく)",
             "⓪ 名·自他动3  联络，联系"
-        ],
-        "notation": "連絡(れんらく)"
+        ]
     },
     {
         "name": "suppai",
         "trans": [
+            "すっぱい",
             "③ イ形  酸的"
-        ],
-        "notation": "すっぱい"
+        ]
     },
     {
         "name": "konoaida",
         "trans": [
+            "この間(あいだ)",
             "⓪ 名  前不久"
-        ],
-        "notation": "この間(あいだ)"
+        ]
     },
     {
         "name": "gairaigo",
         "trans": [
+            "外来語(がいらいご)",
             "⓪ 名  外来语"
-        ],
-        "notation": "外来語(がいらいご)"
+        ]
     },
     {
         "name": "harau",
         "trans": [
+            "払(はら)う",
             "② 他动1  支付"
-        ],
-        "notation": "払(はら)う"
+        ]
     },
     {
         "name": "koumuin",
         "trans": [
+            "公務員(こうむいん)",
             "③ 名  公务员"
-        ],
-        "notation": "公務員(こうむいん)"
+        ]
     },
     {
         "name": "toshi",
         "trans": [
+            "都市(とし)",
             "① 名  都市，城市"
-        ],
-        "notation": "都市(とし)"
+        ]
     },
     {
         "name": "mukaeru",
         "trans": [
+            "迎(むか)える",
             "⓪ 他动2  迎接"
-        ],
-        "notation": "迎(むか)える"
+        ]
     },
     {
         "name": "kakari",
         "trans": [
+            "係(かかり)",
             "① 名  负责人，主管"
-        ],
-        "notation": "係(かかり)"
+        ]
     },
     {
         "name": "anshin",
         "trans": [
+            "安心(あんしん)",
             "⓪ 名·ナ形·自动3  安心，放心"
-        ],
-        "notation": "安心(あんしん)"
+        ]
     },
     {
         "name": "doubutsuen",
         "trans": [
+            "動物園(どうぶつえん)",
             "④ 名  动物园"
-        ],
-        "notation": "動物園(どうぶつえん)"
+        ]
     },
     {
         "name": "minamiguchi",
         "trans": [
+            "南口(みなみぐち)",
             "③ 名  南侧出入口"
-        ],
-        "notation": "南口(みなみぐち)"
+        ]
     },
     {
         "name": "oohaba",
         "trans": [
+            "大幅(おおはば)",
             "⓪ 名·ナ形  大幅度，大规模"
-        ],
-        "notation": "大幅(おおはば)"
+        ]
     },
     {
         "name": "naoru",
         "trans": [
+            "治(なお)る",
             "② 自动1  治愈，痊愈"
-        ],
-        "notation": "治(なお)る"
+        ]
     },
     {
         "name": "yuukai",
         "trans": [
+            "誘拐(ゆうかい)",
             "⓪ 名·他动3  拐骗，诱拐"
-        ],
-        "notation": "誘拐(ゆうかい)"
+        ]
     },
     {
         "name": "ame",
         "trans": [
+            "飴(あめ)",
             "⓪ 名  糖果"
-        ],
-        "notation": "飴(あめ)"
+        ]
     },
     {
         "name": "chikaku",
         "trans": [
+            "近(ちか)く",
             "② 名  附近"
-        ],
-        "notation": "近(ちか)く"
+        ]
     },
     {
         "name": "hiruyasumi",
         "trans": [
+            "昼休(ひるやす)み",
             "③ 名  午休"
-        ],
-        "notation": "昼休(ひるやす)み"
+        ]
     },
     {
         "name": "koshou",
         "trans": [
+            "故障(こしょう)",
             "⓪ 名·自动3  故障"
-        ],
-        "notation": "故障(こしょう)"
+        ]
     },
     {
         "name": "toorinukeru",
         "trans": [
+            "通(とお)り抜(ぬ)ける",
             "⑤ 自动2  穿过"
-        ],
-        "notation": "通(とお)り抜(ぬ)ける"
+        ]
     },
     {
         "name": "kyuuri",
         "trans": [
+            "きゅうり",
             "① 名  黄瓜"
-        ],
-        "notation": "きゅうり"
+        ]
     },
     {
         "name": "ichibu",
         "trans": [
+            "一部(いちぶ)",
             "② 名  一部分"
-        ],
-        "notation": "一部(いちぶ)"
+        ]
     },
     {
         "name": "dokkai",
         "trans": [
+            "読解(どっかい)",
             "⓪ 名·他动3  阅读理解"
-        ],
-        "notation": "読解(どっかい)"
+        ]
     },
     {
         "name": "mikomu",
         "trans": [
+            "見込(みこ)む",
             "⓪ 他动1  预料，估计；有希望"
-        ],
-        "notation": "見込(みこ)む"
+        ]
     },
     {
         "name": "ryoukin",
         "trans": [
+            "料金(りょうきん)",
             "① 名  费用"
-        ],
-        "notation": "料金(りょうきん)"
+        ]
     },
     {
         "name": "shitagi",
         "trans": [
+            "下着(したぎ)",
             "⓪ 名  内衣，贴身衣物"
-        ],
-        "notation": "下着(したぎ)"
+        ]
     },
     {
         "name": "kubaru",
         "trans": [
+            "配(くば)る",
             "② 他动1  分配，分给"
-        ],
-        "notation": "配(くば)る"
+        ]
     },
     {
         "name": "tenshoku",
         "trans": [
+            "転職(てんしょく)",
             "⓪ 名·自动3  转行，转业"
-        ],
-        "notation": "転職(てんしょく)"
+        ]
     },
     {
         "name": "hahaoya",
         "trans": [
+            "母親(ははおや)",
             "⓪ 名  母亲"
-        ],
-        "notation": "母親(ははおや)"
+        ]
     },
     {
         "name": "sukunakutomo",
         "trans": [
+            "少(すく)なくとも",
             "② 副  至少"
-        ],
-        "notation": "少(すく)なくとも"
+        ]
     },
     {
         "name": "kokusai",
         "trans": [
+            "国際(こくさい)",
             "⓪ 名  国际"
-        ],
-        "notation": "国際(こくさい)"
+        ]
     },
     {
         "name": "kakkou",
         "trans": [
+            "格好(かっこう)",
             "⓪ 名  样子，外形；装束"
-        ],
-        "notation": "格好(かっこう)"
+        ]
     },
     {
         "name": "ku/kyuu",
         "trans": [
+            "九(く/きゅう)",
             "① 数  九"
-        ],
-        "notation": "九(く/きゅう)"
+        ]
     },
     {
         "name": "yuuri",
         "trans": [
+            "有利(ゆうり)",
             "① 名·ナ形  有利"
-        ],
-        "notation": "有利(ゆうり)"
+        ]
     },
     {
         "name": "shisha",
         "trans": [
+            "支社(ししゃ)",
             "① 名  分公司"
-        ],
-        "notation": "支社(ししゃ)"
+        ]
     },
     {
         "name": "nagareru",
         "trans": [
+            "流(なが)れる",
             "③ 自动2  流动；（时间）流逝"
-        ],
-        "notation": "流(なが)れる"
+        ]
     },
     {
         "name": "henji",
         "trans": [
+            "返事(へんじ)",
             "③ 名·自动3  回复"
-        ],
-        "notation": "返事(へんじ)"
+        ]
     },
     {
         "name": "igai",
         "trans": [
+            "以外(いがい)",
             "① 名  之外，以外"
-        ],
-        "notation": "以外(いがい)"
+        ]
     },
     {
         "name": "kitaguchi",
         "trans": [
+            "北口(きたぐち)",
             "⓪ 名  北侧出入口"
-        ],
-        "notation": "北口(きたぐち)"
+        ]
     },
     {
         "name": "fune",
         "trans": [
+            "船(ふね)",
             "① 名  船"
-        ],
-        "notation": "船(ふね)"
+        ]
     },
     {
         "name": "sanka",
         "trans": [
+            "参加(さんか)",
             "⓪ 名·自动3  参加"
-        ],
-        "notation": "参加(さんか)"
+        ]
     },
     {
         "name": "afurika",
         "trans": [
+            "アフリカ",
             "⓪ 名  非洲"
-        ],
-        "notation": "アフリカ"
+        ]
     },
     {
         "name": "konogoro",
         "trans": [
+            "このごろ",
             "⓪ 名  最近，近来"
-        ],
-        "notation": "このごろ"
+        ]
     },
     {
         "name": "shoppai",
         "trans": [
+            "しょっぱい",
             "③ イ形  咸的"
-        ],
-        "notation": "しょっぱい"
+        ]
     },
     {
         "name": "mitsukaru",
         "trans": [
+            "見(み)つかる",
             "⓪ 自动1  找到，发现"
-        ],
-        "notation": "見(み)つかる"
+        ]
     },
     {
         "name": "sa-bisu",
         "trans": [
+            "サービス",
             "① 名  服务；赠品"
-        ],
-        "notation": "サービス"
+        ]
     },
     {
         "name": "kotobadukai",
         "trans": [
+            "言葉遣(ことばづか)い",
             "④ 名  说法，措辞"
-        ],
-        "notation": "言葉遣(ことばづか)い"
+        ]
     },
     {
         "name": "totsuzen",
         "trans": [
+            "突然(とつぜん)",
             "⓪ ナ形·副  突然"
-        ],
-        "notation": "突然(とつぜん)"
+        ]
     },
     {
         "name": "houkou",
         "trans": [
+            "方向(ほうこう)",
             "⓪ 名  方向；方针"
-        ],
-        "notation": "方向(ほうこう)"
+        ]
     },
     {
         "name": "yononaka",
         "trans": [
+            "世(よ)の中(なか)",
             "② 名  世间，社会"
-        ],
-        "notation": "世(よ)の中(なか)"
+        ]
     },
     {
         "name": "zutto",
         "trans": [
+            "ずっと",
             "⓪ 副  比……得多；一直"
-        ],
-        "notation": "ずっと"
+        ]
     },
     {
         "name": "kashu",
         "trans": [
+            "歌手(かしゅ)",
             "① 名  歌手"
-        ],
-        "notation": "歌手(かしゅ)"
+        ]
     },
     {
         "name": "mairu",
         "trans": [
+            "参(まい)る",
             "① 自动1  （自谦语）去，来"
-        ],
-        "notation": "参(まい)る"
+        ]
     },
     {
         "name": "ryoujikan",
         "trans": [
+            "領事館(りょうじかん)",
             "③ 名  领事馆"
-        ],
-        "notation": "領事館(りょうじかん)"
+        ]
     },
     {
         "name": "wan",
         "trans": [
+            "碗(わん)",
             "⓪ 名  碗"
-        ],
-        "notation": "碗(わん)"
+        ]
     },
     {
         "name": "bikkuri",
         "trans": [
+            "びっくり",
             "③ 副·自动3  吃惊，吓一跳"
-        ],
-        "notation": "びっくり"
+        ]
     },
     {
         "name": "taiou",
         "trans": [
+            "対応(たいおう)",
             "⓪ 名·自动3  适应，应付；协调"
-        ],
-        "notation": "対応(たいおう)"
+        ]
     },
     {
         "name": "zen'in",
         "trans": [
+            "全員(ぜんいん)",
             "⓪ 名  全体，全员"
-        ],
-        "notation": "全員(ぜんいん)"
+        ]
     },
     {
         "name": "wataru",
         "trans": [
+            "渡(わた)る",
             "② 自动1  渡，过"
-        ],
-        "notation": "渡(わた)る"
+        ]
     },
     {
         "name": "sotogawa",
         "trans": [
+            "外側(そとがわ)",
             "⓪ 名  外侧"
-        ],
-        "notation": "外側(そとがわ)"
+        ]
     },
     {
         "name": "jissai",
         "trans": [
+            "実際(じっさい)",
             "⓪ 名·副  实际；的确，真的"
-        ],
-        "notation": "実際(じっさい)"
+        ]
     },
     {
         "name": "yasui",
         "trans": [
+            "易(やす)い",
             "② イ形  容易的"
-        ],
-        "notation": "易(やす)い"
+        ]
     },
     {
         "name": "hayame",
         "trans": [
+            "早(はや)め",
             "⓪ 名·ナ形  提前"
-        ],
-        "notation": "早(はや)め"
+        ]
     },
     {
         "name": "kubi",
         "trans": [
+            "首(くび)",
             "⓪ 名  头，头部"
-        ],
-        "notation": "首(くび)"
+        ]
     },
     {
         "name": "ochitsuku",
         "trans": [
+            "落(お)ち着(つ)く",
             "⓪ 自动1  沉着；稳定"
-        ],
-        "notation": "落(お)ち着(つ)く"
+        ]
     },
     {
         "name": "choukai",
         "trans": [
+            "聴解(ちょうかい)",
             "⓪ 名·他动3  听力理解"
-        ],
-        "notation": "聴解(ちょうかい)"
+        ]
     },
     {
         "name": "negi",
         "trans": [
+            "葱(ねぎ)",
             "① 名  葱"
-        ],
-        "notation": "葱(ねぎ)"
+        ]
     },
     {
         "name": "modoru",
         "trans": [
+            "戻(もど)る",
             "② 自动1  返回，回到；回家"
-        ],
-        "notation": "戻(もど)る"
+        ]
     },
     {
         "name": "reikin",
         "trans": [
+            "礼金(れいきん)",
             "⓪ 名  （租房等的）酬谢金"
-        ],
-        "notation": "礼金(れいきん)"
+        ]
     },
     {
         "name": "hi",
         "trans": [
+            "火(ひ)",
             "① 名  火"
-        ],
-        "notation": "火(ひ)"
+        ]
     },
     {
         "name": "shikataganai",
         "trans": [
+            "しかたがない",
             "⑤ イ形  没办法的，不得已的"
-        ],
-        "notation": "しかたがない"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "離(はな)す",
             "② 他动1  松开；使……离开"
-        ],
-        "notation": "離(はな)す"
+        ]
     },
     {
         "name": "apa-to",
         "trans": [
+            "アパート",
             "② 名  公寓"
-        ],
-        "notation": "アパート"
+        ]
     },
     {
         "name": "nemureru",
         "trans": [
+            "眠(ねむ)れる",
             "⓪ 自动2  睡得着"
-        ],
-        "notation": "眠(ねむ)れる"
+        ]
     },
     {
         "name": "hirosa",
         "trans": [
+            "広(ひろ)さ",
             "① 名  面积；宽度"
-        ],
-        "notation": "広(ひろ)さ"
+        ]
     },
     {
         "name": "ra-men",
         "trans": [
+            "ラーメン",
             "① 名  拉面"
-        ],
-        "notation": "ラーメン"
+        ]
     },
     {
         "name": "saboru",
         "trans": [
+            "サボる",
             "② 自动1  旷工，旷课"
-        ],
-        "notation": "サボる"
+        ]
     },
     {
         "name": "kuchigenka",
         "trans": [
+            "口(くち)げんか",
             "③ 名·自动3  吵架，争吵"
-        ],
-        "notation": "口(くち)げんか"
+        ]
     },
     {
         "name": "imamade",
         "trans": [
+            "今(いま)まで",
             "③ 副  迄今为止"
-        ],
-        "notation": "今(いま)まで"
+        ]
     },
     {
         "name": "mi",
         "trans": [
+            "実(み)",
             "⓪ 名  果实；内容"
-        ],
-        "notation": "実(み)"
+        ]
     },
     {
         "name": "tasukeru",
         "trans": [
+            "助(たす)ける",
             "③ 他动2  帮助；救助"
-        ],
-        "notation": "助(たす)ける"
+        ]
     },
     {
         "name": "shita",
         "trans": [
+            "舌(した)",
             "② 名  舌头"
-        ],
-        "notation": "舌(した)"
+        ]
     },
     {
         "name": "ke",
         "trans": [
+            "毛(け)",
             "⓪ 名  头发；毛"
-        ],
-        "notation": "毛(け)"
+        ]
     },
     {
         "name": "nakunaru",
         "trans": [
+            "無(な)くなる",
             "⓪ 自动1  丢失，遗失；消失"
-        ],
-        "notation": "無(な)くなる"
+        ]
     },
     {
         "name": "yoyaku",
         "trans": [
+            "予約(よやく)",
             "⓪ 名·他动3  预约，预订"
-        ],
-        "notation": "予約(よやく)"
+        ]
     },
     {
         "name": "sawagi",
         "trans": [
+            "騒(さわ)ぎ",
             "① 名  吵闹；骚乱"
-        ],
-        "notation": "騒(さわ)ぎ"
+        ]
     },
     {
         "name": "kakkoku",
         "trans": [
+            "各国(かっこく)",
             "① 名  各国"
-        ],
-        "notation": "各国(かっこく)"
+        ]
     },
     {
         "name": "rokka-",
         "trans": [
+            "ロッカー",
             "① 名  柜子"
-        ],
-        "notation": "ロッカー"
+        ]
     },
     {
         "name": "choushi",
         "trans": [
+            "調子(ちょうし)",
             "⓪ 名  情况，样子"
-        ],
-        "notation": "調子(ちょうし)"
+        ]
     },
     {
         "name": "tazuneru",
         "trans": [
+            "訪(たず)ねる",
             "③ 他动2  访问，拜访"
-        ],
-        "notation": "訪(たず)ねる"
+        ]
     },
     {
         "name": "koukoku",
         "trans": [
+            "広告(こうこく)",
             "⓪ 名·他动3  广告，宣传"
-        ],
-        "notation": "広告(こうこく)"
+        ]
     },
     {
         "name": "rakki-",
         "trans": [
+            "ラッキー",
             "① 名·ナ形  幸运"
-        ],
-        "notation": "ラッキー"
+        ]
     },
     {
         "name": "dekireba",
         "trans": [
+            "できれば",
             "② 接续  如果可以的话"
-        ],
-        "notation": "できれば"
+        ]
     },
     {
         "name": "zutsuu",
         "trans": [
+            "頭痛(ずつう)",
             "⓪ 名  头痛"
-        ],
-        "notation": "頭痛(ずつう)"
+        ]
     },
     {
         "name": "kisoku",
         "trans": [
+            "規則(きそく)",
             "① 名  规则"
-        ],
-        "notation": "規則(きそく)"
+        ]
     },
     {
         "name": "hayaru",
         "trans": [
+            "流行(はや)る",
             "② 自动1  流行，时髦；（疾病）蔓延"
-        ],
-        "notation": "流行(はや)る"
+        ]
     },
     {
         "name": "roudou",
         "trans": [
+            "労働(ろうどう)",
             "⓪ 名·自动3  劳动"
-        ],
-        "notation": "労働(ろうどう)"
+        ]
     },
     {
         "name": "chiri",
         "trans": [
+            "地理(ちり)",
             "① 名  地理；地形"
-        ],
-        "notation": "地理(ちり)"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "建(た)つ",
             "① 自动1  建，盖"
-        ],
-        "notation": "建(た)つ"
+        ]
     },
     {
         "name": "shuuden",
         "trans": [
+            "終電(しゅうでん)",
             "⓪ 名  末班电车"
-        ],
-        "notation": "終電(しゅうでん)"
+        ]
     },
     {
         "name": "fukuzatsu",
         "trans": [
+            "複雑(ふくざつ)",
             "⓪ 名·ナ形  复杂"
-        ],
-        "notation": "複雑(ふくざつ)"
+        ]
     },
     {
         "name": "yorokobu",
         "trans": [
+            "喜(よろこ)ぶ",
             "③ 自他动1  高兴，欢喜"
-        ],
-        "notation": "喜(よろこ)ぶ"
+        ]
     },
     {
         "name": "robi-",
         "trans": [
+            "ロビー",
             "① 名  大厅，前厅"
-        ],
-        "notation": "ロビー"
+        ]
     },
     {
         "name": "kuuseki",
         "trans": [
+            "空席(くうせき)",
             "⓪ 名  空座位"
-        ],
-        "notation": "空席(くうせき)"
+        ]
     },
     {
         "name": "sameru",
         "trans": [
+            "覚(さ)める",
             "② 自动2  醒来；清醒，醒悟"
-        ],
-        "notation": "覚(さ)める"
+        ]
     },
     {
         "name": "kaoiro",
         "trans": [
+            "顔色(かおいろ)",
             "⓪ 名  脸色；气色"
-        ],
-        "notation": "顔色(かおいろ)"
+        ]
     },
     {
         "name": "bun'ya",
         "trans": [
+            "分野(ぶんや)",
             "① 名  领域"
-        ],
-        "notation": "分野(ぶんや)"
+        ]
     },
     {
         "name": "yabureru",
         "trans": [
+            "破(やぶ)れる",
             "③ 自动2  破，裂；打破"
-        ],
-        "notation": "破(やぶ)れる"
+        ]
     },
     {
         "name": "shitsurei",
         "trans": [
+            "失礼(しつれい)",
             "② 名·ナ形·自动3  不礼貌；对不起；告辞"
-        ],
-        "notation": "失礼(しつれい)"
+        ]
     },
     {
         "name": "painappuru",
         "trans": [
+            "パイナップル",
             "③ 名  菠萝"
-        ],
-        "notation": "パイナップル"
+        ]
     },
     {
         "name": "hieru",
         "trans": [
+            "冷(ひ)える",
             "② 自动2  变冷；感觉冷"
-        ],
-        "notation": "冷(ひ)える"
+        ]
     },
     {
         "name": "kitsuenjo",
         "trans": [
+            "喫煙所(きつえんじょ)",
             "⓪ 名  吸烟处"
-        ],
-        "notation": "喫煙所(きつえんじょ)"
+        ]
     },
     {
         "name": "wasuremono",
         "trans": [
+            "忘(わす)れ物(もの)",
             "⓪ 名  遗失物"
-        ],
-        "notation": "忘(わす)れ物(もの)"
+        ]
     },
     {
         "name": "korobu",
         "trans": [
+            "転(ころ)ぶ",
             "⓪ 自动1  滚动；摔倒"
-        ],
-        "notation": "転(ころ)ぶ"
+        ]
     },
     {
         "name": "shinseki",
         "trans": [
+            "親戚(しんせき)",
             "⓪ 名  亲戚"
-        ],
-        "notation": "親戚(しんせき)"
+        ]
     },
     {
         "name": "tsuukou",
         "trans": [
+            "通行(つうこう)",
             "⓪ 名·自动3  通行，往来"
-        ],
-        "notation": "通行(つうこう)"
+        ]
     },
     {
         "name": "naguru",
         "trans": [
+            "殴(なぐ)る",
             "② 他动1  殴打"
-        ],
-        "notation": "殴(なぐ)る"
+        ]
     },
     {
         "name": "hikkoshi",
         "trans": [
+            "引(ひ)っ越(こ)し",
             "⓪ 名  搬家，搬迁"
-        ],
-        "notation": "引(ひ)っ越(こ)し"
+        ]
     },
     {
         "name": "shoushika",
         "trans": [
+            "少子化(しょうしか)",
             "⓪ 名  少子化"
-        ],
-        "notation": "少子化(しょうしか)"
+        ]
     },
     {
         "name": "irassharu",
         "trans": [
+            "いらっしゃる",
             "④ 自动1  （尊他语）来；去；在"
-        ],
-        "notation": "いらっしゃる"
+        ]
     },
     {
         "name": "saikai",
         "trans": [
+            "再会(さいかい)",
             "⓪ 名·自动3  再会，重逢"
-        ],
-        "notation": "再会(さいかい)"
+        ]
     },
     {
         "name": "beruto",
         "trans": [
+            "ベルト",
             "⓪ 名  皮带，腰带"
-        ],
-        "notation": "ベルト"
+        ]
     },
     {
         "name": "chuugaku",
         "trans": [
+            "中学(ちゅうがく)",
             "① 名  初中，中学"
-        ],
-        "notation": "中学(ちゅうがく)"
+        ]
     },
     {
         "name": "an'nani",
         "trans": [
+            "あんなに",
             "⓪ 副  那么，那样地"
-        ],
-        "notation": "あんなに"
+        ]
     },
     {
         "name": "saiyou",
         "trans": [
+            "採用(さいよう)",
             "⓪ 名·他动3  采用，采纳；录用"
-        ],
-        "notation": "採用(さいよう)"
+        ]
     },
     {
         "name": "pawa-",
         "trans": [
+            "パワー",
             "① 名  力量，权力；动力"
-        ],
-        "notation": "パワー"
+        ]
     },
     {
         "name": "ikiru",
         "trans": [
+            "生(い)きる",
             "② 自动2  生活，生存"
-        ],
-        "notation": "生(い)きる"
+        ]
     },
     {
         "name": "daigakuin",
         "trans": [
+            "大学院(だいがくいん)",
             "④ 名  研究生院"
-        ],
-        "notation": "大学院(だいがくいん)"
+        ]
     },
     {
         "name": "jinmingen",
         "trans": [
+            "人民元(じんみんげん)",
             "③ 名  人民币"
-        ],
-        "notation": "人民元(じんみんげん)"
+        ]
     },
     {
         "name": "kabin",
         "trans": [
+            "花瓶(かびん)",
             "⓪ 名  花瓶"
-        ],
-        "notation": "花瓶(かびん)"
+        ]
     },
     {
         "name": "madamada",
         "trans": [
+            "まだまだ",
             "① 副  仍，还"
-        ],
-        "notation": "まだまだ"
+        ]
     },
     {
         "name": "kawari",
         "trans": [
+            "変(か)わり",
             "⓪ 名  变化，改变"
-        ],
-        "notation": "変(か)わり"
+        ]
     },
     {
         "name": "sagaru",
         "trans": [
+            "下(さ)がる",
             "② 自动1  降低，下降；后退"
-        ],
-        "notation": "下(さ)がる"
+        ]
     },
     {
         "name": "kinu",
         "trans": [
+            "絹(きぬ)",
             "① 名  丝绸"
-        ],
-        "notation": "絹(きぬ)"
+        ]
     },
     {
         "name": "chigai",
         "trans": [
+            "違(ちが)い",
             "⓪ 名  差异，不同；错误"
-        ],
-        "notation": "違(ちが)い"
+        ]
     },
     {
         "name": "sodatsu",
         "trans": [
+            "育(そだ)つ",
             "② 自动1  发育，成长"
-        ],
-        "notation": "育(そだ)つ"
+        ]
     },
     {
         "name": "iji",
         "trans": [
+            "意地(いじ)",
             "② 名  心术，用心"
-        ],
-        "notation": "意地(いじ)"
+        ]
     },
     {
         "name": "dentou",
         "trans": [
+            "電燈(でんとう)",
             "⓪ 名  电灯"
-        ],
-        "notation": "電燈(でんとう)"
+        ]
     },
     {
         "name": "shousetsu",
         "trans": [
+            "小説(しょうせつ)",
             "⓪ 名  小说"
-        ],
-        "notation": "小説(しょうせつ)"
+        ]
     },
     {
         "name": "kikaseru",
         "trans": [
+            "聞(き)かせる",
             "⓪ 他动2  说给……听，让……听"
-        ],
-        "notation": "聞(き)かせる"
+        ]
     },
     {
         "name": "yushutsu",
         "trans": [
+            "輸出(ゆしゅつ)",
             "⓪ 名·他动3  出口，输出"
-        ],
-        "notation": "輸出(ゆしゅつ)"
+        ]
     },
     {
         "name": "kata",
         "trans": [
+            "肩(かた)",
             "① 名  肩膀"
-        ],
-        "notation": "肩(かた)"
+        ]
     },
     {
         "name": "todoku",
         "trans": [
+            "届(とど)く",
             "② 自动1  送达；达到"
-        ],
-        "notation": "届(とど)く"
+        ]
     },
     {
         "name": "futatsu",
         "trans": [
+            "二(ふた)つ",
             "③ 名  两个；两岁"
-        ],
-        "notation": "二(ふた)つ"
+        ]
     },
     {
         "name": "dankai",
         "trans": [
+            "段階(だんかい)",
             "⓪ 名  阶段，步骤"
-        ],
-        "notation": "段階(だんかい)"
+        ]
     },
     {
         "name": "zonjiru",
         "trans": [
+            "存(ぞん)じる",
             "③ 他动2  想，认为；知道"
-        ],
-        "notation": "存(ぞん)じる"
+        ]
     },
     {
         "name": "kagaku",
         "trans": [
+            "科学(かがく)",
             "① 名  科学"
-        ],
-        "notation": "科学(かがく)"
+        ]
     },
     {
         "name": "tanoshimi",
         "trans": [
+            "楽(たの)しみ",
             "③ 名  乐趣；兴趣；期待"
-        ],
-        "notation": "楽(たの)しみ"
+        ]
     },
     {
         "name": "irodoru",
         "trans": [
+            "彩(いろど)る",
             "③ 他动1  上色；装饰，点缀"
-        ],
-        "notation": "彩(いろど)る"
+        ]
     },
     {
         "name": "fushinsetsu",
         "trans": [
+            "不親切(ふしんせつ)",
             "② 名·ナ形  不亲切，不热情"
-        ],
-        "notation": "不親切(ふしんせつ)"
+        ]
     },
     {
         "name": "saka",
         "trans": [
+            "坂(さか)",
             "② 名  斜坡"
-        ],
-        "notation": "坂(さか)"
+        ]
     },
     {
         "name": "tasukaru",
         "trans": [
+            "助(たす)かる",
             "③ 自动1  有帮助；得救，脱险"
-        ],
-        "notation": "助(たす)かる"
+        ]
     },
     {
         "name": "chi-mu",
         "trans": [
+            "チーム",
             "① 名  队，组"
-        ],
-        "notation": "チーム"
+        ]
     },
     {
         "name": "kisha",
         "trans": [
+            "汽車(きしゃ)",
             "② 名  火车"
-        ],
-        "notation": "汽車(きしゃ)"
+        ]
     },
     {
         "name": "makaseru",
         "trans": [
+            "任(まか)せる",
             "③ 他动2  委托，托付；听任，听凭"
-        ],
-        "notation": "任(まか)せる"
+        ]
     },
     {
         "name": "inku",
         "trans": [
+            "インク",
             "⓪ 名  墨水"
-        ],
-        "notation": "インク"
+        ]
     },
     {
         "name": "baka",
         "trans": [
+            "馬鹿(ばか)",
             "① 名·ナ形  傻瓜；愚蠢"
-        ],
-        "notation": "馬鹿(ばか)"
+        ]
     },
     {
         "name": "tadashii",
         "trans": [
+            "正(ただ)しい",
             "③ イ形  正确的，正当的"
-        ],
-        "notation": "正(ただ)しい"
+        ]
     },
     {
         "name": "kiken",
         "trans": [
+            "危険(きけん)",
             "⓪ 名·ナ形  危险"
-        ],
-        "notation": "危険(きけん)"
+        ]
     },
     {
         "name": "shusseki",
         "trans": [
+            "出席(しゅっせき)",
             "⓪ 名·自动3  出席"
-        ],
-        "notation": "出席(しゅっせき)"
+        ]
     },
     {
         "name": "tsukamaru",
         "trans": [
+            "捕(つか)まる",
             "⓪ 自动1  抓住；被逮捕"
-        ],
-        "notation": "捕(つか)まる"
+        ]
     },
     {
         "name": "kazu",
         "trans": [
+            "数(かず)",
             "① 名  数字，数目"
-        ],
-        "notation": "数(かず)"
+        ]
     },
     {
         "name": "chuui",
         "trans": [
+            "注意(ちゅうい)",
             "① 名·自动3  注意，留神；提醒，警告"
-        ],
-        "notation": "注意(ちゅうい)"
+        ]
     },
     {
         "name": "uruou",
         "trans": [
+            "潤(うるお)う",
             "③ 自动1  湿润，弄湿"
-        ],
-        "notation": "潤(うるお)う"
+        ]
     },
     {
         "name": "sonokoro",
         "trans": [
+            "そのころ",
             "③ 名  那时，当时"
-        ],
-        "notation": "そのころ"
+        ]
     },
     {
         "name": "kankoku",
         "trans": [
+            "韓国(かんこく)",
             "① 名  韩国"
-        ],
-        "notation": "韓国(かんこく)"
+        ]
     },
     {
         "name": "hirou",
         "trans": [
+            "拾(ひろ)う",
             "⓪ 他动1  拾，捡；选出，挑选"
-        ],
-        "notation": "拾(ひろ)う"
+        ]
     },
     {
         "name": "kibun",
         "trans": [
+            "気分(きぶん)",
             "① 名  心情，情绪"
-        ],
-        "notation": "気分(きぶん)"
+        ]
     },
     {
         "name": "bijinesu",
         "trans": [
+            "ビジネス",
             "① 名  商业；事务，工作"
-        ],
-        "notation": "ビジネス"
+        ]
     },
     {
         "name": "tazuneru",
         "trans": [
+            "尋(たず)ねる",
             "③ 他动2  寻找；询问"
-        ],
-        "notation": "尋(たず)ねる"
+        ]
     },
     {
         "name": "kaeri",
         "trans": [
+            "帰(かえ)り",
             "③ 名  回来，回来的时候"
-        ],
-        "notation": "帰(かえ)り"
+        ]
     },
     {
         "name": "zettai",
         "trans": [
+            "絶対(ぜったい)",
             "⓪ 名·副  绝对，无与伦比；一定，坚决"
-        ],
-        "notation": "絶対(ぜったい)"
+        ]
     },
     {
         "name": "inu",
         "trans": [
+            "犬(いぬ)",
             "② 名  狗"
-        ],
-        "notation": "犬(いぬ)"
+        ]
     },
     {
         "name": "eikyou",
         "trans": [
+            "影響(えいきょう)",
             "⓪ 名·自动3  影响"
-        ],
-        "notation": "影響(えいきょう)"
+        ]
     },
     {
         "name": "touzen",
         "trans": [
+            "当然(とうぜん)",
             "⓪ ナ形·副  当然，理所应当"
-        ],
-        "notation": "当然(とうぜん)"
+        ]
     },
     {
         "name": "kibo",
         "trans": [
+            "規模(きぼ)",
             "① 名  规模；范围"
-        ],
-        "notation": "規模(きぼ)"
+        ]
     },
     {
         "name": "nokosu",
         "trans": [
+            "残(のこ)す",
             "② 他动1  留下，剩下"
-        ],
-        "notation": "残(のこ)す"
+        ]
     },
     {
         "name": "kanpai",
         "trans": [
+            "乾杯(かんぱい)",
             "⓪ 名·自动3  干杯"
-        ],
-        "notation": "乾杯(かんぱい)"
+        ]
     },
     {
         "name": "eapo-to",
         "trans": [
+            "エアポート",
             "③ 名  机场"
-        ],
-        "notation": "エアポート"
+        ]
     },
     {
         "name": "kasegu",
         "trans": [
+            "稼(かせ)ぐ",
             "② 他动1  赚钱，挣钱"
-        ],
-        "notation": "稼(かせ)ぐ"
+        ]
     },
     {
         "name": "hakimono",
         "trans": [
+            "履物(はきもの)",
             "⓪ 名  （统称）鞋子"
-        ],
-        "notation": "履物(はきもの)"
+        ]
     },
     {
         "name": "sofa-",
         "trans": [
+            "ソファー",
             "① 名  沙发"
-        ],
-        "notation": "ソファー"
+        ]
     },
     {
         "name": "omotai",
         "trans": [
+            "重(おも)たい",
             "⓪ イ形  （物品）重的；（心情、感觉等）沉重的"
-        ],
-        "notation": "重(おも)たい"
+        ]
     },
     {
         "name": "bo-rupen",
         "trans": [
+            "ボールペン",
             "⓪ 名  圆珠笔"
-        ],
-        "notation": "ボールペン"
+        ]
     },
     {
         "name": "hajimari",
         "trans": [
+            "始(はじ)まり",
             "⓪ 名  开始；起源"
-        ],
-        "notation": "始(はじ)まり"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "経(た)つ",
             "① 自动1  （时间）流逝"
-        ],
-        "notation": "経(た)つ"
+        ]
     },
     {
         "name": "gurasu",
         "trans": [
+            "グラス",
             "① 名  玻璃；玻璃杯"
-        ],
-        "notation": "グラス"
+        ]
     },
     {
         "name": "dondon",
         "trans": [
+            "どんどん",
             "① 副  连续不断；（进展）顺利，（势头）旺盛"
-        ],
-        "notation": "どんどん"
+        ]
     },
     {
         "name": "hipparu",
         "trans": [
+            "引(ひ)っ張(ぱ)る",
             "③ 他动1  拉，拽，硬拉"
-        ],
-        "notation": "引(ひ)っ張(ぱ)る"
+        ]
     },
     {
         "name": "gaman",
         "trans": [
+            "我慢(がまん)",
             "① 名·他动3  忍耐，容忍"
-        ],
-        "notation": "我慢(がまん)"
+        ]
     },
     {
         "name": "shoukai",
         "trans": [
+            "紹介(しょうかい)",
             "⓪ 名·他动3  介绍"
-        ],
-        "notation": "紹介(しょうかい)"
+        ]
     },
     {
         "name": "nakanaka",
         "trans": [
+            "なかなか",
             "⓪ 副  非常，相当；（后接否定）不容易……"
-        ],
-        "notation": "なかなか"
+        ]
     },
     {
         "name": "kusa",
         "trans": [
+            "草(くさ)",
             "② 名  草，杂草"
-        ],
-        "notation": "草(くさ)"
+        ]
     },
     {
         "name": "shingururu-mu",
         "trans": [
+            "シングルルーム",
             "⑤ 名  单人间"
-        ],
-        "notation": "シングルルーム"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "描(か)く",
             "① 他动1  画"
-        ],
-        "notation": "描(か)く"
+        ]
     },
     {
         "name": "doko",
         "trans": [
+            "どこ",
             "① 代  哪里，哪个地方"
-        ],
-        "notation": "どこ"
+        ]
     },
     {
         "name": "o-sutoraria",
         "trans": [
+            "オーストラリア",
             "⑤ 名  澳大利亚"
-        ],
-        "notation": "オーストラリア"
+        ]
     },
     {
         "name": "tateru",
         "trans": [
+            "立(た)てる",
             "② 他动2  立起，竖起；制定（方案、计划等）"
-        ],
-        "notation": "立(た)てる"
+        ]
     },
     {
         "name": "kanshin",
         "trans": [
+            "関心(かんしん)",
             "⓪ 名·自动3  关心，感兴趣"
-        ],
-        "notation": "関心(かんしん)"
+        ]
     },
     {
         "name": "yattsu",
         "trans": [
+            "八(やっ)つ",
             "③ 名  八个；八岁"
-        ],
-        "notation": "八(やっ)つ"
+        ]
     },
     {
         "name": "chairoi",
         "trans": [
+            "茶色(ちゃいろ)い",
             "⓪ イ形  茶色的，褐色的"
-        ],
-        "notation": "茶色(ちゃいろ)い"
+        ]
     },
     {
         "name": "ganko",
         "trans": [
+            "頑固(がんこ)",
             "① ナ形  顽固的，固执的"
-        ],
-        "notation": "頑固(がんこ)"
+        ]
     },
     {
         "name": "joudan",
         "trans": [
+            "冗談(じょうだん)",
             "③ 名  玩笑，笑话"
-        ],
-        "notation": "冗談(じょうだん)"
+        ]
     },
     {
         "name": "nageru",
         "trans": [
+            "投(な)げる",
             "② 他动2  投掷；放弃"
-        ],
-        "notation": "投(な)げる"
+        ]
     },
     {
         "name": "futsuka",
         "trans": [
+            "二日(ふつか)",
             "⓪ 名  （每个月的）二号；两天"
-        ],
-        "notation": "二日(ふつか)"
+        ]
     },
     {
         "name": "kettei",
         "trans": [
+            "決定(けってい)",
             "⓪ 名·自他动3  决定"
-        ],
-        "notation": "決定(けってい)"
+        ]
     },
     {
         "name": "kinou",
         "trans": [
+            "昨日(きのう)",
             "② 名  昨天"
-        ],
-        "notation": "昨日(きのう)"
+        ]
     },
     {
         "name": "chekkuin",
         "trans": [
+            "チェックイン",
             "③ 名·自动3  办理入住手续"
-        ],
-        "notation": "チェックイン"
+        ]
     },
     {
         "name": "kokugo",
         "trans": [
+            "国語(こくご)",
             "⓪ 名  本国语言；语文"
-        ],
-        "notation": "国語(こくご)"
+        ]
     },
     {
         "name": "kami",
         "trans": [
+            "神(かみ)",
             "① 名  神灵"
-        ],
-        "notation": "神(かみ)"
+        ]
     },
     {
         "name": "kyaku",
         "trans": [
+            "客(きゃく)",
             "⓪ 名  客人，顾客"
-        ],
-        "notation": "客(きゃく)"
+        ]
     },
     {
         "name": "maiban",
         "trans": [
+            "毎晩(まいばん)",
             "① 名  每天晚上"
-        ],
-        "notation": "毎晩(まいばん)"
+        ]
     },
     {
         "name": "yotei",
         "trans": [
+            "予定(よてい)",
             "⓪ 名·他动3  预订，计划"
-        ],
-        "notation": "予定(よてい)"
+        ]
     },
     {
         "name": "kensetsu",
         "trans": [
+            "建設(けんせつ)",
             "⓪ 名·他动3  建设，修建"
-        ],
-        "notation": "建設(けんせつ)"
+        ]
     },
     {
         "name": "rokku",
         "trans": [
+            "ロック",
             "① 名·他动3  锁；上锁"
-        ],
-        "notation": "ロック"
+        ]
     },
     {
         "name": "kiseru",
         "trans": [
+            "着(き)せる",
             "⓪ 他动2  给……穿上，给……蒙上"
-        ],
-        "notation": "着(き)せる"
+        ]
     },
     {
         "name": "taipu",
         "trans": [
+            "タイプ",
             "① 名  类型"
-        ],
-        "notation": "タイプ"
+        ]
     },
     {
         "name": "kanji",
         "trans": [
+            "感(かん)じ",
             "⓪ 名  感觉；印象"
-        ],
-        "notation": "感(かん)じ"
+        ]
     },
     {
         "name": "hidoi",
         "trans": [
+            "ひどい",
             "② イ形  残酷的，无情的；激烈的"
-        ],
-        "notation": "ひどい"
+        ]
     },
     {
         "name": "tana",
         "trans": [
+            "棚(たな)",
             "⓪ 名  架子，棚"
-        ],
-        "notation": "棚(たな)"
+        ]
     },
     {
         "name": "kanarazu",
         "trans": [
+            "必(かなら)ず",
             "⓪ 副  一定，必定"
-        ],
-        "notation": "必(かなら)ず"
+        ]
     },
     {
         "name": "hyaku",
         "trans": [
+            "百(ひゃく)",
             "② 数  百"
-        ],
-        "notation": "百(ひゃく)"
+        ]
     },
     {
         "name": "kusai",
         "trans": [
+            "臭(くさ)い",
             "② イ形  臭的，难闻的"
-        ],
-        "notation": "臭(くさ)い"
+        ]
     },
     {
         "name": "tsuitachi",
         "trans": [
+            "一日(ついたち)",
             "④ 名  （每个月的）一号"
-        ],
-        "notation": "一日(ついたち)"
+        ]
     },
     {
         "name": "kanashimu",
         "trans": [
+            "悲(かな)しむ",
             "③ 他动1  （感到）悲伤"
-        ],
-        "notation": "悲(かな)しむ"
+        ]
     },
     {
         "name": "chikagoro",
         "trans": [
+            "近頃(ちかごろ)",
             "② 名  近来，近日"
-        ],
-        "notation": "近頃(ちかごろ)"
+        ]
     },
     {
         "name": "fudan",
         "trans": [
+            "普段(ふだん)",
             "① 名·副  平时，平常"
-        ],
-        "notation": "普段(ふだん)"
+        ]
     },
     {
         "name": "sageru",
         "trans": [
+            "下(さ)げる",
             "② 他动2  降低，降下；使后退"
-        ],
-        "notation": "下(さ)げる"
+        ]
     },
     {
         "name": "kisha",
         "trans": [
+            "記者(きしゃ)",
             "① 名  记者"
-        ],
-        "notation": "記者(きしゃ)"
+        ]
     },
     {
         "name": "tadaima",
         "trans": [
+            "ただ今(いま)",
             "② 副  现在；刚才；马上"
-        ],
-        "notation": "ただ今(いま)"
+        ]
     },
     {
         "name": "ooyoso",
         "trans": [
+            "おおよそ",
             "⓪ 名·副  大概"
-        ],
-        "notation": "おおよそ"
+        ]
     },
     {
         "name": "basuketto",
         "trans": [
+            "バスケット",
             "③ 名  篮，筐"
-        ],
-        "notation": "バスケット"
+        ]
     },
     {
         "name": "kawari",
         "trans": [
+            "代(か)わり",
             "⓪ 名  代替，取代；补偿；再来一碗"
-        ],
-        "notation": "代(か)わり"
+        ]
     },
     {
         "name": "tanoshimu",
         "trans": [
+            "楽(たの)しむ",
             "③ 他动1  享受；期待"
-        ],
-        "notation": "楽(たの)しむ"
+        ]
     },
     {
         "name": "hisashiburi",
         "trans": [
+            "久(ひさ)しぶり",
             "⓪ 名·ナ形  （隔了）许久，久违"
-        ],
-        "notation": "久(ひさ)しぶり"
+        ]
     },
     {
         "name": "geshuku",
         "trans": [
+            "下宿(げしゅく)",
             "⓪ 名·自动3  公寓；寄宿"
-        ],
-        "notation": "下宿(げしゅく)"
+        ]
     },
     {
         "name": "shiokarai",
         "trans": [
+            "塩辛(しおから)い",
             "④ イ形  咸的"
-        ],
-        "notation": "塩辛(しおから)い"
+        ]
     },
     {
         "name": "gen'in",
         "trans": [
+            "原因(げんいん)",
             "⓪ 名  原因"
-        ],
-        "notation": "原因(げんいん)"
+        ]
     },
     {
         "name": "shinpai",
         "trans": [
+            "心配(しんぱい)",
             "⓪ 名·ナ形·自他动3  担心，挂念"
-        ],
-        "notation": "心配(しんぱい)"
+        ]
     },
     {
         "name": "kusaru",
         "trans": [
+            "腐(くさ)る",
             "② 自动1  腐烂，腐坏"
-        ],
-        "notation": "腐(くさ)る"
+        ]
     },
     {
         "name": "sewa",
         "trans": [
+            "世話(せわ)",
             "② 名·他动3  帮助；照料"
-        ],
-        "notation": "世話(せわ)"
+        ]
     },
     {
         "name": "hatten",
         "trans": [
+            "発展(はってん)",
             "⓪ 名·自动3  发展"
-        ],
-        "notation": "発展(はってん)"
+        ]
     },
     {
         "name": "sodateru",
         "trans": [
+            "育(そだ)てる",
             "③ 他动2  培养，抚育"
-        ],
-        "notation": "育(そだ)てる"
+        ]
     },
     {
         "name": "kurasume-to",
         "trans": [
+            "クラスメート",
             "④ 名  同班同学"
-        ],
-        "notation": "クラスメート"
+        ]
     },
     {
         "name": "dokidoki",
         "trans": [
+            "どきどき",
             "① 副·自动3  （忐忑不安）心扑通扑通地跳"
-        ],
-        "notation": "どきどき"
+        ]
     },
     {
         "name": "shucchou",
         "trans": [
+            "出張(しゅっちょう)",
             "⓪ 名·自动3  出差"
-        ],
-        "notation": "出張(しゅっちょう)"
+        ]
     },
     {
         "name": "kyanseru",
         "trans": [
+            "キャンセル",
             "① 名·他动3  取消，作废"
-        ],
-        "notation": "キャンセル"
+        ]
     },
     {
         "name": "natsukashii",
         "trans": [
+            "懐(なつ)かしい",
             "④ イ形  怀念的，眷恋的"
-        ],
-        "notation": "懐(なつ)かしい"
+        ]
     },
     {
         "name": "natsu",
         "trans": [
+            "夏(なつ)",
             "② 名  夏季"
-        ],
-        "notation": "夏(なつ)"
+        ]
     },
     {
         "name": "chikara",
         "trans": [
+            "力(ちから)",
             "③ 名  力气；权力；精力"
-        ],
-        "notation": "力(ちから)"
+        ]
     },
     {
         "name": "sunao",
         "trans": [
+            "素直(すなお)",
             "① ナ形  坦率的，纯朴的"
-        ],
-        "notation": "素直(すなお)"
+        ]
     },
     {
         "name": "keiei",
         "trans": [
+            "経営(けいえい)",
             "⓪ 名·他动3  经营，运营"
-        ],
-        "notation": "経営(けいえい)"
+        ]
     },
     {
         "name": "miyage",
         "trans": [
+            "土産(みやげ)",
             "⓪ 名  特产，小礼物"
-        ],
-        "notation": "土産(みやげ)"
+        ]
     },
     {
         "name": "gakkari",
         "trans": [
+            "がっかり",
             "③ 副·自动3  失望，心灰意冷"
-        ],
-        "notation": "がっかり"
+        ]
     },
     {
         "name": "gochisou",
         "trans": [
+            "ご馳走(ちそう)",
             "⓪ 名·他动3  酒席；款待"
-        ],
-        "notation": "ご馳走(ちそう)"
+        ]
     },
     {
         "name": "tekitou",
         "trans": [
+            "適当(てきとう)",
             "⓪ 名·ナ形  适当，适宜；随便，敷衍"
-        ],
-        "notation": "適当(てきとう)"
+        ]
     },
     {
         "name": "subarashii",
         "trans": [
+            "素晴(すば)らしい",
             "④ イ形  极好的，绝佳的"
-        ],
-        "notation": "素晴(すば)らしい"
+        ]
     },
     {
         "name": "kemuri",
         "trans": [
+            "煙(けむり)",
             "⓪ 名  烟，烟状物"
-        ],
-        "notation": "煙(けむり)"
+        ]
     },
     {
         "name": "chokin",
         "trans": [
+            "貯金(ちょきん)",
             "⓪ 名·自动3  存款；储蓄"
-        ],
-        "notation": "貯金(ちょきん)"
+        ]
     },
     {
         "name": "hayaku",
         "trans": [
+            "早(はや)く",
             "① 副  （时间）早；（速度）快"
-        ],
-        "notation": "早(はや)く"
+        ]
     },
     {
         "name": "genba",
         "trans": [
+            "現場(げんば)",
             "⓪ 名  现场；工地"
-        ],
-        "notation": "現場(げんば)"
+        ]
     },
     {
         "name": "son'nani",
         "trans": [
+            "そんなに",
             "⓪ 副  那么，那样地"
-        ],
-        "notation": "そんなに"
+        ]
     },
     {
         "name": "shikkari",
         "trans": [
+            "しっかり",
             "③ 副·自动3  健壮，结实；可靠；扎实，充分"
-        ],
-        "notation": "しっかり"
+        ]
     },
     {
         "name": "koori",
         "trans": [
+            "氷(こおり)",
             "⓪ 名  冰"
-        ],
-        "notation": "氷(こおり)"
+        ]
     },
     {
         "name": "purasuchikku",
         "trans": [
+            "プラスチック",
             "④ 名  塑料，塑胶"
-        ],
-        "notation": "プラスチック"
+        ]
     },
     {
         "name": "sukoshimo",
         "trans": [
+            "少(すこ)しも",
             "② 副  （后接否定）一点儿也不……"
-        ],
-        "notation": "少(すこ)しも"
+        ]
     },
     {
         "name": "akeru",
         "trans": [
+            "開(あ)ける",
             "⓪ 他动2  打开，拉开"
-        ],
-        "notation": "開(あ)ける"
+        ]
     },
     {
         "name": "tomato",
         "trans": [
+            "トマト",
             "① 名  番茄"
-        ],
-        "notation": "トマト"
+        ]
     },
     {
         "name": "shizen'ni",
         "trans": [
+            "自然(しぜん)に",
             "⓪ 副  自然而然地"
-        ],
-        "notation": "自然(しぜん)に"
+        ]
     },
     {
         "name": "sain",
         "trans": [
+            "サイン",
             "① 名·自动3  信号，暗号；签名"
-        ],
-        "notation": "サイン"
+        ]
     },
     {
         "name": "ten'nai",
         "trans": [
+            "店内(てんない)",
             "① 名  店内，店里"
-        ],
-        "notation": "店内(てんない)"
+        ]
     },
     {
         "name": "zehi",
         "trans": [
+            "ぜひ",
             "① 副  务必，一定"
-        ],
-        "notation": "ぜひ"
+        ]
     },
     {
         "name": "kanshin",
         "trans": [
+            "感心(かんしん)",
             "⓪ 名·自动3  钦佩，佩服"
-        ],
-        "notation": "感心(かんしん)"
+        ]
     },
     {
         "name": "teinei",
         "trans": [
+            "丁寧(ていねい)",
             "① 名·ナ形  礼貌，恭敬；认真，细心"
-        ],
-        "notation": "丁寧(ていねい)"
+        ]
     },
     {
         "name": "somatsu",
         "trans": [
+            "粗末(そまつ)",
             "① 名·ナ形  粗糙，不精致；怠慢"
-        ],
-        "notation": "粗末(そまつ)"
+        ]
     },
     {
         "name": "kichinto",
         "trans": [
+            "きちんと",
             "② 副  整齐，干净；准时；好好地"
-        ],
-        "notation": "きちんと"
+        ]
     },
     {
         "name": "rusu",
         "trans": [
+            "留守(るす)",
             "① 名·自动3  看家，看门；不在家"
-        ],
-        "notation": "留守(るす)"
+        ]
     },
     {
         "name": "matsuri",
         "trans": [
+            "祭(まつ)り",
             "⓪ 名  节日；祭祀"
-        ],
-        "notation": "祭(まつ)り"
+        ]
     },
     {
         "name": "daibu",
         "trans": [
+            "だいぶ",
             "⓪ 副  相当，颇为"
-        ],
-        "notation": "だいぶ"
+        ]
     },
     {
         "name": "hasami",
         "trans": [
+            "はさみ",
             "③ 名  剪刀"
-        ],
-        "notation": "はさみ"
+        ]
     },
     {
         "name": "shouchi",
         "trans": [
+            "承知(しょうち)",
             "⓪ 名·他动3  知道；同意，赞成"
-        ],
-        "notation": "承知(しょうち)"
+        ]
     },
     {
         "name": "nandemo",
         "trans": [
+            "なんでも",
             "① 副  无论什么；不管怎样"
-        ],
-        "notation": "なんでも"
+        ]
     },
     {
         "name": "orei",
         "trans": [
+            "お礼(れい)",
             "⓪ 名·他动3  感谢；回礼，酬谢"
-        ],
-        "notation": "お礼(れい)"
+        ]
     },
     {
         "name": "tokui",
         "trans": [
+            "得意(とくい)",
             "② 名·ナ形  擅长"
-        ],
-        "notation": "得意(とくい)"
+        ]
     },
     {
         "name": "sekkaku",
         "trans": [
+            "せっかく",
             "⓪ 副  特意，好不容易"
-        ],
-        "notation": "せっかく"
+        ]
     },
     {
         "name": "kyuusoku",
         "trans": [
+            "急速(きゅうそく)",
             "⓪ 名·ナ形  迅速，快速"
-        ],
-        "notation": "急速(きゅうそく)"
+        ]
     },
     {
         "name": "kakikata",
         "trans": [
+            "書(か)き方(かた)",
             "③ 名  写法"
-        ],
-        "notation": "書(か)き方(かた)"
+        ]
     },
     {
         "name": "zenzen",
         "trans": [
+            "全然(ぜんぜん)",
             "⓪ 副  （后接否定）完全不……"
-        ],
-        "notation": "全然(ぜんぜん)"
+        ]
     },
     {
         "name": "saikou",
         "trans": [
+            "最高(さいこう)",
             "⓪ 名·ナ形  最高；最好"
-        ],
-        "notation": "最高(さいこう)"
+        ]
     },
     {
         "name": "kokunai",
         "trans": [
+            "国内(こくない)",
             "② 名  国内"
-        ],
-        "notation": "国内(こくない)"
+        ]
     },
     {
         "name": "hijouni",
         "trans": [
+            "非常(ひじょう)に",
             "⓪ 副  非常，特别"
-        ],
-        "notation": "非常(ひじょう)に"
+        ]
     },
     {
         "name": "chekku",
         "trans": [
+            "チェック",
             "① 名·他动3  检验，检查；支票；格子花纹"
-        ],
-        "notation": "チェック"
+        ]
     },
     {
         "name": "higashiguchi",
         "trans": [
+            "東口(ひがしぐち)",
             "⓪ 名  东侧出入口"
-        ],
-        "notation": "東口(ひがしぐち)"
+        ]
     },
     {
         "name": "gutto",
         "trans": [
+            "ぐっと",
             "⓪ 副  使劲，一口气；更加，格外"
-        ],
-        "notation": "ぐっと"
+        ]
     },
     {
         "name": "hassha",
         "trans": [
+            "発車(はっしゃ)",
             "⓪ 名·自动3  开车，发车"
-        ],
-        "notation": "発車(はっしゃ)"
+        ]
     },
     {
         "name": "mizukara",
         "trans": [
+            "自(みずか)ら",
             "① 名·副  自己；亲身，亲自"
-        ],
-        "notation": "自(みずか)ら"
+        ]
     },
     {
         "name": "don'nani",
         "trans": [
+            "どんなに",
             "① 副  多么地；无论如何，不管怎么样"
-        ],
-        "notation": "どんなに"
+        ]
     },
     {
         "name": "hantai",
         "trans": [
+            "反対(はんたい)",
             "⓪ 名·自动3  反对"
-        ],
-        "notation": "反対(はんたい)"
+        ]
     },
     {
         "name": "sasuga",
         "trans": [
+            "さすが",
             "⓪ 副  不愧是"
-        ],
-        "notation": "さすが"
+        ]
     },
     {
         "name": "sonohoka",
         "trans": [
+            "そのほか",
             "② 连语  除此之外，另外"
-        ],
-        "notation": "そのほか"
+        ]
     },
     {
         "name": "pa-sento",
         "trans": [
+            "パーセント",
             "③ 名  百分比，百分之……"
-        ],
-        "notation": "パーセント"
+        ]
     },
     {
         "name": "kon'nani",
         "trans": [
+            "こんなに",
             "⓪ 副  这么，这样地"
-        ],
-        "notation": "こんなに"
+        ]
     },
     {
         "name": "haiken",
         "trans": [
+            "拝見(はいけん)",
             "⓪ 名·他动3  拜读"
-        ],
-        "notation": "拝見(はいけん)"
+        ]
     },
     {
         "name": "muri",
         "trans": [
+            "無理(むり)",
             "① 名·ナ形  困难，难以办到；强迫，强制"
-        ],
-        "notation": "無理(むり)"
+        ]
     },
     {
         "name": "jitsuha",
         "trans": [
+            "実(じつ)は",
             "② 副  说真的，老实说"
-        ],
-        "notation": "実(じつ)は"
+        ]
     },
     {
         "name": "bakuhatsu",
         "trans": [
+            "爆発(ばくはつ)",
             "⓪ 名·自动3  爆炸；爆发"
-        ],
-        "notation": "爆発(ばくはつ)"
+        ]
     },
     {
         "name": "teian",
         "trans": [
+            "提案(ていあん)",
             "⓪ 名·他动3  提案，建议"
-        ],
-        "notation": "提案(ていあん)"
+        ]
     },
     {
         "name": "zaazaa",
         "trans": [
+            "ざあざあ",
             "① 副  （下雨或流水声）哗啦哗啦"
-        ],
-        "notation": "ざあざあ"
+        ]
     },
     {
         "name": "biza",
         "trans": [
+            "ビザ",
             "① 名  签证"
-        ],
-        "notation": "ビザ"
+        ]
     },
     {
         "name": "soreni",
         "trans": [
+            "それに",
             "⓪ 接续  而且"
-        ],
-        "notation": "それに"
+        ]
     },
     {
         "name": "nebou",
         "trans": [
+            "寝坊(ねぼう)",
             "⓪ 名·ナ形·自动3  睡懒觉；爱睡懒觉的人"
-        ],
-        "notation": "寝坊(ねぼう)"
+        ]
     },
     {
         "name": "setsuzoku",
         "trans": [
+            "接続(せつぞく)",
             "⓪ 名·自他动3  连接，接续"
-        ],
-        "notation": "接続(せつぞく)"
+        ]
     },
     {
         "name": "perapera",
         "trans": [
+            "ぺらぺら",
             "① 副·ナ形  （说外语）流利；哗啦哗啦地（翻纸等）"
-        ],
-        "notation": "ぺらぺら"
+        ]
     },
     {
         "name": "tattaima",
         "trans": [
+            "たった今(いま)",
             "④ 副  刚才，刚刚；马上"
-        ],
-        "notation": "たった今(いま)"
+        ]
     },
     {
         "name": "sonomama",
         "trans": [
+            "そのまま",
             "⓪ 副  原封不动，照原样"
-        ],
-        "notation": "そのまま"
+        ]
     },
     {
         "name": "harahara",
         "trans": [
+            "はらはら",
             "① 副·自动3  （树叶、水滴等）落下；担心，捏一把汗"
-        ],
-        "notation": "はらはら"
+        ]
     },
     {
         "name": "yorokonde",
         "trans": [
+            "喜(よろこ)んで",
             "③ 副  乐意地，欣然地"
-        ],
-        "notation": "喜(よろこ)んで"
+        ]
     },
     {
         "name": "tsugini",
         "trans": [
+            "次(つぎ)に",
             "② 接续  然后，其次"
-        ],
-        "notation": "次(つぎ)に"
+        ]
     },
     {
         "name": "tashika",
         "trans": [
+            "確(たし)か",
             "① ナ形·副  确实，确切；大概，好像"
-        ],
-        "notation": "確(たし)か"
+        ]
     },
     {
         "name": "chittomo",
         "trans": [
+            "ちっとも",
             "③ 副  （后接否定）一点儿也不……"
-        ],
-        "notation": "ちっとも"
+        ]
     },
     {
         "name": "asagohan",
         "trans": [
+            "朝(あさ)ご飯(はん)",
             "③ 名  早饭"
-        ],
-        "notation": "朝(あさ)ご飯(はん)"
+        ]
     }
 ]

--- a/assets/dicts/Japanesebasicword.json
+++ b/assets/dicts/Japanesebasicword.json
@@ -2,701 +2,701 @@
     {
         "name": "ohayougozaimasu",
         "trans": [
+            "おはようございます",
             "Good morning"
-        ],
-        "notation": "おはようございます"
+        ]
     },
     {
         "name": "konnichiha",
         "trans": [
+            "こんにちは",
             "Hello/ good afternoon"
-        ],
-        "notation": "こんにちは"
+        ]
     },
     {
         "name": "konbanha",
         "trans": [
+            "こんばんは",
             "Good evening"
-        ],
-        "notation": "こんばんは"
+        ]
     },
     {
         "name": "oyasuminasai",
         "trans": [
+            "おやすみなさい",
             "Goodnight"
-        ],
-        "notation": "おやすみなさい"
+        ]
     },
     {
         "name": "arigatougozaimasu",
         "trans": [
+            "ありがとうございます",
             "Thank you"
-        ],
-        "notation": "ありがとうございます"
+        ]
     },
     {
         "name": "sumimasen",
         "trans": [
+            "すみません",
             "Excuse me/ sorry"
-        ],
-        "notation": "すみません"
+        ]
     },
     {
         "name": "gomennasai",
         "trans": [
+            "ごめんなさい",
             "Sorry"
-        ],
-        "notation": "ごめんなさい"
+        ]
     },
     {
         "name": "hai",
         "trans": [
+            "はい",
             "Yes"
-        ],
-        "notation": "はい"
+        ]
     },
     {
         "name": "iie",
         "trans": [
+            "いいえ",
             "No"
-        ],
-        "notation": "いいえ"
+        ]
     },
     {
         "name": "watashi",
         "trans": [
+            "わたし",
             "I/me"
-        ],
-        "notation": "わたし"
+        ]
     },
     {
         "name": "anata",
         "trans": [
+            "あなた",
             "You"
-        ],
-        "notation": "あなた"
+        ]
     },
     {
         "name": "okaasan",
         "trans": [
+            "お母(かあ)さん",
             "Mother"
-        ],
-        "notation": "お母(かあ)さん"
+        ]
     },
     {
         "name": "otousan",
         "trans": [
+            "お父(とう)さん",
             "Father"
-        ],
-        "notation": "お父(とう)さん"
+        ]
     },
     {
         "name": "ojiisan",
         "trans": [
+            "お爺(じい)さん",
             "Grandfather"
-        ],
-        "notation": "お爺(じい)さん"
+        ]
     },
     {
         "name": "obaasan",
         "trans": [
+            "お婆(ばあ)さん",
             "Grandmother"
-        ],
-        "notation": "お婆(ばあ)さん"
+        ]
     },
     {
         "name": "ojisan",
         "trans": [
+            "おじさん",
             "Uncle"
-        ],
-        "notation": "おじさん"
+        ]
     },
     {
         "name": "obasan",
         "trans": [
+            "おばさん",
             "Aunt"
-        ],
-        "notation": "おばさん"
+        ]
     },
     {
         "name": "oniisan",
         "trans": [
+            "お兄(にい)さん",
             "Older brother"
-        ],
-        "notation": "お兄(にい)さん"
+        ]
     },
     {
         "name": "oneesan",
         "trans": [
+            "お姉(ねえ)さん",
             "Older sister"
-        ],
-        "notation": "お姉(ねえ)さん"
+        ]
     },
     {
         "name": "otouto",
         "trans": [
+            "弟(おとうと)",
             "Younger brother"
-        ],
-        "notation": "弟(おとうと)"
+        ]
     },
     {
         "name": "imouto",
         "trans": [
+            "妹(いもうと)",
             "Younger sister"
-        ],
-        "notation": "妹(いもうと)"
+        ]
     },
     {
         "name": "ichi",
         "trans": [
+            "一(いち)",
             "One"
-        ],
-        "notation": "一(いち)"
+        ]
     },
     {
         "name": "ni",
         "trans": [
+            "二(に)",
             "Two"
-        ],
-        "notation": "二(に)"
+        ]
     },
     {
         "name": "san",
         "trans": [
+            "三(さん)",
             "Three"
-        ],
-        "notation": "三(さん)"
+        ]
     },
     {
         "name": "yon",
         "trans": [
+            "四(よん)",
             "Four"
-        ],
-        "notation": "四(よん)"
+        ]
     },
     {
         "name": "go",
         "trans": [
+            "五(ご)",
             "Five"
-        ],
-        "notation": "五(ご)"
+        ]
     },
     {
         "name": "roku",
         "trans": [
+            "六(ろく)",
             "Six"
-        ],
-        "notation": "六(ろく)"
+        ]
     },
     {
         "name": "nana",
         "trans": [
+            "七(なな)",
             "Seven"
-        ],
-        "notation": "七(なな)"
+        ]
     },
     {
         "name": "hachi",
         "trans": [
+            "八(はち)",
             "Eight"
-        ],
-        "notation": "八(はち)"
+        ]
     },
     {
         "name": "kyuu",
         "trans": [
+            "九(きゅう)",
             "Nine"
-        ],
-        "notation": "九(きゅう)"
+        ]
     },
     {
         "name": "juu",
         "trans": [
+            "十(じゅう)",
             "Ten"
-        ],
-        "notation": "十(じゅう)"
+        ]
     },
     {
         "name": "ichigatsu",
         "trans": [
+            "一月(いちがつ)",
             "January"
-        ],
-        "notation": "一月(いちがつ)"
+        ]
     },
     {
         "name": "nigatsu",
         "trans": [
+            "二月(にがつ)",
             "February"
-        ],
-        "notation": "二月(にがつ)"
+        ]
     },
     {
         "name": "sangatsu",
         "trans": [
+            "三月(さんがつ)",
             "March"
-        ],
-        "notation": "三月(さんがつ)"
+        ]
     },
     {
         "name": "shigatsu",
         "trans": [
+            "四月(しがつ)",
             "April"
-        ],
-        "notation": "四月(しがつ)"
+        ]
     },
     {
         "name": "gogatsu",
         "trans": [
+            "五月(ごがつ)",
             "May"
-        ],
-        "notation": "五月(ごがつ)"
+        ]
     },
     {
         "name": "rokugatsu",
         "trans": [
+            "六月(ろくがつ)",
             "June"
-        ],
-        "notation": "六月(ろくがつ)"
+        ]
     },
     {
         "name": "shichigatsu",
         "trans": [
+            "七月(しちがつ)",
             "July"
-        ],
-        "notation": "七月(しちがつ)"
+        ]
     },
     {
         "name": "hachigatsu",
         "trans": [
+            "八月(はちがつ)",
             "August"
-        ],
-        "notation": "八月(はちがつ)"
+        ]
     },
     {
         "name": "kugatsu",
         "trans": [
+            "九月(くがつ)",
             "September"
-        ],
-        "notation": "九月(くがつ)"
+        ]
     },
     {
         "name": "juugatsu",
         "trans": [
+            "十月(じゅうがつ)",
             "October"
-        ],
-        "notation": "十月(じゅうがつ)"
+        ]
     },
     {
         "name": "juuichigatsu",
         "trans": [
+            "十一月(じゅういちがつ)",
             "November"
-        ],
-        "notation": "十一月(じゅういちがつ)"
+        ]
     },
     {
         "name": "juunigatsu",
         "trans": [
+            "十二月(じゅうにがつ)",
             "December"
-        ],
-        "notation": "十二月(じゅうにがつ)"
+        ]
     },
     {
         "name": "getsuyoubi",
         "trans": [
+            "月曜日(げつようび)",
             "Monday"
-        ],
-        "notation": "月曜日(げつようび)"
+        ]
     },
     {
         "name": "kayoubi",
         "trans": [
+            "火曜日(かようび)",
             "Tuesday"
-        ],
-        "notation": "火曜日(かようび)"
+        ]
     },
     {
         "name": "suiyoubi",
         "trans": [
+            "水曜日(すいようび)",
             "Wednesday"
-        ],
-        "notation": "水曜日(すいようび)"
+        ]
     },
     {
         "name": "mokuyoubi",
         "trans": [
+            "木曜日(もくようび)",
             "Thursday"
-        ],
-        "notation": "木曜日(もくようび)"
+        ]
     },
     {
         "name": "kinyoubi",
         "trans": [
+            "金曜日(きんようび)",
             "Friday"
-        ],
-        "notation": "金曜日(きんようび)"
+        ]
     },
     {
         "name": "doyoubi",
         "trans": [
+            "土曜日(どようび)",
             "Saturday"
-        ],
-        "notation": "土曜日(どようび)"
+        ]
     },
     {
         "name": "nichiyoubi",
         "trans": [
+            "日曜日(にちようび)",
             "Sunday"
-        ],
-        "notation": "日曜日(にちようび)"
+        ]
     },
     {
         "name": "kinou",
         "trans": [
+            "昨日(きのう)",
             "Yesterday"
-        ],
-        "notation": "昨日(きのう)"
+        ]
     },
     {
         "name": "kyou",
         "trans": [
+            "今日(きょう)",
             "Today"
-        ],
-        "notation": "今日(きょう)"
+        ]
     },
     {
         "name": "ashita",
         "trans": [
+            "明日(あした)",
             "Tomorrow"
-        ],
-        "notation": "明日(あした)"
+        ]
     },
     {
         "name": "asa",
         "trans": [
+            "朝(あさ)",
             "Morning"
-        ],
-        "notation": "朝(あさ)"
+        ]
     },
     {
         "name": "hiru",
         "trans": [
+            "昼(ひる)",
             "Noon"
-        ],
-        "notation": "昼(ひる)"
+        ]
     },
     {
         "name": "yuugata",
         "trans": [
+            "夕方(ゆうがた)",
             "Evening"
-        ],
-        "notation": "夕方(ゆうがた)"
+        ]
     },
     {
         "name": "yoru",
         "trans": [
+            "夜(よる)",
             "Night"
-        ],
-        "notation": "夜(よる)"
+        ]
     },
     {
         "name": "tanoshii",
         "trans": [
+            "楽(たの)しい",
             "Happy"
-        ],
-        "notation": "楽(たの)しい"
+        ]
     },
     {
         "name": "kanashii",
         "trans": [
+            "悲(かな)しい",
             "Sad"
-        ],
-        "notation": "悲(かな)しい"
+        ]
     },
     {
         "name": "takai",
         "trans": [
+            "高(たか)い",
             "High/expensive"
-        ],
-        "notation": "高(たか)い"
+        ]
     },
     {
         "name": "hikui",
         "trans": [
+            "低(ひく)い",
             "Low"
-        ],
-        "notation": "低(ひく)い"
+        ]
     },
     {
         "name": "yasui",
         "trans": [
+            "安(やす)い",
             "Cheap"
-        ],
-        "notation": "安(やす)い"
+        ]
     },
     {
         "name": "hayai",
         "trans": [
+            "早(はや)い",
             "Fast/early"
-        ],
-        "notation": "早(はや)い"
+        ]
     },
     {
         "name": "osoi",
         "trans": [
+            "遅(おそ)い",
             "Slow"
-        ],
-        "notation": "遅(おそ)い"
+        ]
     },
     {
         "name": "isogashii",
         "trans": [
+            "忙(いそが)しい",
             "Busy"
-        ],
-        "notation": "忙(いそが)しい"
+        ]
     },
     {
         "name": "oishii",
         "trans": [
+            "美味(おい)しい",
             "Delicious"
-        ],
-        "notation": "美味(おい)しい"
+        ]
     },
     {
         "name": "mazui",
         "trans": [
+            "不味(まず)い",
             "Awful"
-        ],
-        "notation": "不味(まず)い"
+        ]
     },
     {
         "name": "amai",
         "trans": [
+            "甘(あま)い",
             "Sweet"
-        ],
-        "notation": "甘(あま)い"
+        ]
     },
     {
         "name": "shoppai",
         "trans": [
+            "塩(しょ)っぱい",
             "Salty"
-        ],
-        "notation": "塩(しょ)っぱい"
+        ]
     },
     {
         "name": "suppai",
         "trans": [
+            "酸(す)っぱい",
             "Sour"
-        ],
-        "notation": "酸(す)っぱい"
+        ]
     },
     {
         "name": "nigai",
         "trans": [
+            "苦(にが)い",
             "Bitter"
-        ],
-        "notation": "苦(にが)い"
+        ]
     },
     {
         "name": "tsurai",
         "trans": [
+            "辛(つら)い",
             "Hot/ spicy"
-        ],
-        "notation": "辛(つら)い"
+        ]
     },
     {
         "name": "atsui",
         "trans": [
+            "熱(あつ)い",
             "Hot"
-        ],
-        "notation": "熱(あつ)い"
+        ]
     },
     {
         "name": "atatakai",
         "trans": [
+            "暖(あたた)かい",
             "Warm"
-        ],
-        "notation": "暖(あたた)かい"
+        ]
     },
     {
         "name": "tsumetai",
         "trans": [
+            "冷(つめ)たい",
             "Cold"
-        ],
-        "notation": "冷(つめ)たい"
+        ]
     },
     {
         "name": "akarui",
         "trans": [
+            "明(あか)るい",
             "Bright"
-        ],
-        "notation": "明(あか)るい"
+        ]
     },
     {
         "name": "kurai",
         "trans": [
+            "暗(くら)い",
             "Dark"
-        ],
-        "notation": "暗(くら)い"
+        ]
     },
     {
         "name": "suru",
         "trans": [
+            "する",
             "To do"
-        ],
-        "notation": "する"
+        ]
     },
     {
         "name": "miru",
         "trans": [
+            "見(み)る",
             "To see"
-        ],
-        "notation": "見(み)る"
+        ]
     },
     {
         "name": "kiku",
         "trans": [
+            "聞(き)く",
             "To listen"
-        ],
-        "notation": "聞(き)く"
+        ]
     },
     {
         "name": "hanasu",
         "trans": [
+            "話(はな)す",
             "To talk/speak"
-        ],
-        "notation": "話(はな)す"
+        ]
     },
     {
         "name": "iu",
         "trans": [
+            "言(い)う",
             "To say"
-        ],
-        "notation": "言(い)う"
+        ]
     },
     {
         "name": "kaku",
         "trans": [
+            "書(か)く",
             "To write"
-        ],
-        "notation": "書(か)く"
+        ]
     },
     {
         "name": "taberu",
         "trans": [
+            "食(た)べる",
             "To eat"
-        ],
-        "notation": "食(た)べる"
+        ]
     },
     {
         "name": "nomu",
         "trans": [
+            "飲(の)む",
             "To drink"
-        ],
-        "notation": "飲(の)む"
+        ]
     },
     {
         "name": "aruku",
         "trans": [
+            "歩(ある)く",
             "To walk"
-        ],
-        "notation": "歩(ある)く"
+        ]
     },
     {
         "name": "hashiru",
         "trans": [
+            "走(はし)る",
             "To run"
-        ],
-        "notation": "走(はし)る"
+        ]
     },
     {
         "name": "suwaru",
         "trans": [
+            "座(すわ)る",
             "To sit"
-        ],
-        "notation": "座(すわ)る"
+        ]
     },
     {
         "name": "tatsu",
         "trans": [
+            "立(た)つ",
             "To stand"
-        ],
-        "notation": "立(た)つ"
+        ]
     },
     {
         "name": "tabemono",
         "trans": [
+            "食(た)べ物(もの)",
             "Food"
-        ],
-        "notation": "食(た)べ物(もの)"
+        ]
     },
     {
         "name": "nomimono",
         "trans": [
+            "飲(の)み物(もの)",
             "Drinks"
-        ],
-        "notation": "飲(の)み物(もの)"
+        ]
     },
     {
         "name": "gohan",
         "trans": [
+            "ご飯(はん)",
             "Rice/meal"
-        ],
-        "notation": "ご飯(はん)"
+        ]
     },
     {
         "name": "mizu",
         "trans": [
+            "水(みず)",
             "Water/cold water"
-        ],
-        "notation": "水(みず)"
+        ]
     },
     {
         "name": "oyu",
         "trans": [
+            "お湯(ゆ)",
             "Hot water"
-        ],
-        "notation": "お湯(ゆ)"
+        ]
     },
     {
         "name": "niku",
         "trans": [
+            "肉(にく)",
             "Meat"
-        ],
-        "notation": "肉(にく)"
+        ]
     },
     {
         "name": "yasai",
         "trans": [
+            "野菜(やさい)",
             "Vegetable"
-        ],
-        "notation": "野菜(やさい)"
+        ]
     },
     {
         "name": "sakana",
         "trans": [
+            "魚(さかな)",
             "Fish"
-        ],
-        "notation": "魚(さかな)"
+        ]
     },
     {
         "name": "raamen",
         "trans": [
+            "ラーメン",
             "Ramen"
-        ],
-        "notation": "ラーメン"
+        ]
     },
     {
         "name": "sushi",
         "trans": [
+            "寿司(すし)",
             "Sushi"
-        ],
-        "notation": "寿司(すし)"
+        ]
     },
     {
         "name": "onigiri",
         "trans": [
+            "おにぎり",
             "Onigiri"
-        ],
-        "notation": "おにぎり"
+        ]
     }
 ]


### PR DESCRIPTION
此前只能显示罗马音，不显示汉字和假名，对日语学习几乎没有帮助，这里把notation里的日文合并到了trans里，使得两者可以同时显示